### PR TITLE
feat(ingestion): add GetPipelines step to the shared pipeline test-connection vertical

### DIFF
--- a/ingestion/src/metadata/core/connections/test_connection/checks/pipeline.py
+++ b/ingestion/src/metadata/core/connections/test_connection/checks/pipeline.py
@@ -44,6 +44,7 @@ class PipelineStep(StepName):
     CheckAccess = "CheckAccess"
     GetJobs = "GetJobs"
     GetRuns = "GetRuns"
+    GetPipelines = "GetPipelines"
 
 
 def _count(number: int, noun: str, cap: int | None = None) -> str:


### PR DESCRIPTION
## What

Adds a `GetPipelines` member to the shared `PipelineStep` enum (`metadata/core/connections/test_connection/checks/pipeline.py`).

## Why

Pipeline connectors whose primary listable unit is a *pipeline* rather than a *job* — e.g. Microsoft Fabric Data Factory — can now name their list step `GetPipelines` accurately, instead of reusing `GetJobs`. Their seeded `testConnections` definitions already declare a `GetPipelines` step, so this lets the connector's `@check` resolve against it through the shared vertical rather than a connector-local `StepName` subclass.

Greenfield-safe: no existing connector or test-connection definition references `GetPipelines`, so nothing changes for `CheckAccess`/`GetJobs`/`GetRuns` connectors.

First consumer: the Microsoft Fabric Pipeline connector (Collate `ingestion-extension`) test-connection migration.

Not for merge — for review.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared step name for pipeline-oriented connection checks. The main change is:

- Adds `GetPipelines` to the string-valued `PipelineStep` enum.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The shared runner resolves configured step names against string-valued enum members.
- Existing pipeline checks and definitions keep their current behavior.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/core/connections/test_connection/checks/pipeline.py | Adds `GetPipelines` using the same string-enum pattern as the existing shared pipeline steps. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ingestion): add GetPipelines step t..."](https://github.com/open-metadata/openmetadata/commit/81b8e1d52555e1737cb1ea9ef7c8a3b88de67ebd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44469089)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->