### PR TITLE
Fixes #30093: database sources own one BaseConnection to avoid a second sign-in

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
@@ -13,8 +13,9 @@ Source connection handler for BurstIQ
 """
 
 import hashlib
-from collections import OrderedDict
 from typing import Optional
+
+from cachetools import LRUCache
 
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
@@ -36,7 +37,7 @@ logger = ingestion_logger()
 
 CLIENT_CACHE_SIZE = 100
 
-_CLIENT_CACHE: "OrderedDict[str, BurstIQClient]" = OrderedDict()
+_CLIENT_CACHE: "LRUCache[str, BurstIQClient]" = LRUCache(maxsize=CLIENT_CACHE_SIZE)
 
 
 class BurstIQConnection(BaseConnection[BurstIQConnectionConfig, BurstIQClient]):
@@ -44,11 +45,11 @@ class BurstIQConnection(BaseConnection[BurstIQConnectionConfig, BurstIQClient]):
         """Return a BurstIQ client, cached by a digest of the serialised config."""
         connection = self.service_connection
         key = hashlib.sha256(connection.model_dump_json().encode()).hexdigest()
-        if key not in _CLIENT_CACHE:
-            _CLIENT_CACHE[key] = BurstIQClient(config=connection)
-            if len(_CLIENT_CACHE) > CLIENT_CACHE_SIZE:
-                _CLIENT_CACHE.popitem(last=False)
-        return _CLIENT_CACHE[key]
+        client = _CLIENT_CACHE.get(key)
+        if client is None:
+            client = BurstIQClient(config=connection)
+            _CLIENT_CACHE[key] = client
+        return client
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
@@ -13,7 +13,8 @@ Source connection handler for BurstIQ
 """
 
 import hashlib
-from typing import Dict, Optional  # noqa: UP035
+from collections import OrderedDict
+from typing import Optional
 
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
@@ -33,29 +34,21 @@ from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 
-_CLIENT_CACHE: Dict[str, BurstIQClient] = {}  # noqa: UP006
+CLIENT_CACHE_SIZE = 100
 
-
-def get_connection(connection: BurstIQConnectionConfig) -> BurstIQClient:
-    """
-    Create or return a cached BurstIQ client connection.
-
-    Caching avoids re-authentication on every table during profiler ingestion,
-    where SamplerInterface.__init__ calls get_ssl_connection once per table.
-    Using id(connection) was unreliable because each table deserialization
-    produces a new object with a different id. A SHA-256 digest of the
-    serialised config is used as the key: collision-resistant but never
-    stores plaintext credentials in the cache keys.
-    """
-    key = hashlib.sha256(connection.model_dump_json().encode()).hexdigest()
-    if key not in _CLIENT_CACHE:
-        _CLIENT_CACHE[key] = BurstIQClient(config=connection)
-    return _CLIENT_CACHE[key]
+_CLIENT_CACHE: "OrderedDict[str, BurstIQClient]" = OrderedDict()
 
 
 class BurstIQConnection(BaseConnection[BurstIQConnectionConfig, BurstIQClient]):
     def _get_client(self) -> BurstIQClient:
-        return get_connection(self.service_connection)
+        """Return a BurstIQ client, cached by a digest of the serialised config."""
+        connection = self.service_connection
+        key = hashlib.sha256(connection.model_dump_json().encode()).hexdigest()
+        if key not in _CLIENT_CACHE:
+            _CLIENT_CACHE[key] = BurstIQClient(config=connection)
+            if len(_CLIENT_CACHE) > CLIENT_CACHE_SIZE:
+                _CLIENT_CACHE.popitem(last=False)
+        return _CLIENT_CACHE[key]
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/burstiq/connection.py
@@ -56,20 +56,7 @@ class BurstIQConnection(BaseConnection[BurstIQConnectionConfig, BurstIQClient]):
         automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
         timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
     ) -> TestConnectionResult:
-        """
-        Test connection to BurstIQ. This can be executed either as part
-        of a metadata workflow or during an Automation Workflow
-
-        Args:
-            metadata: OpenMetadata client
-            client: BurstIQClient instance
-            service_connection: BurstIQConnection configuration
-            automation_workflow: Optional automation workflow
-            timeout_seconds: Timeout for connection test
-
-        Returns:
-            TestConnectionResult
-        """
+        """Test connection to BurstIQ, as a metadata workflow or an Automation Workflow."""
         client = self.client
         service_connection = self.service_connection
 

--- a/ingestion/src/metadata/ingestion/source/database/burstiq/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/burstiq/metadata.py
@@ -13,7 +13,7 @@ BurstIQ LifeGraph source module for OpenMetadata
 """
 
 import traceback
-from typing import Any, Iterable, List, Optional, Tuple  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -57,13 +57,16 @@ from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import create_connection, get_connection
-from metadata.ingestion.source.database.burstiq.client import BurstIQClient
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.burstiq.models import BurstIQDictionary
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_table
 from metadata.utils.logger import ingestion_logger
+
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+    from metadata.ingestion.source.database.burstiq.client import BurstIQClient
 
 logger = ingestion_logger()
 
@@ -80,11 +83,10 @@ class Burstiqsource(DatabaseServiceSource):
         self.metadata = metadata
         self.source_config: DatabaseServiceMetadataPipeline = self.config.sourceConfig.config
         self.service_connection: BurstIQConnection = self.config.serviceConnection.root.config
-        self.client: Optional[BurstIQClient] = None  # noqa: UP045
         self._current_dictionary: Optional[BurstIQDictionary] = None  # noqa: UP045
 
         self._connection = create_connection(self.service_connection)
-        self.connection_obj = self._get_client()
+        self.client: BurstIQClient = cast("BaseConnection", self._connection).client
         try:
             self.test_connection()
         except Exception:
@@ -104,15 +106,6 @@ class Burstiqsource(DatabaseServiceSource):
             raise InvalidSourceException(f"Expected BurstIQConnection, but got {connection}")
         return cls(config, metadata)
 
-    def _get_client(self) -> BurstIQClient:
-        """Get or create BurstIQ client"""
-        if self.client is None:
-            client: BurstIQClient = (
-                self._connection.client if self._connection else get_connection(self.service_connection)
-            )
-            self.client = client
-        return self.client
-
     def _get_current_dictionary(self, table_name: str) -> Optional[BurstIQDictionary]:  # noqa: UP045
         """
         Get the currently cached dictionary for the given table name
@@ -128,7 +121,7 @@ class Burstiqsource(DatabaseServiceSource):
 
         # If not cached or doesn't match, fetch from API
         logger.warning(f"Dictionary for table '{table_name}' not in cache, fetching from API...")
-        client = self._get_client()
+        client = self.client
         return client.get_dictionary_by_name(table_name)
 
     def get_database_names(self) -> Iterable[str]:
