### PR TITLE
Fixes #27946: preserve search preview ranking order (backport to 1.12.14)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx
@@ -14,7 +14,7 @@ import Icon from '@ant-design/icons';
 import { Button, Col, Input, Row, Typography } from 'antd';
 import { AxiosError } from 'axios';
 import { debounce } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as IconSearchV1 } from '../../../assets/svg/search.svg';
 import { ENTITY_PATH } from '../../../constants/constants';
@@ -53,6 +53,7 @@ const SearchPreview = ({
   const [isLoading, setIsLoading] = useState(true);
   const [data, setData] = useState<SearchedDataProps['data']>([]);
   const [searchValue, setSearchValue] = useState<string>('');
+  const latestRequestId = useRef(0);
   const {
     currentPage,
     pageSize,
@@ -75,6 +76,8 @@ const SearchPreview = ({
       searchTerm = searchValue,
     }: { page?: number; searchTerm?: string } = {}) => {
       if (searchConfig && Object.keys(searchConfig).length > 0) {
+        const requestId = latestRequestId.current + 1;
+        latestRequestId.current = requestId;
         try {
           setIsLoading(true);
           const res = await searchPreview({
@@ -86,15 +89,25 @@ const SearchPreview = ({
             searchSettings: searchConfig,
           });
 
+          // Ignore responses from superseded requests so a slow, stale response
+          // can never overwrite the latest preview.
+          if (requestId !== latestRequestId.current) {
+            return;
+          }
+
           const hits = res.hits.hits as unknown as SearchedDataProps['data'];
           const totalCount = res?.hits?.total.value ?? 0;
 
           handlePagingChange({ total: totalCount });
           setData(hits);
         } catch (error) {
-          showErrorToast(error as AxiosError);
+          if (requestId === latestRequestId.current) {
+            showErrorToast(error as AxiosError);
+          }
         } finally {
-          setIsLoading(false);
+          if (requestId === latestRequestId.current) {
+            setIsLoading(false);
+          }
         }
       }
     },
@@ -177,7 +190,8 @@ const SearchPreview = ({
         <Col>
           <Typography.Text
             className="header-title"
-            data-testid="search-preview">
+            data-testid="search-preview"
+          >
             {t('label.preview')}
           </Typography.Text>
         </Col>
@@ -185,7 +199,8 @@ const SearchPreview = ({
           <Button
             className="restore-defaults-btn font-semibold"
             data-testid="restore-defaults-btn"
-            onClick={handleRestoreDefaults}>
+            onClick={handleRestoreDefaults}
+          >
             {t('label.restore-default-plural')}
           </Button>
           <Button
@@ -193,7 +208,8 @@ const SearchPreview = ({
             data-testid="save-btn"
             disabled={disabledSave}
             loading={isSaving}
-            onClick={handleSaveChanges}>
+            onClick={handleSaveChanges}
+          >
             {t('label.save')}
           </Button>
         </Col>


### PR DESCRIPTION
Backport of #30058 to the `1.12.14` branch.

**Fix:** `SearchPreview.fetchAssets` had no latest-wins guard, so a slow `/search/preview` response from an earlier field weight could resolve after a newer one and overwrite it — leaving the preview showing a ranking that did not match the current settings (fixed by save + refresh). Added a monotonic request-id guard that drops responses from superseded requests.

Fix-only backport: the Playwright regression test is on the main PR #30058 (the search-settings test layout/utilities differ on this branch).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves the ranking order shown in search previews. The main changes are:

- Tracks preview requests with a monotonic request ID.
- Prevents superseded responses from updating results or pagination.
- Suppresses stale error and loading-state updates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The latest dispatched request is the only one allowed to update preview state.
- No blocking issue tied to the earlier review was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/SearchSettings/SearchPreview/SearchPreview.tsx | Adds a latest-request guard around preview results, errors, pagination, and loading state. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fixes #27946: preserve search preview ra..."](https://github.com/open-metadata/openmetadata/commit/179c8e4cb43047581f4ffddae9beb85412ff659c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44439537)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->