### PR TITLE
fix(ui): skip idle route prefetch on unauthenticated shell

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/App.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/App.test.tsx
@@ -15,8 +15,22 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import App from './App';
 import AppRouter from './components/AppRouter/AppRouter';
+import { useApplicationStore } from './hooks/useApplicationStore';
+import { idlePrefetchRoutes } from './utils/idlePrefetchRoutes';
 
 const mockAuthProvider = jest.fn();
+
+let mockIsAuthenticated = false;
+
+jest.mock('./utils/idlePrefetchRoutes', () => ({
+  idlePrefetchRoutes: jest.fn(),
+}));
+
+jest.mock('./hooks/useApplicationStore', () => ({
+  useApplicationStore: jest.fn((selector) =>
+    selector({ isAuthenticated: mockIsAuthenticated })
+  ),
+}));
 
 jest.mock('./components/AppRouter/AppRouter', () => ({
   __esModule: true,
@@ -50,6 +64,7 @@ jest.mock('./components/Auth/AuthProviders/AuthProvider', () => ({
 describe('App', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsAuthenticated = false;
   });
 
   it('should render AuthProvider wrapping AppRouter', () => {
@@ -65,5 +80,27 @@ describe('App', () => {
     expect(mockAuthProvider).toHaveBeenCalledWith({
       childComponentType: AppRouter,
     });
+  });
+
+  it('should not prefetch route chunks on the unauthenticated shell', () => {
+    mockIsAuthenticated = false;
+
+    render(React.createElement(App));
+
+    expect(idlePrefetchRoutes).not.toHaveBeenCalled();
+  });
+
+  it('should prefetch route chunks once authenticated', () => {
+    mockIsAuthenticated = true;
+
+    render(React.createElement(App));
+
+    expect(idlePrefetchRoutes).toHaveBeenCalledTimes(1);
+  });
+
+  it('should read isAuthenticated from the application store', () => {
+    render(React.createElement(App));
+
+    expect(useApplicationStore).toHaveBeenCalled();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/App.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/App.tsx
@@ -15,17 +15,22 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { FC, useEffect } from 'react';
 import AppRouter from './components/AppRouter/AppRouter';
 import { AuthProvider } from './components/Auth/AuthProviders/AuthProvider';
+import { useApplicationStore } from './hooks/useApplicationStore';
 import { queryClient } from './queryClient';
 import { idlePrefetchRoutes } from './utils/idlePrefetchRoutes';
 
 const App: FC = () => {
-  // After first paint, warm the chunk cache for Explore / Settings / EntityRouter
-  // during browser idle. Most users land on /my-data and click into Explore or an
-  // entity link next; pre-fetching those route chunks turns the click into a cache
-  // hit (~5ms) instead of a network round-trip (~200–500ms).
+  const isAuthenticated = useApplicationStore((state) => state.isAuthenticated);
+
+  // Warm route chunks during idle, only when authenticated — the unauth shell
+  // (SignIn etc.) never reaches these routes and would needlessly pull Explore's
+  // import graph (TourProvider, tour.enum, …).
   useEffect(() => {
+    if (!isAuthenticated) {
+      return;
+    }
     idlePrefetchRoutes();
-  }, []);
+  }, [isAuthenticated]);
 
   // QueryClientProvider sits ABOVE AuthProvider so that the singleton is available everywhere
   // — including AuthProvider's onLogout handler, which needs to clear the query cache so a


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## What

Gate `idlePrefetchRoutes()` behind `isAuthenticated` in `App.tsx` so the login/unauthenticated shell no longer warms authenticated route chunks.

## Why

On the SignIn page, `idlePrefetchRoutes()` ran on first mount and prefetched `ExplorePageV1` + `EntityRouter`. Their static import graphs pull in heavy provider modules the login page has no use for:

- **Tour** — `TourProvider`, `tour.enum` (via `ExplorePageV1`)
- **Lineage** — `Lineage` / `LineageTab` (via `EntitySummaryPanel` in Explore)
- **ER Diagram** — entity-relationship diagram component (via `EntityRouter` entity-detail tabs)

These were downloading on `/signin` (visible in the Network panel) despite the unauthenticated shell (SignIn, ForgotPassword, ResetPassword, …) never navigating to Explore/Entity routes.

## Change

- `App.tsx`: read `isAuthenticated` from `useApplicationStore`; run `idlePrefetchRoutes()` only when authenticated, with `[isAuthenticated]` as the effect dependency.

## Behavior

- **Unauthenticated:** no prefetch → Tour, Lineage, and ER Diagram chunks no longer load on the login page.
- **Authenticated:** unchanged. `App` is the root component (mounted once); `isAuthenticated` flips `false → true` on login and initializes `true` on reload when a token exists, so prefetch still fires right after auth — same warm-cache benefit.
- Prefetch only populates the HTTP/Service Worker cache; nothing reads its result, so gating it has no functional dependents.



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents authenticated route chunks from being prefetched on the unauthenticated shell. The main changes are:

- Gates idle route prefetching on `isAuthenticated` in `App.tsx`.
- Runs prefetching when authentication changes to true.
- Adds tests for authenticated and unauthenticated initial states.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The authentication transition triggers the updated effect.
- Unauthenticated sessions skip the route prefetch.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/App.tsx | Reads authentication state from the application store and limits idle route prefetching to authenticated sessions. |
| openmetadata-ui/src/main/resources/ui/src/App.test.tsx | Adds coverage for prefetch behavior in authenticated and unauthenticated initial states. |

</details>

<sub>Reviews (2): Last reviewed commit: ["add test"](https://github.com/open-metadata/openmetadata/commit/0f60edd738278947d0fd61f0c09d36d15fcad5ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44378537)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->