@@ -195,8 +188,7 @@ class Burstiqsource(DatabaseServiceSource):
         schema_name = self.context.get().database_schema
         try:
             if self.source_config.includeTables:
-                # Get BurstIQ client
-                client = self._get_client()
+                client = self.client
 
                 # Fetch and iterate dictionaries directly
                 logger.info("Fetching dictionaries from BurstIQ LifeGraph...")
@@ -506,10 +498,5 @@ class Burstiqsource(DatabaseServiceSource):
         return []
 
     def close(self):
-        """
-        Clean up resources
-        """
         self._current_dictionary = None
-        self.client = None
-        if self._connection is not None:
-            self._connection.close()
+        super().close()

--- a/ingestion/src/metadata/ingestion/source/database/burstiq/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/burstiq/metadata.py
@@ -57,8 +57,8 @@ from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.connections import create_connection, get_connection
 from metadata.ingestion.source.database.burstiq.client import BurstIQClient
-from metadata.ingestion.source.database.burstiq.connection import get_connection
 from metadata.ingestion.source.database.burstiq.models import BurstIQDictionary
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.utils import fqn
@@ -83,9 +83,13 @@ class Burstiqsource(DatabaseServiceSource):
         self.client: Optional[BurstIQClient] = None  # noqa: UP045
         self._current_dictionary: Optional[BurstIQDictionary] = None  # noqa: UP045
 
