### PR TITLE
Fixes #27946: preserve search preview ranking order (ignore superseded responses)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts
@@ -44,6 +44,75 @@ const test = base.extend<{ page: Page }>({
   },
 });
 
+// A minimal, valid /search/preview response with a single marker hit, used to
+// make preview responses deterministic and distinguishable in the ordering test.
+const buildDatabasePreviewResponse = (marker: 'fresh' | 'stale') => {
+  const name = `${marker}_result`;
+  const fullyQualifiedName = `pw_race_service.${name}`;
+
+  return {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+    hits: {
+      total: { relation: 'eq', value: 1 },
+      max_score: 1,
+      hits: [
+        {
+          _id: `pw-race-${marker}`,
+          _index: 'database_search_index',
+          _score: 1,
+          sort: [1, name],
+          _source: {
+            id: `00000000-0000-0000-0000-0000000000${
+              marker === 'fresh' ? '01' : '02'
+            }`,
+            name,
+            fullyQualifiedName,
+            displayName: `${marker.toUpperCase()}-RESULT`,
+            description: `${marker} marker`,
+            entityType: 'database',
+            serviceType: 'Mysql',
+            deleted: false,
+            service: {
+              id: '00000000-0000-0000-0000-0000000000aa',
+              type: 'databaseService',
+              name: 'pw_race_service',
+              fullyQualifiedName: 'pw_race_service',
+              displayName: 'pw_race_service',
+              deleted: false,
+            },
+            fqnParts: [fullyQualifiedName, 'pw_race_service'],
+            owners: [],
+            domains: [],
+            followers: [],
+            tags: [],
+            entityStatus: 'Unprocessed',
+          },
+        },
+      ],
+    },
+    aggregations: {},
+  };
+};
+
+const getDatabaseNgramBoost = (request: { postDataJSON: () => unknown }) => {
+  const body = request.postDataJSON() as {
+    searchSettings?: {
+      assetTypeConfigurations?: {
+        assetType: string;
+        searchFields?: { field: string; boost: number }[];
+      }[];
+    };
+  };
+
+  return (
+    body?.searchSettings?.assetTypeConfigurations
+      ?.find((config) => config.assetType === 'database')
+      ?.searchFields?.find((field) => field.field === 'name.ngram')?.boost ?? 0
+  );
+};
+
 test.describe('Search Settings', () => {
   test.beforeAll(async ({ browser }) => {
     adminUser = new AdminClass();
@@ -469,6 +538,102 @@ test.describe('Search Settings', () => {
         // After restore the preview API must be called — body must be present.
         expect(body).not.toBeNull();
         expect(body?.searchSettings?.assetTypeConfigurations).toBeDefined();
+      });
+    }
+  );
+
+  test.describe(
+    'Search Preview Ordering',
+    PLAYWRIGHT_BASIC_TEST_TAG_OBJ,
+    () => {
+      test.beforeEach(async ({ page }) => {
+        await redirectToHomePage(page);
+      });
+
+      // A slow, superseded preview request (high n-gram) must NOT overwrite the
+      // latest one (n-gram reverted to 0). Without a latest-wins guard in
+      // SearchPreview.fetchAssets the last-resolved response wins instead of the
+      // last-issued one, and the preview shows a stale ranking while the slider
+      // reads a different weight.
+      test('Latest preview config wins when a superseded request resolves late', async ({
+        page,
+      }) => {
+        const STALE_BOOST_THRESHOLD = 50;
+        const STALE_DELAY_MS = 2000;
+
+        // The high-n-gram request is delayed so it resolves after the reverted
+        // one. Every non-stale request is served immediately. Bodies are marked so
+        // the test can assert exactly which response the preview rendered.
+        await page.route('**/api/v1/search/preview', async (route) => {
+          const isStale =
+            getDatabaseNgramBoost(route.request()) >= STALE_BOOST_THRESHOLD;
+
+          if (isStale) {
+            await new Promise((resolve) => setTimeout(resolve, STALE_DELAY_MS));
+          }
+
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(
+              buildDatabasePreviewResponse(isStale ? 'stale' : 'fresh')
+            ),
+          });
+        });
+
+        await settingClick(page, GlobalSettingOptions.SEARCH_SETTINGS);
+        await page.getByTestId('preferences.search-settings.databases').click();
+
+        await expect(page).toHaveURL(
+          /settings\/preferences\/search-settings\/databases$/
+        );
+        await waitForAllLoadersToDisappear(page);
+
+        await page.getByTestId('searchbar').fill('test');
+
+        const freshCard = page.getByTestId(
+          'table-data-card_pw_race_service.fresh_result'
+        );
+        const staleCard = page.getByTestId(
+          'table-data-card_pw_race_service.stale_result'
+        );
+
+        // Baseline: the fresh (current-config) response is what the preview shows.
+        await expect(freshCard).toBeVisible();
+
+        await openMatchingFieldsPanel(page);
+        await page.getByTestId('field-configuration-panel-name.ngram').click();
+
+        const ngramSliderHandle = page
+          .getByTestId('field-configuration-panel-name.ngram')
+          .getByTestId('field-weight-slider')
+          .locator('.ant-slider-handle');
+
+        // Register before triggering so the delayed stale response is awaited.
+        const stalePreviewResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/preview') &&
+            getDatabaseNgramBoost(response.request()) >= STALE_BOOST_THRESHOLD
+        );
+
+        // End -> max weight fires the slow "stale" request (delayed by the route);
+        // Home -> 0 weight fires the fast "fresh" request, issued last.
+        await ngramSliderHandle.focus();
+        await page.keyboard.press('End');
+        await page.keyboard.press('Home');
+
+        // Wait until the delayed stale response has been delivered, then give the
+        // app a bounded moment to commit it. Without the fix the stale results
+        // would have replaced the fresh ones by now; with the fix the response is
+        // dropped and produces no observable change, so there is no positive
+        // signal to await instead — a short, bounded settle is required here.
+        await stalePreviewResponse;
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(1000);
+
+        // The latest (reverted) config must win: fresh stays, stale never renders.
+        await expect(freshCard).toBeVisible();
+        await expect(staleCard).toHaveCount(0);
       });
     }
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
@@ -15,7 +15,7 @@ import { Toggle } from '@openmetadata/ui-core-components';
 import { Button, Col, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { debounce } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconSearchV1 } from '../../../assets/svg/search.svg';
 import { ENTITY_PATH } from '../../../constants/constants';
