### PR TITLE
fix(ui): auto-close error toast after 60s

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-store.ts
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-store.ts
@@ -25,6 +25,8 @@ export const toastQueue = new ToastQueue<ToastContent>({
   maxVisibleToasts: 5,
 });
 
+const ERROR_TOAST_TIMEOUT = 60000;
+
 export interface ShowToastOptions {
   /** Whether the toast should dismiss automatically. Defaults to true. */
   autoDismiss?: boolean;
@@ -57,7 +59,7 @@ export const toast = {
   success: (message: string | ReactNode, options?: ShowToastOptions) =>
     add(message, 'success', options),
   error: (message: string | ReactNode, options?: ShowToastOptions) =>
-    add(message, 'error', { timeout: 0, ...options }),
+    add(message, 'error', { timeout: ERROR_TOAST_TIMEOUT, ...options }),
   warning: (message: string | ReactNode, options?: ShowToastOptions) =>
     add(message, 'warning', options),
   info: (message: string | ReactNode, options?: ShowToastOptions) =>


### PR DESCRIPTION
### Describe your changes:

I made error toasts auto-dismiss after 60s instead of staying on screen until manually closed, because a stuck error toast lingers indefinitely and clutters the UI. The close button is retained so users can still dismiss early.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change. `toast.error` previously passed `timeout: 0` (no auto-dismiss); it now uses a `ERROR_TOAST_TIMEOUT` constant of 60000ms. Callers can still override via `options`.

#
### Tests:

#### Manual testing performed
1. Triggered an error toast in the UI; confirmed it auto-closes after ~60s and the close button still dismisses it immediately.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes error toasts close automatically after 60 seconds. The main changes are:

- Adds a named 60-second error-toast timeout.
- Applies the timeout as the default for `toast.error`.
- Preserves caller timeout overrides and manual dismissal.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Explicit `timeout` values still override the new default.
- `autoDismiss: false` and `timeout: 0` still keep a toast open.
- Error toasts retain their close button.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast-store.ts | Changes the default error-toast lifetime from persistent to 60 seconds while retaining explicit option overrides. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): auto-close error toast after 60..."](https://github.com/open-metadata/openmetadata/commit/e903a9c3fe754f87f7db27aed8374d6886c3683a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44392609)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->