-        # Initialize connection and test it
+        self._connection = create_connection(self.service_connection)
         self.connection_obj = self._get_client()
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     @classmethod
     def create(
@@ -103,7 +107,10 @@ class Burstiqsource(DatabaseServiceSource):
     def _get_client(self) -> BurstIQClient:
         """Get or create BurstIQ client"""
         if self.client is None:
-            self.client = get_connection(self.service_connection)
+            client: BurstIQClient = (
+                self._connection.client if self._connection else get_connection(self.service_connection)
+            )
+            self.client = client
         return self.client
 
     def _get_current_dictionary(self, table_name: str) -> Optional[BurstIQDictionary]:  # noqa: UP045
@@ -502,8 +509,7 @@ class Burstiqsource(DatabaseServiceSource):
         """
         Clean up resources
         """
-        # Clear cached dictionary
         self._current_dictionary = None
-        # Close client if needed (currently no cleanup required for requests.Session)
-        if self.client:
-            self.client = None
+        self.client = None
+        if self._connection is not None:
+            self._connection.close()

--- a/ingestion/src/metadata/ingestion/source/database/common_db_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_db_source.py
@@ -62,7 +62,7 @@ from metadata.ingestion.connections.session import create_and_bind_thread_safe_s
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.models.patch_request import PatchedEntity, PatchRequest
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection, get_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.sql_column_handler import SqlColumnHandlerMixin
 from metadata.ingestion.source.database.sqlalchemy_source import SqlAlchemySource
@@ -119,15 +119,21 @@ class CommonDbSourceService(DatabaseServiceSource, SqlColumnHandlerMixin, SqlAlc
         if self.ssl_manager:
             self.service_connection = self.ssl_manager.setup_ssl(self.service_connection)
 
-        self.engine: Engine = get_connection(self.service_connection)
+        self._connection_map = {}  # Lazy init as well
+        self._inspector_map = {}
+
+        self._connection = create_connection(self.service_connection)
+        self.engine: Engine = self._connection.client if self._connection else get_connection(self.service_connection)
         self.session = create_and_bind_thread_safe_session(self.engine)
 
         # Flag the connection for the test connection
         self.connection_obj = self.engine
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
-        self._connection_map = {}  # Lazy init as well
-        self._inspector_map = {}
         self.table_constraints = None
         self.database_source_state = set()
         self.context.get_global().table_constrains = []
@@ -147,7 +153,8 @@ class CommonDbSourceService(DatabaseServiceSource, SqlColumnHandlerMixin, SqlAlc
 
         new_service_connection = deepcopy(self.service_connection)
         new_service_connection.database = database_name
-        self.engine = get_connection(new_service_connection)
+        self._connection = create_connection(new_service_connection)
+        self.engine = self._connection.client if self._connection else get_connection(new_service_connection)
         self.session = create_and_bind_thread_safe_session(self.engine)
         self.connection_obj = self.engine
 
@@ -178,6 +185,9 @@ class CommonDbSourceService(DatabaseServiceSource, SqlColumnHandlerMixin, SqlAlc
             logger.error(f"Failed to dispose engine: {exc}")
         self.engine = None
         self.connection_obj = None
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
 
     def get_database_names(self) -> Iterable[str]:
         """

--- a/ingestion/src/metadata/ingestion/source/database/common_nosql_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/common_nosql_source.py
@@ -47,7 +47,7 @@ from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntit
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection, get_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
 from metadata.utils import fqn
@@ -90,9 +90,14 @@ class CommonNoSQLSource(DatabaseServiceSource, ABC):
         self.ssl_manager = check_ssl_and_init(self.service_connection)
         if self.ssl_manager:
             self.service_connection = self.ssl_manager.setup_ssl(self.service_connection)
-        self.connection_obj = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.connection_obj = self._connection.client if self._connection else get_connection(self.service_connection)
 
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     def prepare(self):
         """
@@ -332,6 +337,5 @@ class CommonNoSQLSource(DatabaseServiceSource, ABC):
         """
 
     def close(self):
-        """
-        By default there is nothing to close
-        """
+        if self._connection is not None:
+            self._connection.close()

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -902,3 +902,8 @@ class DatabaseServiceSource(TopologyRunnerMixin, Source, ABC):  # pylint: disabl
             run_test_connection(self.metadata, self._connection)
         else:
             test_connection_common(self.metadata, self.connection_obj, self.service_connection)
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -59,6 +59,7 @@ from metadata.ingestion.api.delete import delete_entity_from_source
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import Source
 from metadata.ingestion.api.topology_runner import TopologyRunnerMixin
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.models.life_cycle import OMetaLifeCycleData
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.models.topology import (
@@ -68,7 +69,7 @@ from metadata.ingestion.models.topology import (
     TopologyNode,
 )
 from metadata.ingestion.ometa.utils import model_str
-from metadata.ingestion.source.connections import test_connection_common
+from metadata.ingestion.source.connections import run_test_connection, test_connection_common
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_stored_procedure
 from metadata.utils.logger import ingestion_logger
@@ -215,6 +216,10 @@ class DatabaseServiceSource(TopologyRunnerMixin, Source, ABC):  # pylint: disabl
 
     # When processing the database, the source will update the inspector if needed
     inspector: Inspector
+
+    # Set by sources that own their connection lifecycle; `None` keeps the
+    # legacy `connection_obj` test path for non-migrated sources.
+    _connection: Optional[BaseConnection] = None  # noqa: UP045
 
     topology = DatabaseServiceTopology()
     context = TopologyContextManager(topology)
@@ -893,4 +898,7 @@ class DatabaseServiceSource(TopologyRunnerMixin, Source, ABC):  # pylint: disabl
         """
 
     def test_connection(self) -> None:
-        test_connection_common(self.metadata, self.connection_obj, self.service_connection)
+        if self._connection is not None:
+            run_test_connection(self.metadata, self._connection)
+        else:
+            test_connection_common(self.metadata, self.connection_obj, self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -45,6 +45,9 @@ from metadata.core.connections.test_connection.network import (
 from metadata.generated.schema.entity.services.connections.database.databricksConnection import (
     DatabricksConnection as DatabricksConnectionConfig,
 )
+from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
+    UnityCatalogConnection as UnityCatalogConnectionConfig,
+)
 from metadata.ingestion.connections.builders import (
     create_generic_db_connection,
     get_connection_args_common,
@@ -55,6 +58,7 @@ from metadata.ingestion.source.database.databricks.auth import (
     get_auth_config,
     normalize_host_port,
 )
+from metadata.ingestion.source.database.databricks.client import DatabricksClient
 from metadata.ingestion.source.database.databricks.log_filters import (
     suppress_user_agent_entry_deprecation_log,
 )
@@ -382,17 +386,37 @@ class DatabricksChecks:
         return run_sql(self._db.client, TEST_COLUMN_LINEAGE, lambda _: "column lineage accessible")
 
 
+class DatabricksApiConnection(
+    BaseConnection[DatabricksConnectionConfig | UnityCatalogConnectionConfig, DatabricksClient]
+):
+    """Owns the Databricks REST client (Jobs, query-history, and lineage APIs):
+    a separate lifetime from the SQL engine, shared by the databricks and Unity
+    Catalog sources."""
+
+    def _get_client(self) -> DatabricksClient:
+        # No pooled resource to close: uses the ``requests`` module, not a Session.
+        return DatabricksClient(self.service_connection)
+
+
 class DatabricksConnection(BaseConnection[DatabricksConnectionConfig, Engine]):
     def __init__(self, service_connection: DatabricksConnectionConfig) -> None:
         super().__init__(service_connection)
         # Honor the user-facing connectionTimeout (default 120s) as the per-step
         # budget; a cold serverless warehouse can exceed the 60s framework default.
         self.step_timeout_seconds = service_connection.connectionTimeout or STEP_TIMEOUT_SECONDS
+        # A sub-owner, not a client: constructing it opens nothing.
+        self.api = DatabricksApiConnection(service_connection)
 
     def _get_client(self) -> Engine:
         engine = get_connection(self.service_connection)
         self._on_close(engine.dispose)
         return engine
+
+    def close(self) -> None:
+        # Not _on_close: that registry is reset by close(), so a sub-owner
+        # registered once would not be released on a later reuse cycle.
+        self.api.close()
+        super().close()
 
     def checks(self) -> ChecksProvider:
         return DatabricksChecks(

--- a/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
@@ -14,7 +14,7 @@ import json
 import re
 import traceback
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union, cast  # noqa: UP035
 
 from sqlalchemy import exc, text, types, util
 from sqlalchemy.engine import Connection, reflection
@@ -48,9 +48,6 @@ from metadata.ingestion.source.database.column_type_parser import create_sqlalch
 from metadata.ingestion.source.database.common_db_source import (
     CommonDbSourceService,
     TableNameAndType,
-)
-from metadata.ingestion.source.database.databricks.connection import (
-    DatabricksConnection as DatabricksConnectionHandler,  # noqa: TC001
 )
 from metadata.ingestion.source.database.databricks.models import (
     ColumnDescriptions,
@@ -93,6 +90,12 @@ from metadata.utils.sqlalchemy_utils import (
     get_view_definition_wrapper,
 )
 from metadata.utils.tag_utils import get_ometa_tag_and_classification
+
+if TYPE_CHECKING:
+    from metadata.ingestion.source.database.databricks.connection import (
+        DatabricksConnection as DatabricksConnectionHandler,
+    )
+
 
 logger = ingestion_logger()
 

--- a/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/metadata.py
@@ -14,7 +14,7 @@ import json
 import re
 import traceback
 from copy import deepcopy
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union  # noqa: UP035
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, cast  # noqa: UP035
 
 from sqlalchemy import exc, text, types, util
 from sqlalchemy.engine import Connection, reflection
@@ -49,7 +49,9 @@ from metadata.ingestion.source.database.common_db_source import (
     CommonDbSourceService,
     TableNameAndType,
 )
-from metadata.ingestion.source.database.databricks.client import DatabricksClient
+from metadata.ingestion.source.database.databricks.connection import (
+    DatabricksConnection as DatabricksConnectionHandler,  # noqa: TC001
+)
 from metadata.ingestion.source.database.databricks.models import (
     ColumnDescriptions,
     DescribeJsonPayload,
@@ -848,7 +850,7 @@ class DatabricksSource(ExternalTableLineageMixin, CommonDbSourceService, MultiDB
         self.table_tags = {}
         self.external_location_map = {}
         self.column_tags = {}
-        self.api_client = DatabricksClient(self.service_connection)
+        self.api_client = cast("DatabricksConnectionHandler", self._connection).api.client
         self.owner_resolver = DatabricksOwnerResolver(
             api_client=self.api_client,
             metadata=self.metadata,

--- a/ingestion/src/metadata/ingestion/source/database/datalake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/connection.py
@@ -53,22 +53,25 @@ class DatalakeConnection(BaseConnection[DatalakeConnectionConfig, DatalakeBaseCl
                 DatalakeS3Client,
             )
 
-            return DatalakeS3Client.from_config(connection.configSource)
-        elif isinstance(connection.configSource, GCSConfig):  # noqa: RET505
+            client: DatalakeBaseClient = DatalakeS3Client.from_config(connection.configSource)
+        elif isinstance(connection.configSource, GCSConfig):
             from metadata.ingestion.source.database.datalake.clients.gcs import (  # noqa: PLC0415
                 DatalakeGcsClient,
             )
 
-            return DatalakeGcsClient.from_config(connection.configSource)
+            client = DatalakeGcsClient.from_config(connection.configSource)
         elif isinstance(connection.configSource, AzureConfig):
             from metadata.ingestion.source.database.datalake.clients.azure_blob import (  # noqa: PLC0415
                 DatalakeAzureBlobClient,
             )
 
-            return DatalakeAzureBlobClient.from_config(connection.configSource)
+            client = DatalakeAzureBlobClient.from_config(connection.configSource)
         else:
             msg = f"Config not implemented for type {type(connection.configSource)}: {connection.configSource}"
             raise NotImplementedError(msg)
+
+        self._on_close(lambda: client.close(self.service_connection))
+        return client
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -16,7 +16,7 @@ DataLake connector to fetch metadata from a files stored s3, gcs and Hdfs
 import json
 import traceback
 from hashlib import md5
-from typing import Any, Iterable, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -50,9 +50,10 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
 from metadata.ingestion.source.storage.storage_service import (
@@ -88,12 +89,17 @@ class DatalakeSource(DatabaseServiceSource):
         self.source_config: DatabaseServiceMetadataPipeline = self.config.sourceConfig.config
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
-        self.client = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.client = cast("BaseConnection", self._connection).client
         self.table_constraints = None
         self.database_source_state = set()
         self.config_source = self.service_connection.configSource
         self.connection_obj = self.client
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
         self.reader = get_reader(config_source=self.config_source, client=self.client.client)
 
     @classmethod

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -356,9 +356,3 @@ class DatalakeSource(DatabaseServiceSource):
             )
             return True
         return False
-
-    def close(self):
-        self.client.close(self.service_connection)
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -16,7 +16,7 @@ DataLake connector to fetch metadata from a files stored s3, gcs and Hdfs
 import json
 import traceback
 from hashlib import md5
-from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -50,7 +50,6 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import create_connection
@@ -71,6 +70,10 @@ from metadata.utils.datalake.datalake_utils import (
 )
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_table
 from metadata.utils.logger import ingestion_logger
+
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+
 
 logger = ingestion_logger()
 
@@ -94,7 +97,6 @@ class DatalakeSource(DatabaseServiceSource):
         self.table_constraints = None
         self.database_source_state = set()
         self.config_source = self.service_connection.configSource
-        self.connection_obj = self.client
         try:
             self.test_connection()
         except Exception:

--- a/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/metadata.py
@@ -359,3 +359,6 @@ class DatalakeSource(DatabaseServiceSource):
 
     def close(self):
         self.client.close(self.service_connection)
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -268,8 +268,3 @@ class DeltalakeSource(DatabaseServiceSource):
 
     def get_stored_procedure_queries(self) -> Iterable[QueryByProcedure]:
         """Not Implemented"""
-
-    def close(self):
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -270,4 +270,6 @@ class DeltalakeSource(DatabaseServiceSource):
         """Not Implemented"""
 
     def close(self):
-        """No client to close"""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -13,7 +13,7 @@ Deltalake source methods.
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -41,9 +41,10 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
 from metadata.utils import fqn
@@ -77,11 +78,16 @@ class DeltalakeSource(DatabaseServiceSource):
         self.metadata = metadata
 
         self.service_connection = self.config.serviceConnection.root.config
-        self.connection = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.connection = cast("BaseConnection", self._connection).client
         self.client = self.connection.client
 
         self.connection_obj = self.connection
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     @classmethod
     def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045

--- a/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/deltalake/metadata.py
@@ -13,7 +13,7 @@ Deltalake source methods.
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -41,7 +41,6 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import create_connection
@@ -50,6 +49,10 @@ from metadata.ingestion.source.database.stored_procedures_mixin import QueryByPr
 from metadata.utils import fqn
 from metadata.utils.filters import filter_by_schema, filter_by_table
 from metadata.utils.logger import ingestion_logger
+
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+
 
 logger = ingestion_logger()
 
@@ -82,7 +85,6 @@ class DeltalakeSource(DatabaseServiceSource):
         self.connection = cast("BaseConnection", self._connection).client
         self.client = self.connection.client
 
-        self.connection_obj = self.connection
         try:
             self.test_connection()
         except Exception:

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -295,8 +295,3 @@ class DomodatabaseSource(DatabaseServiceSource):
         self, schema: str, table: str
     ) -> str:
         return table
-
-    def close(self) -> None:
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -297,4 +297,6 @@ class DomodatabaseSource(DatabaseServiceSource):
         return table
 
     def close(self) -> None:
-        """Nothing to close"""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -14,7 +14,7 @@ Domo Database source to extract metadata
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -48,9 +48,10 @@ from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntit
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.domodatabase.models import (
     OutputDataset,
@@ -81,9 +82,14 @@ class DomodatabaseSource(DatabaseServiceSource):
         self.source_config: DatabaseServiceMetadataPipeline = self.config.sourceConfig.config
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
-        self.domo_client = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.domo_client = cast("BaseConnection", self._connection).client
         self.connection_obj = self.domo_client
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     @classmethod
     def create(

--- a/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/domodatabase/metadata.py
@@ -14,7 +14,7 @@ Domo Database source to extract metadata
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -48,7 +48,6 @@ from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntit
 from metadata.generated.schema.type.entityReferenceList import EntityReferenceList
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import create_connection
@@ -67,6 +66,10 @@ from metadata.utils.filters import filter_by_table
 from metadata.utils.helpers import clean_uri
 from metadata.utils.logger import ingestion_logger
 
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+
+
 logger = ingestion_logger()
 
 
@@ -84,7 +87,6 @@ class DomodatabaseSource(DatabaseServiceSource):
         self.service_connection = self.config.serviceConnection.root.config
         self._connection = create_connection(self.service_connection)
         self.domo_client = cast("BaseConnection", self._connection).client
-        self.connection_obj = self.domo_client
         try:
             self.test_connection()
         except Exception:

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -491,8 +491,3 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
             logger.debug(traceback.format_exc())
             logger.error(f"Unable to get source url: {exc}")
         return None
-
-    def close(self):
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -493,4 +493,6 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
         return None
 
     def close(self):
-        """Nothing to close"""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -13,7 +13,7 @@ Glue source methods.
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -50,7 +50,6 @@ from metadata.generated.schema.type.basic import (
 )
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import create_connection
@@ -71,6 +70,10 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_table
 from metadata.utils.logger import ingestion_logger
 
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+
+
 logger = ingestion_logger()
 
 
@@ -89,7 +92,6 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
         self._connection = create_connection(self.service_connection)
         self.glue = cast("BaseConnection", self._connection).client
 
-        self.connection_obj = self.glue
         self.schema_description_map = {}
         self.external_location_map = {}
         try:

--- a/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/metadata.py
@@ -13,7 +13,7 @@ Glue source methods.
 """
 
 import traceback
-from typing import Any, Iterable, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -50,9 +50,10 @@ from metadata.generated.schema.type.basic import (
 )
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.column_helpers import truncate_column_name
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
@@ -85,12 +86,17 @@ class GlueSource(ExternalTableLineageMixin, DatabaseServiceSource):
         self.source_config: DatabaseServiceMetadataPipeline = self.config.sourceConfig.config
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
-        self.glue = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.glue = cast("BaseConnection", self._connection).client
 
         self.connection_obj = self.glue
         self.schema_description_map = {}
         self.external_location_map = {}
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     @classmethod
     def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -368,8 +368,3 @@ class SalesforceSource(DatabaseServiceSource):
             logger.debug(traceback.format_exc())
             logger.warning(f"Unable to get source url for {table_name}: {exc}")
         return None
-
-    def close(self):
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -370,4 +370,6 @@ class SalesforceSource(DatabaseServiceSource):
         return None
 
     def close(self):
-        """Nothing to close"""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -81,6 +81,11 @@ class SalesforceSource(DatabaseServiceSource):
             self.service_connection = self.ssl_manager.setup_ssl(self.service_connection)
         self._connection = create_connection(self.service_connection)
         self.client = cast("BaseConnection", self._connection).client
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
         self.table_constraints = None
         self.database_source_state = set()
 

--- a/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py
@@ -13,7 +13,7 @@ Salesforce source ingestion
 """
 
 import traceback
-from typing import Any, Iterable, List, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
@@ -47,12 +47,10 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import EntityName, FullyQualifiedEntityName
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.test_connections import (
-    raise_test_connection_exception,
-)
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection, get_test_connection_fn
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
 from metadata.utils import fqn
@@ -81,7 +79,8 @@ class SalesforceSource(DatabaseServiceSource):
         self.ssl_manager: SSLManager = check_ssl_and_init(self.service_connection)
         if self.ssl_manager:
             self.service_connection = self.ssl_manager.setup_ssl(self.service_connection)
-        self.client = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.client = cast("BaseConnection", self._connection).client
         self.table_constraints = None
         self.database_source_state = set()
 
@@ -372,8 +371,3 @@ class SalesforceSource(DatabaseServiceSource):
 
     def close(self):
         """Nothing to close"""
-
-    def test_connection(self) -> None:
-        test_connection_fn = get_test_connection_fn(self.service_connection)
-        result = test_connection_fn(self.client, self.service_connection)
-        raise_test_connection_exception(result)

--- a/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
@@ -930,8 +930,3 @@ class SasSource(DatabaseServiceSource):  # pylint: disable=too-many-instance-att
 
     def yield_stored_procedure(self, stored_procedure: Any) -> Iterable[Either[CreateStoredProcedureRequest]]:
         """Not implemented"""
-
-    def close(self) -> None:
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
@@ -932,4 +932,6 @@ class SasSource(DatabaseServiceSource):  # pylint: disable=too-many-instance-att
         """Not implemented"""
 
     def close(self) -> None:
-        pass
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None

--- a/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
@@ -20,7 +20,7 @@ import re
 import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Iterable, Optional, Tuple  # noqa: UP035
+from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from requests.exceptions import HTTPError
 
@@ -71,9 +71,10 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.common import Entity
 from metadata.ingestion.api.models import Either, StackTraceError
 from metadata.ingestion.api.steps import InvalidSourceException
+from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection, test_connection_common
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
 from metadata.ingestion.source.database.sas.client import SASClient
@@ -179,9 +180,14 @@ class SasSource(DatabaseServiceSource):  # pylint: disable=too-many-instance-att
         self.source_config: DatabaseServiceMetadataPipeline = self.config.sourceConfig.config
         self.service_connection = self.config.serviceConnection.root.config
 
-        self.sas_client = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.sas_client = cast("BaseConnection", self._connection).client
         self.connection_obj = self.sas_client
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
         self.db_service_name = self.config.serviceName
         self.db_name = None
@@ -927,6 +933,3 @@ class SasSource(DatabaseServiceSource):  # pylint: disable=too-many-instance-att
 
     def close(self) -> None:
         pass
-
-    def test_connection(self) -> None:
-        test_connection_common(self.metadata, self.connection_obj, self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/sas/metadata.py
@@ -20,7 +20,7 @@ import re
 import traceback
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Iterable, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple, cast  # noqa: UP035
 
 from requests.exceptions import HTTPError
 
@@ -71,7 +71,6 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.common import Entity
 from metadata.ingestion.api.models import Either, StackTraceError
 from metadata.ingestion.api.steps import InvalidSourceException
-from metadata.ingestion.connections.connection import BaseConnection  # noqa: TC001
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import create_connection
@@ -81,6 +80,10 @@ from metadata.ingestion.source.database.sas.client import SASClient
 from metadata.ingestion.source.database.sas.extension_attr import TABLE_CUSTOM_ATTR
 from metadata.utils import fqn
 from metadata.utils.logger import ingestion_logger
+
+if TYPE_CHECKING:
+    from metadata.ingestion.connections.connection import BaseConnection
+
 
 logger = ingestion_logger()
 
@@ -182,7 +185,6 @@ class SasSource(DatabaseServiceSource):  # pylint: disable=too-many-instance-att
 
         self._connection = create_connection(self.service_connection)
         self.sas_client = cast("BaseConnection", self._connection).client
-        self.connection_obj = self.sas_client
         try:
             self.test_connection()
         except Exception:

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -455,8 +455,7 @@ class UnityCatalogChecks:
 
 
 class UnityCatalogSqlConnection(BaseConnection[UnityCatalogConnectionConfig, Engine]):
-    """Owns the SQL-warehouse Engine: a separate lifetime from the workspace client,
-    reached only by the lineage and tag steps and never built without an httpPath."""
+    """Owns the SQL-warehouse Engine: a separate lifetime from the workspace client."""
 
     def _get_client(self) -> Engine:
         engine = get_sqlalchemy_connection(self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -67,6 +67,9 @@ from metadata.ingestion.source.database.databricks.auth import (
     get_auth_config,
     normalize_host_port,
 )
+from metadata.ingestion.source.database.databricks.connection import (
+    DatabricksApiConnection,
+)
 from metadata.ingestion.source.database.databricks.log_filters import (
     suppress_user_agent_entry_deprecation_log,
 )
@@ -467,8 +470,9 @@ class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, Worksp
         # Honor the user-facing connectionTimeout as the per-step budget; a cold
         # serverless warehouse can exceed the framework default.
         self.step_timeout_seconds = service_connection.connectionTimeout or STEP_TIMEOUT_SECONDS
-        # A sub-owner, not a client: constructing it opens nothing.
+        # Sub-owners, not clients: constructing them opens nothing.
         self.sql = UnityCatalogSqlConnection(service_connection)
+        self.api = DatabricksApiConnection(service_connection)
 
     def _get_client(self) -> WorkspaceClient:
         return get_connection(self.service_connection)
@@ -476,6 +480,7 @@ class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, Worksp
     def close(self) -> None:
         # Not _on_close: that registry is reset by close(), so a sub-owner
         # registered once would not be released on a later reuse cycle.
+        self.api.close()
         self.sql.close()
         super().close()
 

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -14,7 +14,7 @@ Databricks Unity Catalog Lineage Source Module
 
 import traceback
 from collections import defaultdict
-from typing import Iterable, Optional  # noqa: UP035
+from typing import Iterable, Optional, cast  # noqa: UP035
 
 from sqlalchemy import text
 
@@ -40,10 +40,13 @@ from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException, Source
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import test_connection_common
+from metadata.ingestion.source.connections import (
+    create_connection,
+    run_test_connection,
+    test_connection_common,
+)
 from metadata.ingestion.source.database.unitycatalog.connection import (
-    get_connection,
-    get_sqlalchemy_connection,
+    UnityCatalogConnection as UnityCatalogConnectionHandler,  # noqa: TC001
 )
 from metadata.ingestion.source.database.unitycatalog.queries import (
     UNITY_CATALOG_COLUMN_LINEAGE,
@@ -74,17 +77,22 @@ class UnitycatalogLineageSource(Source):
         self.metadata = metadata
         self.service_connection = self.config.serviceConnection.root.config
         self.source_config = self.config.sourceConfig.config
-        self.connection_obj = get_connection(self.service_connection)
-        self.engine = get_sqlalchemy_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        connection = cast("UnityCatalogConnectionHandler", self._connection)
+        self.connection_obj = connection.client
+        self.engine = connection.sql.client
         self.table_lineage_map: dict[str, set[str]] = defaultdict(set)
         self.column_lineage_map: dict[tuple[str, str], list[tuple[str, str]]] = defaultdict(list)
         self.external_location_map: dict[str, str] = {}
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     def close(self):
-        """
-        By default, there is nothing to close
-        """
+        if self._connection is not None:
+            self._connection.close()
 
     def prepare(self):
         """
@@ -341,4 +349,7 @@ class UnitycatalogLineageSource(Source):
                     yield from self._process_external_location_lineage(table, databricks_table_fqn)
 
     def test_connection(self) -> None:
-        test_connection_common(self.metadata, self.connection_obj, self.service_connection)
+        if self._connection is not None:
+            run_test_connection(self.metadata, self._connection)
+        else:
+            test_connection_common(self.metadata, self.connection_obj, self.service_connection)

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/lineage.py
@@ -14,7 +14,7 @@ Databricks Unity Catalog Lineage Source Module
 
 import traceback
 from collections import defaultdict
-from typing import Iterable, Optional, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Iterable, Optional, cast  # noqa: UP035
 
 from sqlalchemy import text
 
@@ -45,9 +45,6 @@ from metadata.ingestion.source.connections import (
     run_test_connection,
     test_connection_common,
 )
-from metadata.ingestion.source.database.unitycatalog.connection import (
-    UnityCatalogConnection as UnityCatalogConnectionHandler,  # noqa: TC001
-)
 from metadata.ingestion.source.database.unitycatalog.queries import (
     UNITY_CATALOG_COLUMN_LINEAGE,
     UNITY_CATALOG_EXTERNAL_TABLES,
@@ -57,6 +54,12 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database, filter_by_schema, filter_by_table
 from metadata.utils.helpers import retry_with_docker_host
 from metadata.utils.logger import ingestion_logger
+
+if TYPE_CHECKING:
+    from metadata.ingestion.source.database.unitycatalog.connection import (
+        UnityCatalogConnection as UnityCatalogConnectionHandler,
+    )
+
 
 logger = ingestion_logger()
 

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -16,7 +16,7 @@ import json
 import traceback
 from functools import partial
 from threading import RLock
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
 from databricks.sdk.service.catalog import ColumnInfo
 from databricks.sdk.service.catalog import TableConstraint as DBTableConstraint
@@ -78,9 +78,6 @@ from metadata.ingestion.source.database.incremental_metadata_extraction import (
 )
 from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
-from metadata.ingestion.source.database.unitycatalog.connection import (
-    UnityCatalogConnection as UnityCatalogConnectionHandler,  # noqa: TC001
-)
 from metadata.ingestion.source.database.unitycatalog.incremental_table_processor import (
     UnityCatalogIncrementalTableProcessor,
 )
@@ -103,6 +100,12 @@ from metadata.utils.filters import filter_by_database, filter_by_schema, filter_
 from metadata.utils.helpers import retry_with_docker_host
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.tag_utils import get_ometa_tag_and_classification
+
+if TYPE_CHECKING:
+    from metadata.ingestion.source.database.unitycatalog.connection import (
+        UnityCatalogConnection as UnityCatalogConnectionHandler,
+    )
+
 
 logger = ingestion_logger()
 

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/metadata.py
@@ -16,7 +16,7 @@ import json
 import traceback
 from functools import partial
 from threading import RLock
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple  # noqa: UP035
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
 from databricks.sdk.service.catalog import ColumnInfo
 from databricks.sdk.service.catalog import TableConstraint as DBTableConstraint
@@ -64,9 +64,9 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.progress.modes import TotalsDeclarer
+from metadata.ingestion.source.connections import create_connection
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DatabaseServiceSource
-from metadata.ingestion.source.database.databricks.client import DatabricksClient
 from metadata.ingestion.source.database.databricks.ownership import (
     DatabricksOwnerResolver,
 )
@@ -79,8 +79,7 @@ from metadata.ingestion.source.database.incremental_metadata_extraction import (
 from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.source.database.stored_procedures_mixin import QueryByProcedure
 from metadata.ingestion.source.database.unitycatalog.connection import (
-    get_connection,
-    get_sqlalchemy_connection,
+    UnityCatalogConnection as UnityCatalogConnectionHandler,  # noqa: TC001
 )
 from metadata.ingestion.source.database.unitycatalog.incremental_table_processor import (
     UnityCatalogIncrementalTableProcessor,
@@ -136,7 +135,9 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
         self.service_connection: UnityCatalogConnection = self.config.serviceConnection.root.config
         self._state_lock = RLock()
         self.external_location_map = {}
-        self.client = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        connection = cast("UnityCatalogConnectionHandler", self._connection)
+        self.client = connection.client
         self.connection_obj = self.client
         self.table_constraints = []
         self.context.storage_location = None
@@ -144,7 +145,7 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
         self._catalog_cache: dict[str, Any] = {}
         self._schema_cache: dict[tuple[str, str], Any] = {}
         self.owner_resolver = DatabricksOwnerResolver(
-            api_client=DatabricksClient(self.service_connection),
+            api_client=connection.api.client,
             metadata=self.metadata,
             include_owners=self.source_config.includeOwners,
         )
@@ -158,10 +159,14 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
                 self.incremental.start_datetime_utc,
             )
 
-        self.test_connection()
-
         self._sql_connection_map = {}
-        self.engine = get_sqlalchemy_connection(self.service_connection)
+        self.engine = connection.sql.client
+
+        try:
+            self.test_connection()
+        except Exception:
+            self.close()
+            raise
 
     @property
     def sql_connection(self) -> Connection:
@@ -877,8 +882,8 @@ class UnitycatalogSource(ExternalTableLineageMixin, DatabaseServiceSource, Multi
             sql_connections = list(self._sql_connection_map.values())
         for sql_connection in sql_connections:
             sql_connection.close()
-        if self.engine:
-            self.engine.dispose()
+        if self._connection is not None:
+            self._connection.close()
 
     # pylint: disable=arguments-renamed
     def get_owner_ref(self, owner: Optional[str]) -> Optional[EntityReferenceList]:  # noqa: UP045

--- a/ingestion/tests/unit/source/database/test_common_db_source_connection.py
+++ b/ingestion/tests/unit/source/database/test_common_db_source_connection.py
@@ -1,0 +1,87 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""CommonDbSourceService owns a single BaseConnection and reuses it for the
+test-connection step."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.database.mysql.metadata import MysqlSource
+from metadata.ingestion.source.database.postgres.metadata import PostgresSource
+
+MYSQL_CONFIG = {
+    "type": "mysql",
+    "serviceName": "local_mysql",
+    "serviceConnection": {
+        "config": {
+            "type": "Mysql",
+            "username": "openmetadata_user",
+            "authType": {"password": "openmetadata_password"},
+            "hostPort": "mysql-host:3306",
+        }
+    },
+    "sourceConfig": {"config": {"type": "DatabaseMetadata"}},
+}
+
+POSTGRES_CONFIG = {
+    "type": "postgres",
+    "serviceName": "local_postgres",
+    "serviceConnection": {
+        "config": {
+            "type": "Postgres",
+            "username": "openmetadata_user",
+            "authType": {"password": "openmetadata_password"},
+            "hostPort": "postgres-host:5432",
+            "database": "postgres",
+        }
+    },
+    "sourceConfig": {"config": {"type": "DatabaseMetadata"}},
+}
+
+
+@pytest.fixture
+def owned_connection():
+    with patch("metadata.ingestion.source.database.common_db_source.create_connection") as mock_create_connection:
+        yield mock_create_connection.return_value
+
+
+def test_owned_connection_reused_for_test_connection(owned_connection):
+    with patch("metadata.ingestion.source.database.database_service.run_test_connection") as mock_run_test_connection:
+        source = MysqlSource.create(MYSQL_CONFIG, MagicMock())
+
+    assert source.engine is owned_connection.client
+    mock_run_test_connection.assert_called_once_with(source.metadata, owned_connection)
+
+
+def test_owned_connection_closed_when_test_connection_fails(owned_connection):
+    with (
+        patch(
+            "metadata.ingestion.source.database.database_service.run_test_connection",
+            side_effect=RuntimeError("cannot connect"),
+        ),
+        pytest.raises(RuntimeError),
+    ):
+        MysqlSource.create(MYSQL_CONFIG, MagicMock())
+
+    owned_connection.close.assert_called_once()
+
+
+def test_set_inspector_disposes_previous_connection(owned_connection):
+    with patch("metadata.ingestion.source.database.database_service.run_test_connection"):
+        source = PostgresSource.create(POSTGRES_CONFIG, MagicMock())
+
+    previous_engine = source.engine
+    source.set_inspector("other_db")
+
+    previous_engine.dispose.assert_called_once()
+    owned_connection.close.assert_called_once()
+    assert source._connection is owned_connection

--- a/ingestion/tests/unit/source/database/test_leaf_sources_inherit_base_test_connection.py
+++ b/ingestion/tests/unit/source/database/test_leaf_sources_inherit_base_test_connection.py
@@ -1,0 +1,38 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Leaf database sources that own a BaseConnection must reuse it for the test
+step by inheriting ``DatabaseServiceSource.test_connection`` — never a private
+override that would build a second client."""
+
+import pytest
+
+from metadata.ingestion.source.database.database_service import DatabaseServiceSource
+from metadata.ingestion.source.database.datalake.metadata import DatalakeSource
+from metadata.ingestion.source.database.deltalake.metadata import DeltalakeSource
+from metadata.ingestion.source.database.domodatabase.metadata import DomodatabaseSource
+from metadata.ingestion.source.database.glue.metadata import GlueSource
+from metadata.ingestion.source.database.salesforce.metadata import SalesforceSource
+from metadata.ingestion.source.database.sas.metadata import SasSource
+
+OWNED_LEAF_SOURCES = [
+    DatalakeSource,
+    DeltalakeSource,
+    DomodatabaseSource,
+    GlueSource,
+    SalesforceSource,
+    SasSource,
+]
+
+
+@pytest.mark.parametrize("source_cls", OWNED_LEAF_SOURCES)
+def test_leaf_source_inherits_base_test_connection(source_cls):
+    assert source_cls.test_connection is DatabaseServiceSource.test_connection
+    assert "test_connection" not in source_cls.__dict__

--- a/ingestion/tests/unit/source/database/test_leaf_sources_inherit_base_test_connection.py
+++ b/ingestion/tests/unit/source/database/test_leaf_sources_inherit_base_test_connection.py
@@ -36,3 +36,9 @@ OWNED_LEAF_SOURCES = [
 def test_leaf_source_inherits_base_test_connection(source_cls):
     assert source_cls.test_connection is DatabaseServiceSource.test_connection
     assert "test_connection" not in source_cls.__dict__
+
+
+@pytest.mark.parametrize("source_cls", OWNED_LEAF_SOURCES)
+def test_leaf_source_releases_owner_via_base_close(source_cls):
+    assert source_cls.close is DatabaseServiceSource.close
+    assert "close" not in source_cls.__dict__

--- a/ingestion/tests/unit/test_handle_partitions.py
+++ b/ingestion/tests/unit/test_handle_partitions.py
@@ -164,7 +164,7 @@ class BigqueryUnitTest(TestCase):
     @patch("metadata.ingestion.connections.builders.create_generic_db_connection")
     @patch("metadata.ingestion.source.database.bigquery.metadata.BigquerySource.set_project_id")
     @patch("metadata.ingestion.source.database.bigquery.metadata.BigquerySource._test_connection")
-    @patch("metadata.ingestion.source.database.common_db_source.get_connection")
+    @patch("metadata.ingestion.source.database.common_db_source.create_connection")
     def __init__(
         self,
         methodName,  # noqa: N803

--- a/ingestion/tests/unit/topology/database/test_burstiq_connection.py
+++ b/ingestion/tests/unit/topology/database/test_burstiq_connection.py
@@ -18,7 +18,9 @@ from unittest.mock import Mock, patch
 from metadata.generated.schema.entity.services.connections.database.burstIQConnection import (
     BurstIQConnection,
 )
-from metadata.ingestion.source.database.burstiq.connection import get_connection
+from metadata.ingestion.source.database.burstiq.connection import (
+    BurstIQConnection as BurstIQConnectionHandler,
+)
 
 
 class TestBurstIQConnection(TestCase):
@@ -41,13 +43,13 @@ class TestBurstIQConnection(TestCase):
 
     @patch("metadata.ingestion.source.database.burstiq.client.requests.post")
     def test_get_connection(self, mock_post):
-        """Test get_connection creates BurstIQClient properly"""
+        """Test the connection handler creates BurstIQClient properly"""
         mock_response = Mock()
         mock_response.json.return_value = self.mock_token_response
         mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
-        client = get_connection(self.config)
+        client = BurstIQConnectionHandler(self.config).client
 
         # Verify client was created
         self.assertIsNotNone(client)
@@ -196,7 +198,7 @@ class TestBurstIQConnection(TestCase):
         mock_post.return_value = mock_response
 
         # Should raise exception when authentication is attempted
-        client = get_connection(self.config)
+        client = BurstIQConnectionHandler(self.config).client
         with self.assertRaises(Exception) as context:
             client.test_authenticate()
 

--- a/ingestion/tests/unit/topology/database/test_db2.py
+++ b/ingestion/tests/unit/topology/database/test_db2.py
@@ -202,7 +202,7 @@ class Db2UnitTest(TestCase):
     Db2 Unit Test
     """
 
-    @patch("metadata.ingestion.source.database.common_db_source.get_connection")
+    @patch("metadata.ingestion.source.database.common_db_source.create_connection")
     @patch("metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection")
     def __init__(
         self,

--- a/ingestion/tests/unit/topology/database/test_doris.py
+++ b/ingestion/tests/unit/topology/database/test_doris.py
@@ -59,7 +59,7 @@ mock_doris_config = {
 
 
 class DorisUnitTest(TestCase):
-    @patch("metadata.ingestion.source.database.common_db_source.get_connection")
+    @patch("metadata.ingestion.source.database.common_db_source.create_connection")
     @patch("metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection")
     def __init__(self, methodName, test_connection, get_connection) -> None:  # noqa: N803
         super().__init__(methodName)

--- a/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_unity_catalog_lineage.py
@@ -73,12 +73,11 @@ def lineage_source():
     with (
         patch("metadata.ingestion.source.database.unitycatalog.lineage.UnitycatalogLineageSource.test_connection"),
         patch("metadata.ingestion.ometa.ometa_api.OpenMetadata") as mock_metadata,
-        patch("metadata.ingestion.source.database.unitycatalog.lineage.get_sqlalchemy_connection") as mock_engine,
-        patch("metadata.ingestion.source.database.unitycatalog.lineage.get_connection"),
+        patch("metadata.ingestion.source.database.unitycatalog.lineage.create_connection") as mock_create_connection,
     ):
         config = WorkflowSource.model_validate(MOCK_CONFIG["source"])
         source = UnitycatalogLineageSource(config, mock_metadata)
-        source.engine = mock_engine.return_value
+        source.engine = mock_create_connection.return_value.sql.client
         yield source
 
 

--- a/ingestion/tests/unit/topology/database/test_unitycatalog_incremental.py
+++ b/ingestion/tests/unit/topology/database/test_unitycatalog_incremental.py
@@ -142,9 +142,7 @@ class TestUnityCatalogIncrementalSource:
 
         try:
             with (
-                patch(f"{UC_METADATA_MODULE}.get_connection", return_value=Mock()),
-                patch(f"{UC_METADATA_MODULE}.DatabricksClient", return_value=Mock()),
-                patch(f"{UC_METADATA_MODULE}.get_sqlalchemy_connection", return_value=Mock()),
+                patch(f"{UC_METADATA_MODULE}.create_connection", return_value=Mock()),
                 patch.object(UnitycatalogSource, "test_connection", return_value=None),
             ):
                 source = UnitycatalogSource(config, metadata, incremental)


### PR DESCRIPTION
Fixes #30093

Database sources built their working client in `__init__` and then a second, throwaway connection for the startup test-connection step. On single-session auth (Tableau PATs, some OAuth) the second sign-in invalidated the first, so ingestion 401'd after the test reported success. This is the database slice of the source-owns-BaseConnection work (dashboard: #29870).

## What
Every database source now owns one `self._connection` `BaseConnection` and reuses it for `test_connection()`:

- `CommonDbSourceService` / `CommonNoSQLSource` bases (all engine + NoSQL sources); `set_inspector` swaps the per-database owner, disposing the previous one.
- The six leaf sources that extend `DatabaseServiceSource` directly and built a raw client — datalake, deltalake, domodatabase, glue, salesforce, sas. salesforce/sas drop their `test_connection` overrides so they inherit the base (which routes through the owned connection); this also fixes salesforce's double *login*.
- Unity Catalog (metadata + lineage) and burstiq.

`connection_obj` and `test_connection_common` stay as compat surfaces for non-migrated / custom connectors.

## How
- Unity Catalog's source engine now comes from the owner's SQL sub-owner (`_connection.sql.client`) instead of a second `get_sqlalchemy_connection` build, so the warehouse connection is created once and reused by the test-connection checks.
- The raw `DatabricksClient` (REST API) becomes an owned `DatabricksApiConnection` sub-owner on `DatabricksConnection` and `UnityCatalogConnection`.
- burstiq's module-level `get_connection` is inlined into `_get_client` and its client cache bounded; other connectors keep their `get_connection` (used by their own `_get_client`, and databricks downstream).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR gives database sources one lifecycle-owned connection and reuses it for startup checks. The main changes are:

- Shared ownership and cleanup in the database source bases.
- Owned connections for the migrated leaf sources.
- SQL and REST sub-owners for Databricks and Unity Catalog.
- Bounded BurstIQ client caching.
- Tests for connection reuse, cleanup, and inherited behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated leaf sources now close their owners during normal shutdown.
- Failed startup checks close the retained owner before propagating the error.
- Datalake cleanup is registered with the owner instead of relying on the removed source override.
- No blocking issue remains in the reviewed fixes.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/database_service.py | Adds shared testing and cleanup for lifecycle-owned connections. |
| ingestion/src/metadata/ingestion/source/database/common_db_source.py | Reuses an owned connection and closes it when switching databases or shutting down. |
| ingestion/src/metadata/ingestion/source/database/datalake/connection.py | Registers datalake client cleanup with the connection owner. |
| ingestion/src/metadata/ingestion/source/database/salesforce/metadata.py | Reuses one authenticated owner for startup testing and ingestion. |
| ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py | Adds owned SQL and REST sub-connections with coordinated cleanup. |

</details>

<sub>Reviews (7): Last reviewed commit: ["address review: close-on-failure guard i..."](https://github.com/open-metadata/openmetadata/commit/ce7df5a5567a8b940057e04eb81e4a71660190be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44463093)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->