### PR TITLE
Fixes #30108: Improve dense 3D Knowledge Graph navigation

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -56,10 +56,11 @@ public class RdfRepository {
   private static final String KNOWLEDGE_GRAPH = "https://open-metadata.org/graph/knowledge";
 
   // Graph nodes only render label/name/FQN/description (core columns, populated
-  // regardless of the fields set) plus tags. Keep this minimal — "*" forced
-  // every relationship/derived-field branch (owners, columns, lineage, votes,
-  // ...) to load per entity, none of which the graph view reads.
-  private static final String GRAPH_NODE_FIELDS = "tags";
+  // regardless of the fields set) plus tags where the entity supports them.
+  // Keep this minimal — "*" forced every relationship/derived-field branch
+  // (owners, columns, lineage, votes, ...) to load per entity, none of which
+  // the graph view reads.
+  private static final String GRAPH_NODE_TAG_FIELDS = Entity.FIELD_TAGS;
 
   // Per-level row cap for the BFS traversal SPARQL. We query one row beyond it
   // (LIMIT cap+1) so a level that hits the cap can be detected and surfaced to
@@ -2557,8 +2558,10 @@ public class RdfRepository {
 
   private void fetchEntityBatch(
       String entityType, List<EntityReference> refs, Map<String, EntityInterface> target) {
+    String fields = "";
     try {
-      List<EntityInterface> entities = Entity.getEntities(refs, GRAPH_NODE_FIELDS, Include.ALL);
+      fields = graphNodeFields(entityType);
+      List<EntityInterface> entities = Entity.getEntities(refs, fields, Include.ALL);
       for (EntityInterface entity : entities) {
         target.put(entity.getId().toString(), entity);
       }
@@ -2573,16 +2576,18 @@ public class RdfRepository {
           refs.size(),
           entityType,
           e.getMessage());
-      fetchEntitiesIndividually(entityType, refs, target);
+      fetchEntitiesIndividually(entityType, refs, target, fields);
     }
   }
 
   private void fetchEntitiesIndividually(
-      String entityType, List<EntityReference> refs, Map<String, EntityInterface> target) {
+      String entityType,
+      List<EntityReference> refs,
+      Map<String, EntityInterface> target,
+      String fields) {
     for (EntityReference ref : refs) {
       try {
-        EntityInterface entity =
-            Entity.getEntity(entityType, ref.getId(), GRAPH_NODE_FIELDS, Include.ALL);
+        EntityInterface entity = Entity.getEntity(entityType, ref.getId(), fields, Include.ALL);
         target.put(entity.getId().toString(), entity);
       } catch (RuntimeException e) {
         LOG.warn(
@@ -2592,6 +2597,10 @@ public class RdfRepository {
             e.getMessage());
       }
     }
+  }
+
+  private String graphNodeFields(String entityType) {
+    return Entity.entityHasField(entityType, GRAPH_NODE_TAG_FIELDS) ? GRAPH_NODE_TAG_FIELDS : "";
   }
 
   private void populateNodeFromEntity(

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.constants.ts
@@ -157,7 +157,7 @@ export const COVERAGE_DIMMED_OPACITY = 0.26;
 /** Labels are rendered up to this cap, then progressively disclosed by priority. */
 export const LABEL_RENDER_LIMIT = 140;
 export const ALWAYS_VISIBLE_LABEL_LIMIT = 18;
-export const PRIORITY_LABEL_LIMIT = 12;
+export const PRIORITY_LABEL_LIMIT = 18;
 
 /** Dense layouts are widened to use a landscape stage and compressed in depth. */
 export const DENSE_GRAPH_NODE_THRESHOLD = 24;

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.constants.ts
@@ -121,8 +121,10 @@ export const PRIMARY_EMPHASIS = 1.5;
 export const CAMERA_FOCUS_DISTANCE = 110;
 export const CAMERA_FOCUS_DURATION_MS = 900;
 
-/** Charge force keeps clusters separated without exploding the layout. */
-export const CHARGE_STRENGTH = -140;
+/** Force tuning for readable hub-and-spoke and dense multi-hop layouts. */
+export const CHARGE_STRENGTH = -360;
+export const LINK_DISTANCE = 84;
+export const LINK_STRENGTH = 0.18;
 
 /**
  * Bound the force simulation so the render loop settles instead of animating
@@ -139,24 +141,29 @@ export const SIMULATION_COOLDOWN_TIME_MS = 8000;
 export const OPACITY_APPLY_FRAMES = 8;
 
 export const ZOOM_TO_FIT_DURATION_MS = 700;
-export const ZOOM_TO_FIT_PADDING = 90;
+export const ZOOM_TO_FIT_PADDING = 60;
 
 /**
- * `zoomToFit` frames node positions, not the (large) node sprites, so sparse
- * graphs end up too close. Pull the camera back to at least this distance from
- * the graph center after framing.
+ * Prevent an early fit from placing the camera inside a graph whose force
+ * simulation has not spread out yet. The settled layout is fitted again when
+ * the simulation stops, so this only acts as an initial visibility guard.
  */
-export const MIN_CAMERA_DISTANCE = 320;
+export const MIN_CAMERA_DISTANCE = 160;
 
 /** Opacity applied to nodes/links outside the active highlight set. */
 export const DIMMED_NODE_OPACITY = 0.13;
 export const COVERAGE_DIMMED_OPACITY = 0.26;
 
-/**
- * Above this node count, always-on labels are both unreadable and costly to
- * rasterize, so they are suppressed (hover still shows the name tooltip).
- */
-export const LABEL_NODE_LIMIT = 140;
+/** Labels are rendered up to this cap, then progressively disclosed by priority. */
+export const LABEL_RENDER_LIMIT = 140;
+export const ALWAYS_VISIBLE_LABEL_LIMIT = 18;
+export const PRIORITY_LABEL_LIMIT = 12;
+
+/** Dense layouts are widened to use a landscape stage and compressed in depth. */
+export const DENSE_GRAPH_NODE_THRESHOLD = 24;
+export const TARGET_LAYOUT_VIEWPORT_RATIO = 0.76;
+export const MAX_HORIZONTAL_LAYOUT_SCALE = 2.2;
+export const DENSE_GRAPH_DEPTH_SCALE = 0.65;
 
 export const LEGEND_TYPES: NodeType[] = [
   'domain',

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.interface.ts
@@ -26,6 +26,7 @@ export interface KnowledgeGraph3DProps {
 
 export interface KnowledgeGraph3DSceneProps {
   data: Graph3DData;
+  focusNodeId?: string;
   level: Level;
   gaps: boolean;
   selectedNodeId: string | null;
@@ -71,6 +72,7 @@ export interface KnowledgeGraph3DPanelProps {
   graph: Graph3DData;
   node: GraphNode3D;
   onClose: () => void;
+  onSelectNode: (node: GraphNode3D) => void;
 }
 
 export interface KnowledgeGraph3DEdgePanelProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.less
@@ -19,6 +19,10 @@
 @kg3d-overlay-border: rgba(255, 255, 255, 0.1);
 @kg3d-caption-muted: #717680;
 @kg3d-caption-text: #414651;
+@kg3d-panel-text-primary: #f4f7fc;
+@kg3d-panel-text-secondary: #eaf0fb;
+@kg3d-panel-text-muted: #94a3b8;
+@kg3d-panel-text-subtle: #8a93a8;
 
 .knowledge-graph-3d {
   height: @asset-details-tab-pane-height;
@@ -92,22 +96,66 @@
 }
 
 .kg3d-panel {
-  // Near-opaque so the busy 3D scene behind doesn't wash out the text.
   background: rgba(11, 16, 33, 0.96);
   backdrop-filter: blur(16px);
   animation: kg3dPanelIn 0.22s ease;
+  color: @kg3d-panel-text-primary;
 
-  // The detail panels are always a dark glass surface (over the 3D scene),
-  // independent of the app's light/dark theme. Pin the core-components text
-  // tokens to explicit light values so `tw:text-*` stays readable regardless
-  // of whether the .dark-mode token flip applies.
-  --color-text-primary: #f6f8fc;
-  --color-text-secondary: #dde4f0;
-  --color-text-tertiary: #aab3c7;
-  --color-text-quaternary: #aab3c7;
-  --text-color-primary: #f6f8fc;
-  --text-color-secondary: #dde4f0;
-  --text-color-tertiary: #aab3c7;
+  .kg3d-panel-text-primary {
+    color: @kg3d-panel-text-primary;
+  }
+
+  .kg3d-panel-text-secondary {
+    color: @kg3d-panel-text-secondary;
+  }
+
+  .kg3d-panel-text-muted {
+    color: @kg3d-panel-text-muted;
+  }
+
+  .kg3d-panel-text-subtle {
+    color: @kg3d-panel-text-subtle;
+  }
+
+  .kg3d-panel-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 9px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.07);
+    color: @kg3d-panel-text-secondary;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 16px;
+  }
+
+  .kg3d-panel-close {
+    flex: none;
+    background: rgba(255, 255, 255, 0.08);
+    color: #c2c9d6;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.14);
+      color: @kg3d-panel-text-primary;
+    }
+  }
+
+  .kg3d-panel-node-link {
+    margin: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    transition: background 0.15s ease;
+
+    &:hover,
+    &:focus-visible {
+      background: rgba(255, 255, 255, 0.07);
+      outline: none;
+    }
+  }
 }
 
 @keyframes kg3dPanelIn {

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.test.tsx
@@ -137,6 +137,9 @@ jest.mock('./KnowledgeGraph3DScene', () => ({
         <span data-testid="kg3d-scene-link-count">
           {props.data.links.length}
         </span>
+        <span data-testid="kg3d-scene-selected-node">
+          {props.selectedNodeId}
+        </span>
         <button
           data-testid="kg3d-select-node"
           type="button"
@@ -327,6 +330,20 @@ describe('KnowledgeGraph3D', () => {
     expect(
       screen.queryByText('message.mapped-to-business-ontology')
     ).not.toBeInTheDocument();
+  });
+
+  it('should focus a related node selected from the detail panel', async () => {
+    mockGetEntityGraphData.mockResolvedValue(GRAPH_DATA);
+
+    renderGraph();
+
+    await screen.findByTestId('kg3d-scene');
+    fireEvent.click(screen.getByTestId('kg3d-select-node'));
+    fireEvent.click(await screen.findByTestId('kg3d-related-node-con-1'));
+
+    expect(screen.getByTestId('kg3d-scene-selected-node')).toHaveTextContent(
+      'con-1'
+    );
   });
 
   it('should not apply the fullscreen layout class by default', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.tsx
@@ -395,6 +395,7 @@ const KnowledgeGraph3D: FC<KnowledgeGraph3DProps> = ({
             <Suspense fallback={<Loader />}>
               <KnowledgeGraph3DScene
                 data={view}
+                focusNodeId={entity.id}
                 gaps={gaps}
                 getLinkTooltip={getLinkTooltip}
                 getNodeTooltip={getNodeTooltip}
@@ -440,6 +441,7 @@ const KnowledgeGraph3D: FC<KnowledgeGraph3DProps> = ({
                   graph={adapted}
                   node={selectedNode}
                   onClose={clearSelection}
+                  onSelectNode={handleSelectNode}
                 />
               )
             )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.test.ts
@@ -251,7 +251,7 @@ describe('getVisibleLabelIds', () => {
   it('shows every label for a small graph', () => {
     const nodes = ['A', 'B', 'C'].map((id) => makeNode({ id, name: id }));
 
-    const visible = getVisibleLabelIds({ nodes, links: [] }, 'A', null, null);
+    const visible = getVisibleLabelIds({ nodes, links: [] }, 'A', null);
 
     expect([...visible].sort()).toEqual(['A', 'B', 'C']);
   });
@@ -260,10 +260,9 @@ describe('getVisibleLabelIds', () => {
     const nodes = [
       makeNode({ id: 'selected', name: 'Selected' }),
       makeNode({ id: 'neighbor', name: 'Neighbor' }),
-      makeNode({ id: 'hovered', name: 'Hovered' }),
       makeNode({ id: 'focus', name: 'Focus' }),
       makeNode({ id: 'hub', name: 'Hub' }),
-      ...Array.from({ length: 15 }, (_, index) =>
+      ...Array.from({ length: 16 }, (_, index) =>
         makeNode({ id: `node-${index}`, name: `Node ${index}` })
       ),
     ];
@@ -274,19 +273,39 @@ describe('getVisibleLabelIds', () => {
       ),
     ];
 
-    const visible = getVisibleLabelIds(
-      { nodes, links },
-      'focus',
-      'selected',
-      'hovered'
-    );
+    const visible = getVisibleLabelIds({ nodes, links }, 'focus', 'selected');
 
-    expect(visible.size).toBe(12);
+    expect(visible.size).toBe(18);
     expect(visible.has('focus')).toBe(true);
     expect(visible.has('selected')).toBe(true);
-    expect(visible.has('hovered')).toBe(true);
     expect(visible.has('neighbor')).toBe(true);
     expect(visible.has('hub')).toBe(true);
+  });
+
+  it('does not reduce the visible count when crossing the dense threshold', () => {
+    const atThreshold = Array.from({ length: 18 }, (_, index) =>
+      makeNode({ id: `node-${index}` })
+    );
+    const aboveThreshold = [...atThreshold, makeNode({ id: 'node-18' })];
+
+    expect(
+      getVisibleLabelIds({ nodes: atThreshold, links: [] }, undefined, null)
+        .size
+    ).toBe(18);
+    expect(
+      getVisibleLabelIds({ nodes: aboveThreshold, links: [] }, undefined, null)
+        .size
+    ).toBe(18);
+  });
+
+  it('skips label ranking when labels are not rendered', () => {
+    const nodes = Array.from({ length: 141 }, (_, index) =>
+      makeNode({ id: `node-${index}` })
+    );
+
+    expect(
+      getVisibleLabelIds({ nodes, links: [] }, 'node-0', 'node-1').size
+    ).toBe(0);
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.test.ts
@@ -14,6 +14,8 @@
 import {
   computeHighlight,
   computeLinkHighlight,
+  expandGraphLayout,
+  getVisibleLabelIds,
   idOf,
   linkKey,
   viewGraph,
@@ -242,5 +244,80 @@ describe('computeLinkHighlight', () => {
 
     expect(result.nodes.size).toBe(0);
     expect(result.links.size).toBe(0);
+  });
+});
+
+describe('getVisibleLabelIds', () => {
+  it('shows every label for a small graph', () => {
+    const nodes = ['A', 'B', 'C'].map((id) => makeNode({ id, name: id }));
+
+    const visible = getVisibleLabelIds({ nodes, links: [] }, 'A', null, null);
+
+    expect([...visible].sort()).toEqual(['A', 'B', 'C']);
+  });
+
+  it('prioritizes the focus, interaction targets and selected neighbors in a dense graph', () => {
+    const nodes = [
+      makeNode({ id: 'selected', name: 'Selected' }),
+      makeNode({ id: 'neighbor', name: 'Neighbor' }),
+      makeNode({ id: 'hovered', name: 'Hovered' }),
+      makeNode({ id: 'focus', name: 'Focus' }),
+      makeNode({ id: 'hub', name: 'Hub' }),
+      ...Array.from({ length: 15 }, (_, index) =>
+        makeNode({ id: `node-${index}`, name: `Node ${index}` })
+      ),
+    ];
+    const links = [
+      makeLink({ source: 'selected', target: 'neighbor' }),
+      ...Array.from({ length: 10 }, (_, index) =>
+        makeLink({ source: 'hub', target: `node-${index}` })
+      ),
+    ];
+
+    const visible = getVisibleLabelIds(
+      { nodes, links },
+      'focus',
+      'selected',
+      'hovered'
+    );
+
+    expect(visible.size).toBe(12);
+    expect(visible.has('focus')).toBe(true);
+    expect(visible.has('selected')).toBe(true);
+    expect(visible.has('hovered')).toBe(true);
+    expect(visible.has('neighbor')).toBe(true);
+    expect(visible.has('hub')).toBe(true);
+  });
+});
+
+describe('expandGraphLayout', () => {
+  it('widens and flattens a dense layout to use a landscape viewport', () => {
+    const nodes = Array.from({ length: 24 }, (_, index) =>
+      makeNode({
+        id: `node-${index}`,
+        x: index % 2 === 0 ? -10 : 10,
+        y: index * 4,
+        z: index % 2 === 0 ? -10 : 10,
+      })
+    );
+
+    const horizontalScale = expandGraphLayout(nodes, 1600, 800);
+
+    expect(horizontalScale).toBe(2.2);
+    expect(nodes[0].x).toBe(-22);
+    expect(nodes[1].x).toBe(22);
+    expect(nodes[0].z).toBe(-6.5);
+    expect(nodes[1].z).toBe(6.5);
+  });
+
+  it('leaves a small layout unchanged', () => {
+    const nodes = [
+      makeNode({ id: 'A', x: -10, y: 0, z: -10 }),
+      makeNode({ id: 'B', x: 10, y: 20, z: 10 }),
+    ];
+
+    expect(expandGraphLayout(nodes, 1600, 800)).toBe(1);
+    expect(nodes[0].x).toBe(-10);
+    expect(nodes[0].z).toBe(-10);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.ts
@@ -11,6 +11,14 @@
  *  limitations under the License.
  */
 
+import {
+  ALWAYS_VISIBLE_LABEL_LIMIT,
+  DENSE_GRAPH_DEPTH_SCALE,
+  DENSE_GRAPH_NODE_THRESHOLD,
+  MAX_HORIZONTAL_LAYOUT_SCALE,
+  PRIORITY_LABEL_LIMIT,
+  TARGET_LAYOUT_VIEWPORT_RATIO,
+} from './KnowledgeGraph3D.constants';
 import { Graph3DData, GraphLink3D, GraphNode3D, Lens, Level } from './types';
 
 export const idOf = (endpoint: string | GraphNode3D): string =>
@@ -108,4 +116,136 @@ export const computeLinkHighlight = (
   });
 
   return { nodes, links: incident };
+};
+
+const degreesOf = (graph: Graph3DData): Map<string, number> => {
+  const degrees = new Map<string, number>();
+  graph.nodes.forEach((node) => degrees.set(node.id, 0));
+  graph.links.forEach((link) => {
+    const source = idOf(link.source);
+    const target = idOf(link.target);
+    degrees.set(source, (degrees.get(source) ?? 0) + 1);
+    degrees.set(target, (degrees.get(target) ?? 0) + 1);
+  });
+
+  return degrees;
+};
+
+/**
+ * Keeps dense-graph labels useful without painting every name at once. The
+ * focus, selection and hover labels win first, followed by selected neighbors
+ * and then the most connected nodes.
+ */
+export const getVisibleLabelIds = (
+  graph: Graph3DData,
+  focusNodeId: string | undefined,
+  selectedNodeId: string | null,
+  hoveredNodeId: string | null
+): Set<string> => {
+  if (graph.nodes.length <= ALWAYS_VISIBLE_LABEL_LIMIT) {
+    return new Set(graph.nodes.map((node) => node.id));
+  }
+
+  const nodeIds = new Set(graph.nodes.map((node) => node.id));
+  const visible = new Set<string>();
+  const addVisible = (nodeId: string | null | undefined): void => {
+    if (nodeId && nodeIds.has(nodeId)) {
+      visible.add(nodeId);
+    }
+  };
+
+  addVisible(selectedNodeId);
+  addVisible(hoveredNodeId);
+  addVisible(focusNodeId);
+
+  const degrees = degreesOf(graph);
+  const selectedNeighborhood = selectedNodeId
+    ? computeHighlight(graph.links, selectedNodeId).nodes
+    : new Set<string>();
+  const ranked = [...graph.nodes].sort((left, right) => {
+    const neighborhoodRank =
+      Number(selectedNeighborhood.has(right.id)) -
+      Number(selectedNeighborhood.has(left.id));
+    if (neighborhoodRank !== 0) {
+      return neighborhoodRank;
+    }
+
+    const degreeRank =
+      (degrees.get(right.id) ?? 0) - (degrees.get(left.id) ?? 0);
+
+    return degreeRank || left.name.localeCompare(right.name);
+  });
+
+  for (const node of ranked) {
+    if (visible.size >= PRIORITY_LABEL_LIMIT) {
+      break;
+    }
+    visible.add(node.id);
+  }
+
+  return visible;
+};
+
+const isFiniteCoordinate = (value: number | undefined): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/**
+ * Force layouts naturally settle into a roughly spherical footprint. Stretch
+ * dense graphs toward the stage aspect ratio and flatten some depth so a wide
+ * viewport is used for separation instead of empty gutters.
+ */
+export const expandGraphLayout = (
+  nodes: GraphNode3D[],
+  viewportWidth: number,
+  viewportHeight: number
+): number => {
+  if (
+    nodes.length < DENSE_GRAPH_NODE_THRESHOLD ||
+    viewportWidth <= 0 ||
+    viewportHeight <= 0
+  ) {
+    return 1;
+  }
+
+  const xCoordinates = nodes.map((node) => node.x).filter(isFiniteCoordinate);
+  const yCoordinates = nodes.map((node) => node.y).filter(isFiniteCoordinate);
+  if (xCoordinates.length < 2 || yCoordinates.length < 2) {
+    return 1;
+  }
+
+  const minX = Math.min(...xCoordinates);
+  const maxX = Math.max(...xCoordinates);
+  const minY = Math.min(...yCoordinates);
+  const maxY = Math.max(...yCoordinates);
+  const graphWidth = maxX - minX;
+  const graphHeight = maxY - minY;
+  if (graphWidth <= 0 || graphHeight <= 0) {
+    return 1;
+  }
+
+  const viewportAspect = viewportWidth / viewportHeight;
+  const targetAspect = Math.max(
+    1,
+    viewportAspect * TARGET_LAYOUT_VIEWPORT_RATIO
+  );
+  const horizontalScale = Math.min(
+    MAX_HORIZONTAL_LAYOUT_SCALE,
+    Math.max(1, targetAspect / (graphWidth / graphHeight))
+  );
+  const centerX = (minX + maxX) / 2;
+  const zCoordinates = nodes.map((node) => node.z).filter(isFiniteCoordinate);
+  const centerZ = zCoordinates.length
+    ? (Math.min(...zCoordinates) + Math.max(...zCoordinates)) / 2
+    : 0;
+
+  nodes.forEach((node) => {
+    if (isFiniteCoordinate(node.x)) {
+      node.x = centerX + (node.x - centerX) * horizontalScale;
+    }
+    if (isFiniteCoordinate(node.z)) {
+      node.z = centerZ + (node.z - centerZ) * DENSE_GRAPH_DEPTH_SCALE;
+    }
+  });
+
+  return horizontalScale;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.ts
@@ -15,6 +15,7 @@ import {
   ALWAYS_VISIBLE_LABEL_LIMIT,
   DENSE_GRAPH_DEPTH_SCALE,
   DENSE_GRAPH_NODE_THRESHOLD,
+  LABEL_RENDER_LIMIT,
   MAX_HORIZONTAL_LAYOUT_SCALE,
   PRIORITY_LABEL_LIMIT,
   TARGET_LAYOUT_VIEWPORT_RATIO,
@@ -133,15 +134,19 @@ const degreesOf = (graph: Graph3DData): Map<string, number> => {
 
 /**
  * Keeps dense-graph labels useful without painting every name at once. The
- * focus, selection and hover labels win first, followed by selected neighbors
- * and then the most connected nodes.
+ * focus and selection labels win first, followed by selected neighbors and
+ * then the most connected nodes. Hover labels are handled imperatively by the
+ * scene so pointer movement does not repeat this ranking work.
  */
 export const getVisibleLabelIds = (
   graph: Graph3DData,
   focusNodeId: string | undefined,
-  selectedNodeId: string | null,
-  hoveredNodeId: string | null
+  selectedNodeId: string | null
 ): Set<string> => {
+  if (graph.nodes.length > LABEL_RENDER_LIMIT) {
+    return new Set();
+  }
+
   if (graph.nodes.length <= ALWAYS_VISIBLE_LABEL_LIMIT) {
     return new Set(graph.nodes.map((node) => node.id));
   }
@@ -155,7 +160,6 @@ export const getVisibleLabelIds = (
   };
 
   addVisible(selectedNodeId);
-  addVisible(hoveredNodeId);
   addVisible(focusNodeId);
 
   const degrees = degreesOf(graph);

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DEdgePanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DEdgePanel.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Badge, CloseButton } from '@openmetadata/ui-core-components';
+import { CloseButton } from '@openmetadata/ui-core-components';
 import { FC, ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -40,10 +40,10 @@ const EndpointRow: FC<{
       style={{ background: colorFor(node.type) }}
     />
     <span className="tw:min-w-0">
-      <span className="tw:block tw:truncate tw:text-sm tw:font-semibold tw:text-primary">
+      <span className="kg3d-panel-text-primary tw:block tw:truncate tw:text-sm tw:font-semibold">
         {node.name}
       </span>
-      <span className="tw:text-xs tw:text-tertiary">{sublabel}</span>
+      <span className="kg3d-panel-text-subtle tw:text-xs">{sublabel}</span>
     </span>
   </button>
 );
@@ -73,10 +73,10 @@ const DerivationChain: FC<{ path: string[] }> = ({ path }) => {
                   boxShadow: `0 0 9px ${dotColor}`,
                 }}
               />
-              <span className="tw:text-[13px] tw:font-semibold tw:text-secondary">
+              <span className="kg3d-panel-text-secondary tw:text-[13px] tw:font-semibold">
                 {step}
               </span>
-              <span className="tw:ml-auto tw:text-[10px] tw:text-quaternary">
+              <span className="kg3d-panel-text-muted tw:ml-auto tw:text-[10px]">
                 {t(isEndpoint ? 'label.asset' : 'label.term')}
               </span>
             </div>
@@ -109,35 +109,44 @@ const KnowledgeGraph3DEdgePanel: FC<KnowledgeGraph3DEdgePanelProps> = ({
     : link.label;
 
   return (
-    <div className="dark-mode kg3d-panel tw:absolute tw:top-3.5 tw:right-3.5 tw:bottom-3.5 tw:flex tw:w-80 tw:flex-col tw:overflow-hidden tw:rounded-2xl tw:border tw:border-white/10 tw:shadow-2xl">
+    <div className="kg3d-panel tw:absolute tw:top-3.5 tw:right-3.5 tw:bottom-3.5 tw:flex tw:w-80 tw:flex-col tw:overflow-hidden tw:rounded-2xl tw:border tw:border-white/10 tw:shadow-2xl">
       <div className="tw:flex tw:items-start tw:gap-3 tw:border-b tw:border-white/[0.08] tw:p-4">
         <span
           className="tw:mt-1 tw:size-3 tw:flex-none tw:rounded-full"
           style={{ background: accent, boxShadow: `0 0 12px ${accent}` }}
         />
         <div className="tw:min-w-0 tw:flex-1">
-          <div className="tw:text-base tw:font-bold tw:text-primary">
+          <div className="kg3d-panel-text-primary tw:text-base tw:font-bold">
             {t(isDerived ? 'label.derived-relationship' : 'label.relationship')}
           </div>
           <div className="tw:mt-1.5">
-            <Badge
-              color={isOntology ? 'warning' : 'blue'}
-              size="sm"
-              type="pill-color">
+            <span
+              className="kg3d-panel-pill"
+              style={{
+                color: accent,
+                background: hexRgba(accent, 0.14),
+                borderColor: hexRgba(accent, 0.35),
+              }}>
               {isDerived
                 ? t('label.ontology-inferred')
                 : isOntology
                 ? t('label.ontology')
                 : t('label.knowledge-graph')}
-            </Badge>
+            </span>
           </div>
         </div>
-        <CloseButton size="sm" onClick={onClose} />
+        <CloseButton
+          className="kg3d-panel-close"
+          label={t('label.close')}
+          size="xs"
+          theme="dark"
+          onClick={onClose}
+        />
       </div>
 
       {isDerived && link.relation && link.path ? (
         <div className="tw:flex-1 tw:overflow-y-auto tw:px-4 tw:pt-4 tw:pb-4">
-          <p className="tw:mb-3 tw:text-xs tw:leading-relaxed tw:text-tertiary">
+          <p className="kg3d-panel-text-subtle tw:mb-3 tw:text-xs tw:leading-relaxed">
             <span
               className="tw:font-semibold"
               style={{ color: LINK_ONTOLOGY_COLOR }}>
@@ -154,7 +163,7 @@ const KnowledgeGraph3DEdgePanel: FC<KnowledgeGraph3DEdgePanelProps> = ({
               className="tw:size-2 tw:rounded-sm"
               style={{ background: accent }}
             />
-            <span className="tw:text-xs tw:font-semibold tw:tracking-wide tw:text-quaternary tw:uppercase">
+            <span className="kg3d-panel-text-muted tw:text-xs tw:font-semibold tw:tracking-wide tw:uppercase">
               {relationLabel}
             </span>
           </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DPanel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DPanel.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { Badge, CloseButton } from '@openmetadata/ui-core-components';
+import { CloseButton } from '@openmetadata/ui-core-components';
 import { FC, ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -23,7 +23,7 @@ import {
 import { KnowledgeGraph3DPanelProps } from './KnowledgeGraph3D.interface';
 import { colorFor } from './nodeCanvas';
 import { relationsOf, RELATION_LABEL_KEYS } from './rdfGraphAdapter';
-import { NodeType, RelationRow, SharedConceptRow } from './types';
+import { GraphNode3D, NodeType, RelationRow, SharedConceptRow } from './types';
 
 const MEMBER_ACCENT = '#26C281';
 const MAPPED_ACCENT = '#17B26A';
@@ -72,61 +72,82 @@ const Section: FC<SectionProps> = ({ accent, title, count, children }) => (
         className="tw:size-2 tw:rounded-sm"
         style={{ background: accent }}
       />
-      <span className="tw:text-xs tw:font-semibold tw:tracking-wide tw:text-quaternary tw:uppercase">
+      <span className="kg3d-panel-text-muted tw:text-xs tw:font-semibold tw:tracking-wide tw:uppercase">
         {title}
       </span>
-      <span className="tw:text-xs tw:text-quaternary">{count}</span>
+      <span className="kg3d-panel-text-subtle tw:text-xs">{count}</span>
     </div>
     {children}
   </div>
 );
 
-const RelationRowItem: FC<{ row: RelationRow }> = ({ row }) => {
+const RelationRowItem: FC<{
+  row: RelationRow;
+  onSelectNode: (node: GraphNode3D) => void;
+}> = ({ row, onSelectNode }) => {
   const { t } = useTranslation();
   const labelKey = RELATION_LABEL_KEYS[row.label];
 
   return (
-    <div className="tw:flex tw:items-center tw:gap-2.5 tw:border-b tw:border-white/[0.08] tw:py-2">
+    <button
+      aria-label={`${t('label.focus-on-node')}: ${row.other.name}`}
+      className="kg3d-panel-node-link tw:flex tw:w-full tw:items-center tw:gap-2.5 tw:border-x-0 tw:border-t-0 tw:border-b tw:border-white/[0.08] tw:py-2 tw:text-left"
+      data-testid={`kg3d-related-node-${row.other.id}`}
+      type="button"
+      onClick={() => onSelectNode(row.other)}>
       <span
         className="tw:size-2 tw:flex-none tw:rounded-full"
         style={{ background: colorFor(row.other.type) }}
       />
       <div className="tw:min-w-0">
-        <div className="tw:truncate tw:text-sm tw:font-semibold tw:text-primary">
+        <div className="kg3d-panel-text-primary tw:truncate tw:text-sm tw:font-semibold">
           {row.other.name}
         </div>
-        <div className="tw:text-xs tw:text-tertiary">
+        <div className="kg3d-panel-text-subtle tw:text-xs">
           {row.direction === 'in' ? '← ' : ''}
           {labelKey ? t(labelKey) : row.label}
           {row.direction === 'out' ? ' →' : ''}
         </div>
       </div>
-    </div>
+    </button>
   );
 };
 
-const SharedRowItem: FC<{ row: SharedConceptRow }> = ({ row }) => (
-  <div className="tw:flex tw:items-start tw:gap-2.5 tw:border-b tw:border-white/[0.06] tw:py-1.5">
-    <span
-      className="tw:mt-1 tw:size-1.5 tw:flex-none tw:rounded-full"
-      style={{ background: colorFor('table') }}
-    />
-    <div>
-      <div className="tw:text-sm tw:font-medium tw:text-secondary">
-        {row.asset.name}
+const SharedRowItem: FC<{
+  row: SharedConceptRow;
+  onSelectNode: (node: GraphNode3D) => void;
+}> = ({ row, onSelectNode }) => {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      aria-label={`${t('label.focus-on-node')}: ${row.asset.name}`}
+      className="kg3d-panel-node-link tw:flex tw:w-full tw:items-start tw:gap-2.5 tw:border-x-0 tw:border-t-0 tw:border-b tw:border-white/[0.06] tw:py-1.5 tw:text-left"
+      data-testid={`kg3d-related-node-${row.asset.id}`}
+      type="button"
+      onClick={() => onSelectNode(row.asset)}>
+      <span
+        className="tw:mt-1 tw:size-1.5 tw:flex-none tw:rounded-full"
+        style={{ background: colorFor('table') }}
+      />
+      <div>
+        <div className="kg3d-panel-text-secondary tw:text-sm tw:font-medium">
+          {row.asset.name}
+        </div>
+        <div className="kg3d-panel-text-subtle tw:text-xs">
+          {row.via ? `${row.via} · ` : ''}
+          <span style={{ color: ONTOLOGY_PARTICLE_COLOR }}>{row.path}</span>
+        </div>
       </div>
-      <div className="tw:text-xs tw:text-tertiary">
-        {row.via ? `${row.via} · ` : ''}
-        <span style={{ color: ONTOLOGY_PARTICLE_COLOR }}>{row.path}</span>
-      </div>
-    </div>
-  </div>
-);
+    </button>
+  );
+};
 
 const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
   graph,
   node,
   onClose,
+  onSelectNode,
 }) => {
   const { t } = useTranslation();
   const relations = useMemo(
@@ -150,7 +171,7 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
     relations.members.length > 0;
 
   return (
-    <div className="dark-mode kg3d-panel tw:absolute tw:top-3.5 tw:right-3.5 tw:bottom-3.5 tw:flex tw:w-80 tw:flex-col tw:overflow-hidden tw:rounded-2xl tw:border tw:border-white/10 tw:shadow-2xl">
+    <div className="kg3d-panel tw:absolute tw:top-3.5 tw:right-3.5 tw:bottom-3.5 tw:flex tw:w-80 tw:flex-col tw:overflow-hidden tw:rounded-2xl tw:border tw:border-white/10 tw:shadow-2xl">
       <div className="tw:border-b tw:border-white/[0.08] tw:p-4">
         <div className="tw:flex tw:items-start tw:gap-3">
           <span
@@ -158,16 +179,26 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
             style={{ background: dotColor, boxShadow: `0 0 12px ${dotColor}` }}
           />
           <div className="tw:min-w-0 tw:flex-1">
-            <div className="tw:text-base tw:font-bold tw:break-words tw:text-primary">
+            <div className="kg3d-panel-text-primary tw:text-base tw:font-bold tw:break-words">
               {node.name}
             </div>
             <div className="tw:mt-1.5">
-              <Badge color="gray" size="sm" type="pill-color">
+              <span className="kg3d-panel-pill">
+                <span
+                  className="tw:size-1.5 tw:rounded-full"
+                  style={{ background: dotColor }}
+                />
                 {t(TYPE_LABEL_KEY[node.type])}
-              </Badge>
+              </span>
             </div>
           </div>
-          <CloseButton size="sm" onClick={onClose} />
+          <CloseButton
+            className="kg3d-panel-close"
+            label={t('label.close')}
+            size="xs"
+            theme="dark"
+            onClick={onClose}
+          />
         </div>
 
         {node.type === 'table' && (
@@ -205,6 +236,7 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
               <RelationRowItem
                 key={`${row.direction}-${row.label}-${row.other.id}`}
                 row={row}
+                onSelectNode={onSelectNode}
               />
             ))}
           </Section>
@@ -216,7 +248,11 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
             count={relations.shared.length}
             title={t('label.related-through-shared-concept-plural')}>
             {relations.shared.map((row) => (
-              <SharedRowItem key={row.asset.id} row={row} />
+              <SharedRowItem
+                key={row.asset.id}
+                row={row}
+                onSelectNode={onSelectNode}
+              />
             ))}
           </Section>
         )}
@@ -230,6 +266,7 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
               <RelationRowItem
                 key={`${row.direction}-${row.label}-${row.other.id}`}
                 row={row}
+                onSelectNode={onSelectNode}
               />
             ))}
           </Section>
@@ -244,6 +281,7 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
               <RelationRowItem
                 key={`${row.direction}-${row.label}-${row.other.id}`}
                 row={row}
+                onSelectNode={onSelectNode}
               />
             ))}
           </Section>
@@ -258,13 +296,14 @@ const KnowledgeGraph3DPanel: FC<KnowledgeGraph3DPanelProps> = ({
               <RelationRowItem
                 key={`${row.direction}-${row.label}-${row.other.id}`}
                 row={row}
+                onSelectNode={onSelectNode}
               />
             ))}
           </Section>
         )}
 
         {!hasBody && (
-          <div className="tw:py-6 tw:text-sm tw:text-tertiary">
+          <div className="kg3d-panel-text-subtle tw:py-6 tw:text-sm">
             {t('message.no-relation-at-level')}
           </div>
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DScene.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DScene.tsx
@@ -68,6 +68,20 @@ type SceneGraphMethods = ForceGraphMethods<SceneNode, SceneLink>;
 const FRAME_DELAY_MS = 600;
 const DIM_LINK_COLOR = hexRgba('#7A8194', 0.07);
 
+const sceneNodeId = (node: SceneNode | null): string | null =>
+  node?.id ? String(node.id) : null;
+
+const setNodeLabelVisibility = (
+  node: SceneNode | null,
+  visible: boolean
+): void => {
+  const object = node?.__threeObj as Object3D | undefined;
+  const label = object?.getObjectByName(NODE_LABEL_OBJECT_NAME);
+  if (label) {
+    label.visible = visible;
+  }
+};
+
 const nodeOpacityFor = (
   node: GraphNode3D,
   gaps: boolean,
@@ -151,8 +165,10 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   const settledFitPendingRef = useRef(true);
   const layoutExpandedRef = useRef(false);
   const cameraGuardTimerRef = useRef(0);
+  const hoveredNodeRef = useRef<SceneNode | null>(null);
+  const pendingHoveredNodeRef = useRef<SceneNode | null>(null);
+  const hoverFrameRef = useRef(0);
   const [size, setSize] = useState({ width: 0, height: 0 });
-  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
   const reducedMotion = useMemo(
     () =>
@@ -173,8 +189,8 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   }, [data.links, selectedNodeId, selectedLinkKey]);
 
   const visibleLabelIds = useMemo(
-    () => getVisibleLabelIds(data, focusNodeId, selectedNodeId, hoveredNodeId),
-    [data, focusNodeId, selectedNodeId, hoveredNodeId]
+    () => getVisibleLabelIds(data, focusNodeId, selectedNodeId),
+    [data, focusNodeId, selectedNodeId]
   );
 
   const resetView = useCallback(() => {
@@ -227,7 +243,49 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
     [level, gaps, renderLabels]
   );
 
+  const handleNodeHover = useCallback(
+    (node: SceneNode | null) => {
+      if (!renderLabels) {
+        return;
+      }
+
+      const queuedNode = hoverFrameRef.current
+        ? pendingHoveredNodeRef.current
+        : hoveredNodeRef.current;
+      if (sceneNodeId(queuedNode) === sceneNodeId(node)) {
+        return;
+      }
+
+      pendingHoveredNodeRef.current = node;
+      window.cancelAnimationFrame(hoverFrameRef.current);
+      hoverFrameRef.current = window.requestAnimationFrame(() => {
+        const previousNode = hoveredNodeRef.current;
+        const nextNode = pendingHoveredNodeRef.current;
+        const previousNodeId = sceneNodeId(previousNode);
+        const nextNodeId = sceneNodeId(nextNode);
+
+        if (
+          previousNodeId &&
+          previousNodeId !== nextNodeId &&
+          !visibleLabelIds.has(previousNodeId)
+        ) {
+          setNodeLabelVisibility(previousNode, false);
+        }
+        if (nextNodeId) {
+          setNodeLabelVisibility(nextNode, true);
+        }
+
+        hoveredNodeRef.current = nextNode;
+        pendingHoveredNodeRef.current = null;
+        hoverFrameRef.current = 0;
+        fgRef.current?.refresh();
+      });
+    },
+    [renderLabels, visibleLabelIds]
+  );
+
   const applyNodePresentation = useCallback(() => {
+    const hoveredNodeId = sceneNodeId(hoveredNodeRef.current);
     data.nodes.forEach((node) => {
       const object = (node as SceneNode).__threeObj as Object3D | undefined;
       if (!object) {
@@ -235,7 +293,8 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
       }
       const label = object.getObjectByName(NODE_LABEL_OBJECT_NAME);
       if (label) {
-        label.visible = visibleLabelIds.has(node.id);
+        label.visible =
+          visibleLabelIds.has(node.id) || hoveredNodeId === node.id;
       }
       const opacity = nodeOpacityFor(node, gaps, highlight);
       object.traverse((child) => {
@@ -258,10 +317,18 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   useEffect(
     () => () => {
       window.clearTimeout(cameraGuardTimerRef.current);
+      window.cancelAnimationFrame(hoverFrameRef.current);
       disposeTextureCaches();
     },
     []
   );
+
+  useEffect(() => {
+    window.cancelAnimationFrame(hoverFrameRef.current);
+    hoveredNodeRef.current = null;
+    pendingHoveredNodeRef.current = null;
+    hoverFrameRef.current = 0;
+  }, [data]);
 
   useLayoutEffect(() => {
     const element = containerRef.current;
@@ -415,9 +482,7 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
         onEngineStop={handleEngineStop}
         onLinkClick={(link: SceneLink) => onSelectLink(link as GraphLink3D)}
         onNodeClick={(node: SceneNode) => onSelectNode(node as GraphNode3D)}
-        onNodeHover={(node: SceneNode | null) =>
-          setHoveredNodeId(node?.id ? String(node.id) : null)
-        }
+        onNodeHover={handleNodeHover}
       />
     </div>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DScene.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DScene.tsx
@@ -25,14 +25,17 @@ import ForceGraph3D, {
   LinkObject,
   NodeObject,
 } from 'react-force-graph-3d';
+import type { Object3D } from 'three';
 import {
   CAMERA_FOCUS_DISTANCE,
   CAMERA_FOCUS_DURATION_MS,
   CHARGE_STRENGTH,
   COVERAGE_DIMMED_OPACITY,
   DIMMED_NODE_OPACITY,
-  LABEL_NODE_LIMIT,
+  LABEL_RENDER_LIMIT,
+  LINK_DISTANCE,
   LINK_ONTOLOGY_COLOR,
+  LINK_STRENGTH,
   LINK_TECHNICAL_COLOR,
   MIN_CAMERA_DISTANCE,
   ONTOLOGY_PARTICLE_COLOR,
@@ -46,17 +49,23 @@ import { KnowledgeGraph3DSceneProps } from './KnowledgeGraph3D.interface';
 import {
   computeHighlight,
   computeLinkHighlight,
+  expandGraphLayout,
+  getVisibleLabelIds,
   HighlightSet,
 } from './KnowledgeGraph3D.utils';
 import { hexRgba, sizeFor } from './nodeCanvas';
-import { buildNodeObject, disposeTextureCaches } from './nodeRendering';
+import {
+  buildNodeObject,
+  disposeTextureCaches,
+  NODE_LABEL_OBJECT_NAME,
+} from './nodeRendering';
 import { GraphLink3D, GraphNode3D } from './types';
 
 type SceneNode = NodeObject<GraphNode3D>;
 type SceneLink = LinkObject<GraphNode3D, GraphLink3D>;
 type SceneGraphMethods = ForceGraphMethods<SceneNode, SceneLink>;
 
-const FRAME_DELAY_MS = 500;
+const FRAME_DELAY_MS = 600;
 const DIM_LINK_COLOR = hexRgba('#7A8194', 0.07);
 
 const nodeOpacityFor = (
@@ -122,6 +131,7 @@ const linkParticlesFor = (
 
 const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   data,
+  focusNodeId,
   level,
   gaps,
   selectedNodeId,
@@ -138,7 +148,11 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const didMountRef = useRef(false);
   const refitPendingRef = useRef(false);
+  const settledFitPendingRef = useRef(true);
+  const layoutExpandedRef = useRef(false);
+  const cameraGuardTimerRef = useRef(0);
   const [size, setSize] = useState({ width: 0, height: 0 });
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
 
   const reducedMotion = useMemo(
     () =>
@@ -158,22 +172,31 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
     return result;
   }, [data.links, selectedNodeId, selectedLinkKey]);
 
+  const visibleLabelIds = useMemo(
+    () => getVisibleLabelIds(data, focusNodeId, selectedNodeId, hoveredNodeId),
+    [data, focusNodeId, selectedNodeId, hoveredNodeId]
+  );
+
   const resetView = useCallback(() => {
     const fg = fgRef.current;
     if (!fg) {
       return;
     }
     fg.zoomToFit(ZOOM_TO_FIT_DURATION_MS, ZOOM_TO_FIT_PADDING);
-    window.setTimeout(() => {
+    window.clearTimeout(cameraGuardTimerRef.current);
+    cameraGuardTimerRef.current = window.setTimeout(() => {
       const { x, y, z } = fg.camera().position;
       const distance = Math.hypot(x, y, z);
-      if (distance > 0 && distance < MIN_CAMERA_DISTANCE) {
-        const ratio = MIN_CAMERA_DISTANCE / distance;
-        fg.cameraPosition(
-          { x: x * ratio, y: y * ratio, z: z * ratio },
-          undefined,
-          400
-        );
+      if (distance < MIN_CAMERA_DISTANCE) {
+        const position =
+          distance === 0
+            ? { x: 0, y: 0, z: MIN_CAMERA_DISTANCE }
+            : {
+                x: x * (MIN_CAMERA_DISTANCE / distance),
+                y: y * (MIN_CAMERA_DISTANCE / distance),
+                z: z * (MIN_CAMERA_DISTANCE / distance),
+              };
+        fg.cameraPosition(position, undefined, 300);
       }
     }, ZOOM_TO_FIT_DURATION_MS + 60);
   }, []);
@@ -193,24 +216,26 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
     return result;
   }, []);
 
-  const showLabels = data.nodes.length <= LABEL_NODE_LIMIT;
+  const renderLabels = data.nodes.length <= LABEL_RENDER_LIMIT;
   const nodeThreeObject = useCallback(
     (node: SceneNode) =>
       buildNodeObject(node as GraphNode3D, {
         level,
         gaps,
-        showLabel: showLabels,
+        showLabel: renderLabels,
       }),
-    [level, gaps, showLabels]
+    [level, gaps, renderLabels]
   );
 
-  const applyNodeOpacity = useCallback(() => {
+  const applyNodePresentation = useCallback(() => {
     data.nodes.forEach((node) => {
-      const object = (node as SceneNode).__threeObj as
-        | { traverse: (cb: (child: unknown) => void) => void }
-        | undefined;
+      const object = (node as SceneNode).__threeObj as Object3D | undefined;
       if (!object) {
         return;
+      }
+      const label = object.getObjectByName(NODE_LABEL_OBJECT_NAME);
+      if (label) {
+        label.visible = visibleLabelIds.has(node.id);
       }
       const opacity = nodeOpacityFor(node, gaps, highlight);
       object.traverse((child) => {
@@ -223,14 +248,20 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
         }
       });
     });
-  }, [data.nodes, gaps, highlight]);
+  }, [data.nodes, gaps, highlight, visibleLabelIds]);
 
   useEffect(() => {
     registerResetView?.(resetView);
     registerExportImage?.(exportImage);
   }, [registerResetView, registerExportImage, resetView, exportImage]);
 
-  useEffect(() => () => disposeTextureCaches(), []);
+  useEffect(
+    () => () => {
+      window.clearTimeout(cameraGuardTimerRef.current);
+      disposeTextureCaches();
+    },
+    []
+  );
 
   useLayoutEffect(() => {
     const element = containerRef.current;
@@ -271,18 +302,36 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
   }, [size.width, size.height, resetView]);
 
   useEffect(() => {
-    const charge = fgRef.current?.d3Force('charge');
+    const graph = fgRef.current;
+    settledFitPendingRef.current = true;
+    layoutExpandedRef.current = false;
+    const charge = graph?.d3Force('charge');
+    const link = graph?.d3Force('link');
     charge?.strength(CHARGE_STRENGTH);
+    link?.distance(LINK_DISTANCE).strength(LINK_STRENGTH);
+    graph?.d3ReheatSimulation();
     const frame = setTimeout(resetView, FRAME_DELAY_MS);
 
     return () => clearTimeout(frame);
   }, [data, resetView]);
 
+  const handleEngineStop = useCallback(() => {
+    if (settledFitPendingRef.current) {
+      settledFitPendingRef.current = false;
+      if (!layoutExpandedRef.current) {
+        layoutExpandedRef.current = true;
+        expandGraphLayout(data.nodes, size.width, size.height);
+        fgRef.current?.refresh();
+      }
+      resetView();
+    }
+  }, [data.nodes, resetView, size.height, size.width]);
+
   useEffect(() => {
     let frame = 0;
     let raf = 0;
     const tick = (): void => {
-      applyNodeOpacity();
+      applyNodePresentation();
       frame += 1;
       if (frame < OPACITY_APPLY_FRAMES) {
         raf = window.requestAnimationFrame(tick);
@@ -291,7 +340,7 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
     raf = window.requestAnimationFrame(tick);
 
     return () => window.cancelAnimationFrame(raf);
-  }, [applyNodeOpacity, level]);
+  }, [applyNodePresentation, level]);
 
   useEffect(() => {
     if (!selectedNodeId) {
@@ -363,8 +412,12 @@ const KnowledgeGraph3DScene: FC<KnowledgeGraph3DSceneProps> = ({
         showNavInfo={false}
         width={size.width}
         onBackgroundClick={() => onSelectNode(null)}
+        onEngineStop={handleEngineStop}
         onLinkClick={(link: SceneLink) => onSelectLink(link as GraphLink3D)}
         onNodeClick={(node: SceneNode) => onSelectNode(node as GraphNode3D)}
+        onNodeHover={(node: SceneNode | null) =>
+          setHoveredNodeId(node?.id ? String(node.id) : null)
+        }
       />
     </div>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/nodeRendering.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/nodeRendering.ts
@@ -34,6 +34,8 @@ import { GraphNode3D, Level, NodeType } from './types';
 const GLOW_CANVAS_SIZE = 128;
 const AVATAR_TEXTURE_CACHE_MAX = 256;
 
+export const NODE_LABEL_OBJECT_NAME = 'knowledge-graph-node-label';
+
 /**
  * Textures are shared across sprites and reused across re-renders. Glow and
  * icon textures are keyed by color/type (a small, fixed set), so plain Maps
@@ -225,8 +227,9 @@ export const buildNodeObject = (
 
   if (options.showLabel) {
     const label = new SpriteText(node.name);
+    label.name = NODE_LABEL_OBJECT_NAME;
     label.color = LABEL_COLOR;
-    label.textHeight = Math.max(3.4, size * 0.32);
+    label.textHeight = Math.max(2.8, size * 0.24);
     label.fontWeight = '600';
     label.position.set(0, -(size * 0.66) - 3, 0);
     label.material.depthWrite = false;

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/types.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/types.ts
@@ -59,6 +59,9 @@ export interface GraphNode3D {
   name: string;
   type: NodeType;
   levels: Level[];
+  x?: number;
+  y?: number;
+  z?: number;
   fullyQualifiedName?: string;
   description?: string;
   /** Tables only: true when at least one ontology (glossary) mapping exists. */


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30108

I improved the 3D Knowledge Graph layout, camera fitting, progressive label disclosure, dark-panel contrast, and related-entity navigation because dense RDF graphs were compact, difficult to read, and cumbersome to traverse.

#
### Type of change:

- [x] Improvement

#
### High-level design:

- Tune charge, link distance, and link strength, then widen the settled layout toward the viewport aspect ratio while compressing excess depth.
- Refit the camera after the force engine settles and retain a minimum-distance guard for early renders.
- Rank persistent labels by focus, selection, hover, neighborhood, and node degree, while revealing interacted labels dynamically.
- Route clicks on relation and shared-concept rows through the existing node-selection flow and apply explicit contrast styles to the dark detail panels.
- Keep the change UI-only with no API, schema, migration, or rollout impact.

Showing every label and uniformly scaling all three axes were considered, but both approaches left dense multi-hop graphs visually noisy.

#
### Tests:

#### Use cases covered

- Dense depth-1 and depth-2 graphs spread across the landscape viewport and refit after settling
- Focused, selected, hovered, neighboring, and high-degree nodes receive priority labels
- Clicking a related entity in the detail panel focuses that graph node
- Entity and edge panels remain readable on the dark graph surface

#### Unit tests

- [x] I added unit tests for the new and changed logic.
- Files updated: `KnowledgeGraph3D.test.tsx`, `KnowledgeGraph3D.utils.test.ts`
- Result: 5 suites and 92 tests passed

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (component behavior is covered by Jest and local end-to-end validation).

#### Manual testing performed

1. Started the local OpenMetadata, MySQL, Elasticsearch, and Fuseki stack with RDF enabled.
2. Seeded a dense table graph and verified 32 nodes / 32 edges at depth 1 and 52 nodes / 273 edges at depth 2.
3. Verified graph settling, camera fitting, progressive labels, panel contrast, and relation-row navigation in the production UI build.
4. Confirmed the deployed JavaScript and CSS asset hashes matched the local production build.

#
### UI screen recording / screenshots:

Pending before ready-for-review: attach the before/after screenshots and short recording from the local RDF validation.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Improvement
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves navigation and readability for dense 3D knowledge graphs. The main changes are:

- Tunes force layout spacing and camera fitting.
- Adds progressive labels based on focus and graph importance.
- Makes related entities selectable from detail panels.
- Improves contrast on dark graph panels.
- Limits RDF tag fields to supported entity types.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No additional blocking issues were found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java | Requests tag fields only for entity types that support them. |
| openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DScene.tsx | Adds force tuning, progressive label presentation, layout expansion, and settled camera fitting. |
| openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.utils.ts | Adds label prioritization and dense-layout transformation helpers. |
| openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3DPanel.tsx | Adds selectable related-node rows and explicit dark-panel styles. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Resolve RDF graph entity labels"](https://github.com/open-metadata/openmetadata/commit/068b6e3091f2148854fde0b5cd3f364d86f437f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44691774)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->