### PR TITLE
Backport customize page utility split to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
@@ -126,7 +126,7 @@ jest.mock('../../../utils/APIEndpoints/APIEndpointClassBase', () => ({
   },
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
   getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),

--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.tsx
@@ -34,7 +34,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
@@ -125,7 +125,7 @@ jest.mock('../../../utils/ChartDetailsClassBase', () => ({
   },
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
   getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.tsx
@@ -36,7 +36,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import {
   DEFAULT_ENTITY_PERMISSION,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/CustomizeTabWidget/CustomizeTabWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/CustomizeTabWidget/CustomizeTabWidget.tsx
@@ -37,12 +37,12 @@ import {
   getUniqueFilteredLayout,
 } from '../../../utils/CustomizableLandingPageUtils';
 import {
-  getAddWidgetHandler,
   getCustomizableWidgetByPage,
   getDefaultTabs,
   getDefaultWidgetForTab,
-  getTabDisplayName,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageDispatchUtils';
+import { getTabDisplayName } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
+import { getAddWidgetHandler } from '../../../utils/CustomizePage/CustomizePageWidgetUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { TabItem } from '../../common/DraggableTabs/DraggableTabs';
 import AddDetailsPageWidgetModal from '../../MyData/CustomizableComponents/AddDetailsPageWidgetModal/AddDetailsPageWidgetModal';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.test.tsx
@@ -19,7 +19,7 @@ import { EntityTabs, EntityType } from '../../../enums/entity.enum';
 import { ThreadType } from '../../../generated/entity/feed/thread';
 import { PageType } from '../../../generated/system/ui/page';
 import { postThread } from '../../../rest/feedsAPI';
-import { updateWidgetHeightRecursively } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { updateWidgetHeightRecursively } from '../../../utils/CustomizePage/CustomizePageWidgetUtils';
 import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
 import ActivityThreadPanel from '../../ActivityFeed/ActivityThreadPanel/ActivityThreadPanel';
 import { GenericProvider, useGenericContext } from './GenericProvider';
@@ -54,7 +54,7 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageWidgetUtils', () => ({
   getLayoutFromCustomizedPage: jest.fn().mockImplementation(() => []),
   updateWidgetHeightRecursively: jest.fn(),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -40,7 +40,7 @@ import { EntityDataMapValue } from '../../../utils/ColumnUpdateUtils.interface';
 import {
   getLayoutFromCustomizedPage,
   updateWidgetHeightRecursively,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageWidgetUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
 import {
   extractColumnsFromData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.test.tsx
@@ -15,7 +15,7 @@ import { useParams } from 'react-router-dom';
 import { EntityTabs } from '../../../enums/entity.enum';
 import { PageType } from '../../../generated/system/ui/page';
 import { useGridLayoutDirection } from '../../../hooks/useGridLayoutDirection';
-import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { GenericTab } from './GenericTab';
 
 jest.mock('react-router-dom', () => ({
@@ -28,7 +28,7 @@ jest.mock('../../../hooks/useGridLayoutDirection', () => ({
 
 jest.mock('../../../hooks/useCustomPages');
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageDispatchUtils', () => ({
   getWidgetsFromKey: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
@@ -17,7 +17,7 @@ import { DetailPageWidgetKeys } from '../../../enums/CustomizeDetailPage.enum';
 import { PageType } from '../../../generated/system/ui/page';
 import { useGridLayoutDirection } from '../../../hooks/useGridLayoutDirection';
 import { WidgetConfig } from '../../../pages/CustomizablePage/CustomizablePage.interface';
-import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { useGenericContext } from '../GenericProvider/GenericProvider';
 import { DynamicHeightWidget } from './DynamicHeightWidget';
 import './generic-tab.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/LeftPanelContainer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/LeftPanelContainer.tsx
@@ -17,7 +17,7 @@ import RGL, { ReactGridLayoutProps, WidthProvider } from 'react-grid-layout';
 import { PageType } from '../../../generated/system/ui/page';
 import { useGridLayoutDirection } from '../../../hooks/useGridLayoutDirection';
 import { WidgetConfig } from '../../../pages/CustomizablePage/CustomizablePage.interface';
-import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { getWidgetsFromKey } from '../../../utils/CustomizePage/CustomizePageDispatchUtils';
 import EmptyWidgetPlaceholder from '../../MyData/CustomizableComponents/EmptyWidgetPlaceholder/EmptyWidgetPlaceholder';
 import { GenericWidget } from '../GenericWidget/GenericWidget';
 import './generic-tab.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/GenericWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericWidget/GenericWidget.tsx
@@ -20,7 +20,7 @@ import { PageType } from '../../../generated/system/ui/page';
 import { WidgetCommonProps } from '../../../pages/CustomizablePage/CustomizablePage.interface';
 import { useCustomizeStore } from '../../../pages/CustomizablePage/CustomizeStore';
 import customizeGlossaryTermPageClassBase from '../../../utils/CustomizeGlossaryTerm/CustomizeGlossaryTermBaseClass';
-import { getDummyDataByPage } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { getDummyDataByPage } from '../../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { WIDGET_COMPONENTS } from '../../../utils/GenericWidget/GenericWidgetUtils';
 import { DEFAULT_ENTITY_PERMISSION } from '../../../utils/PermissionsUtils';
 import { EntityUnion } from '../../Explore/ExplorePage.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
@@ -126,7 +126,7 @@ jest.mock('../../../utils/DashboardDetailsClassBase', () => ({
   },
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
   getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.tsx
@@ -36,7 +36,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import dashboardDetailsClassBase from '../../../utils/DashboardDetailsClassBase';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
@@ -112,11 +112,14 @@ jest.mock('../../../../utils/DashboardDataModelClassBase', () => ({
   },
 }));
 
-jest.mock('../../../../utils/CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
-  getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
-  checkIfExpandViewSupported: jest.fn().mockReturnValue(false),
-}));
+jest.mock(
+  '../../../../utils/CustomizePage/CustomizePageEntityTabUtils',
+  () => ({
+    getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
+    getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
+    checkIfExpandViewSupported: jest.fn().mockReturnValue(false),
+  })
+);
 
 describe('DataModelDetails component', () => {
   it('should render successfully', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.tsx
@@ -32,7 +32,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import dashboardDataModelClassBase from '../../../../utils/DashboardDataModelClassBase';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { getPrioritizedEditPermission } from '../../../../utils/PermissionsUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -77,7 +77,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getDataContractStatusIcon } from '../../../utils/DataContract/DataContractUtils';
 import dataProductClassBase from '../../../utils/DataProduct/DataProductClassBase';
 import { getQueryFilterToIncludeDomain } from '../../../utils/DomainUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -70,7 +70,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import domainClassBase from '../../../utils/Domain/DomainClassBase';
 import {
   getQueryFilterForDataProducts,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
@@ -43,7 +43,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import directoryClassBase from '../../../utils/DirectoryClassBase';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityReferenceUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
@@ -42,7 +42,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityReferenceUtils';
 import fileClassBase from '../../../utils/FileClassBase';

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
@@ -42,7 +42,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityReferenceUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
@@ -41,7 +41,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityReferenceUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryDetails/GlossaryDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryDetails/GlossaryDetails.component.tsx
@@ -26,7 +26,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getGlossaryTermDetailsPath } from '../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import { ActivityFeedTab } from '../../ActivityFeed/ActivityFeedTab/ActivityFeedTab.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.component.tsx
@@ -38,7 +38,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityVersionByField } from '../../../utils/EntityVersionUtils';
 import glossaryTermClassBase from '../../../utils/Glossary/GlossaryTermClassBase';
 import { getQueryFilterToExcludeTerm } from '../../../utils/GlossaryUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermsV1.test.tsx
@@ -136,7 +136,7 @@ jest.mock('../../../hooks/useCustomPages', () => ({
     .mockReturnValue({ customizedPage: null, isLoading: false }),
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),
   getDetailsTabWithNewLabel: jest.fn().mockImplementation((items) => items),
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
@@ -113,7 +113,7 @@ jest.mock('../../../utils/MetricEntityUtils/MetricDetailsClassBase', () => ({
   },
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
   getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.tsx
@@ -35,7 +35,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import metricDetailsClassBase from '../../../utils/MetricEntityUtils/MetricDetailsClassBase';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.tsx
@@ -39,7 +39,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import mlModelDetailsClassBase from '../../../utils/MlModel/MlModelClassBase';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.component.tsx
@@ -35,7 +35,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import {
   DEFAULT_ENTITY_PERMISSION,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
@@ -132,7 +132,7 @@ jest.mock('../../../utils/TopicClassBase', () => ({
   },
 }));
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabLabelMapFromTabs: jest.fn().mockReturnValue({}),
   getDetailsTabWithNewLabel: jest.fn().mockReturnValue([]),
   checkIfExpandViewSupported: jest.fn().mockReturnValue(false),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.tsx
@@ -37,7 +37,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../../utils/CustomizePage/CustomizePageUtils';
+} from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { getEntityReferenceFromEntity } from '../../../utils/EntityReferenceUtils';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DraggableTabs/DraggableTabs.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DraggableTabs/DraggableTabs.test.tsx
@@ -15,7 +15,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { TabItem } from './DraggableTabs';
 
-jest.mock('../../../utils/CustomizePage/CustomizePageUtils', () => ({
+jest.mock('../../../utils/CustomizePage/CustomizePageEntityTabUtils', () => ({
   getTabDisplayName: jest.fn().mockReturnValue('Test Tab'),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DraggableTabs/DraggableTabs.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DraggableTabs/DraggableTabs.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import { useDrag, useDrop } from 'react-dnd';
 import { useTranslation } from 'react-i18next';
 import { Tab } from '../../../generated/system/ui/tab';
-import { getTabDisplayName } from '../../../utils/CustomizePage/CustomizePageUtils';
+import { getTabDisplayName } from '../../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import './draggable-tabs.less';
 
 type TargetKey = React.MouseEvent | React.KeyboardEvent | string;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.tsx
@@ -70,7 +70,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityMissingError } from '../../utils/EntityDisplayUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import entityUtilClassBase from '../../utils/EntityUtilClassBase';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
@@ -73,7 +73,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import Fqn from '../../utils/Fqn';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizableDataProductPage/CustomizableDataProductPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizableDataProductPage/CustomizableDataProductPage.tsx
@@ -27,7 +27,7 @@ import { DataProduct } from '../../generated/entity/domains/dataProduct';
 import { Page } from '../../generated/system/ui/page';
 import { PageType } from '../../generated/system/ui/uiCustomization';
 import { useMarketplaceStore } from '../../hooks/useMarketplaceStore';
-import { getDummyDataByPage } from '../../utils/CustomizePage/CustomizePageUtils';
+import { getDummyDataByPage } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { useCustomizeStore } from '../CustomizablePage/CustomizeStore';
 import '../CustomizeDetailsPage/customize-details-page.less';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizableDomainPage/CustomizableDomainPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizableDomainPage/CustomizableDomainPage.tsx
@@ -27,7 +27,7 @@ import { EntityType } from '../../enums/entity.enum';
 import { Domain } from '../../generated/entity/domains/domain';
 import { Page } from '../../generated/system/ui/page';
 import { PageType } from '../../generated/system/ui/uiCustomization';
-import { getDummyDataByPage } from '../../utils/CustomizePage/CustomizePageUtils';
+import { getDummyDataByPage } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import Fqn from '../../utils/Fqn';
 import { getDomainPath } from '../../utils/RouterUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomizeDetailsPage/CustomizeDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomizeDetailsPage/CustomizeDetailsPage.tsx
@@ -25,10 +25,8 @@ import { EntityType } from '../../enums/entity.enum';
 import { Table } from '../../generated/entity/data/table';
 import { Page, PageType } from '../../generated/system/ui/page';
 import { useGridLayoutDirection } from '../../hooks/useGridLayoutDirection';
-import {
-  asyncNoop,
-  getDummyDataByPage,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+import { getDummyDataByPage } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
+import { asyncNoop } from '../../utils/CustomizePage/CustomizePageWidgetUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { useCustomizeStore } from '../CustomizablePage/CustomizeStore';
 import './customize-details-page.less';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -34,10 +34,8 @@ import { Page, PageType } from '../../generated/system/ui/page';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { useGridLayoutDirection } from '../../hooks/useGridLayoutDirection';
 import { getDocumentByFQN } from '../../rest/DocStoreAPI';
-import {
-  getLayoutFromCustomizedPage,
-  getWidgetsFromKey,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+import { getWidgetsFromKey } from '../../utils/CustomizePage/CustomizePageDispatchUtils';
+import { getLayoutFromCustomizedPage } from '../../utils/CustomizePage/CustomizePageWidgetUtils';
 import dataMarketplaceClassBase from '../../utils/DataMarketplace/DataMarketplaceClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';
 import { WidgetConfig } from '../CustomizablePage/CustomizablePage.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
@@ -75,7 +75,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getQueryFilterForDatabase } from '../../utils/Database/Database.util';
 import databaseClassBase from '../../utils/Database/DatabaseClassBase';
 import { getEntityName } from '../../utils/EntityNameUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -79,7 +79,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import databaseSchemaClassBase from '../../utils/DatabaseSchemaClassBase';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import entityUtilClassBase from '../../utils/EntityUtilClassBase';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
@@ -59,7 +59,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import {
   DEFAULT_ENTITY_PERMISSION,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
@@ -62,7 +62,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import {
   DEFAULT_ENTITY_PERMISSION,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -79,7 +79,7 @@ import {
   checkIfExpandViewSupported,
   getDetailsTabWithNewLabel,
   getTabLabelMapFromTabs,
-} from '../../utils/CustomizePage/CustomizePageUtils';
+} from '../../utils/CustomizePage/CustomizePageEntityTabUtils';
 import {
   defaultFields,
   defaultFieldsWithColumns,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageDispatchUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageDispatchUtils.ts
@@ -11,21 +11,17 @@
  *  limitations under the License.
  */
 
-import { TabsProps } from 'antd';
-import { get, noop, uniqueId } from 'lodash';
-import { EntityUnion } from '../../components/Explore/ExplorePage.interface';
+import type { EntityUnion } from '../../components/Explore/ExplorePage.interface';
 import { TAB_LABEL_MAP } from '../../constants/Customize.constants';
-import { CommonWidgetType } from '../../constants/CustomizeWidgets.constants';
-import { LandingPageWidgetKeys } from '../../enums/CustomizablePage.enum';
+import type { CommonWidgetType } from '../../constants/CustomizeWidgets.constants';
 import { EntityTabs } from '../../enums/entity.enum';
-import { Page, PageType, Tab } from '../../generated/system/ui/page';
-import { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
+import type { Tab } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
+import type { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
 import apiCollectionClassBase from '../APICollection/APICollectionClassBase';
 import apiEndpointClassBase from '../APIEndpoints/APIEndpointClassBase';
 import chartDetailsClassBase from '../ChartDetailsClassBase';
 import containerDetailsClassBase from '../ContainerDetailsClassBase';
-import { getNewWidgetPlacement } from '../CustomizableLandingPageUtils';
-import customizeDetailPageClassBase from '../CustomizeDetailPage/CustomizeDetailPageClassBase';
 import customizeGlossaryPageClassBase from '../CustomizeGlossaryPage/CustomizeGlossaryPage';
 import customizeGlossaryTermPageClassBase from '../CustomizeGlossaryTerm/CustomizeGlossaryTermBaseClass';
 import dashboardDataModelClassBase from '../DashboardDataModelClassBase';
@@ -36,7 +32,6 @@ import dataMarketplaceClassBase from '../DataMarketplace/DataMarketplaceClassBas
 import dataProductClassBase from '../DataProduct/DataProductClassBase';
 import directoryClassBase from '../DirectoryClassBase';
 import domainClassBase from '../Domain/DomainClassBase';
-import { getEntityName } from '../EntityNameUtils';
 import fileClassBase from '../FileClassBase';
 import i18n from '../i18next/LocalUtil';
 import metricDetailsClassBase from '../MetricEntityUtils/MetricDetailsClassBase';
@@ -242,28 +237,6 @@ export const getDefaultWidgetForTab = (pageType: PageType, tab: EntityTabs) => {
     default:
       return [];
   }
-};
-
-export const sortTabs = (tabs: TabsProps['items'], order: string[]) => {
-  return [...(tabs ?? [])].sort((a, b) => {
-    const orderA = order.indexOf(a.key);
-    const orderB = order.indexOf(b.key);
-
-    if (orderA !== -1 && orderB !== -1) {
-      return orderA - orderB;
-    }
-    if (orderA !== -1) {
-      return -1;
-    }
-    if (orderB !== -1) {
-      return 1;
-    }
-
-    const ia = tabs?.indexOf(a) ?? 0;
-    const ib = tabs?.indexOf(b) ?? 0;
-
-    return ia - ib;
-  });
 };
 
 export const getCustomizableWidgetByPage = (
@@ -499,302 +472,4 @@ export const getWidgetHeight = (pageType: PageType, widgetName: string) => {
     default:
       return 0;
   }
-};
-
-const calculateNewPosition = (
-  currentLayout: WidgetConfig[],
-  newWidget: { w: number; h: number },
-  maxCols = 8
-) => {
-  // Sort layout by y position to find last row
-  const sortedLayout = [...currentLayout].sort(
-    (a, b) => a.y + a.h - (b.y + b.h)
-  );
-
-  // Get the last widget
-  const lastWidget = sortedLayout.at(sortedLayout.length - 1);
-
-  if (!lastWidget) {
-    // If no widgets exist, start at 0,0
-    return { x: 0, y: 0 };
-  }
-
-  // Calculate next position
-  const lastRowY = lastWidget.y + lastWidget.h;
-  const lastRowWidgets = sortedLayout.filter(
-    (widget) => widget.y + widget.h === lastRowY
-  );
-
-  // Find the rightmost x position in the last row
-  const lastX = lastRowWidgets.reduce(
-    (maxX, widget) => Math.max(maxX, widget.x + widget.w),
-    0
-  );
-
-  // If there's room in the current row
-  if (lastX + newWidget.w <= maxCols) {
-    return { x: lastX, y: lastRowY - lastWidget.h };
-  }
-
-  // Otherwise, start a new row
-  return { x: 0, y: lastRowY };
-};
-
-export const getAddWidgetHandler =
-  (
-    newWidgetData: CommonWidgetType,
-    placeholderWidgetKey: string,
-    widgetWidth: number,
-    pageType: PageType
-  ) =>
-  (currentLayout: Array<WidgetConfig>): WidgetConfig[] => {
-    const widgetFQN = uniqueId(`${newWidgetData.fullyQualifiedName}-`);
-    const widgetHeight = getWidgetHeight(
-      pageType,
-      newWidgetData.fullyQualifiedName
-    );
-
-    // The widget with key "ExtraWidget.EmptyWidgetPlaceholder" will always remain in the bottom
-    // and is not meant to be replaced hence
-    // if placeholderWidgetKey is "ExtraWidget.EmptyWidgetPlaceholder"
-    // append the new widget in the array
-    // else replace the new widget with other placeholder widgets
-    if (
-      placeholderWidgetKey === LandingPageWidgetKeys.EMPTY_WIDGET_PLACEHOLDER
-    ) {
-      const newPlacement = getNewWidgetPlacement(currentLayout, widgetWidth);
-
-      return [
-        ...currentLayout.map((widget) =>
-          widget.i === placeholderWidgetKey
-            ? // Push down emptyWidget to 1 row
-              { ...widget, y: newPlacement.y + 1 }
-            : widget
-        ),
-        {
-          i: widgetFQN,
-          h: widgetHeight,
-          w: widgetWidth,
-          static: false,
-          ...newPlacement,
-        },
-      ];
-    } else {
-      // To handle case of adding widget from top button instead of empty widget placeholder
-      const { x: widgetX, y: widgetY } = calculateNewPosition(
-        currentLayout.filter(
-          (widget) =>
-            widget.i !== LandingPageWidgetKeys.EMPTY_WIDGET_PLACEHOLDER
-        ),
-        {
-          w: widgetWidth,
-          h: widgetHeight,
-        }
-      );
-
-      return [
-        ...currentLayout,
-        {
-          i: widgetFQN,
-          h: widgetHeight,
-          w: widgetWidth,
-          x: widgetX,
-          y: widgetY,
-        },
-      ];
-    }
-  };
-
-export const getDetailsTabWithNewLabel = (
-  defaultTabs: Array<
-    NonNullable<TabsProps['items']>[number] & { isHidden?: boolean }
-  >,
-  customizedTabs?: Tab[],
-  defaultTabId: EntityTabs = EntityTabs.OVERVIEW,
-  isVersionView = false
-) => {
-  if (!customizedTabs || isVersionView) {
-    return defaultTabs.filter((data) => !data.isHidden);
-  }
-  const overviewTab = defaultTabs?.find((t) => t.key === defaultTabId);
-
-  const newTabs =
-    customizedTabs?.map((t) => {
-      const tabItemDetails = defaultTabs?.find((i) => i.key === t.id);
-
-      return (
-        tabItemDetails ?? {
-          label: getEntityName(t),
-          key: t.id,
-          children: overviewTab?.children,
-        }
-      );
-    }) ?? defaultTabs;
-
-  return newTabs.filter((data) => !data.isHidden);
-};
-
-export const getTabLabelMapFromTabs = (
-  tabs?: Tab[]
-): Record<EntityTabs, string> => {
-  const labelMap = {} as Record<EntityTabs, string>;
-
-  return (
-    tabs?.reduce((acc: Record<EntityTabs, string>, item) => {
-      if (item.id && item.displayName) {
-        const tab = item.id as EntityTabs;
-        acc[tab] = item.displayName;
-      }
-
-      return acc;
-    }, labelMap) ?? labelMap
-  );
-};
-
-export const asyncNoop = async () => {
-  noop();
-};
-
-export const getLayoutFromCustomizedPage = (
-  pageType: PageType,
-  tab: EntityTabs,
-  customizedPage?: Page | null,
-  isVersionView = false
-) => {
-  if (!customizedPage || isVersionView) {
-    return getDefaultWidgetForTab(pageType, tab);
-  }
-
-  if (customizedPage?.tabs?.length) {
-    return tab
-      ? customizedPage.tabs?.find((t: Tab) => t.id === tab)?.layout
-      : get(customizedPage, 'tabs.0.layout', []);
-  } else {
-    return getDefaultWidgetForTab(pageType, tab);
-  }
-};
-
-export const checkIfExpandViewSupported = (
-  firstTab: NonNullable<TabsProps['items']>[number],
-  activeTab: EntityTabs,
-  pageType: PageType
-) => {
-  switch (pageType) {
-    case PageType.Table:
-    case PageType.Topic:
-    case PageType.APIEndpoint:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.SCHEMA) ||
-        activeTab === EntityTabs.SCHEMA
-      );
-
-    case PageType.Glossary:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.TERMS) ||
-        activeTab === EntityTabs.TERMS
-      );
-    case PageType.GlossaryTerm:
-    case PageType.Metric:
-    case PageType.File:
-    case PageType.Worksheet:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.OVERVIEW) ||
-        activeTab === EntityTabs.OVERVIEW
-      );
-    case PageType.Dashboard:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.DETAILS) ||
-        activeTab === EntityTabs.DETAILS
-      );
-    case PageType.DashboardDataModel:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.MODEL) ||
-        activeTab === EntityTabs.MODEL
-      );
-    case PageType.Container:
-    case PageType.Directory:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.CHILDREN) ||
-        activeTab === EntityTabs.CHILDREN
-      );
-    case PageType.Database:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.SCHEMAS) ||
-        activeTab === EntityTabs.SCHEMAS
-      );
-    case PageType.SearchIndex:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.FIELDS) ||
-        activeTab === EntityTabs.FIELDS
-      );
-    case PageType.DatabaseSchema:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.TABLE) ||
-        activeTab === EntityTabs.TABLE
-      );
-    case PageType.Pipeline:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.TASKS) ||
-        activeTab === EntityTabs.TASKS
-      );
-    case PageType.APICollection:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.API_ENDPOINT) ||
-        activeTab === EntityTabs.API_ENDPOINT
-      );
-
-    case PageType.StoredProcedure:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.CODE) ||
-        activeTab === EntityTabs.CODE
-      );
-
-    case PageType.MlModel:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.FEATURES) ||
-        activeTab === EntityTabs.FEATURES
-      );
-    case PageType.Spreadsheet:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.WORKSHEETS) ||
-        activeTab === EntityTabs.WORKSHEETS
-      );
-    case PageType.Domain:
-    case PageType.DataProduct:
-      return (
-        (!activeTab && firstTab.key === EntityTabs.DOCUMENTATION) ||
-        activeTab === EntityTabs.DOCUMENTATION
-      );
-    default:
-      return false;
-  }
-};
-
-export const updateWidgetHeightRecursively = (
-  widgetId: string,
-  height: number,
-  widgets: WidgetConfig[]
-) =>
-  widgets.reduce((acc, widget) => {
-    if (widget.i === widgetId) {
-      acc.push({ ...widget, h: height });
-    } else if (widget.children) {
-      acc.push({
-        ...widget,
-        children: widget.children.map((child) =>
-          child.i === widgetId ? { ...child, h: height } : child
-        ),
-      });
-    } else {
-      acc.push(widget);
-    }
-
-    return acc;
-  }, [] as WidgetConfig[]);
-
-export const getTabDisplayName = (item: Tab) => {
-  return (
-    item.displayName ??
-    customizeDetailPageClassBase.getTabLabelFromId(item.name as EntityTabs)
-  );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts
@@ -1,0 +1,190 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import type { TabsProps } from 'antd';
+import { EntityTabs } from '../../enums/entity.enum';
+import type { Tab } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
+import customizeDetailPageClassBase from '../CustomizeDetailPage/CustomizeDetailPageClassBase';
+import { getEntityName } from '../EntityNameUtils';
+
+export const sortTabs = (tabs: TabsProps['items'], order: string[]) => {
+  return [...(tabs ?? [])].sort((a, b) => {
+    const orderA = order.indexOf(a.key);
+    const orderB = order.indexOf(b.key);
+
+    if (orderA !== -1 && orderB !== -1) {
+      return orderA - orderB;
+    }
+    if (orderA !== -1) {
+      return -1;
+    }
+    if (orderB !== -1) {
+      return 1;
+    }
+
+    const ia = tabs?.indexOf(a) ?? 0;
+    const ib = tabs?.indexOf(b) ?? 0;
+
+    return ia - ib;
+  });
+};
+
+export const getDetailsTabWithNewLabel = (
+  defaultTabs: Array<
+    NonNullable<TabsProps['items']>[number] & { isHidden?: boolean }
+  >,
+  customizedTabs?: Tab[],
+  defaultTabId: EntityTabs = EntityTabs.OVERVIEW,
+  isVersionView = false
+) => {
+  if (!customizedTabs || isVersionView) {
+    return defaultTabs.filter((data) => !data.isHidden);
+  }
+  const overviewTab = defaultTabs?.find((t) => t.key === defaultTabId);
+
+  const newTabs =
+    customizedTabs?.map((t) => {
+      const tabItemDetails = defaultTabs?.find((i) => i.key === t.id);
+
+      return (
+        tabItemDetails ?? {
+          label: getEntityName(t),
+          key: t.id,
+          children: overviewTab?.children,
+        }
+      );
+    }) ?? defaultTabs;
+
+  return newTabs.filter((data) => !data.isHidden);
+};
+
+export const getTabLabelMapFromTabs = (
+  tabs?: Tab[]
+): Record<EntityTabs, string> => {
+  const labelMap = {} as Record<EntityTabs, string>;
+
+  return (
+    tabs?.reduce((acc: Record<EntityTabs, string>, item) => {
+      if (item.id && item.displayName) {
+        const tab = item.id as EntityTabs;
+        acc[tab] = item.displayName;
+      }
+
+      return acc;
+    }, labelMap) ?? labelMap
+  );
+};
+
+export const checkIfExpandViewSupported = (
+  firstTab: NonNullable<TabsProps['items']>[number],
+  activeTab: EntityTabs,
+  pageType: PageType
+) => {
+  switch (pageType) {
+    case PageType.Table:
+    case PageType.Topic:
+    case PageType.APIEndpoint:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.SCHEMA) ||
+        activeTab === EntityTabs.SCHEMA
+      );
+
+    case PageType.Glossary:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.TERMS) ||
+        activeTab === EntityTabs.TERMS
+      );
+    case PageType.GlossaryTerm:
+    case PageType.Metric:
+    case PageType.File:
+    case PageType.Worksheet:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.OVERVIEW) ||
+        activeTab === EntityTabs.OVERVIEW
+      );
+    case PageType.Dashboard:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.DETAILS) ||
+        activeTab === EntityTabs.DETAILS
+      );
+    case PageType.DashboardDataModel:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.MODEL) ||
+        activeTab === EntityTabs.MODEL
+      );
+    case PageType.Container:
+    case PageType.Directory:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.CHILDREN) ||
+        activeTab === EntityTabs.CHILDREN
+      );
+    case PageType.Database:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.SCHEMAS) ||
+        activeTab === EntityTabs.SCHEMAS
+      );
+    case PageType.SearchIndex:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.FIELDS) ||
+        activeTab === EntityTabs.FIELDS
+      );
+    case PageType.DatabaseSchema:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.TABLE) ||
+        activeTab === EntityTabs.TABLE
+      );
+    case PageType.Pipeline:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.TASKS) ||
+        activeTab === EntityTabs.TASKS
+      );
+    case PageType.APICollection:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.API_ENDPOINT) ||
+        activeTab === EntityTabs.API_ENDPOINT
+      );
+
+    case PageType.StoredProcedure:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.CODE) ||
+        activeTab === EntityTabs.CODE
+      );
+
+    case PageType.MlModel:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.FEATURES) ||
+        activeTab === EntityTabs.FEATURES
+      );
+    case PageType.Spreadsheet:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.WORKSHEETS) ||
+        activeTab === EntityTabs.WORKSHEETS
+      );
+    case PageType.Domain:
+    case PageType.DataProduct:
+      return (
+        (!activeTab && firstTab.key === EntityTabs.DOCUMENTATION) ||
+        activeTab === EntityTabs.DOCUMENTATION
+      );
+    default:
+      return false;
+  }
+};
+
+export const getTabDisplayName = (item: Tab) => {
+  return (
+    item.displayName ??
+    customizeDetailPageClassBase.getTabLabelFromId(item.name as EntityTabs)
+  );
+};

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageUtils.test.ts
@@ -14,15 +14,15 @@ import { TabsProps } from 'antd';
 import { EntityTabs } from '../../enums/entity.enum';
 import { PageType, Tab } from '../../generated/system/ui/page';
 import { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
-import { getTabLabelFromId } from './CustomizePagePureUtils';
+import { getDefaultTabs } from './CustomizePageDispatchUtils';
 import {
   checkIfExpandViewSupported,
-  getDefaultTabs,
   getTabDisplayName,
   getTabLabelMapFromTabs,
   sortTabs,
-  updateWidgetHeightRecursively,
-} from './CustomizePageUtils';
+} from './CustomizePageEntityTabUtils';
+import { getTabLabelFromId } from './CustomizePagePureUtils';
+import { updateWidgetHeightRecursively } from './CustomizePageWidgetUtils';
 
 describe('CustomizePageUtils', () => {
   describe('getTabDisplayName', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageWidgetUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageWidgetUtils.ts
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { get, noop, uniqueId } from 'lodash';
+import type { CommonWidgetType } from '../../constants/CustomizeWidgets.constants';
+import { LandingPageWidgetKeys } from '../../enums/CustomizablePage.enum';
+import { EntityTabs } from '../../enums/entity.enum';
+import type { Page, Tab } from '../../generated/system/ui/page';
+import { PageType } from '../../generated/system/ui/page';
+import type { WidgetConfig } from '../../pages/CustomizablePage/CustomizablePage.interface';
+import { getNewWidgetPlacement } from '../CustomizableLandingPageUtils';
+import {
+  getDefaultWidgetForTab,
+  getWidgetHeight,
+} from './CustomizePageDispatchUtils';
+
+const calculateNewPosition = (
+  currentLayout: WidgetConfig[],
+  newWidget: { w: number; h: number },
+  maxCols = 8
+) => {
+  const sortedLayout = [...currentLayout].sort(
+    (a, b) => a.y + a.h - (b.y + b.h)
+  );
+
+  const lastWidget = sortedLayout.at(sortedLayout.length - 1);
+
+  if (!lastWidget) {
+    return { x: 0, y: 0 };
+  }
+
+  const lastRowY = lastWidget.y + lastWidget.h;
+  const lastRowWidgets = sortedLayout.filter(
+    (widget) => widget.y + widget.h === lastRowY
+  );
+
+  const lastX = lastRowWidgets.reduce(
+    (maxX, widget) => Math.max(maxX, widget.x + widget.w),
+    0
+  );
+
+  if (lastX + newWidget.w <= maxCols) {
+    return { x: lastX, y: lastRowY - lastWidget.h };
+  }
+
+  return { x: 0, y: lastRowY };
+};
+
+export const getAddWidgetHandler =
+  (
+    newWidgetData: CommonWidgetType,
+    placeholderWidgetKey: string,
+    widgetWidth: number,
+    pageType: PageType
+  ) =>
+  (currentLayout: Array<WidgetConfig>): WidgetConfig[] => {
+    const widgetFQN = uniqueId(`${newWidgetData.fullyQualifiedName}-`);
+    const widgetHeight = getWidgetHeight(
+      pageType,
+      newWidgetData.fullyQualifiedName
+    );
+
+    if (
+      placeholderWidgetKey === LandingPageWidgetKeys.EMPTY_WIDGET_PLACEHOLDER
+    ) {
+      const newPlacement = getNewWidgetPlacement(currentLayout, widgetWidth);
+
+      return [
+        ...currentLayout.map((widget) =>
+          widget.i === placeholderWidgetKey
+            ? { ...widget, y: newPlacement.y + 1 }
+            : widget
+        ),
+        {
+          i: widgetFQN,
+          h: widgetHeight,
+          w: widgetWidth,
+          static: false,
+          ...newPlacement,
+        },
+      ];
+    } else {
+      const { x: widgetX, y: widgetY } = calculateNewPosition(
+        currentLayout.filter(
+          (widget) =>
+            widget.i !== LandingPageWidgetKeys.EMPTY_WIDGET_PLACEHOLDER
+        ),
+        {
+          w: widgetWidth,
+          h: widgetHeight,
+        }
+      );
+
+      return [
+        ...currentLayout,
+        {
+          i: widgetFQN,
+          h: widgetHeight,
+          w: widgetWidth,
+          x: widgetX,
+          y: widgetY,
+        },
+      ];
+    }
+  };
+
+export const asyncNoop = async () => {
+  noop();
+};
+
+export const getLayoutFromCustomizedPage = (
+  pageType: PageType,
+  tab: EntityTabs,
+  customizedPage?: Page | null,
+  isVersionView = false
+) => {
+  if (!customizedPage || isVersionView) {
+    return getDefaultWidgetForTab(pageType, tab);
+  }
+
+  if (customizedPage?.tabs?.length) {
+    return tab
+      ? customizedPage.tabs?.find((t: Tab) => t.id === tab)?.layout
+      : get(customizedPage, 'tabs.0.layout', []);
+  } else {
+    return getDefaultWidgetForTab(pageType, tab);
+  }
+};
+
+export const updateWidgetHeightRecursively = (
+  widgetId: string,
+  height: number,
+  widgets: WidgetConfig[]
+) =>
+  widgets.reduce((acc, widget) => {
+    if (widget.i === widgetId) {
+      acc.push({ ...widget, h: height });
+    } else if (widget.children) {
+      acc.push({
+        ...widget,
+        children: widget.children.map((child) =>
+          child.i === widgetId ? { ...child, h: height } : child
+        ),
+      });
+    } else {
+      acc.push(widget);
+    }
+
+    return acc;
+  }, [] as WidgetConfig[]);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DirectoryClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DirectoryClassBase.test.ts
@@ -69,20 +69,6 @@ jest.mock('../constants/Directory.constant', () => ({
   } as Directory,
 }));
 
-jest.mock('./CustomizePage/CustomizePagePureUtils', () => ({
-  getTabLabelFromId: jest.fn((tabId: EntityTabs) => {
-    const labelMap: Partial<Record<EntityTabs, string>> = {
-      [EntityTabs.CHILDREN]: 'Children',
-      [EntityTabs.ACTIVITY_FEED]: 'Activity Feed',
-      [EntityTabs.LINEAGE]: 'Lineage',
-      [EntityTabs.CONTRACT]: 'Contract',
-      [EntityTabs.CUSTOM_PROPERTIES]: 'Custom Properties',
-    };
-
-    return labelMap[tabId] || tabId;
-  }),
-}));
-
 jest.mock('./DirectoryDetailsUtils', () => ({
   getDirectoryDetailsPageTabs: jest.fn((): TabProps[] => [
     {
@@ -200,28 +186,28 @@ describe('DirectoryClassBase', () => {
       expect(result[1]).toEqual({
         id: EntityTabs.ACTIVITY_FEED,
         name: EntityTabs.ACTIVITY_FEED,
-        displayName: 'Activity Feed',
+        displayName: 'label.activity-feed-and-task-plural',
         layout: [],
         editable: false,
       });
       expect(result[2]).toEqual({
         id: EntityTabs.LINEAGE,
         name: EntityTabs.LINEAGE,
-        displayName: 'Lineage',
+        displayName: 'label.lineage',
         layout: [],
         editable: false,
       });
       expect(result[3]).toEqual({
         id: EntityTabs.CONTRACT,
         name: EntityTabs.CONTRACT,
-        displayName: 'Contract',
+        displayName: 'label.contract',
         layout: [],
         editable: false,
       });
       expect(result[4]).toEqual({
         id: EntityTabs.CUSTOM_PROPERTIES,
         name: EntityTabs.CUSTOM_PROPERTIES,
-        displayName: 'Custom Properties',
+        displayName: 'label.custom-property-plural',
         layout: [],
         editable: false,
       });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Domain/DomainClassBase.test.ts
@@ -44,10 +44,6 @@ jest.mock('../i18next/LocalUtil', () => ({
   default: { t: jest.fn((key: string) => key) },
 }));
 
-jest.mock('../CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelFromId: jest.fn((tab: string) => tab),
-}));
-
 const mockProps = {
   domain: { fullyQualifiedName: 'Finance' },
   isVersionsView: false,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FileClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FileClassBase.test.ts
@@ -69,20 +69,6 @@ jest.mock('../constants/File.constant', () => ({
   } as File,
 }));
 
-jest.mock('./CustomizePage/CustomizePagePureUtils', () => ({
-  getTabLabelFromId: jest.fn((tabId: EntityTabs) => {
-    const labelMap: Partial<Record<EntityTabs, string>> = {
-      [EntityTabs.OVERVIEW]: 'Overview',
-      [EntityTabs.ACTIVITY_FEED]: 'Activity Feed',
-      [EntityTabs.LINEAGE]: 'Lineage',
-      [EntityTabs.CONTRACT]: 'Contract',
-      [EntityTabs.CUSTOM_PROPERTIES]: 'Custom Properties',
-    };
-
-    return labelMap[tabId] || tabId;
-  }),
-}));
-
 jest.mock('./FileDetailsUtils', () => ({
   getFileDetailsPageTabs: jest.fn((): TabProps[] => [
     {
@@ -187,42 +173,42 @@ describe('FileClassBase', () => {
       expect(result[0]).toEqual({
         id: EntityTabs.OVERVIEW,
         name: EntityTabs.OVERVIEW,
-        displayName: 'Overview',
+        displayName: 'label.overview',
         layout: expect.any(Array),
         editable: true,
       });
       expect(result[1]).toEqual({
         id: EntityTabs.SCHEMA,
         name: EntityTabs.SCHEMA,
-        displayName: 'schema',
+        displayName: 'label.schema',
         layout: [],
         editable: false,
       });
       expect(result[2]).toEqual({
         id: EntityTabs.ACTIVITY_FEED,
         name: EntityTabs.ACTIVITY_FEED,
-        displayName: 'Activity Feed',
+        displayName: 'label.activity-feed-and-task-plural',
         layout: [],
         editable: false,
       });
       expect(result[3]).toEqual({
         id: EntityTabs.LINEAGE,
         name: EntityTabs.LINEAGE,
-        displayName: 'Lineage',
+        displayName: 'label.lineage',
         layout: [],
         editable: false,
       });
       expect(result[4]).toEqual({
         id: EntityTabs.CONTRACT,
         name: EntityTabs.CONTRACT,
-        displayName: 'Contract',
+        displayName: 'label.contract',
         layout: [],
         editable: false,
       });
       expect(result[5]).toEqual({
         id: EntityTabs.CUSTOM_PROPERTIES,
         name: EntityTabs.CUSTOM_PROPERTIES,
-        displayName: 'Custom Properties',
+        displayName: 'label.custom-property-plural',
         layout: [],
         editable: false,
       });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Glossary/GlossaryTermClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Glossary/GlossaryTermClassBase.test.ts
@@ -25,10 +25,6 @@ jest.mock('./GlossaryTermUtils', () => ({
     .mockReturnValue([{ key: 'mock-tab' }]),
 }));
 
-jest.mock('../../utils/CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelFromId: jest.fn((tab: string) => tab),
-}));
-
 jest.mock(
   '../../components/DataQuality/DataQualityDashboard/DataQualityDashboard.component',
   () => ({ __esModule: true, default: () => null })

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SpreadsheetClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SpreadsheetClassBase.test.ts
@@ -71,20 +71,6 @@ jest.mock('../constants/Spreadsheet.constant', () => ({
   } as Spreadsheet,
 }));
 
-jest.mock('./CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelFromId: jest.fn((tabId: EntityTabs) => {
-    const labelMap: Partial<Record<EntityTabs, string>> = {
-      [EntityTabs.WORKSHEETS]: 'Worksheets',
-      [EntityTabs.ACTIVITY_FEED]: 'Activity Feed',
-      [EntityTabs.LINEAGE]: 'Lineage',
-      [EntityTabs.CONTRACT]: 'Contract',
-      [EntityTabs.CUSTOM_PROPERTIES]: 'Custom Properties',
-    };
-
-    return labelMap[tabId] || tabId;
-  }),
-}));
-
 jest.mock('./SpreadsheetDetailsUtils', () => ({
   getSpreadsheetDetailsPageTabs: jest.fn((): TabProps[] => [
     {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TagClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TagClassBase.test.ts
@@ -40,10 +40,6 @@ jest.mock('./SearchUtils', () => ({
   })),
 }));
 
-jest.mock('./CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelFromId: jest.fn().mockReturnValue('Tab Label'),
-}));
-
 jest.mock('../components/DataAssets/CommonWidgets/CommonWidgets', () => ({
   CommonWidgets: 'CommonWidgets',
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetClassBase.test.ts
@@ -74,20 +74,6 @@ jest.mock('../constants/Worksheet.constant', () => ({
   } as Worksheet,
 }));
 
-jest.mock('./CustomizePage/CustomizePageUtils', () => ({
-  getTabLabelFromId: jest.fn((tabId: EntityTabs) => {
-    const labelMap: Partial<Record<EntityTabs, string>> = {
-      [EntityTabs.SCHEMA]: 'Schema',
-      [EntityTabs.ACTIVITY_FEED]: 'Activity Feed',
-      [EntityTabs.LINEAGE]: 'Lineage',
-      [EntityTabs.CONTRACT]: 'Contract',
-      [EntityTabs.CUSTOM_PROPERTIES]: 'Custom Properties',
-    };
-
-    return labelMap[tabId] || tabId;
-  }),
-}));
-
 jest.mock('./WorksheetDetailsUtils', () => ({
   getWorksheetDetailsPageTabs: jest.fn((): TabProps[] => [
     {


### PR DESCRIPTION
## Summary
- Backports the #28937 customize-page utility split to 1.13.
- Keeps 1.13 detail-page behavior intact while moving customize-page tab/widget helpers into focused modules.

## Testing
- Ran UI checkstyle sequence on changed UI source files: organize-imports-cli, ESLint --fix, Prettier.
- Ran git diff --check.
- Attempted focused Jest test: ./node_modules/.bin/jest src/utils/CustomizePage/CustomizePageUtils.test.ts --runInBand. Local run is blocked by incomplete local UI dependencies/generated artifacts in the isolated worktree (missing notistack after generated schema links); CI should run with a complete install.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR splits the customize-page utilities into focused modules. The main changes are:

- Moves page-type dispatch helpers into `CustomizePageDispatchUtils`.
- Moves tab and label helpers into `CustomizePageEntityTabUtils`.
- Moves widget and layout helpers into `CustomizePageWidgetUtils`.
- Updates component imports, Jest mocks, and utility tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The moved implementations preserve their previous behavior.
- Production imports and Jest mocks point to the new modules.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageDispatchUtils.ts | Retains the existing page-type dispatch helpers and uses type-only imports where appropriate. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageEntityTabUtils.ts | Extracts tab ordering, labeling, customization, and expanded-view helpers without changing their behavior. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageWidgetUtils.ts | Extracts widget placement, layout selection, and height update helpers while preserving existing behavior. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomizePage/CustomizePageUtils.test.ts | Updates utility test imports to match the new module boundaries. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): split CustomizePageUtils.ts in..."](https://github.com/open-metadata/openmetadata/commit/0f7eedef8f7248e213fb47386114247b61985990) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44697067)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->