### PR TITLE
Fix flaky entity summary panel Playwright tests: dismiss stray popovers before card click

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -52,6 +52,29 @@ const findOptionByScrolling = async (page: Page, endpoint: string) => {
   );
 };
 
+const dismissVisiblePopovers = async (page: Page) => {
+  const visiblePopovers = page.locator('.ant-popover:not(.ant-popover-hidden)');
+
+  if ((await visiblePopovers.count()) === 0) {
+    return;
+  }
+
+  await page.mouse.move(0, 0);
+  await page.keyboard.press('Escape');
+
+  await expect(visiblePopovers)
+    .toHaveCount(0, { timeout: 5000 })
+    .catch(async () => {
+      await page.locator('body').click({
+        position: {
+          x: 0,
+          y: 0,
+        },
+      });
+      await expect(visiblePopovers).toHaveCount(0, { timeout: 5000 });
+    });
+};
+
 export const openEntitySummaryPanel = async ({
   page,
   entityName,
@@ -101,7 +124,7 @@ export const openEntitySummaryPanel = async ({
   if (fullyQualifiedName) {
     const cardByFqn = page.getByTestId(`table-data-card_${fullyQualifiedName}`);
     await cardByFqn.waitFor({ state: 'visible' });
-
+    await dismissVisiblePopovers(page);
     // Since the directly clicking on the card can sometimes click on title element which is link,
     // we need to click on description container to open the summary panel.
     await cardByFqn.getByTestId('description-text').click();
@@ -115,13 +138,17 @@ export const openEntitySummaryPanel = async ({
     await knowledgeCenterItem.click();
   }
 
-  await page
+  const cardByEntityName = page
     .locator('[data-testid^="table-data-card"]')
     .filter({
       has: page.getByTestId('entity-link').filter({ hasText: entityName }),
     })
-    .getByTestId('description-text')
-    .click();
+    .first();
+  await cardByEntityName.getByTestId('description-text').waitFor({
+    state: 'visible',
+  });
+  await dismissVisiblePopovers(page);
+  await cardByEntityName.getByTestId('description-text').click();
 };
 // ... (lines 48-468 unchanged)
 export async function navigateToExploreAndSelectTable(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Description

The entity summary panel Playwright helper (`openEntitySummaryPanel`) is **flaky**: it intermittently fails because a hover popover (`.ant-popover`) stays open over the data card and intercepts the click on `description-text`, so the summary panel never opens. The failure is timing-dependent — it only reproduces when the popover has not auto-closed
before the click fires, which is why it passes locally but flakes in CI.

This adds a `dismissVisiblePopovers` helper that:
- No-ops when no visible popover exists.
- Moves the mouse to the corner and presses `Escape`.
- Falls back to a corner body click if the popover is still visible after 5s.

It runs before both card-click paths (FQN lookup and entity-name lookup). The entity-name path is also refactored to capture the card locator once, wait for `description-text` to be visible, dismiss popovers, then click — removing a race that contributed to the flakiness.

## Changes
- `playwright/utils/entityPanel.ts`
  - Add `dismissVisiblePopovers(page)` helper.
  - Call it before both `description-text` clicks in `openEntitySummaryPanel`.
  - Refactor entity-name click into a stable `.first()` locator with an explicit visibility wait.

## Type of change
- [x] Bug fix (test flakiness)


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes entity summary panel clicks when stray popovers remain open. The main changes are:

- Adds Escape and body-click fallback behavior for visible popovers.
- Runs popover dismissal before both card-click paths.
- Waits for the first entity-name card description before clicking it.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The popover fix is mergeable after tightening the entity-name card selection.

- The popover dismissal path has a bounded fallback.
- The name-only path can silently select the wrong card when names overlap.

openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts | Adds popover dismissal and explicit card waiting, but the new first-match selection can open the wrong entity for ambiguous names. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix flaky entity summary panel Playwrigh..."](https://github.com/open-metadata/openmetadata/commit/5fa9075ea21a98dd4b2bb02dc6cb10633a7f2040) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44395297)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->