### PR TITLE
feat(mcp): annotate tools with title/readOnly/destructive/openWorld hints

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpUtils.java
@@ -114,6 +114,9 @@ public class McpUtils {
   @SuppressWarnings("unchecked")
   private static McpSchema.ToolAnnotations buildToolAnnotations(
       Map<String, Object> toolDef, String title) {
+    // openWorldHint defaults to true per the MCP spec when omitted, which would mislabel every
+    // tool here as reaching external/public systems. All tools only read/write our own
+    // OpenMetadata catalog, so tools.json sets it to false explicitly for each tool.
     McpSchema.ToolAnnotations result = null;
     Map<String, Object> annotations = (Map<String, Object>) toolDef.get("annotations");
     if (annotations != null) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpUtils.java
@@ -83,23 +83,50 @@ public class McpUtils {
         throw new RuntimeException("Failed to load tool definitions");
       }
       LOG.debug("Successfully loaded {} tool definitions", cachedTools.size());
-      for (int i = 0; i < cachedTools.size(); i++) {
-        Map<String, Object> toolDef = cachedTools.get(i);
-        String name = (String) toolDef.get("name");
-        String description = (String) toolDef.get("description");
-        Map<String, Object> schema = JsonUtils.getMap(toolDef.get("parameters"));
-        result.add(
-            McpSchema.Tool.builder()
-                .name(name)
-                .description(description)
-                .inputSchema(JSON_MAPPER, JsonUtils.pojoToJson(schema))
-                .build());
+      for (Map<String, Object> toolDef : cachedTools) {
+        result.add(buildTool(toolDef));
       }
       return result;
     } catch (Exception e) {
       LOG.error("Error during server startup", e);
       throw new RuntimeException("Failed to start MCP server", e);
     }
+  }
+
+  private static McpSchema.Tool buildTool(Map<String, Object> toolDef) {
+    String name = (String) toolDef.get("name");
+    String title = (String) toolDef.get("title");
+    String description = (String) toolDef.get("description");
+    Map<String, Object> schema = JsonUtils.getMap(toolDef.get("parameters"));
+    McpSchema.Tool.Builder builder =
+        McpSchema.Tool.builder()
+            .name(name)
+            .title(title)
+            .description(description)
+            .inputSchema(JSON_MAPPER, JsonUtils.pojoToJson(schema));
+    McpSchema.ToolAnnotations annotations = buildToolAnnotations(toolDef, title);
+    if (annotations != null) {
+      builder.annotations(annotations);
+    }
+    return builder.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static McpSchema.ToolAnnotations buildToolAnnotations(
+      Map<String, Object> toolDef, String title) {
+    McpSchema.ToolAnnotations result = null;
+    Map<String, Object> annotations = (Map<String, Object>) toolDef.get("annotations");
+    if (annotations != null) {
+      result =
+          new McpSchema.ToolAnnotations(
+              title,
+              (Boolean) annotations.get("readOnlyHint"),
+              (Boolean) annotations.get("destructiveHint"),
+              (Boolean) annotations.get("idempotentHint"),
+              (Boolean) annotations.get("openWorldHint"),
+              (Boolean) annotations.get("returnDirect"));
+    }
+    return result;
   }
 
   public static List<McpSchema.Prompt> getPrompts(String jsonFilePath) {

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateClassificationTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateClassificationTool.java
@@ -62,6 +62,8 @@ public class CreateClassificationTool implements McpTool {
     repo.prepareInternal(entity, false);
 
     final String userName = CommonUtils.principal(securityContext);
+    // createOrUpdate silently overwrites an existing classification with this name —
+    // tools.json marks this tool destructiveHint:true for that reason.
     final RestUtil.PutResponse<Classification> response =
         repo.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateContextMemoryTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateContextMemoryTool.java
@@ -57,6 +57,9 @@ public class CreateContextMemoryTool implements McpTool {
     repo.prepareInternal(entity, false);
 
     final String userName = CommonUtils.principal(securityContext);
+    // createOrUpdate overwrites an existing memory with this name (the tool description
+    // documents this as intentional reuse) — tools.json still marks this tool
+    // destructiveHint:true since the prior content is discarded.
     final RestUtil.PutResponse<ContextMemory> response =
         repo.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDataProductTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDataProductTool.java
@@ -74,6 +74,8 @@ public class CreateDataProductTool implements McpTool {
     repo.prepareInternal(entity, false);
 
     final String userName = CommonUtils.principal(securityContext);
+    // createOrUpdate silently overwrites an existing data product with this name —
+    // tools.json marks this tool destructiveHint:true for that reason.
     final RestUtil.PutResponse<DataProduct> response =
         repo.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDomainTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDomainTool.java
@@ -73,6 +73,8 @@ public class CreateDomainTool implements McpTool {
     repo.prepareInternal(entity, false);
 
     final String userName = CommonUtils.principal(securityContext);
+    // createOrUpdate silently overwrites an existing domain with this name — tools.json
+    // marks this tool destructiveHint:true for that reason.
     final RestUtil.PutResponse<Domain> response =
         repo.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateMetricTool.java
@@ -184,6 +184,8 @@ public class CreateMetricTool implements McpTool {
 
     String userName = securityContext.getUserPrincipal().getName();
     String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+    // createOrUpdate silently overwrites an existing metric with this name — tools.json
+    // marks this tool destructiveHint:true for that reason.
     RestUtil.PutResponse<Metric> response =
         repo.createOrUpdate(null, metric, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTagTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTagTool.java
@@ -73,6 +73,8 @@ public class CreateTagTool implements McpTool {
     repo.prepareInternal(entity, false);
 
     final String userName = CommonUtils.principal(securityContext);
+    // createOrUpdate silently overwrites an existing tag at this FQN — tools.json marks
+    // this tool destructiveHint:true for that reason.
     final RestUtil.PutResponse<Tag> response =
         repo.createOrUpdate(null, entity, userName, ImpersonationContext.getImpersonatedBy());
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateTestCaseTool.java
@@ -116,6 +116,8 @@ public class CreateTestCaseTool implements McpTool {
         testDefinitionName,
         fqn);
     String impersonatedBy = ImpersonationContext.getImpersonatedBy();
+    // createOrUpdate silently overwrites an existing test case with this name — tools.json
+    // marks this tool destructiveHint:true for that reason.
     RestUtil.PutResponse<TestCase> response =
         repository.createOrUpdate(null, testCase, updatedBy, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
@@ -63,6 +63,8 @@ public class GlossaryTermTool implements McpTool {
     String impersonatedBy = ImpersonationContext.getImpersonatedBy();
 
     String userName = securityContext.getUserPrincipal().getName();
+    // createOrUpdate silently overwrites an existing term at this FQN — tools.json marks
+    // this tool destructiveHint:true for that reason.
     RestUtil.PutResponse<GlossaryTerm> response =
         glossaryTermRepository.createOrUpdate(null, glossaryTerm, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTool.java
@@ -71,6 +71,8 @@ public class GlossaryTool implements McpTool {
     String impersonatedBy = ImpersonationContext.getImpersonatedBy();
 
     String userName = securityContext.getUserPrincipal().getName();
+    // createOrUpdate silently overwrites an existing glossary at this name — tools.json
+    // marks this tool destructiveHint:true for that reason.
     RestUtil.PutResponse<Glossary> response =
         glossaryRepository.createOrUpdate(null, glossary, userName, impersonatedBy);
     McpChangeEventUtil.publishChangeEvent(response.getEntity(), response.getChangeType(), userName);

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -479,7 +479,7 @@
       "title": "Create Glossary Term",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Glossary Term. Note that a glossary term must be part of a Glossary, so the glossary must be specified in the parameters. If you can't find the right glossary to use, respond back to the user to create a new Glossary first. Note that you can help the user to create the Glossary as well. If you don't find any Glossary that could be related, please list to the user the available Glossaries so users can choose if they want to create or reuse something. Also, note that glossary terms can be hierarchical: for example, a glossary term 'Accounts' can have a child term 'Credit Account', 'Savings Account', etc. So if you find any terms that can be related, it might make sense to create a new term as a child of an existing term.",
@@ -529,7 +529,7 @@
       "title": "Create Glossary",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Glossary. A Glossary is a collection of terms that are used to define the business vocabulary of an organization. Typically, similar terms are grouped together in a Glossary. For example, a Glossary names 'Marketing' could contain terms like 'Campaign', 'Lead', 'Opportunity', etc.",
@@ -746,7 +746,7 @@
       "title": "Create Test Case",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "This tool can be used to create a test case for a table or a table's column. It needs test definitions. These test definition can be found using the get_test_definitions tool. If this fails do not do other operations.",
@@ -814,7 +814,7 @@
       "title": "Create Metric",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Metric entity in OpenMetadata. A Metric represents a measurable business or technical KPI (e.g. daily revenue, error rate). Use this to register new metrics with optional expression, type, granularity, and unit of measurement. Metric can be expressed in SQL, Python, Java, or JavaScript.",
@@ -947,7 +947,7 @@
       "title": "Create Classification",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g. 'PII', 'Tier'). The 'name' becomes the root segment of every tag FQN under it. The 'mutuallyExclusive' flag is immutable once the classification exists: if you set it on an existing classification it is ignored and a '_warning' is returned. Owner and reviewer names must already exist in OpenMetadata. Any domain FQNs must already exist.",
@@ -1003,7 +1003,7 @@
       "title": "Create Tag",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Tag inside a Classification in OpenMetadata. The tag FQN is 'Classification.TagName' (e.g. 'PII.Sensitive'). At least one of 'classification' or 'parent' MUST be provided. Provide 'classification' (the root classification name, which must already exist), and optionally 'parent' for a nested tag (the parent tag FQN, e.g. 'PII.PersonalData', which must already exist). If only 'parent' is given, the classification is derived from its root segment. If both are given, 'classification' must equal the root segment of 'parent'. Owner and reviewer names must already exist.",
@@ -1067,7 +1067,7 @@
       "title": "Create Domain",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set 'parent' to the FQN of an existing parent domain (it must already exist). 'domainType' must be one of Source-aligned, Consumer-aligned, or Aggregate; it defaults to 'Aggregate' if omitted. 'experts' are OpenMetadata login names that must already exist. Owner names must also already exist.",
@@ -1132,7 +1132,7 @@
       "title": "Create Data Product",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. Provide 'domains' as a list of existing domain FQNs (required, at least one; each must already exist). 'experts' are OpenMetadata login names that must already exist. Owner and reviewer names must also already exist.",
@@ -1250,7 +1250,7 @@
       "title": "Create Context Memory",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "Creates a reusable Context Center memory in OpenMetadata — a piece of knowledge the assistant should retain across conversations (e.g. a team preference, a recurring instruction, a runbook step, or an answer to a frequently asked question). Memories created here are recorded as an explicit 'remember this' request and, when the Memory Agent is enabled, may be used to derive glossary terms and metrics. Use this when the user explicitly asks you to remember, note, or store something for later reuse.",

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -2,6 +2,11 @@
   "tools": [
     {
       "name": "search_company_context",
+      "title": "Search Company Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Semantic search over Company Context knowledge pills extracted from Context Center files. Returns each pill's title, question, answer, summary, and source file in one call. Use this to answer questions from company documents, runbooks, FAQs, and policies.",
       "parameters": {
         "description": "Provide a natural-language 'query'. Returns the most semantically relevant knowledge pills.",
@@ -33,6 +38,11 @@
     },
     {
       "name": "get_company_context",
+      "title": "Get Company Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Fetch a single Company Context knowledge pill, returning its full title, question, answer, summary, and source file. Pass the 'fullyQualifiedName' (or 'name') from a search_company_context result, exactly as returned.",
       "parameters": {
         "description": "Provide the 'fqn' of the knowledge pill to fetch.",
@@ -50,6 +60,11 @@
     },
     {
       "name": "search_metadata",
+      "title": "Search Metadata",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Keyword-based search for data assets and data quality entities in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Also searches data quality test cases and test suites when entityType is 'testCase' or 'testSuite' — these are NOT part of the default search scope, so always set entityType explicitly for data quality questions. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' for keyword search or 'queryFilter' for advanced OpenSearch DSL. Best for exact matches and filtering by metadata properties.",
@@ -173,6 +188,11 @@
     },
     {
       "name": "semantic_search",
+      "title": "Semantic Search",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
         "description": "Use 'query' to describe what you're looking for in plain language. The system finds conceptually similar assets using vector similarity. Optionally filter by entity type, service, or tags.",
@@ -251,6 +271,11 @@
     },
     {
       "name": "get_entity_details",
+      "title": "Get Entity Details",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context: verbose index/noise metadata fields are excluded. Descriptions (entity-level and per-column) are returned in FULL and are never truncated — total response size is bounded by column pagination instead. Only the raw schema DDL and dbt model SQL carry a large safety cap (~30000 characters, flagged with 'schemaDefinitionTruncated' or 'sqlTruncated' inside 'dataModel') to keep the response retrievable; realistic DDL/SQL is well under this. For wide entities (many columns), the 'columns' array is paginated: when it is capped the response sets 'columnsTruncated' with 'totalColumns', 'returnedColumns', 'columnOffset' and 'hasMoreColumns'. When 'hasMoreColumns' is true, fetch the next page by calling again with 'columnOffset' set to the previous 'columnOffset' + 'returnedColumns'; when it is false there are no further columns to retrieve.",
       "parameters": {
         "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
@@ -281,6 +306,11 @@
     },
     {
       "name": "get_asset_context",
+      "title": "Get Asset Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Get the full AI Context (Context Profile) for a single data asset in one call: the business knowledge attached to it (approved glossary term definitions, Context Center articles) plus the type-specific structural context. For tables this includes the column schema, primary key, foreign keys (with the referenced columns and cardinality), and the columns most frequently joined with other tables — the strong, deterministic signals needed for SQL generation. Returns a compact, LLM-friendly markdown document by default. Prefer this over get_entity_details when you have already selected the asset(s) and need their business rules and join keys. Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results.",
       "parameters": {
         "description": "Use 'fullyQualifiedName' and 'entityType' from search results directly.",
@@ -316,6 +346,11 @@
     },
     {
       "name": "get_persona_context",
+      "title": "Get Persona Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Get the shared AI context document curated for a persona. With no personaName, uses the caller's active persona. The document can contain many assets and is returned in deterministic parts; call again with part=2, part=3, and so on while hasMore is true. Access is limited to persona members, admins, and bots.",
       "parameters": {
         "type": "object",
@@ -345,6 +380,11 @@
     },
     {
       "name": "find_context",
+      "title": "Find Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "For a business question when no specific asset has been chosen yet: semantically searches the company-knowledge layer (glossary term definitions, metric definitions, Context Center articles) and returns the relevant definitions PLUS the candidate data assets each concept points to (glossary terms → the tables tagged with them, metrics → the assets they apply to, articles → the assets they are about). Use this to bootstrap a data question from business concepts into candidate tables, then call get_asset_context on those candidate fullyQualifiedNames. Returns LLM-friendly markdown by default.",
       "parameters": {
         "description": "Provide a natural-language 'query' using the business terms or concepts from the user's request.",
@@ -376,6 +416,11 @@
     },
     {
       "name": "get_knowledge_content",
+      "title": "Get Knowledge Content",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Progressive disclosure for attached knowledge. get_asset_context and find_context return bounded EXCERPTS of long glossary definitions, metric definitions, and Context Center articles (each marked contentTruncated) so a bundle never overwhelms the context window. When you need the full detail of one specific item, call this with that item's type and fullyQualifiedName. Without a 'query' it returns the full body; with a 'query' it returns only the passages of a long article most relevant to that query. Returns LLM-friendly markdown by default.",
       "parameters": {
         "description": "Provide the knowledge item's 'entityType' and 'fqn' (as given in the get_asset_context/find_context result). Optionally pass a 'query' to retrieve only the relevant passages of a long article.",
@@ -422,6 +467,11 @@
     },
     {
       "name": "create_glossary_term",
+      "title": "Create Glossary Term",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Glossary Term. Note that a glossary term must be part of a Glossary, so the glossary must be specified in the parameters. If you can't find the right glossary to use, respond back to the user to create a new Glossary first. Note that you can help the user to create the Glossary as well. If you don't find any Glossary that could be related, please list to the user the available Glossaries so users can choose if they want to create or reuse something. Also, note that glossary terms can be hierarchical: for example, a glossary term 'Accounts' can have a child term 'Credit Account', 'Savings Account', etc. So if you find any terms that can be related, it might make sense to create a new term as a child of an existing term.",
       "parameters": {
         "type": "object",
@@ -466,6 +516,11 @@
     },
     {
       "name": "create_glossary",
+      "title": "Create Glossary",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Glossary. A Glossary is a collection of terms that are used to define the business vocabulary of an organization. Typically, similar terms are grouped together in a Glossary. For example, a Glossary names 'Marketing' could contain terms like 'Campaign', 'Lead', 'Opportunity', etc.",
       "parameters": {
         "type": "object",
@@ -507,6 +562,11 @@
     },
     {
       "name": "patch_entity",
+      "title": "Patch Entity",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true
+      },
       "description": "Patches an Entity based on a JSONPatch. Beforehand the Entity should be validated by finding it and creating a proper patch. IMPORTANT field naming rules: all array/list fields use PLURAL names in the JSON body — use 'domains' (not 'domain'), 'owners' (not 'owner'), 'tags' (not 'tag'), 'reviewers' (not 'reviewer'). Domain values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"domain\"}. Owner values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"user\" or \"team\"}. To add a domain: [{\"op\": \"add\", \"path\": \"/domains/0\", \"value\": {\"id\": \"<domain-id>\", \"type\": \"domain\", \"name\": \"<domain-name>\"}}]. To replace description: [{\"op\": \"add\", \"path\": \"/description\", \"value\": \"new description\"}]. Always look up entity UUIDs using search or get tools before patching.",
       "parameters": {
         "type": "object",
@@ -533,6 +593,11 @@
     },
     {
       "name": "get_entity_lineage",
+      "title": "Get Entity Lineage",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. By default the response is table-level and optimized for size: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql), with long SQL truncated. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
       "parameters": {
         "description": "Fqn is the fully qualified name of the entity. Entity type could be table, topic etc.",
@@ -570,6 +635,11 @@
     },
     {
       "name": "create_lineage",
+      "title": "Create Lineage",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "This tool can be used to create lineage between two assets. It takes the source and target asset details and creates a lineage relationship between them.",
       "parameters": {
         "description": "Required to create lineage between two assets.",
@@ -620,6 +690,11 @@
     },
     {
       "name": "get_test_definitions",
+      "title": "Get Test Definitions",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "This tool can be used to get all the test definitions in the OpenMetadata. It returns a list of test definitions. These test definition can be used to create a test case for a table or a table's column. While creating column test for entity, column data type should be in supportedDataTypes of parameterDefinition.",
       "parameters": {
         "description": "These test definition are required to create a test case for table or a table's column.",
@@ -653,6 +728,11 @@
     },
     {
       "name": "create_test_case",
+      "title": "Create Test Case",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "This tool can be used to create a test case for a table or a table's column. It needs test definitions. These test definition can be found using the get_test_definitions tool. If this fails do not do other operations.",
       "parameters": {
         "description": "This tool can be used to create a test case for a table or a table's column. It requires the test definition and the entity (table or column) to be tested.",
@@ -715,6 +795,11 @@
     },
     {
       "name": "create_metric",
+      "title": "Create Metric",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Metric entity in OpenMetadata. A Metric represents a measurable business or technical KPI (e.g. daily revenue, error rate). Use this to register new metrics with optional expression, type, granularity, and unit of measurement. Metric can be expressed in SQL, Python, Java, or JavaScript.",
       "parameters": {
         "type": "object",
@@ -842,6 +927,11 @@
     },
     {
       "name": "create_classification",
+      "title": "Create Classification",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g. 'PII', 'Tier'). The 'name' becomes the root segment of every tag FQN under it. The 'mutuallyExclusive' flag is immutable once the classification exists: if you set it on an existing classification it is ignored and a '_warning' is returned. Owner and reviewer names must already exist in OpenMetadata. Any domain FQNs must already exist.",
       "parameters": {
         "type": "object",
@@ -892,6 +982,11 @@
     },
     {
       "name": "create_tag",
+      "title": "Create Tag",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Tag inside a Classification in OpenMetadata. The tag FQN is 'Classification.TagName' (e.g. 'PII.Sensitive'). At least one of 'classification' or 'parent' MUST be provided. Provide 'classification' (the root classification name, which must already exist), and optionally 'parent' for a nested tag (the parent tag FQN, e.g. 'PII.PersonalData', which must already exist). If only 'parent' is given, the classification is derived from its root segment. If both are given, 'classification' must equal the root segment of 'parent'. Owner and reviewer names must already exist.",
       "parameters": {
         "type": "object",
@@ -950,6 +1045,11 @@
     },
     {
       "name": "create_domain",
+      "title": "Create Domain",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set 'parent' to the FQN of an existing parent domain (it must already exist). 'domainType' must be one of Source-aligned, Consumer-aligned, or Aggregate; it defaults to 'Aggregate' if omitted. 'experts' are OpenMetadata login names that must already exist. Owner names must also already exist.",
       "parameters": {
         "type": "object",
@@ -1009,6 +1109,11 @@
     },
     {
       "name": "create_data_product",
+      "title": "Create Data Product",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. Provide 'domains' as a list of existing domain FQNs (required, at least one; each must already exist). 'experts' are OpenMetadata login names that must already exist. Owner and reviewer names must also already exist.",
       "parameters": {
         "type": "object",
@@ -1070,6 +1175,11 @@
     },
     {
       "name": "root_cause_analysis",
+      "title": "Root Cause Analysis",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false
+      },
       "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed. Responses are compact and table-level by default: node and edge details are trimmed and SQL queries truncated to keep the payload within LLM context limits. Set 'includeColumnLineage' to true only when column-level lineage is needed.",
       "parameters": {
         "type": "object",
@@ -1115,6 +1225,11 @@
     },
     {
       "name": "create_context_memory",
+      "title": "Create Context Memory",
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false
+      },
       "description": "Creates a reusable Context Center memory in OpenMetadata — a piece of knowledge the assistant should retain across conversations (e.g. a team preference, a recurring instruction, a runbook step, or an answer to a frequently asked question). Memories created here are recorded as an explicit 'remember this' request and, when the Memory Agent is enabled, may be used to derive glossary terms and metrics. Use this when the user explicitly asks you to remember, note, or store something for later reuse.",
       "parameters": {
         "type": "object",

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -5,7 +5,8 @@
       "title": "Search Company Context",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Semantic search over Company Context knowledge pills extracted from Context Center files. Returns each pill's title, question, answer, summary, and source file in one call. Use this to answer questions from company documents, runbooks, FAQs, and policies.",
       "parameters": {
@@ -41,7 +42,8 @@
       "title": "Get Company Context",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Fetch a single Company Context knowledge pill, returning its full title, question, answer, summary, and source file. Pass the 'fullyQualifiedName' (or 'name') from a search_company_context result, exactly as returned.",
       "parameters": {
@@ -63,7 +65,8 @@
       "title": "Search Metadata",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Keyword-based search for data assets and data quality entities in OpenMetadata. Best when you know specific names, owners, tags, tiers, services, or column names. Use this for exact lookups (e.g., 'find table X', 'tables owned by team Y'), filtering by metadata properties, counting assets, and aggregations. Also searches data quality test cases and test suites when entityType is 'testCase' or 'testSuite' — these are NOT part of the default search scope, so always set entityType explicitly for data quality questions. Supports pagination and advanced OpenSearch DSL queries. Choose this over semantic_search when the query targets known identifiers or structured attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
@@ -191,7 +194,8 @@
       "title": "Semantic Search",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
       "parameters": {
@@ -274,7 +278,8 @@
       "title": "Get Entity Details",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Get detailed information about a specific entity by its fully qualified name, including its custom properties (returned under the 'extension' field). IMPORTANT: Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results — do not construct the FQN manually. Response is optimized for LLM context: verbose index/noise metadata fields are excluded. Descriptions (entity-level and per-column) are returned in FULL and are never truncated — total response size is bounded by column pagination instead. Only the raw schema DDL and dbt model SQL carry a large safety cap (~30000 characters, flagged with 'schemaDefinitionTruncated' or 'sqlTruncated' inside 'dataModel') to keep the response retrievable; realistic DDL/SQL is well under this. For wide entities (many columns), the 'columns' array is paginated: when it is capped the response sets 'columnsTruncated' with 'totalColumns', 'returnedColumns', 'columnOffset' and 'hasMoreColumns'. When 'hasMoreColumns' is true, fetch the next page by calling again with 'columnOffset' set to the previous 'columnOffset' + 'returnedColumns'; when it is false there are no further columns to retrieve.",
       "parameters": {
@@ -309,7 +314,8 @@
       "title": "Get Asset Context",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Get the full AI Context (Context Profile) for a single data asset in one call: the business knowledge attached to it (approved glossary term definitions, Context Center articles) plus the type-specific structural context. For tables this includes the column schema, primary key, foreign keys (with the referenced columns and cardinality), and the columns most frequently joined with other tables — the strong, deterministic signals needed for SQL generation. Returns a compact, LLM-friendly markdown document by default. Prefer this over get_entity_details when you have already selected the asset(s) and need their business rules and join keys. Use the 'fullyQualifiedName' and 'entityType' values directly from search_metadata or semantic_search results.",
       "parameters": {
@@ -349,7 +355,8 @@
       "title": "Get Persona Context",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Get the shared AI context document curated for a persona. With no personaName, uses the caller's active persona. The document can contain many assets and is returned in deterministic parts; call again with part=2, part=3, and so on while hasMore is true. Access is limited to persona members, admins, and bots.",
       "parameters": {
@@ -383,7 +390,8 @@
       "title": "Find Context",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "For a business question when no specific asset has been chosen yet: semantically searches the company-knowledge layer (glossary term definitions, metric definitions, Context Center articles) and returns the relevant definitions PLUS the candidate data assets each concept points to (glossary terms → the tables tagged with them, metrics → the assets they apply to, articles → the assets they are about). Use this to bootstrap a data question from business concepts into candidate tables, then call get_asset_context on those candidate fullyQualifiedNames. Returns LLM-friendly markdown by default.",
       "parameters": {
@@ -419,7 +427,8 @@
       "title": "Get Knowledge Content",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Progressive disclosure for attached knowledge. get_asset_context and find_context return bounded EXCERPTS of long glossary definitions, metric definitions, and Context Center articles (each marked contentTruncated) so a bundle never overwhelms the context window. When you need the full detail of one specific item, call this with that item's type and fullyQualifiedName. Without a 'query' it returns the full body; with a 'query' it returns only the passages of a long article most relevant to that query. Returns LLM-friendly markdown by default.",
       "parameters": {
@@ -470,7 +479,8 @@
       "title": "Create Glossary Term",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Glossary Term. Note that a glossary term must be part of a Glossary, so the glossary must be specified in the parameters. If you can't find the right glossary to use, respond back to the user to create a new Glossary first. Note that you can help the user to create the Glossary as well. If you don't find any Glossary that could be related, please list to the user the available Glossaries so users can choose if they want to create or reuse something. Also, note that glossary terms can be hierarchical: for example, a glossary term 'Accounts' can have a child term 'Credit Account', 'Savings Account', etc. So if you find any terms that can be related, it might make sense to create a new term as a child of an existing term.",
       "parameters": {
@@ -519,7 +529,8 @@
       "title": "Create Glossary",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Glossary. A Glossary is a collection of terms that are used to define the business vocabulary of an organization. Typically, similar terms are grouped together in a Glossary. For example, a Glossary names 'Marketing' could contain terms like 'Campaign', 'Lead', 'Opportunity', etc.",
       "parameters": {
@@ -565,7 +576,8 @@
       "title": "Patch Entity",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": true
+        "destructiveHint": true,
+        "openWorldHint": false
       },
       "description": "Patches an Entity based on a JSONPatch. Beforehand the Entity should be validated by finding it and creating a proper patch. IMPORTANT field naming rules: all array/list fields use PLURAL names in the JSON body — use 'domains' (not 'domain'), 'owners' (not 'owner'), 'tags' (not 'tag'), 'reviewers' (not 'reviewer'). Domain values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"domain\"}. Owner values must be entity reference objects: {\"id\": \"<uuid>\", \"type\": \"user\" or \"team\"}. To add a domain: [{\"op\": \"add\", \"path\": \"/domains/0\", \"value\": {\"id\": \"<domain-id>\", \"type\": \"domain\", \"name\": \"<domain-name>\"}}]. To replace description: [{\"op\": \"add\", \"path\": \"/description\", \"value\": \"new description\"}]. Always look up entity UUIDs using search or get tools before patching.",
       "parameters": {
@@ -596,7 +608,8 @@
       "title": "Get Entity Lineage",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Get a compact lineage graph (upstream/downstream dependencies) of a specific entity. Use this for root cause (upstream entities) or impact (downstream entities) analysis and explaining dependencies between entities. By default the response is table-level and optimized for size: each edge carries the connected assets' names, FQNs, types and relationship info (pipeline or sql), with long SQL truncated. Set includeColumnLineage=true only when the user explicitly asks about column-level lineage.",
       "parameters": {
@@ -638,7 +651,8 @@
       "title": "Create Lineage",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "This tool can be used to create lineage between two assets. It takes the source and target asset details and creates a lineage relationship between them.",
       "parameters": {
@@ -693,7 +707,8 @@
       "title": "Get Test Definitions",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "This tool can be used to get all the test definitions in the OpenMetadata. It returns a list of test definitions. These test definition can be used to create a test case for a table or a table's column. While creating column test for entity, column data type should be in supportedDataTypes of parameterDefinition.",
       "parameters": {
@@ -731,7 +746,8 @@
       "title": "Create Test Case",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "This tool can be used to create a test case for a table or a table's column. It needs test definitions. These test definition can be found using the get_test_definitions tool. If this fails do not do other operations.",
       "parameters": {
@@ -798,7 +814,8 @@
       "title": "Create Metric",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Metric entity in OpenMetadata. A Metric represents a measurable business or technical KPI (e.g. daily revenue, error rate). Use this to register new metrics with optional expression, type, granularity, and unit of measurement. Metric can be expressed in SQL, Python, Java, or JavaScript.",
       "parameters": {
@@ -930,7 +947,8 @@
       "title": "Create Classification",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Classification in OpenMetadata. A Classification is a top-level container that groups related Tags (e.g. 'PII', 'Tier'). The 'name' becomes the root segment of every tag FQN under it. The 'mutuallyExclusive' flag is immutable once the classification exists: if you set it on an existing classification it is ignored and a '_warning' is returned. Owner and reviewer names must already exist in OpenMetadata. Any domain FQNs must already exist.",
       "parameters": {
@@ -985,7 +1003,8 @@
       "title": "Create Tag",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Tag inside a Classification in OpenMetadata. The tag FQN is 'Classification.TagName' (e.g. 'PII.Sensitive'). At least one of 'classification' or 'parent' MUST be provided. Provide 'classification' (the root classification name, which must already exist), and optionally 'parent' for a nested tag (the parent tag FQN, e.g. 'PII.PersonalData', which must already exist). If only 'parent' is given, the classification is derived from its root segment. If both are given, 'classification' must equal the root segment of 'parent'. Owner and reviewer names must already exist.",
       "parameters": {
@@ -1048,7 +1067,8 @@
       "title": "Create Domain",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Domain in OpenMetadata. A Domain is a top-level governance grouping of data assets. To create a child domain, set 'parent' to the FQN of an existing parent domain (it must already exist). 'domainType' must be one of Source-aligned, Consumer-aligned, or Aggregate; it defaults to 'Aggregate' if omitted. 'experts' are OpenMetadata login names that must already exist. Owner names must also already exist.",
       "parameters": {
@@ -1112,7 +1132,8 @@
       "title": "Create Data Product",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a new Data Product in OpenMetadata. A Data Product groups data assets that deliver business value and must belong to at least one Domain. Provide 'domains' as a list of existing domain FQNs (required, at least one; each must already exist). 'experts' are OpenMetadata login names that must already exist. Owner and reviewer names must also already exist.",
       "parameters": {
@@ -1178,7 +1199,8 @@
       "title": "Root Cause Analysis",
       "annotations": {
         "readOnlyHint": true,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Performs comprehensive root cause analysis via data quality lineage. First identifies upstream failures that may be causing issues for the specified asset. If failures are found, automatically analyzes downstream impact to show which assets may be affected. Returns both upstream root causes and downstream impact analysis. In the response 'status' indicates whether upstream failures were found. If 'status' is 'failed', the 'upstreamAnalysis' can be used to identify the nodes and edges leading to failures and downstreamAnalysis can tell what all nodes in downstream are impacted. If 'status' is 'success', it means no upstream failures were found, and downstream impact analysis was not performed. Responses are compact and table-level by default: node and edge details are trimmed and SQL queries truncated to keep the payload within LLM context limits. Set 'includeColumnLineage' to true only when column-level lineage is needed.",
       "parameters": {
@@ -1228,7 +1250,8 @@
       "title": "Create Context Memory",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false
+        "destructiveHint": false,
+        "openWorldHint": false
       },
       "description": "Creates a reusable Context Center memory in OpenMetadata — a piece of knowledge the assistant should retain across conversations (e.g. a team preference, a recurring instruction, a runbook step, or an answer to a frequently asked question). Memories created here are recorded as an explicit 'remember this' request and, when the Memory Agent is enabled, may be used to derive glossary terms and metrics. Use this when the user explicitly asks you to remember, note, or store something for later reuse.",
       "parameters": {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
@@ -218,6 +218,22 @@ public class McpSdkUpgradeTest {
   }
 
   @Test
+  void testMcpUtilsGetToolPropertiesEveryToolHasExplicitOpenWorldHintFalse() {
+    // Regression guard: openWorldHint defaults to true when omitted, which would mislabel
+    // every tool as reaching external/public systems and fail OpenAI Apps SDK review
+    // ("incorrect or missing action labels"). All tools only touch our own OpenMetadata
+    // catalog, so every tool must set this explicitly to false.
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    assertThat(tools)
+        .allSatisfy(
+            tool ->
+                assertThat(tool.annotations().openWorldHint())
+                    .as("openWorldHint for tool %s", tool.name())
+                    .isFalse());
+  }
+
+  @Test
   void testServerCapabilitiesDoNotAdvertiseLogging() {
     // The stateless MCP server has no handler for logging/setLevel.
     // Advertising logging capability causes spec-compliant clients (e.g. VSCode)

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
@@ -203,6 +203,35 @@ public class McpSdkUpgradeTest {
     assertThat(patchTool.annotations().destructiveHint()).isTrue();
   }
 
+  private static final List<String> UPSERT_CAPABLE_CREATE_TOOLS =
+      List.of(
+          "create_glossary_term",
+          "create_glossary",
+          "create_tag",
+          "create_metric",
+          "create_classification",
+          "create_domain",
+          "create_data_product",
+          "create_test_case",
+          "create_context_memory");
+
+  @Test
+  void testMcpUtilsGetToolPropertiesMarksUpsertCapableCreateToolsAsDestructive() {
+    // These tools call repository.createOrUpdate(), so an existing entity with the requested
+    // name/FQN is silently overwritten instead of producing a create conflict. destructiveHint
+    // must be true so MCP clients require confirmation before the overwrite.
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    assertThat(tools)
+        .filteredOn(tool -> UPSERT_CAPABLE_CREATE_TOOLS.contains(tool.name()))
+        .hasSize(UPSERT_CAPABLE_CREATE_TOOLS.size())
+        .allSatisfy(
+            tool ->
+                assertThat(tool.annotations().destructiveHint())
+                    .as("destructiveHint for tool %s", tool.name())
+                    .isTrue());
+  }
+
   @Test
   void testMcpUtilsGetToolPropertiesEveryToolHasTitleAndAnnotations() {
     // Regression guard: a new tool added to tools.json without title/annotations would fail

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java
@@ -175,6 +175,49 @@ public class McpSdkUpgradeTest {
   }
 
   @Test
+  void testMcpUtilsGetToolPropertiesSetsTitleAndReadOnlyAnnotation() {
+    // Anthropic's Claude Connectors Directory requires every tool to carry a title plus
+    // readOnlyHint/destructiveHint. Verify a read-only tool is annotated correctly.
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    McpSchema.Tool searchTool =
+        tools.stream().filter(t -> "search_metadata".equals(t.name())).findFirst().orElse(null);
+
+    assertThat(searchTool).isNotNull();
+    assertThat(searchTool.title()).isEqualTo("Search Metadata");
+    assertThat(searchTool.annotations()).isNotNull();
+    assertThat(searchTool.annotations().readOnlyHint()).isTrue();
+    assertThat(searchTool.annotations().destructiveHint()).isFalse();
+  }
+
+  @Test
+  void testMcpUtilsGetToolPropertiesMarksPatchEntityAsDestructive() {
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    McpSchema.Tool patchTool =
+        tools.stream().filter(t -> "patch_entity".equals(t.name())).findFirst().orElse(null);
+
+    assertThat(patchTool).isNotNull();
+    assertThat(patchTool.annotations()).isNotNull();
+    assertThat(patchTool.annotations().readOnlyHint()).isFalse();
+    assertThat(patchTool.annotations().destructiveHint()).isTrue();
+  }
+
+  @Test
+  void testMcpUtilsGetToolPropertiesEveryToolHasTitleAndAnnotations() {
+    // Regression guard: a new tool added to tools.json without title/annotations would fail
+    // Claude Connectors Directory review. Fail the build instead of failing review.
+    List<McpSchema.Tool> tools = McpUtils.getToolProperties("json/data/mcp/tools.json");
+
+    assertThat(tools)
+        .allSatisfy(
+            tool -> {
+              assertThat(tool.title()).as("title for tool %s", tool.name()).isNotBlank();
+              assertThat(tool.annotations()).as("annotations for tool %s", tool.name()).isNotNull();
+            });
+  }
+
+  @Test
   void testServerCapabilitiesDoNotAdvertiseLogging() {
     // The stateless MCP server has no handler for logging/setLevel.
     // Advertising logging capability causes spec-compliant clients (e.g. VSCode)


### PR DESCRIPTION
Fixes #30107

## Summary
- Adds `title`, `readOnlyHint`, `destructiveHint`, `openWorldHint` annotations to all 23 MCP tools in `tools.json`.

## Why
Both Anthropic's Claude Connectors Directory and OpenAI's ChatGPT Apps directory require these tool annotations for submission review — missing or incorrect labels are a stated rejection cause. `openWorldHint` defaults to `true` per the MCP spec when omitted, which would mislabel every tool here as reaching external/public systems; all of them only read/write our own OpenMetadata catalog, so it's set explicitly to `false`.

## Test plan
- [x] Added regression tests asserting every tool has `title`, `readOnlyHint`/`destructiveHint`, and `openWorldHint == false`.
- [x] `mvn test -pl openmetadata-mcp -Dtest=McpSdkUpgradeTest` — 17/17 pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds MCP tool annotations required by connector directories. The main changes are:

- Adds titles and behavior hints to all 23 tool definitions.
- Maps the annotations into the MCP SDK tool schema.
- Marks all entity upsert tools as destructive.
- Adds tests for titles, destructive operations, and closed-world behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The latest fix looks safe to merge.

- Every entity tool identified as overwrite-capable is now marked destructive.
- Tests cover the full set of affected create-or-update tools.
- No separate issue meets the follow-up review criteria.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/resources/json/data/mcp/tools.json | Adds titles and behavior annotations to every MCP tool and marks all previously identified upsert tools as destructive. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/McpUtils.java | Maps titles and tool annotations from the JSON definitions into the MCP SDK schema. |
| openmetadata-mcp/src/test/java/org/openmetadata/mcp/McpSdkUpgradeTest.java | Adds tests for required annotations and all entity tools that overwrite through create-or-update behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): mark upsert-capable create too..."](https://github.com/open-metadata/openmetadata/commit/6c78eb6dde6d56d4044e4e100a92ac01d059f6c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44609227)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->