### PR TITLE
Fixes #29804: test-connection checks borrow the client their connection owns

### DIFF
--- a/ingestion/src/metadata/core/connections/lifetime.py
+++ b/ingestion/src/metadata/core/connections/lifetime.py
@@ -9,12 +9,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-The reference a collaborator may hold to a client it does not own.
-
-A connection owns exactly one client: it knows the recipe (the service config and
-``_get_client``) and it owns the teardown. A collaborator - a checks provider -
-needs to *use* that client without being able to build another one or to close
-this one. ``Borrowed`` is that reference.
+The reference a collaborator holds to a client it does not own.
 """
 
 from __future__ import annotations
@@ -30,14 +25,8 @@ C = TypeVar("C")
 class Borrowed(Generic[C]):
     """A client someone else owns: read it, never build it, never close it.
 
-    Reads through to the owner, which builds the client on first read and caches
-    it, so every reader sees the one client the owner also uses. Carries no
-    service config - so a holder cannot construct a second client - and no
-    teardown - so it cannot destroy the one it borrowed.
-
-    A checks provider takes its clients as ``Borrowed``: reading one inside a
-    ``@check`` is what makes the owner build it, which keeps the first connection
-    behind the runner's gate instead of running while the provider is assembled.
+    Reading ``client`` delegates to the owner, which builds it once on first read.
+    Carries no config and no teardown, so a holder can do neither.
     """
 
     __slots__ = ("_read",)

--- a/ingestion/src/metadata/core/connections/lifetime.py
+++ b/ingestion/src/metadata/core/connections/lifetime.py
@@ -1,0 +1,55 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+The reference a collaborator may hold to a client it does not own.
+
+A connection owns exactly one client: it knows the recipe (the service config and
+``_get_client``) and it owns the teardown. A collaborator - a checks provider -
+needs to *use* that client without being able to build another one or to close
+this one. ``Borrowed`` is that reference.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+C = TypeVar("C")
+
+
+class Borrowed(Generic[C]):
+    """A client someone else owns: read it, never build it, never close it.
+
+    Reads through to the owner, which builds the client on first read and caches
+    it, so every reader sees the one client the owner also uses. Carries no
+    service config - so a holder cannot construct a second client - and no
+    teardown - so it cannot destroy the one it borrowed.
+
+    A checks provider takes its clients as ``Borrowed``: reading one inside a
+    ``@check`` is what makes the owner build it, which keeps the first connection
+    behind the runner's gate instead of running while the provider is assembled.
+    """
+
+    __slots__ = ("_read",)
+
+    def __init__(self, read: Callable[[], C]) -> None:
+        self._read = read
+
+    @property
+    def client(self) -> C:
+        return self._read()
+
+    @classmethod
+    def of(cls, client: C) -> Borrowed[C]:
+        """A handle over an already-built client. For tests and fakes."""
+        return cls(lambda: client)

--- a/ingestion/src/metadata/ingestion/connections/connection.py
+++ b/ingestion/src/metadata/ingestion/connections/connection.py
@@ -75,12 +75,8 @@ class BaseConnection(ABC, Generic[S, C]):
         return self._client
 
     def borrow(self) -> Borrowed[C]:
-        """A read-only reference to this connection's client, for a collaborator
-        such as its checks: readable, not buildable, not closable.
-
-        Reading it is what triggers the build, so a collaborator that only reads it
-        inside a ``@check`` never connects before the runner's gate - and it always
-        gets the one client this connection owns, never a second one."""
+        """A read-only reference to this connection's client: readable, not
+        buildable, not closable. The first read is what builds the client."""
         return Borrowed(lambda: self.client)
 
     def _build_client(self) -> C:

--- a/ingestion/src/metadata/ingestion/connections/connection.py
+++ b/ingestion/src/metadata/ingestion/connections/connection.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from contextlib import ExitStack
 from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.constants import STEP_TIMEOUT_SECONDS
 from metadata.core.connections.test_connection.runner import TestConnectionRunner
 from metadata.generated.schema.entity.automations.workflow import (
@@ -70,14 +71,26 @@ class BaseConnection(ABC, Generic[S, C]):
         """The service client, built once on first access and cached. Rebuilt if
         requested after ``close()``."""
         if self._client is None:
-            if self._was_closed:
-                logger.info(
-                    "Connection client for %s was closed; opening a new client.",
-                    type(self).__name__,
-                )
-                self._was_closed = False
-            self._client = self._get_client()
+            self._client = self._build_client()
         return self._client
+
+    def borrow(self) -> Borrowed[C]:
+        """A read-only reference to this connection's client, for a collaborator
+        such as its checks: readable, not buildable, not closable.
+
+        Reading it is what triggers the build, so a collaborator that only reads it
+        inside a ``@check`` never connects before the runner's gate - and it always
+        gets the one client this connection owns, never a second one."""
+        return Borrowed(lambda: self.client)
+
+    def _build_client(self) -> C:
+        if self._was_closed:
+            logger.info(
+                "Connection client for %s was closed; opening a new client.",
+                type(self).__name__,
+            )
+            self._was_closed = False
+        return self._get_client()
 
     @abstractmethod
     def _get_client(self) -> C:

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
@@ -44,6 +44,7 @@ from metadata.ingestion.source.dashboard.powerbi.client import (
 from metadata.ingestion.source.dashboard.powerbi.file_client import PowerBiFileClient
 
 if TYPE_CHECKING:
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -136,28 +137,20 @@ class PowerBIChecks:
     principal fails fast before any list endpoint is dialled. ``GetDashboards``
     then exercises list access.
 
-    The REST client is built lazily inside the first check, never at
-    construction: the underlying MSAL client performs authority/instance
-    discovery over the network in its constructor, so building it eagerly would
-    run before the runner's gate and surface as a raw workflow error instead of a
-    classified ``CheckAccess`` failure.
+    The client is borrowed from the connection that owns it, so the checks and the
+    ingestion share one authenticated session instead of acquiring a second token.
+    The MSAL client does authority/instance discovery over the network in its
+    constructor, and the borrow defers that to the first read - inside
+    ``CheckAccess``, the gate - so a bad service principal fails there.
     """
 
     errors = POWERBI_ERRORS
 
-    def __init__(self, connection: PowerBIConnectionConfig) -> None:
-        self._connection = connection
-        self._api_client: PowerBiApiClient | None = None
+    def __init__(self, powerbi: Borrowed[PowerBiClient]) -> None:
+        self._powerbi = powerbi
 
     def _client(self) -> PowerBiApiClient:
-        """Build (once) and return the REST client. Built directly rather than via
-        ``get_connection`` so the file client (unused by the checks) is never
-        constructed. The MSAL client it wraps does authority/instance discovery
-        over the network in its constructor, so this is only ever called from
-        inside a check - never at construction."""
-        if self._api_client is None:
-            self._api_client = PowerBiApiClient(self._connection)
-        return self._api_client
+        return self._powerbi.client.api_client
 
     @check(DashboardStep.CheckAccess)
     def check_access(self) -> Evidence:
@@ -195,4 +188,4 @@ class PowerBIConnection(BaseConnection[PowerBIConnectionConfig, PowerBiClient]):
         )
 
     def checks(self) -> ChecksProvider:
-        return PowerBIChecks(connection=self.service_connection)
+        return PowerBIChecks(powerbi=self.borrow())

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
@@ -137,11 +137,8 @@ class PowerBIChecks:
     principal fails fast before any list endpoint is dialled. ``GetDashboards``
     then exercises list access.
 
-    The client is borrowed from the connection that owns it, so the checks and the
-    ingestion share one authenticated session instead of acquiring a second token.
-    The MSAL client does authority/instance discovery over the network in its
-    constructor, and the borrow defers that to the first read - inside
-    ``CheckAccess``, the gate - so a bad service principal fails there.
+    ``CheckAccess`` is the gate: reading the borrowed client does MSAL discovery
+    and acquires the token, so a bad service principal fails there.
     """
 
     errors = POWERBI_ERRORS

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -239,14 +239,8 @@ def build_server_config(connection: TableauConnectionConfig) -> Dict[str, Dict[s
 class TableauChecks:
     """Test-connection checks for Tableau.
 
-    The server client is borrowed from the connection that owns it. Signing in is
-    what building it does, and the borrow defers that to the first read - inside
-    ``ServerInfo``, the gate - so bad credentials or an unreachable host fail there
-    and the remaining steps are skipped rather than each re-dialling.
-
-    Reusing the owner's client is what keeps a Personal Access Token working: a PAT
-    allows a single active session, so signing in a second time here would silently
-    invalidate the session the ingestion is about to use.
+    ``ServerInfo`` is the gate: reading the borrowed client signs in, so bad
+    credentials or an unreachable server fail there and the rest are skipped.
     """
 
     errors = TABLEAU_ERRORS
@@ -256,9 +250,8 @@ class TableauChecks:
 
     @check(DashboardStep.ServerInfo)
     def server_info(self) -> Evidence:
-        # The lambda is load-bearing: reading the borrow signs in, and that must
-        # happen inside the helper's try so a bad credential is classified as a
-        # failed ServerInfo step instead of escaping while the argument is built.
+        # Lambda, not a bound method: the sign-in must happen inside verify_access's
+        # try, or a bad credential escapes unclassified.
         return verify_access(
             lambda: self._server.client.server_info(),  # noqa: PLW0108
             command="sign in and read server info",
@@ -308,8 +301,7 @@ class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
 
     def _get_client(self) -> TableauClient:
         client = get_connection(self.service_connection)
-        # Signing in holds a server session, and sign_out also clears the SSL temp
-        # files. Deferred via a lambda so building the client touches none of it.
+        # sign_out releases the server session and clears the SSL temp files.
         self._on_close(lambda: client.sign_out())  # noqa: PLW0108
         return client
 

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -59,6 +59,7 @@ from metadata.utils.logger import ingestion_logger
 from metadata.utils.ssl_manager import SSLManager
 
 if TYPE_CHECKING:
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -238,70 +239,65 @@ def build_server_config(connection: TableauConnectionConfig) -> Dict[str, Dict[s
 class TableauChecks:
     """Test-connection checks for Tableau.
 
-    ``ServerInfo`` is the gate: building the client signs in, so bad credentials,
-    a wrong site, or an unreachable server fail there and the remaining steps are
-    skipped rather than each re-dialling the host.
+    The server client is borrowed from the connection that owns it. Signing in is
+    what building it does, and the borrow defers that to the first read - inside
+    ``ServerInfo``, the gate - so bad credentials or an unreachable host fail there
+    and the remaining steps are skipped rather than each re-dialling.
 
-    The client is built lazily inside the first check, never at construction: its
-    constructor signs in over the network, and doing that while the provider is
-    assembled would run before the runner's gate and surface as a raw workflow
-    error instead of a classified ``ServerInfo`` failure.
+    Reusing the owner's client is what keeps a Personal Access Token working: a PAT
+    allows a single active session, so signing in a second time here would silently
+    invalidate the session the ingestion is about to use.
     """
 
     errors = TABLEAU_ERRORS
 
-    def __init__(self, connection: TableauConnectionConfig) -> None:
-        self._connection = connection
-        self._tableau_client: TableauClient | None = None
-
-    def _client(self) -> TableauClient:
-        """Build (once) and return the signed-in client. Only ever called from
-        inside a check, since signing in touches the network."""
-        if self._tableau_client is None:
-            self._tableau_client = get_connection(self._connection)
-        return self._tableau_client
+    def __init__(self, server: Borrowed[TableauClient]) -> None:
+        self._server = server
 
     @check(DashboardStep.ServerInfo)
     def server_info(self) -> Evidence:
+        # The lambda is load-bearing: reading the borrow signs in, and that must
+        # happen inside the helper's try so a bad credential is classified as a
+        # failed ServerInfo step instead of escaping while the argument is built.
         return verify_access(
-            lambda: self._client().server_info(),
+            lambda: self._server.client.server_info(),  # noqa: PLW0108
             command="sign in and read server info",
         )
 
     @check(DashboardStep.ValidateApiVersion)
     def validate_api_version(self) -> Evidence:
         command = "read the server REST API version"
-        version = call_endpoint(lambda: self._client().server_api_version(), command=command)
+        version = call_endpoint(lambda: self._server.client.server_api_version(), command=command)  # noqa: PLW0108
         return Evidence(summary=f"REST API version {version}", command=command)
 
     @check(DashboardStep.ValidateSiteUrl)
     def validate_site_url(self) -> Evidence:
         command = "validate the configured site name"
-        call_endpoint(lambda: self._client().test_site_url(), command=command)
+        call_endpoint(lambda: self._server.client.test_site_url(), command=command)  # noqa: PLW0108
         return Evidence(summary="site name is well formed", command=command)
 
     @check(DashboardStep.GetWorkbooks)
     def get_workbooks(self) -> Evidence:
         command = "fetch workbooks"
-        call_endpoint(lambda: self._client().test_get_workbooks(), command=command)
+        call_endpoint(lambda: self._server.client.test_get_workbooks(), command=command)  # noqa: PLW0108
         return Evidence(summary="workbooks are readable", command=command)
 
     @check(DashboardStep.GetViews)
     def get_views(self) -> Evidence:
         command = "fetch the views of a workbook"
-        call_endpoint(lambda: self._client().test_get_workbook_views(), command=command)
+        call_endpoint(lambda: self._server.client.test_get_workbook_views(), command=command)  # noqa: PLW0108
         return Evidence(summary="workbook views are readable", command=command)
 
     @check(DashboardStep.GetOwners)
     def get_owners(self) -> Evidence:
         command = "fetch the owner of a workbook"
-        call_endpoint(lambda: self._client().test_get_owners(), command=command)
+        call_endpoint(lambda: self._server.client.test_get_owners(), command=command)  # noqa: PLW0108
         return Evidence(summary="workbook owners are resolvable", command=command)
 
     @check(DashboardStep.GetDataModels)
     def get_data_models(self) -> Evidence:
         command = "query the Metadata API for the data sources of a workbook"
-        call_endpoint(lambda: self._client().test_get_datamodels(), command=command)
+        call_endpoint(lambda: self._server.client.test_get_datamodels(), command=command)  # noqa: PLW0108
         return Evidence(summary="data sources are readable", command=command)
 
 
@@ -311,7 +307,11 @@ class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
     step_timeout_seconds = THREE_MIN
 
     def _get_client(self) -> TableauClient:
-        return get_connection(self.service_connection)
+        client = get_connection(self.service_connection)
+        # Signing in holds a server session, and sign_out also clears the SSL temp
+        # files. Deferred via a lambda so building the client touches none of it.
+        self._on_close(lambda: client.sign_out())  # noqa: PLW0108
+        return client
 
     def checks(self) -> ChecksProvider:
-        return TableauChecks(connection=self.service_connection)
+        return TableauChecks(server=self.borrow())

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -294,6 +294,15 @@ class TableauChecks:
         return Evidence(summary="data sources are readable", command=command)
 
 
+def _sign_out(client: TableauClient) -> None:
+    """Best-effort: close() unwinds teardowns without catching, so a failed sign-out
+    must not replace the error being unwound."""
+    try:
+        client.sign_out()
+    except Exception:
+        logger.warning("Tableau sign-out failed while closing the connection", exc_info=True)
+
+
 class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
     # The workbook and Metadata API steps can be slow on large servers; keep the
     # legacy 3-minute budget the imperative handler used, now applied per step.
@@ -302,7 +311,7 @@ class TableauConnection(BaseConnection[TableauConnectionConfig, TableauClient]):
     def _get_client(self) -> TableauClient:
         client = get_connection(self.service_connection)
         # sign_out releases the server session and clears the SSL temp files.
-        self._on_close(lambda: client.sign_out())  # noqa: PLW0108
+        self._on_close(lambda: _sign_out(client))
         return client
 
     def checks(self) -> ChecksProvider:

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -288,8 +288,7 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
         return engine
 
     def checks(self) -> ChecksProvider:
-        # The borrow defers the build: reading it inside CheckAccess keeps the STS
-        # assume-role handshake behind the gate, where a denial is classified.
+        # The borrow defers the build, keeping the STS handshake behind the gate.
         return AthenaChecks(
             db=self.borrow(),
             schema_filter_pattern=self.service_connection.schemaFilterPattern,

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -52,8 +52,7 @@ from metadata.ingestion.connections.connection import BaseConnection
 from metadata.utils.filters import filter_by_schema
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
     from metadata.generated.schema.type.filterPattern import FilterPattern
@@ -139,26 +138,14 @@ class AthenaChecks:
 
     def __init__(
         self,
-        client_factory: Callable[[], Engine],
+        db: Borrowed[Engine],
         schema_filter_pattern: FilterPattern | None = None,
         catalog_id: str | None = None,
     ) -> None:
-        self._client_factory = client_factory
-        self._client: Engine | None = None
+        self._db = db
         self.schema_filter_pattern = schema_filter_pattern
         self.catalog_id = catalog_id
         self._targeted: list[str] | None = None
-
-    @property
-    def client(self) -> Engine:
-        """The Athena engine, built on first use - which is inside CheckAccess, the
-        gate. Building it runs the STS assume-role handshake (when an assumeRoleArn
-        is configured), so a bad credential or assume-role denial fails the gate and
-        is classified like any other access error, instead of raising eagerly at
-        provider construction - before the runner - and bypassing the gate."""
-        if self._client is None:
-            self._client = self._client_factory()
-        return self._client
 
     @property
     def _catalog_label(self) -> str:
@@ -178,7 +165,7 @@ class AthenaChecks:
         MAX_SCHEMAS_TO_PROBE so a catalog with very many databases cannot exhaust
         the test-connection timeout."""
         if self._targeted is None:
-            inspector = inspect(self.client)
+            inspector = inspect(self._db.client)
             targeted: list[str] = []
             for schema in inspector.get_schema_names() or []:
                 if filter_by_schema(self.schema_filter_pattern, schema):
@@ -194,12 +181,12 @@ class AthenaChecks:
         # run_sql, not ping: the URL carries the AWS endpoint host:port but the
         # transport is HTTPS over botocore, so a raw TCP preflight to it would be
         # meaningless. A real reachability failure still surfaces via NETWORK_ERRORS.
-        return run_sql(self.client, "SELECT 1", lambda _: "connection established")
+        return run_sql(self._db.client, "SELECT 1", lambda _: "connection established")
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
         command = f"{LIST_DATABASES} (CatalogName={self._catalog_name})"
-        return replace(list_schemas(self.client), command=command)
+        return replace(list_schemas(self._db.client), command=command)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
@@ -221,7 +208,7 @@ class AthenaChecks:
                     "catalog and schemaFilterPattern are not excluding everything.",
                 ),
             )
-        inspector = inspect(self.client)
+        inspector = inspect(self._db.client)
         command = f"{LIST_TABLE_METADATA} (CatalogName={self._catalog_name})"
         readable = any(inspector.get_table_names(schema) for schema in targeted)
         result = Evidence(
@@ -247,7 +234,7 @@ class AthenaChecks:
         # Views are frequently absent and GetViews is non-mandatory, so we probe
         # for visibility but never raise on an empty result.
         targeted = self._targeted_schemas()
-        inspector = inspect(self.client)
+        inspector = inspect(self._db.client)
         visible = any(inspector.get_view_names(schema) for schema in targeted)
         summary = "views visible" if visible else "no views visible (not required)"
         return Evidence(
@@ -301,10 +288,10 @@ class AthenaConnection(BaseConnection[AthenaConnectionConfig, Engine]):
         return engine
 
     def checks(self) -> ChecksProvider:
-        # Pass a thunk, not self.client: deferring the build keeps the STS
-        # assume-role handshake out of provider construction and inside the gate.
+        # The borrow defers the build: reading it inside CheckAccess keeps the STS
+        # assume-role handshake behind the gate, where a denial is classified.
         return AthenaChecks(
-            client_factory=lambda: self.client,
+            db=self.borrow(),
             schema_filter_pattern=self.service_connection.schemaFilterPattern,
             catalog_id=self.service_connection.catalogId,
         )

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -282,10 +282,8 @@ class BigQueryChecks:
     happens a layer up (``BigquerySource._test_connection`` clones the connection
     per project and drives this provider once per clone).
 
-    The engine is built lazily on first use inside ``CheckAccess`` (never at
-    construction), so credential parsing - which happens while building the engine
-    (e.g. a malformed private key) - fails *inside the gate step* and is classified
-    by the error pack, instead of escaping before the runner starts.
+    Reading the borrowed engine is what builds it, so credential parsing (e.g. a
+    malformed private key) fails inside the gate step and is classified.
     """
 
     errors = BIGQUERY_ERRORS

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -69,8 +69,7 @@ from metadata.utils.credentials import (
 from metadata.utils.logger import ingestion_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
 
 logger = ingestion_logger()
@@ -293,34 +292,27 @@ class BigQueryChecks:
 
     def __init__(
         self,
-        get_client: Callable[[], Engine],
+        db: Borrowed[Engine],
         service_connection: BigQueryConnectionConfig,
     ) -> None:
-        self._get_client = get_client
-        self._client: Engine | None = None
+        self._db = db
         self.service_connection = service_connection
-
-    @property
-    def client(self) -> Engine:
-        if self._client is None:
-            self._client = self._get_client()
-        return self._client
 
     @check(DatabaseStep.CheckAccess)
     def check_access(self) -> Evidence:
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
-        return list_schemas(self.client)
+        return list_schemas(self._db.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return probe_table_view_enumeration(self.client)
+        return probe_table_view_enumeration(self._db.client)
 
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
-        return probe_table_view_enumeration(self.client)
+        return probe_table_view_enumeration(self._db.client)
 
     @check(DatabaseStep.GetTags)
     def get_tags(self) -> Evidence | None:
@@ -332,12 +324,12 @@ class BigQueryChecks:
             region=self.service_connection.usageLocation,
             creation_date=datetime.now().strftime("%Y-%m-%d"),
         )
-        return run_sql(self.client, statement, lambda _: "query history accessible")
+        return run_sql(self._db.client, statement, lambda _: "query history accessible")
 
     def _taxonomy_project_ids(self) -> list[str]:
         project_ids: list[str] = []
-        if self.client.url.host:
-            project_ids.append(self.client.url.host)
+        if self._db.client.url.host:
+            project_ids.append(self._db.client.url.host)
         if self.service_connection.taxonomyProjectID:
             project_ids.extend(self.service_connection.taxonomyProjectID)
         return project_ids
@@ -389,6 +381,6 @@ class BigQueryConnection(BaseConnection[BigQueryConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return BigQueryChecks(
-            get_client=lambda: self.client,
+            db=self.borrow(),
             service_connection=self.service_connection,
         )

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -161,9 +161,8 @@ def _summarize(rows: Sequence[object], noun: str) -> str:
 
 
 class DatabricksEngineWrapper:
-    """Wraps the borrowed engine, caching the resolved catalog and schema. Every
-    lookup reads the engine through the borrow, so the first read - and therefore
-    the first connection - happens inside a check, behind the CheckAccess gate."""
+    """Wraps the borrowed engine, caching the resolved catalog and schema. Lookups
+    are lazy, so constructing it touches no network and stays behind the gate."""
 
     def __init__(self, db: Borrowed[Engine]):
         self._db = db

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -74,6 +74,7 @@ from metadata.utils.logger import ingestion_logger
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
 
 logger = ingestion_logger()
@@ -160,15 +161,20 @@ def _summarize(rows: Sequence[object], noun: str) -> str:
 
 
 class DatabricksEngineWrapper:
-    """Engine wrapper caching the resolved catalog and schema. Lookups are lazy, so
-    constructing it touches no network and stays behind the CheckAccess gate."""
+    """Wraps the borrowed engine, caching the resolved catalog and schema. Every
+    lookup reads the engine through the borrow, so the first read - and therefore
+    the first connection - happens inside a check, behind the CheckAccess gate."""
 
-    def __init__(self, engine: Engine):
-        self.engine = engine
+    def __init__(self, db: Borrowed[Engine]):
+        self._db = db
         self._inspector = None
         self.schemas = None
         self.first_schema = None
         self.first_catalog = None
+
+    @property
+    def engine(self) -> Engine:
+        return self._db.client
 
     @property
     def inspector(self):
@@ -275,10 +281,10 @@ class DatabricksChecks:
 
     errors = DATABRICKS_ERRORS
 
-    def __init__(self, client: Engine, service_connection: DatabricksConnectionConfig) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine], service_connection: DatabricksConnectionConfig) -> None:
+        self._db = db
         self.service_connection = service_connection
-        self._engine_wrapper = DatabricksEngineWrapper(client)
+        self._engine_wrapper = DatabricksEngineWrapper(db)
 
     def _first_catalog(self) -> str:
         """Resolve and cache the catalog to scope tag probes to."""
@@ -310,7 +316,7 @@ class DatabricksChecks:
             tcp_probe(host, port)
         except NetworkUnreachableError as error:
             raise CheckError(error, Evidence(command=f"TCP connect {host}:{port}")) from error
-        return run_sql(self.client, "SELECT 1", lambda _: "connection established")
+        return run_sql(self._db.client, "SELECT 1", lambda _: "connection established")
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
@@ -342,39 +348,39 @@ class DatabricksChecks:
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
         statement = DATABRICKS_SQL_STATEMENT_TEST.format(query_history=self.service_connection.queryHistoryTable)
-        return run_sql(self.client, statement, lambda _: "query history accessible")
+        return run_sql(self._db.client, statement, lambda _: "query history accessible")
 
     @check(DatabaseStep.GetViewDefinitions)
     def get_view_definitions(self) -> Evidence:
-        return run_sql(self.client, TEST_VIEW_DEFINITIONS, lambda _: "view definitions accessible")
+        return run_sql(self._db.client, TEST_VIEW_DEFINITIONS, lambda _: "view definitions accessible")
 
     @check(DatabaseStep.GetCatalogTags)
     def get_catalog_tags(self) -> Evidence:
         statement = TEST_CATALOG_TAGS.format(database_name=self._first_catalog())
-        return run_sql(self.client, statement, lambda _: "catalog tags accessible")
+        return run_sql(self._db.client, statement, lambda _: "catalog tags accessible")
 
     @check(DatabaseStep.GetSchemaTags)
     def get_schema_tags(self) -> Evidence:
         statement = TEST_SCHEMA_TAGS.format(database_name=self._first_catalog())
-        return run_sql(self.client, statement, lambda _: "schema tags accessible")
+        return run_sql(self._db.client, statement, lambda _: "schema tags accessible")
 
     @check(DatabaseStep.GetTableTags)
     def get_table_tags(self) -> Evidence:
         statement = TEST_TABLE_TAGS.format(database_name=self._first_catalog())
-        return run_sql(self.client, statement, lambda _: "table tags accessible")
+        return run_sql(self._db.client, statement, lambda _: "table tags accessible")
 
     @check(DatabaseStep.GetColumnTags)
     def get_column_tags(self) -> Evidence:
         statement = TEST_COLUMN_TAGS.format(database_name=self._first_catalog())
-        return run_sql(self.client, statement, lambda _: "column tags accessible")
+        return run_sql(self._db.client, statement, lambda _: "column tags accessible")
 
     @check(DatabaseStep.GetTableLineage)
     def get_table_lineage(self) -> Evidence:
-        return run_sql(self.client, TEST_TABLE_LINEAGE, lambda _: "table lineage accessible")
+        return run_sql(self._db.client, TEST_TABLE_LINEAGE, lambda _: "table lineage accessible")
 
     @check(DatabaseStep.GetColumnLineage)
     def get_column_lineage(self) -> Evidence:
-        return run_sql(self.client, TEST_COLUMN_LINEAGE, lambda _: "column lineage accessible")
+        return run_sql(self._db.client, TEST_COLUMN_LINEAGE, lambda _: "column lineage accessible")
 
 
 class DatabricksConnection(BaseConnection[DatabricksConnectionConfig, Engine]):
@@ -391,6 +397,6 @@ class DatabricksConnection(BaseConnection[DatabricksConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return DatabricksChecks(
-            client=self.client,
+            db=self.borrow(),
             service_connection=self.service_connection,
         )

--- a/ingestion/src/metadata/ingestion/source/database/glue/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/connection.py
@@ -31,8 +31,7 @@ from metadata.generated.schema.entity.services.connections.database.glueConnecti
 from metadata.ingestion.connections.connection import BaseConnection
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
 
 
@@ -142,21 +141,21 @@ def _no_tables_caveat() -> Diagnosis:
 class GlueChecks:
     """Test-connection checks for the Glue Data Catalog.
 
-    The client is built lazily inside the checks: an assume-role config calls STS
-    while the session is created, which must not happen before the gate."""
+    The client is borrowed from the connection that owns it: reading it inside a
+    check is what builds it, so the STS assume-role handshake stays behind the gate."""
 
     errors = GLUE_ERRORS
 
-    def __init__(self, connect: Callable[[], Any]) -> None:
-        self._connect = connect
+    def __init__(self, catalog: Borrowed[Any]) -> None:
+        self._catalog = catalog
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
-        return list_databases(self._connect())
+        return list_databases(self._catalog.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return list_tables(self._connect())
+        return list_tables(self._catalog.client)
 
 
 class GlueConnection(BaseConnection[GlueConnectionConfig, Any]):
@@ -164,4 +163,4 @@ class GlueConnection(BaseConnection[GlueConnectionConfig, Any]):
         return AWSClient(self.service_connection.awsConfig).get_glue_client()
 
     def checks(self) -> ChecksProvider:
-        return GlueChecks(connect=lambda: self.client)
+        return GlueChecks(catalog=self.borrow())

--- a/ingestion/src/metadata/ingestion/source/database/glue/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/connection.py
@@ -141,8 +141,8 @@ def _no_tables_caveat() -> Diagnosis:
 class GlueChecks:
     """Test-connection checks for the Glue Data Catalog.
 
-    The client is borrowed from the connection that owns it: reading it inside a
-    check is what builds it, so the STS assume-role handshake stays behind the gate."""
+    Reading the borrowed client is what builds it, so an assume-role config's STS
+    handshake stays behind the gate."""
 
     errors = GLUE_ERRORS
 

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -53,6 +53,7 @@ from metadata.ingestion.source.database.mssql.utils import is_query_store_enable
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.records import Evidence
 
@@ -149,39 +150,39 @@ class MssqlChecks:
         }
     )
 
-    def __init__(self, client: Engine, get_databases_statement: str) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine], get_databases_statement: str) -> None:
+        self._db = db
         self.get_databases_statement = get_databases_statement
 
     @check(DatabaseStep.CheckAccess)
     def check_access(self) -> Evidence:
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
-        return run_sql(self.client, self.get_databases_statement, _databases_enumerated)
+        return run_sql(self._db.client, self.get_databases_statement, _databases_enumerated)
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
-        return list_schemas(self.client)
+        return list_schemas(self._db.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return list_tables(self.client, None, self.SYSTEM_SCHEMAS)
+        return list_tables(self._db.client, None, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
-        return list_views(self.client, None, self.SYSTEM_SCHEMAS)
+        return list_views(self._db.client, None, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
-        if is_query_store_enabled(self.client):
+        if is_query_store_enabled(self._db.client):
             query = MSSQL_TEST_GET_QUERIES_FROM_QUERY_STORE
             summary = "query history accessible via Query Store"
         else:
             query = MSSQL_TEST_GET_QUERIES
             summary = "query history accessible via plan-cache DMVs"
-        return run_sql(self.client, query, lambda _: summary)
+        return run_sql(self._db.client, query, lambda _: summary)
 
 
 class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
@@ -201,6 +202,6 @@ class MssqlConnection(BaseConnection[MssqlConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return MssqlChecks(
-            client=self.client,
+            db=self.borrow(),
             get_databases_statement=self._get_databases_statement(),
         )

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -64,6 +64,7 @@ from metadata.ingestion.source.database.mysql.queries import (
 from metadata.utils.credentials import get_azure_access_token, set_google_credentials
 
 if TYPE_CHECKING:
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.records import Evidence
 
@@ -129,30 +130,30 @@ class MySQLChecks:
     # MySQL 8 system databases - skipped when auto-selecting a schema to probe.
     SYSTEM_SCHEMAS = frozenset({"information_schema", "performance_schema", "mysql", "sys"})
 
-    def __init__(self, client: Engine, schema: str | None, queries_statement: str) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine], schema: str | None, queries_statement: str) -> None:
+        self._db = db
         self.schema = schema
         self.queries_statement = queries_statement
 
     @check(DatabaseStep.CheckAccess)
     def check_access(self) -> Evidence:
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
-        return list_schemas(self.client)
+        return list_schemas(self._db.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return list_tables(self.client, self.schema, self.SYSTEM_SCHEMAS)
+        return list_tables(self._db.client, self.schema, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
-        return list_views(self.client, self.schema, self.SYSTEM_SCHEMAS)
+        return list_views(self._db.client, self.schema, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
-        return run_sql(self.client, self.queries_statement, lambda _: "query history accessible")
+        return run_sql(self._db.client, self.queries_statement, lambda _: "query history accessible")
 
 
 def _basic_engine(connection: MySQLConnectionConfig) -> Engine:
@@ -328,7 +329,7 @@ class MySQLConnection(BaseConnection[MySQLConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return MySQLChecks(
-            client=self.client,
+            db=self.borrow(),
             schema=self.service_connection.databaseSchema,
             queries_statement=self._test_queries_statement(),
         )

--- a/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
@@ -54,6 +54,7 @@ from metadata.ingestion.source.database.postgres.utils import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
     from metadata.core.connections.test_connection.records import Evidence
@@ -153,17 +154,17 @@ class PostgresChecks:
     # System schemas - skipped when auto-selecting a schema to probe.
     SYSTEM_SCHEMAS = frozenset({"information_schema", "pg_catalog", "pg_toast"})
 
-    def __init__(self, client: Engine, query_statement_source: str | None) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine], query_statement_source: str | None) -> None:
+        self._db = db
         self.query_statement_source = query_statement_source
 
     @check(DatabaseStep.CheckAccess)
     def check_access(self) -> Evidence:
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
-        return run_sql(self.client, POSTGRES_GET_DATABASE, self._summarize_databases)
+        return run_sql(self._db.client, POSTGRES_GET_DATABASE, self._summarize_databases)
 
     @staticmethod
     def _summarize_databases(rows: Sequence[object]) -> str:
@@ -175,41 +176,43 @@ class PostgresChecks:
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
-        return list_schemas(self.client)
+        return list_schemas(self._db.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return list_tables(self.client, None, self.SYSTEM_SCHEMAS)
+        return list_tables(self._db.client, None, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
-        return list_views(self.client, None, self.SYSTEM_SCHEMAS)
+        return list_views(self._db.client, None, self.SYSTEM_SCHEMAS)
 
     @check(DatabaseStep.GetTags)
     def get_tags(self) -> Evidence:
-        return run_sql(self.client, POSTGRES_TEST_GET_TAGS, lambda _: "policy tags accessible")
+        return run_sql(self._db.client, POSTGRES_TEST_GET_TAGS, lambda _: "policy tags accessible")
 
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
         # Built here, not at construction, so the version-probe query runs only
         # after CheckAccess has confirmed reachability - never ahead of the gate.
         statement = POSTGRES_TEST_GET_QUERIES.format(
-            time_column_name=get_postgres_time_column_name(engine=self.client),
+            time_column_name=get_postgres_time_column_name(engine=self._db.client),
             query_statement_source=self.query_statement_source or "pg_stat_statements",
         )
-        return run_sql(self.client, statement, lambda _: "query history accessible")
+        return run_sql(self._db.client, statement, lambda _: "query history accessible")
 
     @check(DatabaseStep.GetColumnMetadata)
     def get_column_metadata(self) -> Evidence:
-        return run_sql(self.client, TEST_COLUMN_METADATA, lambda _: "column metadata accessible")
+        return run_sql(self._db.client, TEST_COLUMN_METADATA, lambda _: "column metadata accessible")
 
     @check(DatabaseStep.GetTableComments)
     def get_table_comments(self) -> Evidence:
-        return run_sql(self.client, TEST_TABLE_COMMENTS, lambda _: "table comments accessible")
+        return run_sql(self._db.client, TEST_TABLE_COMMENTS, lambda _: "table comments accessible")
 
     @check(DatabaseStep.GetInformationSchemaColumns)
     def get_information_schema_columns(self) -> Evidence:
-        return run_sql(self.client, TEST_INFORMATION_SCHEMA_COLUMNS, lambda _: "information_schema.columns accessible")
+        return run_sql(
+            self._db.client, TEST_INFORMATION_SCHEMA_COLUMNS, lambda _: "information_schema.columns accessible"
+        )
 
 
 class PostgresConnection(BaseConnection[PostgresConnectionConfig, Engine]):
@@ -224,6 +227,6 @@ class PostgresConnection(BaseConnection[PostgresConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return PostgresChecks(
-            client=self.client,
+            db=self.borrow(),
             query_statement_source=self.service_connection.queryStatementSource,
         )

--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.engine import Row
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -318,37 +319,37 @@ class RedshiftChecks:
     # keeps it cheap since the step only proves the read is permitted.
     _RELATIONS_PROBE = REDSHIFT_GET_ALL_RELATIONS.format(schema_clause="", table_clause="", limit_clause="LIMIT 1")
 
-    def __init__(self, client: Engine) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine]) -> None:
+        self._db = db
 
     @check(DatabaseStep.CheckAccess)
     def check_access(self) -> Evidence:
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
-        return run_sql(self.client, REDSHIFT_GET_DATABASE_NAMES, _summarize_databases)
+        return run_sql(self._db.client, REDSHIFT_GET_DATABASE_NAMES, _summarize_databases)
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
-        return list_schemas(self.client)
+        return list_schemas(self._db.client)
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
-        return run_sql(self.client, self._RELATIONS_PROBE, lambda rows: f"{len(rows)} relations accessible")
+        return run_sql(self._db.client, self._RELATIONS_PROBE, lambda rows: f"{len(rows)} relations accessible")
 
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
-        return run_sql(self.client, self._RELATIONS_PROBE, lambda rows: f"{len(rows)} relations accessible")
+        return run_sql(self._db.client, self._RELATIONS_PROBE, lambda rows: f"{len(rows)} relations accessible")
 
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
         # Resolved here, not at construction, so the instance-type probe and the
         # privilege query run only after CheckAccess - never ahead of the gate.
-        instance_type = get_redshift_instance_type(self.client)
+        instance_type = get_redshift_instance_type(self._db.client)
         statement = REDSHIFT_TEST_GET_QUERIES_MAP[instance_type]
         try:
-            evidence = run_sql(self.client, statement, lambda rows: _summarize_queries(instance_type, rows))
+            evidence = run_sql(self._db.client, statement, lambda rows: _summarize_queries(instance_type, rows))
         except SourceConnectionException as missing_privilege:
             # The privilege probe raises from the summary callback, outside run_sql's
             # own CheckError wrapping - re-raise with the statement so the failed step
@@ -368,4 +369,4 @@ class RedshiftConnection(BaseConnection[RedshiftConnectionConfig, Engine]):
         return engine
 
     def checks(self) -> ChecksProvider:
-        return RedshiftChecks(client=self.client)
+        return RedshiftChecks(db=self.borrow())

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -325,8 +325,7 @@ class SnowflakeChecks:
 
     @property
     def _engine_wrapper(self) -> SnowflakeEngineWrapper:
-        """Built on first use, never at construction: it holds the engine, and
-        reading the borrow is what builds it."""
+        """Built on first use: it holds the engine, and reading the borrow builds it."""
         if self._wrapper is None:
             self._wrapper = SnowflakeEngineWrapper(
                 service_connection=self.service_connection,

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -76,6 +76,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.engine import Row
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.classifier import Matcher
 
@@ -316,15 +317,23 @@ class SnowflakeChecks:
     before the gate.
     """
 
-    def __init__(self, client: Engine, service_connection: SnowflakeConnectionConfig) -> None:
-        self.client = client
+    def __init__(self, db: Borrowed[Engine], service_connection: SnowflakeConnectionConfig) -> None:
+        self._db = db
         self.service_connection = service_connection
         self.errors = _snowflake_errors(service_connection.accountUsageSchema)
-        self._engine_wrapper = SnowflakeEngineWrapper(
-            service_connection=service_connection,
-            engine=client,
-            database_name=None,
-        )
+        self._wrapper: SnowflakeEngineWrapper | None = None
+
+    @property
+    def _engine_wrapper(self) -> SnowflakeEngineWrapper:
+        """Built on first use, never at construction: it holds the engine, and
+        reading the borrow is what builds it."""
+        if self._wrapper is None:
+            self._wrapper = SnowflakeEngineWrapper(
+                service_connection=self.service_connection,
+                engine=self._db.client,
+                database_name=None,
+            )
+        return self._wrapper
 
     def _database(self) -> str | None:
         """Resolve (and cache) the database to probe. Runs ``SHOW DATABASES`` only
@@ -357,16 +366,16 @@ class SnowflakeChecks:
                 tcp_probe(host, port)
             except NetworkUnreachableError as error:
                 raise CheckError(error, Evidence(command=f"TCP connect {host}:{port}")) from error
-        return ping(self.client)
+        return ping(self._db.client)
 
     @check(DatabaseStep.GetDatabases)
     def get_databases(self) -> Evidence:
-        return run_sql(self.client, SNOWFLAKE_GET_DATABASES, lambda rows: _count_summary(rows, "database"))
+        return run_sql(self._db.client, SNOWFLAKE_GET_DATABASES, lambda rows: _count_summary(rows, "database"))
 
     @check(DatabaseStep.GetSchemas)
     def get_schemas(self) -> Evidence:
         statement = SNOWFLAKE_TEST_GET_SCHEMAS.format(database_name=self._database())
-        return run_sql(self.client, statement, lambda rows: _count_summary(rows, "schema"))
+        return run_sql(self._db.client, statement, lambda rows: _count_summary(rows, "schema"))
 
     @check(DatabaseStep.GetTables)
     def get_tables(self) -> Evidence:
@@ -378,7 +387,7 @@ class SnowflakeChecks:
             counts.append(len(rows))
             return _count_summary(rows, "table")
 
-        evidence = run_sql(self.client, statement, summarize)
+        evidence = run_sql(self._db.client, statement, summarize)
         if not counts[0]:
             evidence = replace(evidence, caveat=_no_tables_caveat(database))
         return evidence
@@ -386,27 +395,27 @@ class SnowflakeChecks:
     @check(DatabaseStep.GetViews)
     def get_views(self) -> Evidence:
         statement = SNOWFLAKE_TEST_GET_VIEWS.format(database_name=self._database())
-        return run_sql(self.client, statement, lambda rows: _count_summary(rows, "view"))
+        return run_sql(self._db.client, statement, lambda rows: _count_summary(rows, "view"))
 
     @check(DatabaseStep.GetStreams)
     def get_streams(self) -> Evidence:
         statement = SNOWFLAKE_TEST_GET_STREAMS.format(database_name=self._database())
-        return run_sql(self.client, statement, lambda rows: _count_summary(rows, "stream"))
+        return run_sql(self._db.client, statement, lambda rows: _count_summary(rows, "stream"))
 
     @check(DatabaseStep.GetTags)
     def get_tags(self) -> Evidence:
         statement = SNOWFLAKE_TEST_FETCH_TAG.format(account_usage=self.service_connection.accountUsageSchema)
-        return run_sql(self.client, statement, lambda _: "tags accessible")
+        return run_sql(self._db.client, statement, lambda _: "tags accessible")
 
     @check(DatabaseStep.GetQueries)
     def get_queries(self) -> Evidence:
         statement = SNOWFLAKE_TEST_GET_QUERIES.format(account_usage=self.service_connection.accountUsageSchema)
-        return run_sql(self.client, statement, lambda _: "query history accessible")
+        return run_sql(self._db.client, statement, lambda _: "query history accessible")
 
     @check(DatabaseStep.GetAccessHistory)
     def get_access_history(self) -> Evidence:
         statement = SNOWFLAKE_ACCESS_HISTORY_PROBE.format(account_usage=self.service_connection.accountUsageSchema)
-        return run_sql(self.client, statement, lambda _: "access history accessible")
+        return run_sql(self._db.client, statement, lambda _: "access history accessible")
 
 
 class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):
@@ -520,6 +529,6 @@ class SnowflakeConnection(BaseConnection[SnowflakeConnectionConfig, Engine]):
 
     def checks(self) -> ChecksProvider:
         return SnowflakeChecks(
-            client=self.client,
+            db=self.borrow(),
             service_connection=self.service_connection,
         )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -337,9 +337,8 @@ def get_sqlalchemy_connection(connection: UnityCatalogConnectionConfig) -> Engin
 class UnityCatalogChecks:
     """Test-connection checks for Unity Catalog.
 
-    Catalog, schema and table steps go through the workspace REST client. The
-    lineage and tag steps need a SQL warehouse, so their Engine is built inside the
-    check that uses it - nothing connects before the gate.
+    Catalog, schema and table steps borrow the workspace client; lineage and tag
+    steps borrow the SQL-warehouse Engine. Each is built on first read, in a check.
     """
 
     errors = UNITY_CATALOG_ERRORS
@@ -438,12 +437,8 @@ class UnityCatalogChecks:
 
 
 class UnityCatalogSqlConnection(BaseConnection[UnityCatalogConnectionConfig, Engine]):
-    """Owns the SQL-warehouse Engine.
-
-    Its own owner because its lifetime differs from the workspace client's: the
-    Engine needs an httpPath to a running warehouse, and only the lineage and tag
-    steps reach for it. A workspace without one never builds it.
-    """
+    """Owns the SQL-warehouse Engine: a separate lifetime from the workspace client,
+    reached only by the lineage and tag steps and never built without an httpPath."""
 
     def _get_client(self) -> Engine:
         engine = get_sqlalchemy_connection(self.service_connection)
@@ -457,13 +452,17 @@ class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, Worksp
         # Honor the user-facing connectionTimeout as the per-step budget; a cold
         # serverless warehouse can exceed the framework default.
         self.step_timeout_seconds = service_connection.connectionTimeout or STEP_TIMEOUT_SECONDS
-        # A sub-owner, not a client: constructing it opens nothing. Its Engine is
-        # built on first read and disposed when this connection closes.
+        # A sub-owner, not a client: constructing it opens nothing.
         self.sql = UnityCatalogSqlConnection(service_connection)
-        self._on_close(self.sql.close)
 
     def _get_client(self) -> WorkspaceClient:
         return get_connection(self.service_connection)
+
+    def close(self) -> None:
+        # Not _on_close: that registry is reset by close(), so a sub-owner
+        # registered once would not be released on a later reuse cycle.
+        self.sql.close()
+        super().close()
 
     def checks(self) -> ChecksProvider:
         return UnityCatalogChecks(

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -27,6 +27,7 @@ from databricks.sdk.errors import (
 )
 from databricks.sdk.service.catalog import TableType
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 
 from metadata.core.connections.test_connection import (
     ErrorPack,
@@ -82,8 +83,7 @@ from metadata.ingestion.source.database.unitycatalog.queries import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from sqlalchemy.engine import Engine
-
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
 
 suppress_user_agent_entry_deprecation_log()
@@ -246,41 +246,35 @@ def get_views(connection: WorkspaceClient, table_obj: DatabricksTable) -> None:
             break
 
 
-def get_tags(service_connection: UnityCatalogConnectionConfig, table_obj: DatabricksTable) -> None:
+def read_tag_tables(engine: Engine, table_obj: DatabricksTable) -> None:
     """
     Validate that the information_schema tag tables are readable for the resolved
     catalog and schema.
     """
-    engine = get_sqlalchemy_connection(service_connection)
-    try:
-        with engine.connect() as connection:
-            connection.execute(
-                text(UNITY_CATALOG_GET_CATALOGS_TAGS.format(database=table_obj.catalog_name).replace(";", " limit 1;"))
+    with engine.connect() as connection:
+        connection.execute(
+            text(UNITY_CATALOG_GET_CATALOGS_TAGS.format(database=table_obj.catalog_name).replace(";", " limit 1;"))
+        )
+        connection.execute(
+            text(UNITY_CATALOG_GET_ALL_SCHEMA_TAGS.format(database=table_obj.catalog_name).replace(";", " limit 1;"))
+        )
+        connection.execute(
+            text(
+                UNITY_CATALOG_GET_ALL_TABLE_TAGS.format(
+                    database=table_obj.catalog_name, schema=table_obj.schema_name
+                ).replace(";", " limit 1;")
             )
-            connection.execute(
-                text(
-                    UNITY_CATALOG_GET_ALL_SCHEMA_TAGS.format(database=table_obj.catalog_name).replace(";", " limit 1;")
-                )
+        )
+        connection.execute(
+            text(
+                UNITY_CATALOG_GET_ALL_TABLE_COLUMNS_TAGS.format(
+                    database=table_obj.catalog_name, schema=table_obj.schema_name
+                ).replace(";", " limit 1;")
             )
-            connection.execute(
-                text(
-                    UNITY_CATALOG_GET_ALL_TABLE_TAGS.format(
-                        database=table_obj.catalog_name, schema=table_obj.schema_name
-                    ).replace(";", " limit 1;")
-                )
-            )
-            connection.execute(
-                text(
-                    UNITY_CATALOG_GET_ALL_TABLE_COLUMNS_TAGS.format(
-                        database=table_obj.catalog_name, schema=table_obj.schema_name
-                    ).replace(";", " limit 1;")
-                )
-            )
-    finally:
-        engine.dispose()
+        )
 
 
-def test_lineage_tables(engine: Engine) -> None:
+def read_lineage_tables(engine: Engine) -> None:
     """
     Validate that the system.access lineage tables are readable.
     """
@@ -350,8 +344,14 @@ class UnityCatalogChecks:
 
     errors = UNITY_CATALOG_ERRORS
 
-    def __init__(self, client: WorkspaceClient, service_connection: UnityCatalogConnectionConfig) -> None:
-        self.client = client
+    def __init__(
+        self,
+        workspace: Borrowed[WorkspaceClient],
+        sql: Borrowed[Engine],
+        service_connection: UnityCatalogConnectionConfig,
+    ) -> None:
+        self._workspace = workspace
+        self._sql = sql
         self.service_connection = service_connection
         self.table_obj = DatabricksTable()
 
@@ -384,13 +384,13 @@ class UnityCatalogChecks:
 
     def _list_first_catalog(self) -> None:
         """Prove the workspace answers an authenticated call, without paging every catalog."""
-        next(iter(self.client.catalogs.list()), None)
+        next(iter(self._workspace.client.catalogs.list()), None)
 
     @check(DatabaseStep.GetDatabases)
     def check_databases(self) -> Evidence:
         configured = self.service_connection.catalog
         return self._probe(
-            lambda: get_catalogs(self.client, self.table_obj, configured),
+            lambda: get_catalogs(self._workspace.client, self.table_obj, configured),
             f"catalogs.get({configured!r})" if configured else "catalogs.list()",
             lambda: f"catalog '{self.table_obj.catalog_name}' resolved",
         )
@@ -399,7 +399,7 @@ class UnityCatalogChecks:
     def check_schemas(self) -> Evidence:
         configured = self.service_connection.databaseSchema
         return self._probe(
-            lambda: get_schemas(self.client, self.table_obj, configured),
+            lambda: get_schemas(self._workspace.client, self.table_obj, configured),
             f"schemas.get({configured!r})" if configured else "schemas.list()",
             lambda: f"schema '{self.table_obj.schema_name}' resolved",
         )
@@ -407,7 +407,7 @@ class UnityCatalogChecks:
     @check(DatabaseStep.GetTables)
     def check_tables(self) -> Evidence:
         return self._probe(
-            lambda: get_tables(self.client, self.table_obj),
+            lambda: get_tables(self._workspace.client, self.table_obj),
             "tables.list()",
             lambda: f"tables enumerated in '{self.table_obj.catalog_name}.{self.table_obj.schema_name}'",
         )
@@ -415,30 +415,40 @@ class UnityCatalogChecks:
     @check(DatabaseStep.GetViews)
     def check_views(self) -> Evidence:
         return self._probe(
-            lambda: get_views(self.client, self.table_obj),
+            lambda: get_views(self._workspace.client, self.table_obj),
             "tables.list(omit_columns=True)",
             lambda: f"views enumerated in '{self.table_obj.catalog_name}.{self.table_obj.schema_name}'",
         )
 
     @check(DatabaseStep.GetQueries)
     def check_queries(self) -> Evidence:
-        engine = get_sqlalchemy_connection(self.service_connection)
-        try:
-            return self._probe(
-                lambda: test_lineage_tables(engine),
-                "SELECT COUNT(*) FROM system.access.table_lineage; SELECT COUNT(*) FROM system.access.column_lineage",
-                lambda: "lineage tables accessible",
-            )
-        finally:
-            engine.dispose()
+        return self._probe(
+            lambda: read_lineage_tables(self._sql.client),
+            "SELECT COUNT(*) FROM system.access.table_lineage; SELECT COUNT(*) FROM system.access.column_lineage",
+            lambda: "lineage tables accessible",
+        )
 
     @check(DatabaseStep.GetTags)
     def check_tags(self) -> Evidence:
         return self._probe(
-            lambda: get_tags(self.service_connection, self.table_obj),
+            lambda: read_tag_tables(self._sql.client, self.table_obj),
             "SELECT * FROM information_schema.{catalog_tags,schema_tags,table_tags,column_tags} LIMIT 1",
             lambda: "tag tables accessible",
         )
+
+
+class UnityCatalogSqlConnection(BaseConnection[UnityCatalogConnectionConfig, Engine]):
+    """Owns the SQL-warehouse Engine.
+
+    Its own owner because its lifetime differs from the workspace client's: the
+    Engine needs an httpPath to a running warehouse, and only the lineage and tag
+    steps reach for it. A workspace without one never builds it.
+    """
+
+    def _get_client(self) -> Engine:
+        engine = get_sqlalchemy_connection(self.service_connection)
+        self._on_close(engine.dispose)
+        return engine
 
 
 class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, WorkspaceClient]):
@@ -447,12 +457,17 @@ class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, Worksp
         # Honor the user-facing connectionTimeout as the per-step budget; a cold
         # serverless warehouse can exceed the framework default.
         self.step_timeout_seconds = service_connection.connectionTimeout or STEP_TIMEOUT_SECONDS
+        # A sub-owner, not a client: constructing it opens nothing. Its Engine is
+        # built on first read and disposed when this connection closes.
+        self.sql = UnityCatalogSqlConnection(service_connection)
+        self._on_close(self.sql.close)
 
     def _get_client(self) -> WorkspaceClient:
         return get_connection(self.service_connection)
 
     def checks(self) -> ChecksProvider:
         return UnityCatalogChecks(
-            client=self.client,
+            workspace=self.borrow(),
+            sql=self.sql.borrow(),
             service_connection=self.service_connection,
         )

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -92,6 +92,10 @@ INTERNAL_CATALOG = "__databricks_internal"
 VIEW_TABLE_TYPES = {TableType.VIEW, TableType.MATERIALIZED_VIEW}
 VIEW_LISTING_SCAN_LIMIT = 100
 DEFAULT_UNITY_CATALOG_PORT = 443
+LINEAGE_PROBE_COMMAND = (
+    "SELECT COUNT(*) FROM system.access.table_lineage; SELECT COUNT(*) FROM system.access.column_lineage"
+)
+TAG_PROBE_COMMAND = "SELECT * FROM information_schema.{catalog_tags,schema_tags,table_tags,column_tags} LIMIT 1"
 
 UNITY_CATALOG_ERRORS = ErrorPack(
     when(Matchers.exception(Unauthenticated)).diagnose(
@@ -419,19 +423,30 @@ class UnityCatalogChecks:
             lambda: f"views enumerated in '{self.table_obj.catalog_name}.{self.table_obj.schema_name}'",
         )
 
+    def _require_warehouse(self, command: str) -> None:
+        """Fail before building an engine that cannot connect: without an httpPath the
+        driver has no warehouse to dial. The message is what the pack diagnoses."""
+        if not self.service_connection.httpPath:
+            cause = SourceConnectionException(
+                "no valid connection settings: the SQL warehouse HTTP Path is not configured"
+            )
+            raise CheckError(cause, Evidence(command=command))
+
     @check(DatabaseStep.GetQueries)
     def check_queries(self) -> Evidence:
+        self._require_warehouse(LINEAGE_PROBE_COMMAND)
         return self._probe(
             lambda: read_lineage_tables(self._sql.client),
-            "SELECT COUNT(*) FROM system.access.table_lineage; SELECT COUNT(*) FROM system.access.column_lineage",
+            LINEAGE_PROBE_COMMAND,
             lambda: "lineage tables accessible",
         )
 
     @check(DatabaseStep.GetTags)
     def check_tags(self) -> Evidence:
+        self._require_warehouse(TAG_PROBE_COMMAND)
         return self._probe(
             lambda: read_tag_tables(self._sql.client, self.table_obj),
-            "SELECT * FROM information_schema.{catalog_tags,schema_tags,table_tags,column_tags} LIMIT 1",
+            TAG_PROBE_COMMAND,
             lambda: "tag tables accessible",
         )
 

--- a/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
@@ -94,9 +94,8 @@ def get_connection(connection: S3ConnectionConfig) -> S3ObjectStoreClient:
 class S3Checks:
     """Test-connection checks for S3.
 
-    The store is borrowed from the connection that owns it: reading it inside a
-    check is what builds it, so the STS assume-role handshake happens behind the
-    runner's gate - and both steps share the one client the owner also uses.
+    Reading the borrowed store is what builds it, so an assume-role config's STS
+    handshake stays behind the runner's gate.
     """
 
     errors = S3_ERRORS

--- a/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
@@ -43,10 +43,9 @@ from metadata.generated.schema.entity.services.connections.storage.s3Connection 
 from metadata.ingestion.connections.connection import BaseConnection
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     from botocore.client import BaseClient
 
+    from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
     from metadata.core.connections.test_connection.records import Evidence
 
@@ -95,29 +94,26 @@ def get_connection(connection: S3ConnectionConfig) -> S3ObjectStoreClient:
 class S3Checks:
     """Test-connection checks for S3.
 
-    The client is built lazily inside the checks: an assume-role configuration
-    calls STS while the boto3 session is created, so building it while the
-    provider is constructed would touch the network before the runner's gate
-    (and outside its per-step timeout). ``connect`` is ``BaseConnection.client``
-    underneath, so both steps share the one cached client.
+    The store is borrowed from the connection that owns it: reading it inside a
+    check is what builds it, so the STS assume-role handshake happens behind the
+    runner's gate - and both steps share the one client the owner also uses.
     """
 
     errors = S3_ERRORS
 
-    def __init__(self, connect: Callable[[], S3ObjectStoreClient], bucket_names: list[str] | None) -> None:
-        self._connect = connect
+    def __init__(self, store: Borrowed[S3ObjectStoreClient], bucket_names: list[str] | None) -> None:
+        self._store = store
         self.bucket_names = bucket_names
 
     @check(StorageStep.ListBuckets)
     def check_buckets(self) -> Evidence:
-        client = self._connect()
         if self.bucket_names:
-            return probe_buckets(client.s3_client, self.bucket_names)
-        return list_buckets(client.s3_client)
+            return probe_buckets(self._store.client.s3_client, self.bucket_names)
+        return list_buckets(self._store.client.s3_client)
 
     @check(StorageStep.GetMetrics)
     def get_metrics(self) -> Evidence:
-        return list_metrics(self._connect().cloudwatch_client, "AWS/S3")
+        return list_metrics(self._store.client.cloudwatch_client, "AWS/S3")
 
 
 class S3Connection(BaseConnection[S3ConnectionConfig, S3ObjectStoreClient]):
@@ -126,6 +122,6 @@ class S3Connection(BaseConnection[S3ConnectionConfig, S3ObjectStoreClient]):
 
     def checks(self) -> ChecksProvider:
         return S3Checks(
-            connect=lambda: self.client,
+            store=self.borrow(),
             bucket_names=self.service_connection.bucketNames,
         )

--- a/ingestion/tests/unit/source/dashboard/powerbi/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/powerbi/test_connection.py
@@ -16,11 +16,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from requests.exceptions import HTTPError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.ometa.client import APIError
+from metadata.ingestion.source.dashboard.powerbi.client import PowerBiApiClient
 from metadata.ingestion.source.dashboard.powerbi.connection import (
     POWERBI_ERRORS,
     PowerBIChecks,
@@ -44,11 +46,11 @@ def _raw_http_error(status_code: int) -> HTTPError:
     return HTTPError("server said no", response=response)
 
 
-def _checks(api_client_cls) -> tuple[PowerBIChecks, MagicMock]:
-    """A provider whose lazily-built REST client is the returned mock."""
+def _checks() -> tuple[PowerBIChecks, MagicMock]:
+    """A provider over a borrowed client - the one its connection owns."""
     api_client = MagicMock()
-    api_client_cls.return_value = api_client
-    return PowerBIChecks(connection=MagicMock()), api_client
+    powerbi_client = MagicMock(api_client=api_client)
+    return PowerBIChecks(powerbi=Borrowed.of(powerbi_client)), api_client
 
 
 def test_powerbi_connection_is_base_connection():
@@ -64,20 +66,33 @@ def test_checks_does_not_touch_the_network():
     mock_client.assert_not_called()
 
 
-def test_collect_checks_maps_every_step():
+def test_checks_reuse_the_connections_client_and_never_authenticate_twice():
+    # The provider borrows the client its connection owns, so the checks and the
+    # ingestion share one authenticated session instead of acquiring a second token.
     with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, _ = _checks(mock_client)
+        # PowerBiClient validates its api_client field, so the fake must carry the spec.
+        mock_client.return_value = MagicMock(spec=PowerBiApiClient)
+        conn = PowerBIConnection(MagicMock(pbitFilesSource=None))
+        provider = conn.checks()
+
+        provider.check_access()
+        provider.get_dashboards()
+
+    assert mock_client.call_count == 1
+
+
+def test_collect_checks_maps_every_step():
+    provider, _ = _checks()
     collected = collect_checks(provider)
 
     assert set(collected) == {DashboardStep.CheckAccess, DashboardStep.GetDashboards}
 
 
 def test_check_access_authenticates():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.get_auth_token.return_value = ("token", "3600")
+    provider, client = _checks()
+    client.get_auth_token.return_value = ("token", "3600")
 
-        evidence = provider.check_access()
+    evidence = provider.check_access()
 
     client.get_auth_token.assert_called_once_with()
     assert evidence.summary == "authenticated"
@@ -85,55 +100,50 @@ def test_check_access_authenticates():
 
 
 def test_check_access_wraps_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.get_auth_token.side_effect = InvalidSourceException("no token")
+    provider, client = _checks()
+    client.get_auth_token.side_effect = InvalidSourceException("no token")
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.check_access()
+    with pytest.raises(CheckError) as exc_info:
+        provider.check_access()
 
     assert isinstance(exc_info.value.cause, InvalidSourceException)
     assert exc_info.value.evidence.command == "acquire OAuth token"
 
 
 def test_get_dashboards_counts_results():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.fetch_dashboards.return_value = [object(), object(), object()]
+    provider, client = _checks()
+    client.fetch_dashboards.return_value = [object(), object(), object()]
 
-        evidence = provider.get_dashboards()
+    evidence = provider.get_dashboards()
 
     assert evidence.summary == "3 dashboards enumerated"
     assert evidence.command == "fetch dashboards"
 
 
 def test_get_dashboards_caps_the_count():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.fetch_dashboards.return_value = [object()] * 250
+    provider, client = _checks()
+    client.fetch_dashboards.return_value = [object()] * 250
 
-        evidence = provider.get_dashboards()
+    evidence = provider.get_dashboards()
 
     assert evidence.summary == "100+ dashboards enumerated"
     assert evidence.caveat is None
 
 
 def test_get_dashboards_at_cap_shows_plus():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.fetch_dashboards.return_value = [object()] * 100
+    provider, client = _checks()
+    client.fetch_dashboards.return_value = [object()] * 100
 
-        evidence = provider.get_dashboards()
+    evidence = provider.get_dashboards()
 
     assert evidence.summary == "100+ dashboards enumerated"
 
 
 def test_get_dashboards_empty_passes_with_caveat():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.fetch_dashboards.return_value = None
+    provider, client = _checks()
+    client.fetch_dashboards.return_value = None
 
-        evidence = provider.get_dashboards()
+    evidence = provider.get_dashboards()
 
     assert evidence.summary == "0 dashboards enumerated"
     assert evidence.caveat is not None
@@ -141,25 +151,23 @@ def test_get_dashboards_empty_passes_with_caveat():
 
 
 def test_get_dashboards_wraps_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider, client = _checks(mock_client)
-        client.fetch_dashboards.side_effect = _api_error(403)
+    provider, client = _checks()
+    client.fetch_dashboards.side_effect = _api_error(403)
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.get_dashboards()
+    with pytest.raises(CheckError) as exc_info:
+        provider.get_dashboards()
 
     assert exc_info.value.evidence.command == "fetch dashboards"
 
 
 def test_get_dashboards_wraps_client_build_failure():
-    # Client construction (MSAL discovery) happens inside fetch_list's try, so a
-    # build failure still reports the step's command rather than escaping raw.
-    with patch(f"{CONNECTION_MODULE}.PowerBiApiClient") as mock_client:
-        provider = PowerBIChecks(connection=MagicMock())
-        mock_client.side_effect = ValueError("authority discovery failed")
+    # Reading the borrow is what builds the client (MSAL discovery), and that read
+    # happens inside fetch_list's try, so a build failure still reports the step's
+    # command rather than escaping raw.
+    provider = PowerBIChecks(powerbi=Borrowed(MagicMock(side_effect=ValueError("authority discovery failed"))))
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.get_dashboards()
+    with pytest.raises(CheckError) as exc_info:
+        provider.get_dashboards()
 
     assert exc_info.value.evidence.command == "fetch dashboards"
     assert isinstance(exc_info.value.cause, ValueError)

--- a/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
@@ -7,6 +7,7 @@ import pytest
 from requests.exceptions import HTTPError, SSLError
 from tableauserverclient.server.endpoint.exceptions import ServerResponseError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
 from metadata.ingestion.connections.connection import BaseConnection
@@ -36,11 +37,10 @@ def _raw_http_error(status_code: int) -> HTTPError:
     return HTTPError("server said no", response=response)
 
 
-def _checks(get_connection) -> tuple[TableauChecks, MagicMock]:
-    """A provider whose lazily-built client is the returned mock."""
+def _checks() -> tuple[TableauChecks, MagicMock]:
+    """A provider over a borrowed client - the one its connection owns."""
     client = MagicMock()
-    get_connection.return_value = client
-    return TableauChecks(connection=MagicMock()), client
+    return TableauChecks(server=Borrowed.of(client)), client
 
 
 def test_tableau_connection_is_base_connection():
@@ -56,6 +56,17 @@ def test_get_client_delegates_to_get_connection():
     mock_get.assert_called_once_with(conn.service_connection)
 
 
+def test_close_signs_out_of_the_server_session():
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = TableauConnection(MagicMock())
+        client = conn.client
+        conn.close()
+
+    # sign_out() releases the server session and clears the SSL temp files.
+    client.sign_out.assert_called_once_with()
+    assert mock_get.call_count == 1
+
+
 def test_checks_does_not_touch_the_network():
     with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
         conn = TableauConnection(MagicMock())
@@ -65,9 +76,24 @@ def test_checks_does_not_touch_the_network():
     mock_get.assert_not_called()
 
 
-def test_collect_checks_maps_every_step():
+def test_checks_reuse_the_connections_client_and_never_sign_in_twice():
+    # A Personal Access Token allows one active session: if the checks signed in
+    # again, they would invalidate the session the ingestion is about to use
+    # (issue #29804). The provider must read the client its connection owns.
     with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, _ = _checks(mock_get)
+        conn = TableauConnection(MagicMock())
+        owned = conn.client
+        provider = conn.checks()
+
+        provider.server_info()
+        provider.get_workbooks()
+
+    assert mock_get.call_count == 1
+    owned.server_info.assert_called_once_with()
+
+
+def test_collect_checks_maps_every_step():
+    provider, _ = _checks()
     collected = collect_checks(provider)
 
     assert set(collected) == {
@@ -81,20 +107,10 @@ def test_collect_checks_maps_every_step():
     }
 
 
-def test_client_is_built_once_and_shared_across_checks():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, _ = _checks(mock_get)
-        provider.server_info()
-        provider.get_workbooks()
-
-    mock_get.assert_called_once_with(provider._connection)
-
-
 def test_server_info_signs_in():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.server_info()
+    evidence = provider.server_info()
 
     client.server_info.assert_called_once_with()
     assert evidence.summary == "authenticated"
@@ -102,98 +118,89 @@ def test_server_info_signs_in():
 
 
 def test_server_info_wraps_sign_in_failure_as_check_error():
-    # Signing in happens inside the gate check, so bad credentials surface as a
-    # classified ServerInfo failure instead of escaping while the provider is built.
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider = TableauChecks(connection=MagicMock())
-        mock_get.side_effect = _server_error("401001")
+    # The client is built on first read, which happens inside the gate check, so
+    # bad credentials surface as a classified ServerInfo failure instead of
+    # escaping while the provider is being assembled.
+    provider = TableauChecks(server=Borrowed(MagicMock(side_effect=_server_error("401001"))))
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.server_info()
+    with pytest.raises(CheckError) as exc_info:
+        provider.server_info()
 
     assert isinstance(exc_info.value.cause, ServerResponseError)
     assert exc_info.value.evidence.command == "sign in and read server info"
 
 
 def test_validate_api_version_reports_the_version():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.server_api_version.return_value = "3.19"
+    provider, client = _checks()
+    client.server_api_version.return_value = "3.19"
 
-        evidence = provider.validate_api_version()
+    evidence = provider.validate_api_version()
 
     assert evidence.summary == "REST API version 3.19"
     assert evidence.command == "read the server REST API version"
 
 
 def test_validate_site_url_passes():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.validate_site_url()
+    evidence = provider.validate_site_url()
 
     client.test_site_url.assert_called_once_with()
     assert evidence.summary == "site name is well formed"
 
 
 def test_validate_site_url_wraps_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.test_site_url.side_effect = ValueError('The site url "https://x" is in incorrect format.')
+    provider, client = _checks()
+    client.test_site_url.side_effect = ValueError('The site url "https://x" is in incorrect format.')
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.validate_site_url()
+    with pytest.raises(CheckError) as exc_info:
+        provider.validate_site_url()
 
     assert exc_info.value.evidence.command == "validate the configured site name"
 
 
 def test_get_workbooks_passes():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.get_workbooks()
+    evidence = provider.get_workbooks()
 
     client.test_get_workbooks.assert_called_once_with()
     assert evidence.summary == "workbooks are readable"
 
 
 def test_get_workbooks_wraps_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.test_get_workbooks.side_effect = TableauWorkBookException("no workbooks")
+    provider, client = _checks()
+    client.test_get_workbooks.side_effect = TableauWorkBookException("no workbooks")
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.get_workbooks()
+    with pytest.raises(CheckError) as exc_info:
+        provider.get_workbooks()
 
     assert exc_info.value.evidence.command == "fetch workbooks"
     assert isinstance(exc_info.value.cause, TableauWorkBookException)
 
 
 def test_get_views_passes():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.get_views()
+    evidence = provider.get_views()
 
     client.test_get_workbook_views.assert_called_once_with()
     assert evidence.summary == "workbook views are readable"
 
 
 def test_get_owners_passes():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.get_owners()
+    evidence = provider.get_owners()
 
     client.test_get_owners.assert_called_once_with()
     assert evidence.summary == "workbook owners are resolvable"
 
 
 def test_get_data_models_passes():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
+    provider, client = _checks()
 
-        evidence = provider.get_data_models()
+    evidence = provider.get_data_models()
 
     client.test_get_datamodels.assert_called_once_with()
     assert evidence.summary == "data sources are readable"
@@ -201,12 +208,11 @@ def test_get_data_models_passes():
 
 
 def test_get_data_models_wraps_failure_as_check_error():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        provider, client = _checks(mock_get)
-        client.test_get_datamodels.side_effect = TableauDataModelsException("metadata api off")
+    provider, client = _checks()
+    client.test_get_datamodels.side_effect = TableauDataModelsException("metadata api off")
 
-        with pytest.raises(CheckError) as exc_info:
-            provider.get_data_models()
+    with pytest.raises(CheckError) as exc_info:
+        provider.get_data_models()
 
     assert isinstance(exc_info.value.cause, TableauDataModelsException)
 

--- a/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/tableau/test_connection.py
@@ -266,3 +266,17 @@ def test_error_pack_ignores_unrelated_code_attribute():
 
 def test_error_pack_ignores_unknown_error():
     assert TABLEAU_ERRORS.classify(ValueError("something else")) is None
+
+
+def test_a_failing_sign_out_does_not_break_close():
+    # close() unwinds teardowns without catching, so a sign-out that fails must not
+    # replace the error being unwound (or fail an otherwise clean close).
+    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+        conn = TableauConnection(MagicMock())
+        client = conn.client
+        client.sign_out.side_effect = ServerResponseError("401002", "summary", "detail")
+
+        conn.close()
+
+    client.sign_out.assert_called_once_with()
+    assert mock_get.call_count == 1

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
 from metadata.core.connections.test_connection.records import Evidence
@@ -90,7 +91,7 @@ def test_checks_returns_provider_over_the_client():
     conn._client = MagicMock()
     provider = conn.checks()
     assert isinstance(provider, AthenaChecks)
-    assert provider.client is conn._client
+    assert provider._db.client is conn._client
 
 
 def test_checks_wires_filter_pattern_and_catalog_from_service_connection():
@@ -103,7 +104,7 @@ def test_checks_wires_filter_pattern_and_catalog_from_service_connection():
 
 
 def test_every_athena_step_resolves_to_a_check():
-    provider = AthenaChecks(client_factory=MagicMock)
+    provider = AthenaChecks(db=Borrowed(MagicMock))
     resolved = collect_checks(provider)
     assert set(resolved) == {
         DatabaseStep.CheckAccess,
@@ -246,12 +247,28 @@ def test_error_pack_returns_none_for_unknown_error():
 
 
 def test_client_is_built_lazily_not_at_construction():
+    # Building the engine runs the STS assume-role handshake, so it must not happen
+    # while the provider is assembled - only when a check reads the borrow.
     calls = []
-    provider = AthenaChecks(client_factory=lambda: calls.append(1) or MagicMock())
+    provider = AthenaChecks(db=Borrowed(lambda: calls.append(1) or MagicMock()))
+
     assert calls == []
-    _ = provider.client
-    _ = provider.client
+
+    _ = provider._db.client
+
     assert calls == [1]
+
+
+def test_client_is_built_once_by_its_owner_and_shared_across_checks():
+    # Caching is the connection's job, not the provider's: every read of the borrow
+    # goes back to the owner, which builds once.
+    conn = AthenaConnection(_config())
+    with patch.object(AthenaConnection, "_get_client", return_value=MagicMock()) as mock_build:
+        provider = conn.checks()
+        _ = provider._db.client
+        _ = provider._db.client
+
+    assert mock_build.call_count == 1
 
 
 def test_check_access_surfaces_client_build_failure_for_classification():
@@ -259,7 +276,7 @@ def test_check_access_surfaces_client_build_failure_for_classification():
     # inside CheckAccess (the gate), so its exception propagates from the check and
     # the runner can classify it - instead of raising at provider construction.
     error = _client_error("InvalidClientTokenId", "The security token included in the request is invalid")
-    provider = AthenaChecks(client_factory=_raising_factory(error))
+    provider = AthenaChecks(db=Borrowed(_raising_factory(error)))
     with pytest.raises(ClientError) as exc_info:
         provider.check_access()
     assert ATHENA_ERRORS.classify(exc_info.value).title == "AWS access key not recognized"

--- a/ingestion/tests/unit/source/database/bigquery/test_connection.py
+++ b/ingestion/tests/unit/source/database/bigquery/test_connection.py
@@ -21,6 +21,7 @@ import pytest
 from google.api_core.exceptions import Forbidden, NotFound
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import Evidence
 from metadata.core.connections.test_connection.check import collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
@@ -132,7 +133,7 @@ def test_malformed_private_key_is_classified():
 
 def _checks(service_connection, client=None) -> BigQueryChecks:
     engine = client if client is not None else MagicMock()
-    return BigQueryChecks(get_client=lambda: engine, service_connection=service_connection)
+    return BigQueryChecks(db=Borrowed.of(engine), service_connection=service_connection)
 
 
 def test_checks_cover_exactly_the_wired_steps():
@@ -152,13 +153,13 @@ def test_construction_does_not_build_the_client():
     # The engine is built lazily inside CheckAccess, never at construction - so
     # credential parsing (and any connect) happens behind the gate, not before it.
     get_client = MagicMock()
-    BigQueryChecks(get_client=get_client, service_connection=_config())
+    BigQueryChecks(db=Borrowed(get_client), service_connection=_config())
     get_client.assert_not_called()
 
 
 def test_check_access_builds_client_lazily_and_pings():
     get_client = MagicMock()
-    checks = BigQueryChecks(get_client=get_client, service_connection=_config())
+    checks = BigQueryChecks(db=Borrowed(get_client), service_connection=_config())
     with patch(f"{_CONNECTION_MODULE}.ping", return_value=Evidence(summary="connection established")) as mock_ping:
         evidence = checks.check_access()
     get_client.assert_called_once_with()
@@ -171,7 +172,7 @@ def test_check_access_surfaces_malformed_key_error():
     # inside CheckAccess, the error reaches the runner (here: the caller) to be
     # classified, instead of escaping before the test starts.
     error = InvalidPrivateKeyException("Cannot serialise key: Unable to load PEM file.")
-    checks = BigQueryChecks(get_client=MagicMock(side_effect=error), service_connection=_config())
+    checks = BigQueryChecks(db=Borrowed(MagicMock(side_effect=error)), service_connection=_config())
     with pytest.raises(InvalidPrivateKeyException):
         checks.check_access()
 

--- a/ingestion/tests/unit/source/database/databricks/test_connection.py
+++ b/ingestion/tests/unit/source/database/databricks/test_connection.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
 from metadata.core.connections.test_connection.network import NetworkUnreachableError
@@ -160,7 +161,7 @@ def test_unknown_error_returns_no_diagnosis():
 
 
 def test_checks_cover_exactly_the_seeded_steps():
-    checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     collected = collect_checks(checks)
     assert set(collected.keys()) == {
         DatabaseStep.CheckAccess,
@@ -182,7 +183,7 @@ def test_checks_cover_exactly_the_seeded_steps():
 def test_construction_does_not_touch_the_network():
     # Building the provider must not connect - that belongs in a gated check.
     engine = MagicMock()
-    DatabricksChecks(client=engine, service_connection=_config())
+    DatabricksChecks(db=Borrowed.of(engine), service_connection=_config())
     engine.connect.assert_not_called()
 
 
@@ -190,14 +191,14 @@ def test_construction_does_not_build_the_inspector():
     # Regression: inspect(engine) connects eagerly, so building it in __init__ would
     # connect before the gate (auth error escapes as a 500). Keep it lazy.
     with patch(f"{CONNECTION_MODULE}.inspect") as mock_inspect:
-        checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+        checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
         mock_inspect.assert_not_called()
         _ = checks._engine_wrapper.inspector
         mock_inspect.assert_called_once()
 
 
 def test_check_access_probes_the_host_port_then_pings():
-    checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     with (
         patch(f"{CONNECTION_MODULE}.tcp_probe") as mock_probe,
         patch(f"{CONNECTION_MODULE}.run_sql", return_value=MagicMock()) as mock_run,
@@ -208,7 +209,7 @@ def test_check_access_probes_the_host_port_then_pings():
 
 
 def test_check_access_reports_unreachable_host_as_network_failure():
-    checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     probe_error = NetworkUnreachableError("my-workspace.cloud.databricks.com:443 is not reachable")
     probe_error.__cause__ = ConnectionRefusedError(61, "Connection refused")
     with (
@@ -224,13 +225,13 @@ def test_check_access_reports_unreachable_host_as_network_failure():
 def test_probe_target_defaults_to_443_when_no_port():
     config = _config()
     config.hostPort = "my-workspace.cloud.databricks.com"
-    checks = DatabricksChecks(client=MagicMock(), service_connection=config)
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=config)
     assert checks._probe_target() == ("my-workspace.cloud.databricks.com", 443)
 
 
 def test_first_catalog_uses_configured_catalog_without_querying():
     engine = MagicMock()
-    checks = DatabricksChecks(client=engine, service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(engine), service_connection=_config())
     assert checks._first_catalog() == "my_catalog"
     engine.connect.assert_not_called()
 
@@ -252,7 +253,7 @@ def test_listing_caps_rows_at_the_sample_size_at_the_source():
     engine = MagicMock()
     engine.connect.return_value.__enter__.return_value = conn
 
-    wrapper = DatabricksEngineWrapper(engine)
+    wrapper = DatabricksEngineWrapper(Borrowed.of(engine))
     wrapper.first_catalog = "my_catalog"
     wrapper.first_schema = "my_schema"
     wrapper.get_tables()
@@ -261,7 +262,7 @@ def test_listing_caps_rows_at_the_sample_size_at_the_source():
 
 
 def test_get_databases_reports_catalog_count():
-    checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     with patch.object(
         checks._engine_wrapper, "get_catalogs", return_value=[("my_catalog",), ("other",)]
     ) as mock_catalogs:
@@ -273,7 +274,7 @@ def test_get_databases_reports_catalog_count():
 def test_get_databases_failure_reports_the_attempted_command_as_evidence():
     config = _config()
     config.catalog = None
-    checks = DatabricksChecks(client=MagicMock(), service_connection=config)
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=config)
     with (
         patch.object(checks._engine_wrapper, "get_catalogs", side_effect=Exception("boom")),
         pytest.raises(CheckError) as exc,
@@ -284,7 +285,7 @@ def test_get_databases_failure_reports_the_attempted_command_as_evidence():
 
 def test_get_databases_omits_the_command_when_catalog_is_configured():
     # A configured catalog is trusted without running SHOW CATALOGS.
-    checks = DatabricksChecks(client=MagicMock(), service_connection=_config())
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     with patch.object(checks._engine_wrapper, "get_catalogs", return_value=[("my_catalog",)]):
         evidence = checks.get_databases()
     assert evidence.command is None
@@ -295,7 +296,7 @@ def test_probe_target_strips_a_pasted_url_scheme_and_path():
     # gate fails with a misleading DNS error before the driver.
     config = _config()
     config.hostPort = "https://my-workspace.cloud.databricks.com:443/sql/1.0/warehouses/x"
-    checks = DatabricksChecks(client=MagicMock(), service_connection=config)
+    checks = DatabricksChecks(db=Borrowed.of(MagicMock()), service_connection=config)
     assert checks._probe_target() == ("my-workspace.cloud.databricks.com", 443)
 
 
@@ -329,7 +330,7 @@ def test_schema_scoped_get_schemas_skips_use_catalog_when_catalog_unresolved():
     )
 
     engine = MagicMock()
-    wrapper = DatabricksEngineWrapper(engine)
+    wrapper = DatabricksEngineWrapper(Borrowed.of(engine))
     wrapper.first_catalog = None
     assert wrapper.get_schemas(schema_name="my_schema") == ["my_schema"]
     engine.connect.assert_not_called()
@@ -341,7 +342,7 @@ def test_get_tables_returns_empty_when_catalog_unresolved():
     )
 
     engine = MagicMock()
-    wrapper = DatabricksEngineWrapper(engine)
+    wrapper = DatabricksEngineWrapper(Borrowed.of(engine))
     wrapper.first_catalog = None
     wrapper.first_schema = "my_schema"
     assert wrapper.get_tables() == []

--- a/ingestion/tests/unit/source/database/glue/test_connection.py
+++ b/ingestion/tests/unit/source/database/glue/test_connection.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.generated.schema.entity.services.connections.database.glueConnection import (
     GlueConnection as GlueConnectionConfig,
@@ -58,7 +59,7 @@ def _paginator(pages: list[dict]) -> MagicMock:
 
 
 def _checks(client=None) -> GlueChecks:
-    return GlueChecks(connect=lambda: client)
+    return GlueChecks(catalog=Borrowed.of(client))
 
 
 def _check_names() -> set[str]:

--- a/ingestion/tests/unit/source/database/mssql/test_connection.py
+++ b/ingestion/tests/unit/source/database/mssql/test_connection.py
@@ -17,6 +17,7 @@ tests/unit/test_source_url.py and tests/unit/test_source_connection.py.
 import socket
 from unittest.mock import MagicMock, patch
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import collect_checks
 from metadata.core.connections.test_connection.checks.database import DEFAULT_SAMPLE_ROWS, DatabaseStep
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
@@ -74,7 +75,7 @@ def test_non_pyodbc_scheme_uses_common_url_builder():
 
 
 def _checks() -> MssqlChecks:
-    return MssqlChecks(client=MagicMock(), get_databases_statement="SELECT 1")
+    return MssqlChecks(db=Borrowed.of(MagicMock()), get_databases_statement="SELECT 1")
 
 
 def test_every_definition_step_resolves_to_a_check():

--- a/ingestion/tests/unit/source/database/mysql/test_mysql_connection.py
+++ b/ingestion/tests/unit/source/database/mysql/test_mysql_connection.py
@@ -13,6 +13,7 @@
 import json
 from pathlib import Path
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import collect_checks
 from metadata.ingestion.source.database.mysql.connection import MYSQL_ERRORS, MySQLChecks
 
@@ -24,7 +25,7 @@ _SEED = (
 
 
 def _check_names():
-    checks = MySQLChecks(client=None, schema=None, queries_statement="")
+    checks = MySQLChecks(db=Borrowed.of(None), schema=None, queries_statement="")
     return {step.value for step in collect_checks(checks)}
 
 

--- a/ingestion/tests/unit/source/database/postgres/test_connection.py
+++ b/ingestion/tests/unit/source/database/postgres/test_connection.py
@@ -18,6 +18,7 @@ from azure.identity import ClientSecretCredential
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.database import (
     DEFAULT_SAMPLE_ROWS,
@@ -198,7 +199,7 @@ def test_unknown_error_returns_no_diagnosis():
 
 def test_checks_cover_exactly_the_seeded_steps():
     engine = create_engine("sqlite://", poolclass=StaticPool)
-    checks = PostgresChecks(client=engine, query_statement_source=None)
+    checks = PostgresChecks(db=Borrowed.of(engine), query_statement_source=None)
     collected = collect_checks(checks)
     assert set(collected.keys()) == {
         DatabaseStep.CheckAccess,
@@ -224,7 +225,7 @@ def test_check_access_reports_unreachable_host_as_network_failure():
     client = MagicMock()
     client.url.host = "db.invalid"
     client.url.port = 5432
-    checks = PostgresChecks(client=client, query_statement_source=None)
+    checks = PostgresChecks(db=Borrowed.of(client), query_statement_source=None)
     probe_error = NetworkUnreachableError("db.invalid:5432 is not reachable")
     probe_error.__cause__ = ConnectionRefusedError(61, "Connection refused")
     with (
@@ -250,7 +251,7 @@ def test_query_statement_is_built_lazily_not_at_construction():
         side_effect=lambda engine: calls.append(1) or "total_exec_time",
     ):
         engine = create_engine("sqlite://", poolclass=StaticPool)
-        PostgresChecks(client=engine, query_statement_source=None)
+        PostgresChecks(db=Borrowed.of(engine), query_statement_source=None)
         assert calls == []
 
 

--- a/ingestion/tests/unit/source/database/redshift/test_connection.py
+++ b/ingestion/tests/unit/source/database/redshift/test_connection.py
@@ -20,6 +20,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.pool import StaticPool
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.database import (
     DEFAULT_SAMPLE_ROWS,
@@ -172,7 +173,7 @@ def test_get_queries_failure_reports_the_attempted_command_as_evidence():
     # CheckError wrapping; get_queries must re-raise with the statement so the
     # failed step still shows the command it ran, like every other step.
     engine = MagicMock()
-    checks = RedshiftChecks(client=engine)
+    checks = RedshiftChecks(db=Borrowed.of(engine))
     with (
         patch(f"{CONNECTION_MODULE}.get_redshift_instance_type", return_value=RedshiftInstanceType.PROVISIONED),
         patch(f"{CONNECTION_MODULE}.run_sql", side_effect=SourceConnectionException("missing privilege")) as mock_run,
@@ -186,7 +187,7 @@ def test_get_queries_failure_reports_the_attempted_command_as_evidence():
 
 def test_checks_cover_exactly_the_seeded_steps():
     engine = create_engine("sqlite://", poolclass=StaticPool)
-    checks = RedshiftChecks(client=engine)
+    checks = RedshiftChecks(db=Borrowed.of(engine))
     collected = collect_checks(checks)
     assert set(collected.keys()) == {
         DatabaseStep.CheckAccess,
@@ -202,7 +203,7 @@ def test_check_access_reports_unreachable_host_as_network_failure():
     client = MagicMock()
     client.url.host = "cluster.invalid"
     client.url.port = 5439
-    checks = RedshiftChecks(client=client)
+    checks = RedshiftChecks(db=Borrowed.of(client))
     probe_error = NetworkUnreachableError("cluster.invalid:5439 is not reachable")
     probe_error.__cause__ = ConnectionRefusedError(61, "Connection refused")
     with (
@@ -228,5 +229,5 @@ def test_instance_type_probe_is_run_lazily_not_at_construction():
         side_effect=lambda engine: calls.append(1),
     ):
         engine = create_engine("sqlite://", poolclass=StaticPool)
-        RedshiftChecks(client=engine)
+        RedshiftChecks(db=Borrowed.of(engine))
         assert calls == []

--- a/ingestion/tests/unit/source/database/snowflake/test_connection.py
+++ b/ingestion/tests/unit/source/database/snowflake/test_connection.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import Evidence
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.database import (
@@ -129,7 +130,7 @@ def test_account_usage_denial_honors_custom_schema():
     # The pack is built from the configured accountUsageSchema, so a denial on a
     # custom schema is still diagnosed as an account_usage gap - not "Object not found".
     schema = "MYDB.MY_USAGE"
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config(accountUsageSchema=schema))
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config(accountUsageSchema=schema))
     error = _SnowflakeError("Object 'MYDB.MY_USAGE.QUERY_HISTORY' does not exist or not authorized.", errno=2003)
     assert checks.errors.classify(error).title == "Account usage not accessible"
     # the default pack, keyed on snowflake.account_usage, does not recognize the custom schema
@@ -194,7 +195,7 @@ def _fake_run_sql(returned_rows):
 def test_get_tables_warns_when_no_user_tables():
     # Empty probe (INFORMATION_SCHEMA filtered out) -> passing step with a caveat,
     # which the runner records as a Warning.
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config(database="MYDB"))
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config(database="MYDB"))
     with patch(
         "metadata.ingestion.source.database.snowflake.connection.run_sql",
         side_effect=_fake_run_sql([]),
@@ -207,7 +208,7 @@ def test_get_tables_warns_when_no_user_tables():
 
 
 def test_get_tables_has_no_caveat_when_tables_exist():
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config(database="MYDB"))
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config(database="MYDB"))
     with patch(
         "metadata.ingestion.source.database.snowflake.connection.run_sql",
         side_effect=_fake_run_sql([object(), object()]),
@@ -229,7 +230,7 @@ def test_table_and_view_probes_exclude_information_schema():
 
 
 def test_checks_cover_exactly_the_wired_steps():
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config())
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     collected = collect_checks(checks)
     assert set(collected.keys()) == {
         DatabaseStep.CheckAccess,
@@ -246,7 +247,7 @@ def test_checks_cover_exactly_the_wired_steps():
 
 def test_get_access_history_is_wired():
     # ACCESS_HISTORY is the default lineage source; its probe is the GetAccessHistory step.
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config())
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config())
     assert DatabaseStep.GetAccessHistory in collect_checks(checks)
 
 
@@ -254,7 +255,7 @@ def test_construction_touches_no_network():
     # Regression for gotcha #2: building the provider must not connect or resolve a
     # database - that would run before the gate and bypass the preflight.
     client = MagicMock()
-    SnowflakeChecks(client=client, service_connection=_config())
+    SnowflakeChecks(db=Borrowed.of(client), service_connection=_config())
     client.connect.assert_not_called()
     client.execute.assert_not_called()
 
@@ -263,7 +264,7 @@ def test_check_access_probes_account_host_and_reports_network_failure():
     # check_access -> tcp_probe(<account>.snowflakecomputing.com, 443); a probe
     # failure is wrapped as a CheckError whose cause classifies via the network
     # pack. tcp_probe is stubbed so the test is deterministic and fast.
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config(account="acc"))
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config(account="acc"))
     probe_error = NetworkUnreachableError("acc.snowflakecomputing.com:443 is not reachable")
     probe_error.__cause__ = TimeoutError("timed out")
     with (
@@ -284,7 +285,7 @@ def test_check_access_prefers_explicit_connection_argument_host():
     # host is what the driver dials, so the gate probe must target it - not the
     # synthesized public account host (which may be unreachable for that deployment).
     checks = SnowflakeChecks(
-        client=MagicMock(),
+        db=Borrowed.of(MagicMock()),
         service_connection=_config(account="acc", connectionArguments={"host": "proxy.internal"}),
     )
     probe_error = NetworkUnreachableError("proxy.internal:443 is not reachable")
@@ -303,7 +304,7 @@ def test_check_access_honors_explicit_connection_argument_port():
     # A custom host may listen on a non-443 port; the preflight must probe that
     # port, not the default 443, or it false-gates the whole connection test.
     checks = SnowflakeChecks(
-        client=MagicMock(),
+        db=Borrowed.of(MagicMock()),
         service_connection=_config(account="acc", connectionArguments={"host": "proxy.internal", "port": 8443}),
     )
     with (
@@ -321,7 +322,7 @@ def test_get_schemas_runs_show_schemas_with_command_and_count():
     # GetSchemas goes through run_sql (like the other probes), so it reports the
     # database-scoped SHOW SCHEMAS command and a counted summary - and a failure
     # would surface as a CheckError carrying that command.
-    checks = SnowflakeChecks(client=MagicMock(), service_connection=_config(database="MYDB"))
+    checks = SnowflakeChecks(db=Borrowed.of(MagicMock()), service_connection=_config(database="MYDB"))
     captured = {}
 
     def fake(client, statement, summarize, *args, **kwargs):
@@ -339,6 +340,6 @@ def test_account_usage_queries_built_lazily_not_at_construction():
     # The account_usage statements must be formatted inside their checks (behind
     # the gate), never at construction; constructing must not read the engine.
     client = MagicMock()
-    checks = SnowflakeChecks(client=client, service_connection=_config(account="acc"))
+    checks = SnowflakeChecks(db=Borrowed.of(client), service_connection=_config(account="acc"))
     assert checks._engine_wrapper.database_name is None
     client.connect.assert_not_called()

--- a/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
+++ b/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
@@ -363,3 +363,21 @@ class TestErrorPack:
 
     def test_an_unmatched_error_is_left_unclassified(self):
         assert UNITY_CATALOG_ERRORS.classify(RuntimeError("something else entirely")) is None
+
+
+def test_closing_disposes_the_sql_engine_on_every_reuse_cycle():
+    # close() resets the teardown registry, so a sub-owner registered once in
+    # __init__ would leak its engine on the second cycle.
+    engines = [MagicMock(), MagicMock()]
+    with (
+        patch(f"{CONNECTION_MODULE}.get_connection"),
+        patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection", side_effect=engines),
+    ):
+        connection = UnityCatalogConnection(_config())
+        _ = connection.sql.client
+        connection.close()
+        _ = connection.sql.client
+        connection.close()
+
+    for engine in engines:
+        engine.dispose.assert_called_once_with()

--- a/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
+++ b/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from databricks.sdk.errors import PermissionDenied, ResourceDoesNotExist, Unauthenticated
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
 from metadata.core.connections.test_connection.network import NetworkUnreachableError
@@ -62,8 +63,14 @@ def _named(name: str, **attributes) -> MagicMock:
     return mock
 
 
-def _checks(client: MagicMock, **config_overrides) -> UnityCatalogChecks:
-    return UnityCatalogChecks(client=client, service_connection=_config(**config_overrides))
+def _checks(client: MagicMock, sql: MagicMock | None = None, **config_overrides) -> UnityCatalogChecks:
+    """A provider over two borrowed clients: the workspace client and the
+    SQL-warehouse engine, each owned by its own connection."""
+    return UnityCatalogChecks(
+        workspace=Borrowed.of(client),
+        sql=Borrowed.of(sql if sql is not None else MagicMock()),
+        service_connection=_config(**config_overrides),
+    )
 
 
 def test_unitycatalog_connection_is_base_connection():
@@ -79,12 +86,59 @@ def test_get_client_delegates_to_the_workspace_client_builder():
 
 
 def test_checks_exposes_the_provider_without_touching_the_network():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get_connection:
+    with (
+        patch(f"{CONNECTION_MODULE}.get_connection") as mock_get_connection,
+        patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection") as mock_engine,
+    ):
         provider = UnityCatalogConnection(_config()).checks()
 
     assert isinstance(provider, UnityCatalogChecks)
-    assert provider.client is mock_get_connection.return_value
-    mock_get_connection.return_value.catalogs.list.assert_not_called()
+    # Neither client is built while the provider is assembled: both are borrowed.
+    mock_get_connection.assert_not_called()
+    mock_engine.assert_not_called()
+
+
+def test_checks_borrow_the_clients_their_connections_own():
+    with (
+        patch(f"{CONNECTION_MODULE}.get_connection") as mock_get_connection,
+        patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection") as mock_engine,
+    ):
+        connection = UnityCatalogConnection(_config())
+        provider = connection.checks()
+
+        assert provider._workspace.client is connection.client
+        assert provider._sql.client is connection.sql.client
+
+    # One workspace client, one engine - each built once, by its owner.
+    assert mock_get_connection.call_count == 1
+    assert mock_engine.call_count == 1
+
+
+def test_sql_engine_is_never_built_when_no_warehouse_step_runs():
+    # The lineage and tag steps need a SQL warehouse; a workspace configured
+    # without an httpPath must never pay for an engine it does not use.
+    with (
+        patch(f"{CONNECTION_MODULE}.get_connection"),
+        patch(f"{CONNECTION_MODULE}.tcp_probe"),
+        patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection") as mock_engine,
+    ):
+        provider = UnityCatalogConnection(_config()).checks()
+        provider.check_access()
+
+    mock_engine.assert_not_called()
+
+
+def test_closing_the_connection_disposes_the_sql_engine():
+    engine = MagicMock()
+    with (
+        patch(f"{CONNECTION_MODULE}.get_connection"),
+        patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection", return_value=engine),
+    ):
+        connection = UnityCatalogConnection(_config())
+        _ = connection.sql.client
+        connection.close()
+
+    engine.dispose.assert_called_once_with()
 
 
 def test_connection_timeout_drives_the_per_step_budget():
@@ -234,37 +288,34 @@ class TestMetadataSteps:
 
 
 class TestWarehouseSteps:
-    def test_get_queries_builds_the_engine_inside_the_check_and_disposes_it(self):
+    def test_get_queries_reads_the_borrowed_engine(self):
         engine = MagicMock()
-        with (
-            patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection", return_value=engine) as mock_engine,
-            patch(f"{CONNECTION_MODULE}.test_lineage_tables") as mock_lineage,
-        ):
-            checks = _checks(MagicMock())
-            mock_engine.assert_not_called()
+        with patch(f"{CONNECTION_MODULE}.read_lineage_tables") as mock_lineage:
+            checks = _checks(MagicMock(), sql=engine)
             evidence = checks.check_queries()
 
         mock_lineage.assert_called_once_with(engine)
-        engine.dispose.assert_called_once_with()
+        # The engine belongs to UnityCatalogSqlConnection: the check never disposes it.
+        engine.dispose.assert_not_called()
         assert evidence.summary == "lineage tables accessible"
 
-    def test_get_queries_disposes_the_engine_when_the_probe_fails(self):
+    def test_get_queries_wraps_a_probe_failure_as_check_error(self):
         engine = MagicMock()
         with (
-            patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection", return_value=engine),
-            patch(f"{CONNECTION_MODULE}.test_lineage_tables", side_effect=PermissionDenied("PERMISSION_DENIED")),
+            patch(f"{CONNECTION_MODULE}.read_lineage_tables", side_effect=PermissionDenied("PERMISSION_DENIED")),
             pytest.raises(CheckError),
         ):
-            _checks(MagicMock()).check_queries()
+            _checks(MagicMock(), sql=engine).check_queries()
 
-        engine.dispose.assert_called_once_with()
+        engine.dispose.assert_not_called()
 
     def test_get_tags_probes_the_information_schema_tag_tables(self):
-        with patch(f"{CONNECTION_MODULE}.get_tags") as mock_tags:
-            checks = _checks(MagicMock())
+        engine = MagicMock()
+        with patch(f"{CONNECTION_MODULE}.read_tag_tables") as mock_tags:
+            checks = _checks(MagicMock(), sql=engine)
             evidence = checks.check_tags()
 
-        mock_tags.assert_called_once_with(checks.service_connection, checks.table_obj)
+        mock_tags.assert_called_once_with(engine, checks.table_obj)
         assert evidence.summary == "tag tables accessible"
 
 

--- a/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
+++ b/ingestion/tests/unit/source/database/unitycatalog/test_connection.py
@@ -28,6 +28,7 @@ from metadata.generated.schema.entity.services.connections.database.unityCatalog
 )
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.unitycatalog.connection import (
+    LINEAGE_PROBE_COMMAND,
     UNITY_CATALOG_ERRORS,
     UnityCatalogChecks,
     UnityCatalogConnection,
@@ -61,6 +62,9 @@ def _named(name: str, **attributes) -> MagicMock:
     mock = MagicMock(**attributes)
     mock.name = name
     return mock
+
+
+WAREHOUSE = {"httpPath": "/sql/1.0/warehouses/abc123"}
 
 
 def _checks(client: MagicMock, sql: MagicMock | None = None, **config_overrides) -> UnityCatalogChecks:
@@ -291,7 +295,7 @@ class TestWarehouseSteps:
     def test_get_queries_reads_the_borrowed_engine(self):
         engine = MagicMock()
         with patch(f"{CONNECTION_MODULE}.read_lineage_tables") as mock_lineage:
-            checks = _checks(MagicMock(), sql=engine)
+            checks = _checks(MagicMock(), sql=engine, **WAREHOUSE)
             evidence = checks.check_queries()
 
         mock_lineage.assert_called_once_with(engine)
@@ -305,14 +309,14 @@ class TestWarehouseSteps:
             patch(f"{CONNECTION_MODULE}.read_lineage_tables", side_effect=PermissionDenied("PERMISSION_DENIED")),
             pytest.raises(CheckError),
         ):
-            _checks(MagicMock(), sql=engine).check_queries()
+            _checks(MagicMock(), sql=engine, **WAREHOUSE).check_queries()
 
         engine.dispose.assert_not_called()
 
     def test_get_tags_probes_the_information_schema_tag_tables(self):
         engine = MagicMock()
         with patch(f"{CONNECTION_MODULE}.read_tag_tables") as mock_tags:
-            checks = _checks(MagicMock(), sql=engine)
+            checks = _checks(MagicMock(), sql=engine, **WAREHOUSE)
             evidence = checks.check_tags()
 
         mock_tags.assert_called_once_with(engine, checks.table_obj)
@@ -381,3 +385,34 @@ def test_closing_disposes_the_sql_engine_on_every_reuse_cycle():
 
     for engine in engines:
         engine.dispose.assert_called_once_with()
+
+
+class TestNoWarehouseConfigured:
+    def test_get_queries_fails_without_building_an_engine(self):
+        with patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection") as mock_engine:
+            checks = _checks(MagicMock(), httpPath=None)
+
+            with pytest.raises(CheckError) as exc_info:
+                checks.check_queries()
+
+        mock_engine.assert_not_called()
+        assert exc_info.value.evidence.command == LINEAGE_PROBE_COMMAND
+
+    def test_get_tags_fails_without_building_an_engine(self):
+        with patch(f"{CONNECTION_MODULE}.get_sqlalchemy_connection") as mock_engine:
+            checks = _checks(MagicMock(), httpPath=None)
+
+            with pytest.raises(CheckError):
+                checks.check_tags()
+
+        mock_engine.assert_not_called()
+
+    def test_the_missing_warehouse_is_still_diagnosed(self):
+        checks = _checks(MagicMock(), httpPath=None)
+
+        with pytest.raises(CheckError) as exc_info:
+            checks.check_queries()
+
+        diagnosis = UNITY_CATALOG_ERRORS.classify(exc_info.value.cause)
+        assert diagnosis is not None
+        assert diagnosis.title == "SQL warehouse not configured"

--- a/ingestion/tests/unit/source/storage/s3/test_connection.py
+++ b/ingestion/tests/unit/source/storage/s3/test_connection.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError, EndpointConnectionError, NoCredentialsError
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.storage import list_buckets
 from metadata.ingestion.connections.connection import BaseConnection
@@ -34,7 +35,7 @@ _SEED = (
 
 
 def _checks(client=None, bucket_names=None):
-    return S3Checks(connect=lambda: client, bucket_names=bucket_names)
+    return S3Checks(store=Borrowed.of(client), bucket_names=bucket_names)
 
 
 def _check_names():

--- a/ingestion/tests/unit/topology/database/test_databricks.py
+++ b/ingestion/tests/unit/topology/database/test_databricks.py
@@ -17,6 +17,7 @@ Test databricks using the topology
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
 )
@@ -510,7 +511,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
 
             self.assertEqual(wrapper.engine, mock_engine)
             self.assertEqual(wrapper.inspector, mock_inspector)
@@ -530,7 +531,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             schemas = wrapper.get_schemas()
 
             self.assertEqual(schemas, ["information_schema", "test_schema", "performance_schema"])
@@ -552,7 +553,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             schemas = wrapper.get_schemas()
 
             self.assertEqual(schemas, ["information_schema", "performance_schema"])
@@ -568,7 +569,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             schemas = wrapper.get_schemas()
 
             self.assertEqual(schemas, [])
@@ -598,7 +599,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             # Set the first_catalog for the wrapper
             wrapper.first_catalog = "test_catalog"
             # First call to get_schemas to set first_schema
@@ -632,7 +633,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             # Set the first_catalog for the wrapper
             wrapper.first_catalog = "test_catalog"
             # Call get_tables directly without calling get_schemas first
@@ -652,7 +653,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             tables = wrapper.get_tables()
 
             self.assertEqual(tables, [])
@@ -681,7 +682,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             # Set the first_catalog for the wrapper
             wrapper.first_catalog = "test_catalog"
             # First call to get_schemas to set first_schema
@@ -715,7 +716,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             # Set the first_catalog for the wrapper
             wrapper.first_catalog = "test_catalog"
             # Call get_views directly without calling get_schemas first
@@ -735,7 +736,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             views = wrapper.get_views()
 
             self.assertEqual(views, [])
@@ -753,7 +754,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
 
             # Call get_schemas multiple times
             schemas1 = wrapper.get_schemas()
@@ -785,7 +786,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             schemas = wrapper.get_schemas()
 
             # Should return all schemas
@@ -817,7 +818,7 @@ class DatabricksConnectionTest(TestCase):
         with patch("metadata.ingestion.source.database.databricks.connection.inspect") as mock_inspect:
             mock_inspect.return_value = mock_inspector
 
-            wrapper = self.DatabricksEngineWrapper(mock_engine)
+            wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
             schemas = wrapper.get_schemas()
 
             # Should return all schemas

--- a/ingestion/tests/unit/topology/database/test_snowflake.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import sqlalchemy.types as sqltypes
 
+from metadata.core.connections.lifetime import Borrowed
 from metadata.generated.schema.entity.data.database import Database
 from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
 from metadata.generated.schema.entity.data.table import Table, TableType
@@ -993,7 +994,7 @@ def test_test_connection_wires_access_history_and_query_history():
     )
 
     checks = SnowflakeChecks(
-        client=MagicMock(),
+        db=Borrowed.of(MagicMock()),
         service_connection=SnowflakeConnectionConfig(username="user", account="acc", warehouse="wh"),
     )
     collected = collect_checks(checks)


### PR DESCRIPTION
## Describe your changes

Fixes #29804.

A connector's `BaseConnection` owns exactly one client, and its test-connection checks are meant to reuse it. The framework had no way to express that, so the 13 migrated connectors wired the client into their checks provider **five different ways** — and two of them were handed the *service config* instead, and built a brand-new client from it.

For **Tableau** that is a live bug on `main`. `TableauClient.__init__` signs in, and a Personal Access Token permits a **single active session**, so the checks' sign-in invalidates the session the ingestion is about to use: every test step passes, then ingestion fails with `401002 Unauthorized`. PR #29870 fixed the framework path; the checks migration then re-created the second sign-in one layer below it.

**PowerBI** does the same with a second MSAL client and OAuth token. **Unity Catalog** builds two throwaway SQLAlchemy engines inside its checks while its owned client is a `WorkspaceClient`.

### The fix

`Borrowed[C]` — a one-member handle over a client someone else owns:

```python
class Borrowed(Generic[C]):
    @property
    def client(self) -> C: ...
```

It carries no service config, so a holder **cannot build a second client**, and no teardown, so it **cannot close the one it borrowed**. Reading it is what triggers the build, so the first connection still lands inside the runner's gate. `BaseConnection.borrow()` hands one out.

`client`, `close()` and `_on_close` keep their exact contracts, so **`get_connection`, `connection_obj` and `test_connection_common` are untouched** — reverse metadata and the Collate connectors are unaffected.

### Per connector

- **tableau** — reuse the owned client; sign out on `close()` (which also clears the SSL temp files), which nothing did before.
- **powerbi** — read the owned client's `api_client` instead of constructing a second one.
- **unitycatalog** — `UnityCatalogSqlConnection` owns the SQL-warehouse engine as a sub-owner, so the lineage and tag steps borrow one engine instead of building and disposing two — and none at all when no `httpPath` is configured.
- **athena, bigquery, s3, glue** — drop the hand-rolled thunks and memos; laziness belongs to the owner.
- **mysql, postgres, mssql, redshift, snowflake, databricks** — mechanical.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes test-connection checks reuse the client owned by each connector connection. The main changes are:

- Added a `Borrowed` client handle for non-owning check providers.
- Updated dashboard, database, and storage checks to borrow existing clients.
- Made Tableau close sign out best-effort during teardown.
- Added Unity Catalog SQL warehouse gating and SQL engine sub-owner cleanup.
- Updated connector tests for borrowed-client reuse and close behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The Tableau close path now guards sign-out failures.
- The Unity Catalog no-warehouse checks now stop before building the SQL engine.
- The borrowed-client annotations are protected by postponed annotations where they are type-only.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/core/connections/lifetime.py | Adds the `Borrowed` wrapper used by checks to read an owned client without taking lifecycle ownership. |
| ingestion/src/metadata/ingestion/connections/connection.py | Adds `BaseConnection.borrow()` and keeps client construction, caching, close, and reopen behavior centralized. |
| ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py | Reuses the connection-owned Tableau client for checks and guards close-time sign-out. |
| ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py | Reuses the connection-owned PowerBI client and its API client during checks. |
| ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py | Adds warehouse checks before SQL probes and owns the SQL engine through a closeable sub-connection. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(unitycatalog): fail the warehouse st..."](https://github.com/open-metadata/openmetadata/commit/5a825d67667a43a8ebdcb4af3e7570e0852bcff9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44200778)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->