### PR TITLE
Fixes #27946: preserve search preview ranking order (backport to 1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
@@ -14,7 +14,7 @@ import Icon from '@ant-design/icons';
 import { Button, Col, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { debounce } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconSearchV1 } from '../../../assets/svg/search.svg';
 import { ENTITY_PATH } from '../../../constants/constants';
@@ -53,6 +53,7 @@ const SearchPreview = ({
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState<SearchedDataProps['data']>([]);
   const [searchValue, setSearchValue] = useState<string>('');
+  const latestRequestId = useRef(0);
   const {
     currentPage,
     pageSize,
@@ -75,6 +76,8 @@ const SearchPreview = ({
       searchTerm = searchValue,
     }: { page?: number; searchTerm?: string } = {}) => {
       if (searchConfig && Object.keys(searchConfig).length > 0) {
+        const requestId = latestRequestId.current + 1;
+        latestRequestId.current = requestId;
         try {
           setIsLoading(true);
           const res = await searchPreview({
@@ -86,15 +89,25 @@ const SearchPreview = ({
             searchSettings: searchConfig,
           });
 
+          // Ignore responses from superseded requests so a slow, stale response
+          // can never overwrite the latest preview.
+          if (requestId !== latestRequestId.current) {
+            return;
+          }
+
           const hits = res.hits.hits as unknown as SearchedDataProps['data'];
           const totalCount = res?.hits?.total.value ?? 0;
 
           handlePagingChange({ total: totalCount });
           setData(hits);
         } catch (error) {
-          showErrorToast(error as AxiosError);
+          if (requestId === latestRequestId.current) {
+            showErrorToast(error as AxiosError);
+          }
         } finally {
-          setIsLoading(false);
+          if (requestId === latestRequestId.current) {
+            setIsLoading(false);
+          }
         }
       }
     },


### PR DESCRIPTION
Backport of #30058 to the `1.13` branch.

**Fix:** `SearchPreview.fetchAssets` had no latest-wins guard, so a slow `/search/preview` response from an earlier field weight could resolve after a newer one and overwrite it — leaving the preview showing a ranking that did not match the current settings (fixed by save + refresh). Added a monotonic request-id guard that drops responses from superseded requests.

Fix-only backport: the Playwright regression test is on the main PR #30058 (the search-settings test layout/utilities differ on this branch).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents stale search-preview responses from replacing newer ranking results. The main changes are:

- Adds a component-local request sequence using `useRef`.
- Drops success responses from superseded requests.
- Limits error and loading updates to the latest request.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The latest request consistently owns success, error, and loading updates.
- The added React hook is supported by the existing React setup.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx | Adds a latest-request guard so superseded preview requests cannot update results, pagination, errors, or loading state. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #27946: preserve search preview ra..."](https://github.com/open-metadata/openmetadata/commit/f44fd18ea300c2ff5a8d50b5f1aadc1a78b2d98a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44435828)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->