### PR TITLE
Cherry-pick #30035: dateTime custom property between filter fix (1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -609,30 +609,23 @@ function buildExtensionQuery(
       operator
     );
   } else if (isRangeOperator(operator)) {
-    // Range query: query longValue, doubleValue, and stringValue with OR
-    // since we don't know which field the value is stored in
-    // (dates are stored as strings, numbers as long/double)
-    const longValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'longValue',
-      value,
-      operator
-    );
-    const doubleValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'doubleValue',
-      value,
-      operator
-    );
-    const stringValueQuery = buildNestedTypedQuery(
-      basePropertyName,
-      'stringValue',
-      value,
-      operator
-    );
+    // Range query: OR across the typed value fields since we don't know which
+    // one holds the value. Date/time custom properties are stored only as
+    // formatted strings in stringValue — sending those strings into a numeric
+    // longValue/doubleValue range raises an ES number_format_exception that
+    // fails the whole search, so route date types to stringValue only.
+    const isDateOmType =
+      omPropertyType === 'date-cp' ||
+      omPropertyType === 'dateTime-cp' ||
+      omPropertyType === 'time-cp';
+    const rangeFields = isDateOmType
+      ? ['stringValue']
+      : ['longValue', 'doubleValue', 'stringValue'];
     mainQuery = {
       bool: {
-        should: [longValueQuery, doubleValueQuery, stringValueQuery],
+        should: rangeFields.map((field) =>
+          buildNestedTypedQuery(basePropertyName, field, value, operator)
+        ),
         minimum_should_match: 1,
       },
     };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -833,17 +833,23 @@ function buildEsRule(fieldName, value, operator, config, valueSrc) {
     );
 
     // For range operators (between / not_between) the value is a two-element
-    // array [from, to]. Pass the full array so buildExtensionQuery can build
-    // a proper gte/lte range query. This is scoped to numeric types where ES
-    // range queries work correctly. Non-numeric types (e.g. dateTime-cp)
-    // store values as formatted strings where ES range comparison is unreliable.
+    // array [from, to]. Pass the full array so buildExtensionQuery can build a
+    // proper gte/lte range query. Numeric types (integer/number/timestamp) query
+    // longValue/doubleValue. Date types (date-cp/dateTime-cp/time-cp) are stored
+    // as formatted strings in stringValue; a keyword range is a lexicographic
+    // comparison, which is chronologically correct for the default big-endian,
+    // zero-padded formats (e.g. yyyy-MM-dd HH:mm:ss). Other types collapse to
+    // value[0] since only a single bound is meaningful.
     const isBetweenOp = op === 'between';
-    const isNumericOmType =
+    const isRangeableOmType =
       omPropertyType === 'integer' ||
       omPropertyType === 'number' ||
-      omPropertyType === 'timestamp';
+      omPropertyType === 'timestamp' ||
+      omPropertyType === 'date-cp' ||
+      omPropertyType === 'dateTime-cp' ||
+      omPropertyType === 'time-cp';
     const extensionValue = hasValue
-      ? isBetweenOp && isNumericOmType
+      ? isBetweenOp && isRangeableOmType
         ? value
         : value[0]
       : null;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -16,7 +16,7 @@ import { elasticSearchFormat } from './QueryBuilderElasticsearchFormatUtils';
 
 // Minimal Immutable-compatible tree stub.
 // elasticSearchFormat only calls .get() on the tree and its properties map.
