### PR TITLE
fix(llm): restore the generic LLMCompletionClient layer (over-removed by #30041)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -124,6 +124,7 @@ import org.openmetadata.service.jobs.JobDAO;
 import org.openmetadata.service.jobs.JobHandlerRegistry;
 import org.openmetadata.service.limits.DefaultLimits;
 import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.llm.LLMClientHolder;
 import org.openmetadata.service.logging.SwitchableAccessLayoutFactory;
 import org.openmetadata.service.logging.SwitchableEventLayoutFactory;
 import org.openmetadata.service.migration.MigrationValidationClient;
@@ -265,6 +266,7 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
 
     // Publish the platform-wide LLM configuration for features that need completions
     LlmConfigHolder.initialize(catalogConfig.getLlmConfiguration());
+    LLMClientHolder.initialize(catalogConfig.getLlmConfiguration());
 
     // init for dataSourceFactory
     DatasourceConfig.initialize(catalogConfig.getDataSourceFactory().getDriverClass());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/AnthropicCompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/AnthropicCompletionClient.java
@@ -1,0 +1,129 @@
+package org.openmetadata.service.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMAnthropicConfig;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+
+/** Anthropic Messages API chat-completion client. */
+@Slf4j
+public final class AnthropicCompletionClient extends LLMCompletionClient {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String ANTHROPIC_VERSION = "2023-06-01";
+  private static final String DEFAULT_BASE_URL = "https://api.anthropic.com";
+
+  private final HttpClient httpClient;
+  private final String apiKey;
+  private final String modelId;
+  private final String endpoint;
+  private final double temperature;
+  private final int maxTokens;
+  private final int timeoutSeconds;
+
+  public AnthropicCompletionClient(LLMConfiguration config) {
+    super(resolveMaxConcurrent(config));
+    LLMAnthropicConfig cfg = config.getAnthropic();
+    if (cfg == null || cfg.getApiKey() == null || cfg.getApiKey().isBlank()) {
+      throw new IllegalArgumentException("Anthropic API key is required for LLM completion");
+    }
+    this.apiKey = cfg.getApiKey();
+    this.modelId = cfg.getModelId();
+    this.temperature = cfg.getTemperature() == null ? 0.0 : cfg.getTemperature();
+    this.maxTokens = cfg.getMaxTokens() == null ? 4096 : cfg.getMaxTokens();
+    this.timeoutSeconds = cfg.getTimeoutSeconds() == null ? 60 : cfg.getTimeoutSeconds();
+    String base =
+        cfg.getBaseUrl() == null || cfg.getBaseUrl().isBlank()
+            ? DEFAULT_BASE_URL
+            : cfg.getBaseUrl().replaceAll("/+$", "");
+    this.endpoint = base + "/v1/messages";
+    this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+  }
+
+  @Override
+  protected CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    String model = options.modelIdOr(this.modelId);
+    int tokens = options.maxTokensOr(this.maxTokens);
+    double temp = options.temperatureOr(this.temperature);
+    int timeout = options.timeoutSecondsOr(this.timeoutSeconds);
+    CompletionResult result;
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(endpoint))
+              .header("Content-Type", "application/json")
+              .header("x-api-key", apiKey)
+              .header("anthropic-version", ANTHROPIC_VERSION)
+              .timeout(Duration.ofSeconds(timeout))
+              .POST(
+                  HttpRequest.BodyPublishers.ofString(
+                      buildRequestBody(systemPrompt, userPrompt, model, tokens, temp)))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new LLMCompletionException(
+            "Anthropic API returned status " + response.statusCode() + ": " + response.body());
+      }
+      result = parseResult(response.body());
+    } catch (IOException e) {
+      throw new LLMCompletionException("Anthropic completion failed due to IO error", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new LLMCompletionException("Anthropic completion was interrupted", e);
+    }
+    return result;
+  }
+
+  static String buildRequestBody(
+      String systemPrompt, String userPrompt, String model, int maxTokens, double temperature) {
+    String result;
+    try {
+      ObjectNode payload = MAPPER.createObjectNode();
+      payload.put("model", model);
+      payload.put("max_tokens", maxTokens);
+      payload.put("temperature", temperature);
+      payload.put("system", systemPrompt);
+      ArrayNode messages = payload.putArray("messages");
+      messages.addObject().put("role", "user").put("content", userPrompt);
+      result = MAPPER.writeValueAsString(payload);
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to build Anthropic request body", e);
+    }
+    return result;
+  }
+
+  static CompletionResult parseResult(String responseBody) {
+    CompletionResult result;
+    try {
+      JsonNode root = MAPPER.readTree(responseBody);
+      JsonNode text = root.path("content").path(0).path("text");
+      if (!text.isTextual()) {
+        throw new LLMCompletionException("Invalid Anthropic response: no text content returned");
+      }
+      JsonNode usage = root.path("usage");
+      result =
+          new CompletionResult(
+              text.asText(),
+              usage.path("input_tokens").asInt(0),
+              usage.path("output_tokens").asInt(0));
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to parse Anthropic response", e);
+    }
+    return result;
+  }
+
+  @Override
+  public String getModelId() {
+    return modelId;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/BedrockCompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/BedrockCompletionClient.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.llm;
+
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMBedrockConfig;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.security.credentials.AWSBaseConfig;
+import org.openmetadata.service.util.AwsCredentialsUtil;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.InferenceConfiguration;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.SystemContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+/** AWS Bedrock chat-completion client (Converse API — works with all Bedrock model families). */
+@Slf4j
+public final class BedrockCompletionClient extends LLMCompletionClient implements AutoCloseable {
+
+  private final BedrockRuntimeClient bedrockClient;
+  private final String modelId;
+  private final double temperature;
+  private final int maxTokens;
+  private final int timeoutSeconds;
+
+  public BedrockCompletionClient(LLMConfiguration config) {
+    super(resolveMaxConcurrent(config));
+    LLMBedrockConfig cfg = config.getBedrock();
+    if (cfg == null) {
+      throw new IllegalArgumentException("Bedrock configuration is required for LLM completion");
+    }
+    AWSBaseConfig awsConfig = cfg.getAwsConfig();
+    if (awsConfig == null || awsConfig.getRegion() == null || awsConfig.getRegion().isBlank()) {
+      throw new IllegalArgumentException("AWS region is required for Bedrock completion");
+    }
+    this.modelId = cfg.getModelId();
+    this.temperature = cfg.getTemperature() == null ? 0.0 : cfg.getTemperature();
+    this.maxTokens = cfg.getMaxTokens() == null ? 4096 : cfg.getMaxTokens();
+    this.timeoutSeconds = cfg.getTimeoutSeconds() == null ? 60 : cfg.getTimeoutSeconds();
+    this.bedrockClient =
+        BedrockRuntimeClient.builder()
+            .credentialsProvider(AwsCredentialsUtil.buildCredentialsProvider(awsConfig))
+            .region(Region.of(awsConfig.getRegion()))
+            .overrideConfiguration(AwsCredentialsUtil.throttleResilientOverrideConfiguration())
+            .build();
+  }
+
+  @Override
+  protected CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    String model = options.modelIdOr(this.modelId);
+    int tokens = options.maxTokensOr(this.maxTokens);
+    double temp = options.temperatureOr(this.temperature);
+    int timeout = options.timeoutSecondsOr(this.timeoutSeconds);
+    CompletionResult result;
+    try {
+      ConverseResponse response =
+          bedrockClient.converse(
+              buildRequest(model, systemPrompt, userPrompt, tokens, temp, timeout));
+      result = toResult(response);
+    } catch (AwsServiceException | SdkClientException e) {
+      throw new LLMCompletionException("Bedrock completion failed", e);
+    }
+    return result;
+  }
+
+  static ConverseRequest buildRequest(
+      String model,
+      String systemPrompt,
+      String userPrompt,
+      int maxTokens,
+      double temperature,
+      int timeoutSeconds) {
+    return ConverseRequest.builder()
+        .modelId(model)
+        .system(SystemContentBlock.fromText(systemPrompt))
+        .messages(
+            Message.builder()
+                .role(ConversationRole.USER)
+                .content(ContentBlock.fromText(userPrompt))
+                .build())
+        .inferenceConfig(
+            InferenceConfiguration.builder()
+                .maxTokens(maxTokens)
+                .temperature((float) temperature)
+                .build())
+        .overrideConfiguration(c -> c.apiCallTimeout(Duration.ofSeconds(timeoutSeconds)))
+        .build();
+  }
+
+  static CompletionResult toResult(ConverseResponse response) {
+    String text = extractText(response);
+    if (text.isEmpty()) {
+      throw new LLMCompletionException("Invalid Bedrock response: no text content returned");
+    }
+    TokenUsage usage = response.usage();
+    int inputTokens = usage != null && usage.inputTokens() != null ? usage.inputTokens() : 0;
+    int outputTokens = usage != null && usage.outputTokens() != null ? usage.outputTokens() : 0;
+    return new CompletionResult(text, inputTokens, outputTokens);
+  }
+
+  private static String extractText(ConverseResponse response) {
+    StringBuilder text = new StringBuilder();
+    if (response.output() != null && response.output().message() != null) {
+      for (ContentBlock block : response.output().message().content()) {
+        if (block.text() != null) {
+          text.append(block.text());
+        }
+      }
+    }
+    return text.toString();
+  }
+
+  @Override
+  public String getModelId() {
+    return modelId;
+  }
+
+  @Override
+  public void close() {
+    if (bedrockClient != null) {
+      bedrockClient.close();
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/CompletionOptions.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/CompletionOptions.java
@@ -1,0 +1,28 @@
+package org.openmetadata.service.llm;
+
+/**
+ * Optional per-call overrides for a single completion. Any null field falls back to the
+ * provider client's configured default (from {@code llmConfiguration}). Use {@link #NONE} to
+ * request the configured defaults.
+ */
+public record CompletionOptions(
+    String modelId, Integer maxTokens, Double temperature, Integer timeoutSeconds) {
+
+  public static final CompletionOptions NONE = new CompletionOptions(null, null, null, null);
+
+  public String modelIdOr(String fallback) {
+    return modelId != null ? modelId : fallback;
+  }
+
+  public int maxTokensOr(int fallback) {
+    return maxTokens != null ? maxTokens : fallback;
+  }
+
+  public double temperatureOr(double fallback) {
+    return temperature != null ? temperature : fallback;
+  }
+
+  public int timeoutSecondsOr(int fallback) {
+    return timeoutSeconds != null ? timeoutSeconds : fallback;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/CompletionResult.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/CompletionResult.java
@@ -1,0 +1,4 @@
+package org.openmetadata.service.llm;
+
+/** Provider-neutral completion result carrying the model text and token usage. */
+public record CompletionResult(String text, int inputTokens, int outputTokens) {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/GoogleCompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/GoogleCompletionClient.java
@@ -1,0 +1,134 @@
+package org.openmetadata.service.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMGoogleConfig;
+
+/** Google Gemini chat-completion client (generateContent). Mirrors GoogleEmbeddingClient. */
+@Slf4j
+public final class GoogleCompletionClient extends LLMCompletionClient {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String DEFAULT_BASE =
+      "https://generativelanguage.googleapis.com/v1beta/models";
+
+  private final HttpClient httpClient;
+  private final String apiKey;
+  private final String modelId;
+  private final String base;
+  private final double temperature;
+  private final int maxTokens;
+  private final int timeoutSeconds;
+
+  public GoogleCompletionClient(LLMConfiguration config) {
+    super(resolveMaxConcurrent(config));
+    LLMGoogleConfig cfg = config.getGoogle();
+    if (cfg == null || cfg.getApiKey() == null || cfg.getApiKey().isBlank()) {
+      throw new IllegalArgumentException("Google API key is required for LLM completion");
+    }
+    this.apiKey = cfg.getApiKey();
+    this.modelId = cfg.getModelId();
+    this.temperature = cfg.getTemperature() == null ? 0.0 : cfg.getTemperature();
+    this.maxTokens = cfg.getMaxTokens() == null ? 4096 : cfg.getMaxTokens();
+    this.timeoutSeconds = cfg.getTimeoutSeconds() == null ? 60 : cfg.getTimeoutSeconds();
+    // API key travels in a header, never the URL, so it can't leak via logged URIs or
+    // exception messages that include the endpoint.
+    this.base =
+        cfg.getEndpoint() == null || cfg.getEndpoint().isBlank()
+            ? DEFAULT_BASE
+            : cfg.getEndpoint().replaceAll("/+$", "");
+    this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+  }
+
+  @Override
+  protected CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    String model = options.modelIdOr(this.modelId);
+    int tokens = options.maxTokensOr(this.maxTokens);
+    double temp = options.temperatureOr(this.temperature);
+    int timeout = options.timeoutSecondsOr(this.timeoutSeconds);
+    String url = String.format("%s/%s:generateContent", base, model);
+    CompletionResult result;
+    try {
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(url))
+              .header("Content-Type", "application/json")
+              .header("x-goog-api-key", apiKey)
+              .timeout(Duration.ofSeconds(timeout))
+              .POST(
+                  HttpRequest.BodyPublishers.ofString(
+                      buildRequestBody(systemPrompt, userPrompt, tokens, temp)))
+              .build();
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new LLMCompletionException(
+            "Google API returned status " + response.statusCode() + ": " + response.body());
+      }
+      result = parseResult(response.body());
+    } catch (IOException e) {
+      throw new LLMCompletionException("Google completion failed due to IO error", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new LLMCompletionException("Google completion was interrupted", e);
+    }
+    return result;
+  }
+
+  static String buildRequestBody(
+      String systemPrompt, String userPrompt, int maxTokens, double temperature) {
+    String result;
+    try {
+      ObjectNode payload = MAPPER.createObjectNode();
+      ObjectNode systemInstruction = payload.putObject("system_instruction");
+      systemInstruction.putArray("parts").addObject().put("text", systemPrompt);
+      ArrayNode contents = payload.putArray("contents");
+      ObjectNode userContent = contents.addObject();
+      userContent.put("role", "user");
+      userContent.putArray("parts").addObject().put("text", userPrompt);
+      ObjectNode generationConfig = payload.putObject("generationConfig");
+      generationConfig.put("temperature", temperature);
+      generationConfig.put("maxOutputTokens", maxTokens);
+      result = MAPPER.writeValueAsString(payload);
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to build Google request body", e);
+    }
+    return result;
+  }
+
+  static CompletionResult parseResult(String responseBody) {
+    CompletionResult result;
+    try {
+      JsonNode root = MAPPER.readTree(responseBody);
+      JsonNode text =
+          root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
+      if (!text.isTextual()) {
+        throw new LLMCompletionException("Invalid Google response: no text content returned");
+      }
+      JsonNode usage = root.path("usageMetadata");
+      result =
+          new CompletionResult(
+              text.asText(),
+              usage.path("promptTokenCount").asInt(0),
+              usage.path("candidatesTokenCount").asInt(0));
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to parse Google response", e);
+    }
+    return result;
+  }
+
+  @Override
+  public String getModelId() {
+    return modelId;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMClientHolder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMClientHolder.java
@@ -1,0 +1,38 @@
+package org.openmetadata.service.llm;
+
+import org.openmetadata.schema.configuration.LLMConfiguration;
+
+/**
+ * Holds the single shared {@link LLMCompletionClient} built from {@code llmConfiguration} at
+ * startup, so downstream features (e.g. Context Center pill extraction) need not thread the config
+ * through every layer. Falls back to a {@link NoopCompletionClient} when unset or disabled.
+ */
+public final class LLMClientHolder {
+  private static volatile LLMCompletionClient instance;
+  private static volatile boolean enabled;
+
+  private LLMClientHolder() {}
+
+  public static synchronized void initialize(LLMConfiguration config) {
+    enabled = config != null && Boolean.TRUE.equals(config.getEnabled());
+    instance = enabled ? LLMCompletionClientFactory.create(config) : new NoopCompletionClient();
+  }
+
+  public static LLMCompletionClient get() {
+    LLMCompletionClient current = instance;
+    if (current == null) {
+      current = new NoopCompletionClient();
+    }
+    return current;
+  }
+
+  public static boolean isEnabled() {
+    return enabled;
+  }
+
+  /** Test seam: inject a deterministic completion client (and force-enable) for integration tests. */
+  public static synchronized void setForTesting(LLMCompletionClient client) {
+    instance = client;
+    enabled = client != null;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClient.java
@@ -1,0 +1,107 @@
+package org.openmetadata.service.llm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+
+/**
+ * Generic, concurrency-bounded chat/completion client. Mirrors {@code EmbeddingClient}: a fixed
+ * permit pool guards provider rate limits, and {@link #completeStructured} parses the model's JSON
+ * array response into typed records (with a single retry on malformed JSON).
+ */
+@Slf4j
+public abstract class LLMCompletionClient {
+  static final int DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final Semaphore concurrencyLimiter;
+
+  protected LLMCompletionClient(int maxConcurrentRequests) {
+    if (maxConcurrentRequests < 1) {
+      throw new IllegalArgumentException(
+          "maxConcurrentRequests must be >= 1, but was " + maxConcurrentRequests);
+    }
+    this.concurrencyLimiter = new Semaphore(maxConcurrentRequests);
+  }
+
+  protected abstract CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options);
+
+  public abstract String getModelId();
+
+  public final CompletionResult complete(String systemPrompt, String userPrompt) {
+    return complete(systemPrompt, userPrompt, CompletionOptions.NONE);
+  }
+
+  public final CompletionResult complete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    acquirePermit();
+    CompletionResult result;
+    try {
+      result = doComplete(systemPrompt, userPrompt, options);
+    } finally {
+      concurrencyLimiter.release();
+    }
+    return result;
+  }
+
+  public final <T> List<T> completeStructured(
+      String systemPrompt, String userPrompt, Class<T> elementType) {
+    List<T> parsed;
+    try {
+      parsed = parseArray(complete(systemPrompt, userPrompt).text(), elementType);
+    } catch (LLMCompletionException firstFailure) {
+      LOG.warn("LLM returned unparseable JSON; retrying once", firstFailure);
+      parsed = parseArray(complete(systemPrompt, userPrompt).text(), elementType);
+    }
+    return parsed;
+  }
+
+  private void acquirePermit() {
+    try {
+      concurrencyLimiter.acquire();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new LLMCompletionException("LLM completion interrupted while waiting for a permit", e);
+    }
+  }
+
+  private <T> List<T> parseArray(String json, Class<T> elementType) {
+    String cleaned = stripCodeFence(json);
+    List<T> result;
+    try {
+      result =
+          MAPPER.readValue(
+              cleaned, MAPPER.getTypeFactory().constructCollectionType(List.class, elementType));
+    } catch (JsonProcessingException e) {
+      throw new LLMCompletionException("Failed to parse LLM JSON array response", e);
+    }
+    return result;
+  }
+
+  private String stripCodeFence(String raw) {
+    String trimmed = raw == null ? "" : raw.trim();
+    String result = trimmed;
+    if (trimmed.startsWith("```")) {
+      int firstNewline = trimmed.indexOf('\n');
+      int lastFence = trimmed.lastIndexOf("```");
+      if (firstNewline > 0 && lastFence > firstNewline) {
+        result = trimmed.substring(firstNewline + 1, lastFence).trim();
+      }
+    }
+    return result;
+  }
+
+  protected static int resolveMaxConcurrent(LLMConfiguration config) {
+    int result = DEFAULT_MAX_CONCURRENT_REQUESTS;
+    if (config != null
+        && config.getMaxConcurrentRequests() != null
+        && config.getMaxConcurrentRequests() > 0) {
+      result = config.getMaxConcurrentRequests();
+    }
+    return result;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClientFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClientFactory.java
@@ -1,0 +1,24 @@
+package org.openmetadata.service.llm;
+
+import org.openmetadata.schema.configuration.LLMConfiguration;
+
+public final class LLMCompletionClientFactory {
+  private LLMCompletionClientFactory() {}
+
+  public static LLMCompletionClient create(LLMConfiguration config) {
+    LLMCompletionClient client;
+    if (config == null || config.getProvider() == null) {
+      client = new NoopCompletionClient();
+    } else {
+      client =
+          switch (config.getProvider()) {
+            case OPENAI, AZURE_OPENAI -> new OpenAICompletionClient(config);
+            case BEDROCK -> new BedrockCompletionClient(config);
+            case GOOGLE -> new GoogleCompletionClient(config);
+            case ANTHROPIC -> new AnthropicCompletionClient(config);
+            case NOOP -> new NoopCompletionClient();
+          };
+    }
+    return client;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionException.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionException.java
@@ -1,0 +1,11 @@
+package org.openmetadata.service.llm;
+
+public class LLMCompletionException extends RuntimeException {
+  public LLMCompletionException(String message) {
+    super(message);
+  }
+
+  public LLMCompletionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/NoopCompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/NoopCompletionClient.java
@@ -1,0 +1,19 @@
+package org.openmetadata.service.llm;
+
+/** No-op client used when LLM completion is disabled or in tests. Returns an empty pill array. */
+public class NoopCompletionClient extends LLMCompletionClient {
+  public NoopCompletionClient() {
+    super(1);
+  }
+
+  @Override
+  protected CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    return new CompletionResult("[]", 0, 0);
+  }
+
+  @Override
+  public String getModelId() {
+    return "noop";
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/llm/OpenAICompletionClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/llm/OpenAICompletionClient.java
@@ -1,0 +1,151 @@
+package org.openmetadata.service.llm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMOpenAIConfig;
+
+/** OpenAI (and Azure OpenAI) chat-completion client. Mirrors {@code OpenAIEmbeddingClient}. */
+@Slf4j
+public final class OpenAICompletionClient extends LLMCompletionClient {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String DEFAULT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+  private final HttpClient httpClient;
+  private final String apiKey;
+  private final String modelId;
+  private final String endpoint;
+  private final boolean isAzure;
+  private final double temperature;
+  private final int maxTokens;
+  private final int timeoutSeconds;
+
+  public OpenAICompletionClient(LLMConfiguration config) {
+    super(resolveMaxConcurrent(config));
+    LLMOpenAIConfig cfg = config.getOpenai();
+    if (cfg == null || cfg.getApiKey() == null || cfg.getApiKey().isBlank()) {
+      throw new IllegalArgumentException("OpenAI API key is required for LLM completion");
+    }
+    this.apiKey = cfg.getApiKey();
+    this.modelId = cfg.getModelId();
+    this.temperature = cfg.getTemperature() == null ? 0.0 : cfg.getTemperature();
+    this.maxTokens = cfg.getMaxTokens() == null ? 4096 : cfg.getMaxTokens();
+    this.timeoutSeconds = cfg.getTimeoutSeconds() == null ? 60 : cfg.getTimeoutSeconds();
+    boolean hasEndpoint = cfg.getEndpoint() != null && !cfg.getEndpoint().isBlank();
+    boolean hasDeployment = cfg.getDeploymentName() != null && !cfg.getDeploymentName().isBlank();
+    this.isAzure = hasEndpoint && hasDeployment;
+    this.endpoint = resolveEndpoint(cfg);
+    this.httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).build();
+  }
+
+  private String resolveEndpoint(LLMOpenAIConfig cfg) {
+    String configured = cfg.getEndpoint();
+    boolean hasEndpoint = configured != null && !configured.isBlank();
+    boolean hasDeployment = cfg.getDeploymentName() != null && !cfg.getDeploymentName().isBlank();
+    String result = DEFAULT_ENDPOINT;
+    if (hasEndpoint && hasDeployment) {
+      String base = configured.replaceAll("/+$", "");
+      result =
+          String.format(
+              "%s/openai/deployments/%s/chat/completions?api-version=%s",
+              base, cfg.getDeploymentName(), cfg.getApiVersion());
+    } else if (hasEndpoint) {
+      result = configured.replaceAll("/+$", "") + "/chat/completions";
+    }
+    return result;
+  }
+
+  @Override
+  protected CompletionResult doComplete(
+      String systemPrompt, String userPrompt, CompletionOptions options) {
+    String model = options.modelIdOr(this.modelId);
+    int tokens = options.maxTokensOr(this.maxTokens);
+    double temp = options.temperatureOr(this.temperature);
+    int timeout = options.timeoutSecondsOr(this.timeoutSeconds);
+    CompletionResult result;
+    try {
+      HttpRequest request =
+          buildRequest(buildRequestBody(systemPrompt, userPrompt, model, tokens, temp), timeout);
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+      if (response.statusCode() != 200) {
+        throw new LLMCompletionException(
+            "OpenAI API returned status " + response.statusCode() + ": " + response.body());
+      }
+      result = parseResult(response.body());
+    } catch (IOException e) {
+      throw new LLMCompletionException("OpenAI completion failed due to IO error", e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new LLMCompletionException("OpenAI completion was interrupted", e);
+    }
+    return result;
+  }
+
+  private HttpRequest buildRequest(String body, int timeoutSeconds) {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder()
+            .uri(URI.create(endpoint))
+            .header("Content-Type", "application/json")
+            .timeout(Duration.ofSeconds(timeoutSeconds))
+            .POST(HttpRequest.BodyPublishers.ofString(body));
+    if (isAzure) {
+      builder.header("api-key", apiKey);
+    } else {
+      builder.header("Authorization", "Bearer " + apiKey);
+    }
+    return builder.build();
+  }
+
+  static String buildRequestBody(
+      String systemPrompt, String userPrompt, String model, int maxTokens, double temperature) {
+    String result;
+    try {
+      ObjectNode payload = MAPPER.createObjectNode();
+      payload.put("model", model);
+      payload.put("temperature", temperature);
+      payload.put("max_tokens", maxTokens);
+      ArrayNode messages = payload.putArray("messages");
+      messages.addObject().put("role", "system").put("content", systemPrompt);
+      messages.addObject().put("role", "user").put("content", userPrompt);
+      result = MAPPER.writeValueAsString(payload);
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to build OpenAI request body", e);
+    }
+    return result;
+  }
+
+  static CompletionResult parseResult(String responseBody) {
+    CompletionResult result;
+    try {
+      JsonNode root = MAPPER.readTree(responseBody);
+      JsonNode content = root.path("choices").path(0).path("message").path("content");
+      if (!content.isTextual()) {
+        throw new LLMCompletionException("Invalid OpenAI response: no message content returned");
+      }
+      JsonNode usage = root.path("usage");
+      result =
+          new CompletionResult(
+              content.asText(),
+              usage.path("prompt_tokens").asInt(0),
+              usage.path("completion_tokens").asInt(0));
+    } catch (IOException e) {
+      throw new LLMCompletionException("Failed to parse OpenAI response", e);
+    }
+    return result;
+  }
+
+  @Override
+  public String getModelId() {
+    return modelId;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/AnthropicCompletionClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/AnthropicCompletionClientTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class AnthropicCompletionClientTest {
+
+  private static final String RESPONSE =
+      "{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}],"
+          + "\"usage\":{\"input_tokens\":21,\"output_tokens\":4}}";
+
+  @Test
+  void parsesTextAndUsage() {
+    CompletionResult result = AnthropicCompletionClient.parseResult(RESPONSE);
+    assertEquals("hi", result.text());
+    assertEquals(21, result.inputTokens());
+    assertEquals(4, result.outputTokens());
+  }
+
+  @Test
+  void requestBodyHonorsOverrides() {
+    String body = AnthropicCompletionClient.buildRequestBody("sys", "user", "claude-x", 256, 0.0);
+    assertTrue(body.contains("\"model\":\"claude-x\""));
+    assertTrue(body.contains("\"max_tokens\":256"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/BedrockCompletionClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/BedrockCompletionClientTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.bedrockruntime.model.ContentBlock;
+import software.amazon.awssdk.services.bedrockruntime.model.ConversationRole;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseOutput;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseRequest;
+import software.amazon.awssdk.services.bedrockruntime.model.ConverseResponse;
+import software.amazon.awssdk.services.bedrockruntime.model.Message;
+import software.amazon.awssdk.services.bedrockruntime.model.TokenUsage;
+
+class BedrockCompletionClientTest {
+
+  @Test
+  void parsesTextAndUsage() {
+    ConverseResponse response =
+        ConverseResponse.builder()
+            .output(
+                ConverseOutput.fromMessage(
+                    Message.builder()
+                        .role(ConversationRole.ASSISTANT)
+                        .content(ContentBlock.fromText("ok"))
+                        .build()))
+            .usage(TokenUsage.builder().inputTokens(30).outputTokens(9).build())
+            .build();
+    CompletionResult result = BedrockCompletionClient.toResult(response);
+    assertEquals("ok", result.text());
+    assertEquals(30, result.inputTokens());
+    assertEquals(9, result.outputTokens());
+  }
+
+  @Test
+  void requestHonorsOverrides() {
+    ConverseRequest request =
+        BedrockCompletionClient.buildRequest("override-model", "sys", "user", 256, 0.0, 15);
+    assertEquals("override-model", request.modelId());
+    assertEquals(256, request.inferenceConfig().maxTokens());
+    assertEquals(0.0f, request.inferenceConfig().temperature(), 0.0001f);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/CompletionOptionsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/CompletionOptionsTest.java
@@ -1,0 +1,26 @@
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class CompletionOptionsTest {
+
+  @Test
+  void noneReturnsAllFallbacks() {
+    CompletionOptions none = CompletionOptions.NONE;
+    assertEquals("default-model", none.modelIdOr("default-model"));
+    assertEquals(4096, none.maxTokensOr(4096));
+    assertEquals(0.0, none.temperatureOr(0.0));
+    assertEquals(60, none.timeoutSecondsOr(60));
+  }
+
+  @Test
+  void presentValuesOverrideFallbacks() {
+    CompletionOptions opts = new CompletionOptions("nlq-model", 256, 0.2, 15);
+    assertEquals("nlq-model", opts.modelIdOr("default-model"));
+    assertEquals(256, opts.maxTokensOr(4096));
+    assertEquals(0.2, opts.temperatureOr(0.0));
+    assertEquals(15, opts.timeoutSecondsOr(60));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/GoogleCompletionClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/GoogleCompletionClientTest.java
@@ -1,0 +1,27 @@
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class GoogleCompletionClientTest {
+
+  private static final String RESPONSE =
+      "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"yo\"}]}}],"
+          + "\"usageMetadata\":{\"promptTokenCount\":15,\"candidatesTokenCount\":3,\"totalTokenCount\":18}}";
+
+  @Test
+  void parsesTextAndUsage() {
+    CompletionResult result = GoogleCompletionClient.parseResult(RESPONSE);
+    assertEquals("yo", result.text());
+    assertEquals(15, result.inputTokens());
+    assertEquals(3, result.outputTokens());
+  }
+
+  @Test
+  void requestBodyHonorsOverrides() {
+    String body = GoogleCompletionClient.buildRequestBody("sys", "user", 256, 0.0);
+    assertTrue(body.contains("\"maxOutputTokens\":256"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMClientHolderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMClientHolderTest.java
@@ -1,0 +1,31 @@
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMProvider;
+
+class LLMClientHolderTest {
+
+  @Test
+  void initializesAndReturnsStableInstance() {
+    LLMClientHolder.initialize(new LLMConfiguration().withProvider(LLMProvider.NOOP));
+    assertNotNull(LLMClientHolder.get());
+    assertSame(LLMClientHolder.get(), LLMClientHolder.get());
+  }
+
+  @Test
+  void disabledConfigNeverConstructsProviderClient() {
+    LLMConfiguration config =
+        new LLMConfiguration().withEnabled(false).withProvider(LLMProvider.OPENAI);
+
+    LLMClientHolder.initialize(config);
+
+    assertFalse(LLMClientHolder.isEnabled());
+    assertInstanceOf(NoopCompletionClient.class, LLMClientHolder.get());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMCompletionClientFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMCompletionClientFactoryTest.java
@@ -1,0 +1,27 @@
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.configuration.LLMConfiguration;
+import org.openmetadata.schema.configuration.LLMProvider;
+
+class LLMCompletionClientFactoryTest {
+
+  @Test
+  void noopProviderYieldsNoopClient() {
+    LLMConfiguration cfg = new LLMConfiguration().withProvider(LLMProvider.NOOP);
+    assertInstanceOf(NoopCompletionClient.class, LLMCompletionClientFactory.create(cfg));
+  }
+
+  @Test
+  void nullConfigYieldsNoopClient() {
+    assertInstanceOf(NoopCompletionClient.class, LLMCompletionClientFactory.create(null));
+  }
+
+  @Test
+  void nullProviderYieldsNoopClient() {
+    assertInstanceOf(
+        NoopCompletionClient.class, LLMCompletionClientFactory.create(new LLMConfiguration()));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMCompletionClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/LLMCompletionClientTest.java
@@ -1,0 +1,128 @@
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LLMCompletionClientTest {
+
+  record PillLike(
+      String title, String question, String answer, String summary, String memoryType) {}
+
+  private static final class StubClient extends LLMCompletionClient {
+    private final String response;
+
+    StubClient(String response) {
+      super(2);
+      this.response = response;
+    }
+
+    @Override
+    protected CompletionResult doComplete(
+        String systemPrompt, String userPrompt, CompletionOptions options) {
+      return new CompletionResult(response, 0, 0);
+    }
+
+    @Override
+    public String getModelId() {
+      return "stub";
+    }
+  }
+
+  private static final class ZeroPermitClient extends LLMCompletionClient {
+    ZeroPermitClient() {
+      super(0);
+    }
+
+    @Override
+    protected CompletionResult doComplete(
+        String systemPrompt, String userPrompt, CompletionOptions options) {
+      return new CompletionResult("[]", 0, 0);
+    }
+
+    @Override
+    public String getModelId() {
+      return "zero";
+    }
+  }
+
+  @Test
+  void completeStructuredParsesPillArray() {
+    String json =
+        "[{\"title\":\"T\",\"question\":\"Q\",\"answer\":\"A\",\"summary\":\"S\",\"memoryType\":\"Faq\"}]";
+    List<PillLike> pills = new StubClient(json).completeStructured("sys", "user", PillLike.class);
+    assertEquals(1, pills.size());
+    assertEquals("Q", pills.get(0).question());
+  }
+
+  @Test
+  void completeStructuredStripsCodeFence() {
+    String json = "```json\n[{\"question\":\"Q\",\"answer\":\"A\"}]\n```";
+    List<PillLike> pills = new StubClient(json).completeStructured("sys", "user", PillLike.class);
+    assertEquals(1, pills.size());
+    assertEquals("A", pills.get(0).answer());
+  }
+
+  @Test
+  void rejectsNonPositiveConcurrency() {
+    assertThrows(IllegalArgumentException.class, ZeroPermitClient::new);
+  }
+
+  @Test
+  void anthropicParseExtractsText() {
+    assertEquals(
+        "hello",
+        AnthropicCompletionClient.parseResult(
+                "{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}],"
+                    + "\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}")
+            .text());
+  }
+
+  @Test
+  void anthropicParseRejectsContentWithoutText() {
+    assertThrows(
+        LLMCompletionException.class,
+        () ->
+            AnthropicCompletionClient.parseResult(
+                "{\"content\":[{\"type\":\"thinking\"}],"
+                    + "\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}"));
+  }
+
+  @Test
+  void openAiParseExtractsContent() {
+    assertEquals(
+        "hi",
+        OpenAICompletionClient.parseResult(
+                "{\"choices\":[{\"message\":{\"content\":\"hi\"}}],"
+                    + "\"usage\":{\"prompt_tokens\":0,\"completion_tokens\":0}}")
+            .text());
+  }
+
+  @Test
+  void openAiParseRejectsNullMessageContent() {
+    assertThrows(
+        LLMCompletionException.class,
+        () ->
+            OpenAICompletionClient.parseResult(
+                "{\"choices\":[{\"message\":{\"content\":null,\"tool_calls\":[]}}]}"));
+  }
+
+  @Test
+  void googleParseExtractsText() {
+    assertEquals(
+        "ok",
+        GoogleCompletionClient.parseResult(
+                "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}")
+            .text());
+  }
+
+  @Test
+  void googleParseRejectsCandidateWithoutContent() {
+    assertThrows(
+        LLMCompletionException.class,
+        () ->
+            GoogleCompletionClient.parseResult("{\"candidates\":[{\"finishReason\":\"SAFETY\"}]}"));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/llm/OpenAICompletionClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/llm/OpenAICompletionClientTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Collate.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openmetadata.service.llm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class OpenAICompletionClientTest {
+
+  private static final String RESPONSE =
+      "{\"choices\":[{\"message\":{\"content\":\"hello\"}}],"
+          + "\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7,\"total_tokens\":18}}";
+
+  @Test
+  void parsesTextAndUsage() {
+    CompletionResult result = OpenAICompletionClient.parseResult(RESPONSE);
+    assertEquals("hello", result.text());
+    assertEquals(11, result.inputTokens());
+    assertEquals(7, result.outputTokens());
+  }
+
+  @Test
+  void requestBodyHonorsOverrides() {
+    String body =
+        OpenAICompletionClient.buildRequestBody("sys", "user", "override-model", 256, 0.3);
+    assertTrue(body.contains("\"model\":\"override-model\""));
+    assertTrue(body.contains("\"max_tokens\":256"));
+    assertTrue(body.contains("\"temperature\":0.3"));
+  }
+}


### PR DESCRIPTION
Follow-up to the merged #30041.

## Why
#30041 reverted the knowledge-pill **extraction feature** and, to do it, deleted the entire `openmetadata-service/.../service/llm/` package. But #28973 introduced that package as a **generic, reusable LLM completion layer** — its own commit words:

> "New generic `llmConfiguration` config block + **`LLMCompletionClient` layer** resolved at startup via `LLMClientHolder`. **Reusable by other platform features.**"

It's the runtime counterpart to the `llmConfiguration` / `LlmConfigHolder` that #30041 already kept. **Collate's NLQ filter extraction reuses it** (`LLMCompletionClient`, `CompletionResult`, `LLMClientHolder`, `NoopCompletionClient`), so deleting it broke the downstream Collate build:
```
NLQFilterExtractor.java: package org.openmetadata.service.llm does not exist
SystemRepositoryExt.java: cannot find symbol class CompletionResult   (11 errors)
```

## What (20 files, +1167)
Restore the **generic** layer; keep **only the extraction feature** removed.
- **Restored:** `LLMCompletionClient`, `LLMClientHolder` (+ its `OpenMetadataApplication` startup init from `llmConfiguration`), `CompletionResult`, `CompletionOptions`, `{Anthropic,Bedrock,Google,OpenAI}CompletionClient`, `NoopCompletionClient`, factory, exception (+ unit tests).
- **Still removed (the actual feature):** `KnowledgePill` and its `ContextMemoryExtractor` / `ContextFileProcessingService` / Memory-Agent consumers.
- `LLMCompletionClientTest`'s structured-parse cases use a local `PillLike` record instead of `KnowledgePill`.

Same "keep load-bearing infra, remove the feature" call already made for ContextMemory / llmConfiguration / objectStorage in #30041 — this layer was just missed.

## Verified
- OSS: `service.llm` unit tests + `AIContextBuilderTest` (persona canary) — 40/40 green; `mvn spotless:apply` clean.
- Downstream: **collate-service compiles green** against this OSS with **no Collate code change** (all 11 original errors gone).

## Follow-up
Bump Collate's OpenMetadata submodule to a `main` commit containing this fix for Collate CI to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the reusable LLM completion layer while leaving knowledge-pill extraction removed. The main changes are:

- Restored provider-neutral completion results, options, concurrency control, and structured JSON parsing.
- Restored OpenAI, Azure OpenAI, Anthropic, Google, Bedrock, and no-op clients.
- Restored the global client holder and application startup initialization.
- Added focused tests for provider payloads, responses, factory behavior, and structured completion.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The structured completion retry path can duplicate failed provider requests and should be fixed before merging.

- Provider, network, and parsing failures currently share one retry branch.
- Replacing a Bedrock client can retain AWS SDK resources in long-lived JVMs.
- Azure configuration without an API version produces an invalid endpoint.
- Provider error bodies can be written to warning logs.

LLMCompletionClient.java, LLMClientHolder.java, and OpenAICompletionClient.java
</details>

<details open><summary><h3>Security Review</h3></summary>

Provider error bodies can flow into warning logs through the structured-completion retry path. Sanitizing these bodies would prevent prompt or account details returned by a provider from entering application logs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java | Initializes the restored shared LLM client during application startup. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClient.java | Adds concurrency control and structured parsing, but retries provider failures along with malformed responses. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMClientHolder.java | Restores global client access but does not close a replaced Bedrock client. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/OpenAICompletionClient.java | Restores OpenAI and Azure requests, with gaps around Azure version validation and error-body sanitization. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/BedrockCompletionClient.java | Restores the Bedrock Converse client and exposes explicit cleanup for its AWS SDK resources. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/AnthropicCompletionClient.java | Restores Anthropic request construction, response parsing, and token usage reporting. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/GoogleCompletionClient.java | Restores Gemini request construction, response parsing, and token usage reporting. |
| openmetadata-service/src/main/java/org/openmetadata/service/llm/LLMCompletionClientFactory.java | Restores provider selection and no-op fallback behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(llm): keep the generic LLMCompletion..."](https://github.com/open-metadata/openmetadata/commit/8873f1d989ea7a406666a630b8cd43b4abd31a59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44568494)</sub>

> Greptile also left **4 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->