### PR TITLE
Fixes #29996: parse Delta struct field names containing colons

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/column_type_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/column_type_parser.py
@@ -400,14 +400,19 @@ class ColumnTypeParser:
         columns = []
         for part in parts:
             name_and_type = ColumnTypeParser._ignore_brackets_split(part, ":")
-            if len(name_and_type) != 2:
+            if len(name_and_type) < 2:
                 raise ValueError("expected format is: 'field_name:field_type', " + f"but got: {part}")
-            field_name = name_and_type[0].strip()
+            # A field type never contains a top-level ':' (colons only appear inside
+            # bracketed types, which the split above protects), so the last segment is
+            # the type and everything before it is the field name. Delta column-mapped
+            # struct fields carry ':' in the name itself, so rejoin the leading segments.
+            field_type_string = name_and_type[-1]
+            field_name = ":".join(name_and_type[:-1]).strip()
             if field_name.startswith("`"):
                 if field_name[-1] != "`":
                     raise ValueError(f"'`' should be the last char, but got: {stuct_type}")
                 field_name = field_name[1:-1]
-            field_type = ColumnTypeParser._parse_datatype_string(name_and_type[1])
+            field_type = ColumnTypeParser._parse_datatype_string(field_type_string)
             field_type["name"] = field_name
             columns.append(field_type)
 

--- a/ingestion/tests/unit/test_column_type_parser.py
+++ b/ingestion/tests/unit/test_column_type_parser.py
@@ -17,6 +17,8 @@ import logging
 import os
 from unittest import TestCase
 
+import pytest
+
 from metadata.generated.schema.entity.data.table import DataType
 from metadata.ingestion.source.dashboard.superset.mixin import SupersetSourceMixin
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
@@ -145,3 +147,47 @@ def test_superset_parse_array_data_type():
     col_parse = {"dataType": "STRING", "arrayDataType": None}
     result = SupersetSourceMixin.parse_array_data_type(None, col_parse)
     assert result == None  # noqa: E711
+
+
+def test_struct_field_name_with_colons():
+    """Delta column-mapped struct field names contain ':' -- issue #29996.
+
+    The last top-level ':' separates name from type; the rest belongs to the name.
+    """
+    parsed = ColumnTypeParser._parse_datatype_string(
+        "struct<baselineproportions:1:behavioral_segment_search_for_dm:bigint>"
+    )
+    children = parsed["children"]
+
+    assert parsed["dataType"] == "STRUCT"
+    assert len(children) == 1
+    assert children[0]["name"] == "baselineproportions:1:behavioral_segment_search_for_dm"
+    assert children[0]["dataType"] == "BIGINT"
+
+
+def test_struct_field_name_with_colons_backtick_quoted():
+    """Databricks may render a colon-path field name backtick-quoted."""
+    parsed = ColumnTypeParser._parse_datatype_string("struct<`a:b:c`:bigint>")
+    children = parsed["children"]
+
+    assert len(children) == 1
+    assert children[0]["name"] == "a:b:c"
+    assert children[0]["dataType"] == "BIGINT"
+
+
+def test_struct_field_name_with_colons_mixed_and_nested():
+    """A colon-name field alongside a normal field and a nested struct field."""
+    parsed = ColumnTypeParser._parse_datatype_string("struct<a:b:string,plain:int,nested:c:struct<inner:int>>")
+    children = parsed["children"]
+
+    assert [child["name"] for child in children] == ["a:b", "plain", "nested:c"]
+    assert children[0]["dataType"] == "STRING"
+    assert children[1]["dataType"] == "INT"
+    assert children[2]["dataType"] == "STRUCT"
+    assert children[2]["children"][0]["name"] == "inner"
+
+
+def test_struct_field_without_colon_still_raises():
+    """A field with no ':' at all is still an invalid struct field format."""
+    with pytest.raises(ValueError, match="field_name:field_type"):
+        ColumnTypeParser._parse_datatype_string("struct<justaname>")


### PR DESCRIPTION
### Describe your changes:

Fixes #29996

I fixed `ColumnTypeParser._parse_struct_fields_string` so it splits each struct field on the **last** top-level `:` instead of requiring exactly `name:type`, because Unity Catalog Delta column-mapped struct fields carry `:` inside the field name itself (e.g. `struct<baselineproportions:1:behavioral_segment_search_for_dm:bigint>`) and previously crashed ingestion with a `ValueError`. A field type never contains a top-level colon (colons only appear inside bracketed types, which the split already protects), so the last segment is unambiguously the type and everything before it is the name.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Unity Catalog metadata ingestion of a Delta table whose struct column has a colon-bearing (column-mapped) field name now succeeds instead of raising `expected format is: 'field_name:field_type'`.

#### Unit tests
- [x] I added unit tests for the changed logic.
- Files added/updated: `ingestion/tests/unit/test_column_type_parser.py` — the exact issue string, backtick-quoted colon names, mixed/nested fields, and a negative no-colon case.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (parser-level fix; covered by unit tests).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Created a real Databricks Unity Catalog Delta table (column mapping on) with `events STRUCT<`+"`"+`baselineproportions:1:behavioral_segment_search_for_dm`+"`"+`: BIGINT>`.
2. Ran the connector's parser against the live table: before the fix it raised the exact issue `ValueError` (exit 1); after the fix both columns parse cleanly (exit 0).
3. `make`-equivalent unit run: `pytest ingestion/tests/unit/test_column_type_parser.py` → 8 passed; `ruff check`/`ruff format` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (issue #29996 referenced in the test docstring).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR allows Delta struct field names to contain colons. The main changes are:

- Uses the last top-level colon as the field name/type separator.
- Preserves colons within unquoted and backtick-quoted field names.
- Adds tests for nested, mixed, quoted, and invalid struct fields.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/column_type_parser.py | Parses the final top-level colon as the struct field name/type separator while preserving earlier colons in the field name. |
| ingestion/tests/unit/test_column_type_parser.py | Adds focused parser tests for colon-bearing field names and malformed fields without a separator. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): parse Delta struct field..."](https://github.com/open-metadata/openmetadata/commit/7fd3cb12768c74f347b747ab7611cc5596422a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44425404)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->