-const makeTree = (operator, value) => ({
+const makeTree = (operator, value, field = 'extension.table.myNumber') => ({
   get(key) {
     if (key === 'type') {
       return 'rule';
@@ -25,7 +25,7 @@ const makeTree = (operator, value) => ({
       return {
         get(k) {
           if (k === 'field') {
-            return 'extension.table.myNumber';
+            return field;
           }
           if (k === 'operator') {
             return operator;
@@ -59,6 +59,12 @@ const configWithNumberType = {
             myNumber: {
               __omPropertyType: 'number',
             },
+            myDateTime: {
+              __omPropertyType: 'dateTime-cp',
+            },
+            myDate: {
+              __omPropertyType: 'date-cp',
+            },
           },
         },
       },
@@ -87,5 +93,56 @@ describe('elasticSearchFormat – extension number field range operators (Issue 
     expect(result).toContain('"must_not"');
     expect(result).toContain('"gte":10');
     expect(result).toContain('"lte":50');
+  });
+});
+
+describe('elasticSearchFormat – extension dateTime field range operators (Issue #28829)', () => {
+  it('dateTime between: should include both gte (from) and lte (to) bounds', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'between',
+          ['2024-01-01 00:00:00', '2024-12-31 23:59:59'],
+          'extension.table.myDateTime'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"gte":"2024-01-01 00:00:00"');
+    expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+  });
+
+  it('dateTime not_between: should wrap both gte/lte bounds in a must_not clause', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'not_between',
+          ['2024-01-01 00:00:00', '2024-12-31 23:59:59'],
+          'extension.table.myDateTime'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"must_not"');
+    expect(result).toContain('"gte":"2024-01-01 00:00:00"');
+    expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+  });
+
+  it('date between: should include both gte (from) and lte (to) bounds', () => {
+    const result = JSON.stringify(
+      elasticSearchFormat(
+        makeTree(
+          'between',
+          ['2024-01-01', '2024-12-31'],
+          'extension.table.myDate'
+        ),
+        configWithNumberType
+      )
+    );
+
+    expect(result).toContain('"gte":"2024-01-01"');
+    expect(result).toContain('"lte":"2024-12-31"');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -111,6 +111,10 @@ describe('elasticSearchFormat – extension dateTime field range operators (Issu
 
     expect(result).toContain('"gte":"2024-01-01 00:00:00"');
     expect(result).toContain('"lte":"2024-12-31 23:59:59"');
+    // Date strings must not be routed into numeric longValue/doubleValue ranges
+    // (that raises an ES number_format_exception and fails the whole search).
+    expect(result).not.toContain('customPropertiesTyped.longValue');
+    expect(result).not.toContain('customPropertiesTyped.doubleValue');
   });
 
   it('dateTime not_between: should wrap both gte/lte bounds in a must_not clause', () => {


### PR DESCRIPTION
Cherry-pick of #30035 to `1.13`.

## Description

Fixes the dateTime/date custom property `between` filter in Explore, which returned incorrect results (matched every asset that had the property set, ignoring the selected range).

## Root cause

Same class of bug as the numeric fix (#27525), scoped one type too narrowly. In `buildEsRule` the `between`/`not_between` `[from, to]` array was only forwarded for numeric OM types (`integer`/`number`/`timestamp`); for `date-cp`/`dateTime-cp` it collapsed to `value[0]`, so `buildNestedTypedQuery` emitted an empty range (`{}`) that matched everything.

## Fix (2 commits)

1. Broaden the range passthrough to include `date-cp`/`dateTime-cp`/`time-cp`. These are stored as formatted strings in `customPropertiesTyped.stringValue` (`keyword`), so a `gte`/`lte` range is a lexicographic comparison — correct for the default big-endian formats (`yyyy-MM-dd`, `yyyy-MM-dd HH:mm:ss`).
2. Route date-type range queries to `stringValue` only. The shared range fan-out also builds `longValue`/`doubleValue` (numeric) clauses; sending a date string there raises an ES `number_format_exception` that fails the whole search. Scoped by `omPropertyType` so date types query `stringValue` only.

## Verification

- Unit tests (`QueryBuilderElasticsearchFormatUtils.test.js`): 5/5 pass, including negative assertions that date ranges never emit numeric-field range clauses.
- End-to-end against a live server with the customer's actual value (`2026-05-06 03:39:06`, format `yyyy-MM-dd HH:mm:ss`): `between` returns exactly the in-window rows and excludes out-of-window rows.
- eslint + prettier clean.

## Known limitation (pre-existing)

Non-sortable configured formats (`MM/dd/yyyy`, `dd-MM-yyyy`, etc.) still range lexicographically-wrong; a format-independent fix needs backend epoch indexing + reindex (separate follow-up).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates custom-property date range filtering in Explore. The main changes are:

- Preserve both bounds for date, date-time, and time range operators.
- Send date-like ranges only to the Elasticsearch string field.
- Add tests for date and date-time `between` and `not_between` queries.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Configured non-big-endian date formats can still return incorrect range results.

- Default ISO-like formats follow chronological string order.
- Valid formats such as `dd/MM/yyyy` do not, so the updated range query can include or exclude the wrong assets.

openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js | Routes date-like ranges to `stringValue`, but configured non-sortable formats still produce incorrect chronological results. |
| openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js | Adds coverage for default-format date and date-time range queries and excludes numeric range fields. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(advanced-search): route date-type ra..."](https://github.com/open-metadata/openmetadata/commit/6d07e662ad038828bb11211596dd17f5c13eb2cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44429805)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->