### PR TITLE
fix(ui): remove constraint from Explorer card footer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
@@ -327,14 +327,14 @@ describe('ExploreSearchCard - Entity type tags', () => {
     expect(screen.queryByText(Constraint.Null)).not.toBeInTheDocument();
   });
 
-  it('renders real constraint metadata for column cards', () => {
+  it('does not render constraint metadata for column cards', () => {
     renderCard({
       entityType: 'tableColumn',
       constraint: Constraint.PrimaryKey,
     } as Partial<ExploreSearchCardProps['source']>);
 
-    expect(screen.getByTestId('label.constraint')).toBeInTheDocument();
-    expect(screen.getByText(Constraint.PrimaryKey)).toBeInTheDocument();
+    expect(screen.queryByTestId('label.constraint')).not.toBeInTheDocument();
+    expect(screen.queryByText(Constraint.PrimaryKey)).not.toBeInTheDocument();
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx
@@ -27,7 +27,7 @@ import {
   EntityStatus,
   GlossaryTerm,
 } from '../../../generated/entity/data/glossaryTerm';
-import { Constraint, Table } from '../../../generated/entity/data/table';
+import { Table } from '../../../generated/entity/data/table';
 import { EntityReference } from '../../../generated/entity/type';
 import { AssetCertification } from '../../../generated/type/assetCertification';
 import { TableColumnSearchSource } from '../../../interface/search.interface';
@@ -256,20 +256,6 @@ const ExploreSearchCard: React.FC<ExploreSearchCardProps> = forwardRef<
                 } as SourceType)}>
                 {getEntityName(columnSource.table)}
               </Link>
-            ),
-          });
-        }
-
-        if (
-          columnSource.constraint &&
-          columnSource.constraint !== Constraint.Null
-        ) {
-          columnDetails.push({
-            key: t('label.constraint'),
-            value: (
-              <Typography.Text className="font-medium">
-                {columnSource.constraint}
-              </Typography.Text>
             ),
           });
         }


### PR DESCRIPTION
### Describe your changes:

Remove constraint metadata from Explorer table-column card footers so the constraint is not rendered. Update the focused component regression test to cover constrained columns.

### Type of change:

- [x] Bug fix

### High-level design:

The change is localized to ExploreSearchCard metadata assembly. Table and owner metadata remain unchanged, while constraint metadata is no longer appended to the shared footer input.

### Tests:

#### Use cases covered

- Explorer table-column cards do not display constraint metadata, including primary-key constraints.

#### Unit tests

- [x] Updated ExploreSearchCard.test.tsx for the changed behavior.
- Focused result: 38 tests passed.

#### Backend integration tests

- [x] Not applicable; no backend changes.

#### Ingestion integration tests

- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests

- [x] No update required; there was no related Explorer-card constraint assertion or helper.

#### Manual testing performed

- Not performed; behavior was verified with focused component tests.

### UI screen recording / screenshots:

Not applicable for this localized metadata removal.

### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] I have added a test that covers the exact scenario being fixed.
- [x] I have added tests and listed them above.
- [x] No JSON Schema or migration changes are required.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes constraint metadata from Explorer table-column card footers. The main changes are:

- Stops adding column constraints to footer metadata.
- Removes the unused `Constraint` import.
- Updates the focused test for constrained columns.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.tsx | Removes constraint metadata only from the table-column footer while preserving table and owner details. |
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx | Updates the constrained-column test to verify that the constraint label and value are absent. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): remove constraint from explorer..."](https://github.com/open-metadata/openmetadata/commit/250df45cd64395a6988f8c0830be6f0770f35401) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44419613)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->