@@ -55,6 +55,7 @@ const SearchPreview = ({
   const [data, setData] = useState<SearchedDataProps['data']>([]);
   const [searchValue, setSearchValue] = useState<string>('');
   const [showRankingDetails, setShowRankingDetails] = useState(false);
+  const latestRequestId = useRef(0);
   const {
     currentPage,
     pageSize,
@@ -77,6 +78,8 @@ const SearchPreview = ({
       searchTerm = searchValue,
     }: { page?: number; searchTerm?: string } = {}) => {
       if (searchConfig && Object.keys(searchConfig).length > 0) {
+        const requestId = latestRequestId.current + 1;
+        latestRequestId.current = requestId;
         try {
           setIsLoading(true);
           const res = await searchPreview({
@@ -89,15 +92,25 @@ const SearchPreview = ({
             searchSettings: searchConfig,
           });
 
+          // Ignore responses from superseded requests so a slow, stale response
+          // can never overwrite the latest preview.
+          if (requestId !== latestRequestId.current) {
+            return;
+          }
+
           const hits = res.hits.hits as unknown as SearchedDataProps['data'];
           const totalCount = res?.hits?.total.value ?? 0;
 
           handlePagingChange({ total: totalCount });
           setData(hits);
         } catch (error) {
-          showErrorToast(error as AxiosError);
+          if (requestId === latestRequestId.current) {
+            showErrorToast(error as AxiosError);
+          }
         } finally {
-          setIsLoading(false);
+          if (requestId === latestRequestId.current) {
+            setIsLoading(false);
+          }
         }
       }
     },


### PR DESCRIPTION
Fixes #27946

### Type of change:
- [x] Bug fix

### Description

In **Settings → Preferences → Search → \<entity\>**, adjusting field weights (e.g. dragging `name.ngram`) or switching Score/Boost mode **before saving** could make the Preview list show results in the wrong order for the current settings — a higher-scoring result appearing below a lower-scoring one, or a ranking that doesn't match the slider. Saving and refreshing always corrected it.

### Root cause

The `/search/preview` API always returns results sorted by `_score` (verified across sequential, concurrent, and `explain=true` calls). The disorder was introduced client-side.

`SearchPreview` fires a fresh, uncancelled `/search/preview` request on **every** config change (the fetch effect depends on `searchConfig`, and the weight sliders use `onChange` with no debounce), and `fetchAssets` had **no latest-wins guard** — it called `setData` for whichever request *resolved* last. So a slow response from an earlier config could resolve **after** a newer one and overwrite it, leaving the preview stale relative to the current settings.

### Fix

Track a monotonic request id in `SearchPreview` and ignore responses (and their loading/error side-effects) from superseded requests, so the latest config always wins. A single clean request on save/refresh already produced the correct order, which is why the issue only appeared during live editing.

### Tests

#### Use cases covered
- While rapidly changing a field weight, a slow response from a previous weight no longer overwrites the latest preview.

#### Playwright (UI) tests
- [x] Added `SearchSettings.spec.ts` → `Search Preview Ordering` → *"Latest preview config wins when a superseded request resolves late"*. It intercepts `/search/preview`, serves a delayed "stale" response for the high-n-gram request and a fast "fresh" response for the reverted one, then asserts the preview keeps the fresh result and never renders the stale one. Deterministic and data-independent (mocked responses; creates no entities). Verified to fail before the fix (the stale response wins) and pass after.

### UI screen recording / screenshots
Before (slider at n-gram = 0, but preview shows the n-gram = 100 ranking because a slow request won the race):

_Repro on a seeded dataset; the fix drops the superseded response so the slider value and preview stay in sync._

### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue.
- [x] For UI changes I added a Playwright test that covers the exact scenario being fixed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes stale search preview results while editing search settings.

- Adds a latest-request guard in `SearchPreview`.
- Prevents superseded preview responses from updating data, loading state, or errors.
- Adds a Playwright test for delayed stale responses during field-weight edits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx | Adds request sequencing so only the newest preview call can update the component state. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchSettings.spec.ts | Adds regression coverage for delayed stale preview responses during search setting edits. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Fixes #27946: preserve search preview ra..."](https://github.com/open-metadata/openmetadata/commit/1f1e1f368239c98d30270312385a25d49bb1b346) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44229120)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->