### PR TITLE
Fixes 30115: Scale RDF indexing for large catalogs

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -838,7 +838,7 @@ rdf:
   enabled: ${RDF_ENABLED:-false}
   baseUri: ${RDF_BASE_URI:-"https://open-metadata.org/"}
   storageType: ${RDF_STORAGE_TYPE:-"FUSEKI"}
-  remoteEndpoint: ${RDF_ENDPOINT:-"http://localhost:3030/openmetadata"}
+  remoteEndpoint: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-"http://localhost:3030/openmetadata"}}
   connectTimeoutMs: ${RDF_CONNECT_TIMEOUT_MS:-2000}
   requestTimeoutMs: ${RDF_REQUEST_TIMEOUT_MS:-60000}
   writeMaxRetries: ${RDF_WRITE_MAX_RETRIES:-2}

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -844,11 +844,13 @@ rdf:
   writeMaxRetries: ${RDF_WRITE_MAX_RETRIES:-2}
   writeRetryInitialBackoffMs: ${RDF_WRITE_RETRY_INITIAL_BACKOFF_MS:-250}
   writeRetryMaxBackoffMs: ${RDF_WRITE_RETRY_MAX_BACKOFF_MS:-2000}
-  bulkEntityBatchSize: ${RDF_BULK_ENTITY_BATCH_SIZE:-50}
-  bulkRelationshipSourceBatchSize: ${RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE:-25}
+  bulkEntityBatchSize: ${RDF_BULK_ENTITY_BATCH_SIZE:-100}
+  bulkRelationshipSourceBatchSize: ${RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE:-100}
+  bulkLineageEdgeBatchSize: ${RDF_BULK_LINEAGE_EDGE_BATCH_SIZE:-50}
   username: ${RDF_REMOTE_USERNAME:-"admin"}
   password: ${RDF_REMOTE_PASSWORD:-"admin"}
   dataset: ${RDF_DATASET:-"openmetadata"}
+  inferenceEnabled: ${RDF_INFERENCE_ENABLED:-false}
 
 # Cache Configuration
 # Caching layer for entity metadata, relationships, and tag usage to reduce database load

--- a/docker/development/docker-compose-fuseki.yml
+++ b/docker/development/docker-compose-fuseki.yml
@@ -7,7 +7,7 @@ services:
     environment:
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}
@@ -22,7 +22,7 @@ services:
     environment:
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -256,7 +256,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}
@@ -484,7 +484,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}

--- a/docker/development/docker-compose-postgres-fuseki.yml
+++ b/docker/development/docker-compose-postgres-fuseki.yml
@@ -256,7 +256,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_REMOTE_ENDPOINT: ${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}
@@ -484,7 +484,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_REMOTE_ENDPOINT: ${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-admin}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}

--- a/docker/development/docker-compose.yml
+++ b/docker/development/docker-compose.yml
@@ -187,7 +187,7 @@ services:
       # RDF / SPARQL backend (optional; default off). Start fuseki with `--profile rdf`.
       RDF_ENABLED: ${RDF_ENABLED:-false}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-"FUSEKI"}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-"http://fuseki:3030/openmetadata"}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-"http://fuseki:3030/openmetadata"}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-"admin"}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-"admin"}
       RDF_DATASET: ${RDF_DATASET:-"openmetadata"}
@@ -422,7 +422,7 @@ services:
       # RDF / SPARQL backend (optional; default off). Start fuseki with `--profile rdf`.
       RDF_ENABLED: ${RDF_ENABLED:-false}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-"FUSEKI"}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-"http://fuseki:3030/openmetadata"}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-"http://fuseki:3030/openmetadata"}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-"admin"}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-"admin"}
       RDF_DATASET: ${RDF_DATASET:-"openmetadata"}

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -190,7 +190,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-${FUSEKI_ADMIN_PASSWORD:-admin}}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}
@@ -360,7 +360,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-${FUSEKI_ADMIN_PASSWORD:-admin}}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}

--- a/docker/docker-compose-quickstart/docker-compose-rdf.yml
+++ b/docker/docker-compose-quickstart/docker-compose-rdf.yml
@@ -190,7 +190,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_REMOTE_ENDPOINT: ${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-${FUSEKI_ADMIN_PASSWORD:-admin}}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}
@@ -360,7 +360,7 @@ services:
       # RDF Configuration
       RDF_ENABLED: ${RDF_ENABLED:-true}
       RDF_STORAGE_TYPE: ${RDF_STORAGE_TYPE:-FUSEKI}
-      RDF_REMOTE_ENDPOINT: ${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}
+      RDF_ENDPOINT: ${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}
       RDF_REMOTE_USERNAME: ${RDF_REMOTE_USERNAME:-admin}
       RDF_REMOTE_PASSWORD: ${RDF_REMOTE_PASSWORD:-${FUSEKI_ADMIN_PASSWORD:-admin}}
       RDF_BASE_URI: ${RDF_BASE_URI:-https://open-metadata.org/}

--- a/docker/rdf-store/kubernetes/fuseki-deployment.yaml
+++ b/docker/rdf-store/kubernetes/fuseki-deployment.yaml
@@ -22,6 +22,8 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
+      # Development default only. Production needs 2-3x the live dataset size
+      # because TDB2 compaction creates a replacement dataset before deleting the old one.
       storage: 10Gi
   storageClassName: standard
 ---
@@ -59,17 +61,19 @@ spec:
                 secretKeyRef:
                   name: fuseki-secrets
                   key: openmetadata-password
-            - name: JAVA_OPTIONS
-              value: "-Xmx2g -Xms1g"
+            - name: JVM_ARGS
+              value: "-Xmx4g -Xms2g"
           volumeMounts:
             - name: fuseki-data
               mountPath: /fuseki-data
           resources:
+            # TDB2 memory-maps indexes outside the JVM heap. Keep the heap modest
+            # and reserve container memory for the OS page cache.
             requests:
-              memory: "1Gi"
+              memory: "4Gi"
               cpu: "500m"
             limits:
-              memory: "3Gi"
+              memory: "8Gi"
               cpu: "2000m"
           livenessProbe:
             httpGet:

--- a/docker/run_local_docker_rdf.sh
+++ b/docker/run_local_docker_rdf.sh
@@ -46,7 +46,7 @@ if [[ $startFuseki == "true" ]]; then
   export RDF_ENABLED=true
   export RDF_AUTO_REINDEX=true
   export RDF_STORAGE_TYPE="${RDF_STORAGE_TYPE:-FUSEKI}"
-  export RDF_ENDPOINT="${RDF_ENDPOINT:-http://fuseki:3030/openmetadata}"
+  export RDF_ENDPOINT="${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-http://fuseki:3030/openmetadata}}"
   export RDF_REMOTE_USERNAME="${RDF_REMOTE_USERNAME:-admin}"
   export RDF_REMOTE_PASSWORD="${RDF_REMOTE_PASSWORD:-admin}"
   export RDF_BASE_URI="${RDF_BASE_URI:-https://open-metadata.org/}"

--- a/docs/rdf-local-development.md
+++ b/docs/rdf-local-development.md
@@ -2,6 +2,8 @@
 
 This guide documents how to set up RDF/Knowledge Graph support for local development with OpenMetadata and Apache Jena Fuseki.
 
+For production sizing, tuning, compaction, scheduling, and monitoring, see [Setting up Apache Jena Fuseki efficiently](rdf-production-setup.md).
+
 ## Overview
 
 OpenMetadata supports RDF (Resource Description Framework) for knowledge graph capabilities using Apache Jena Fuseki as the triple store. This enables:
@@ -141,9 +143,15 @@ rdf:
   baseUri: ${RDF_BASE_URI:-"https://open-metadata.org/"}
   storageType: ${RDF_STORAGE_TYPE:-"FUSEKI"}
   remoteEndpoint: ${RDF_ENDPOINT:-"http://localhost:3030/openmetadata"}
+  connectTimeoutMs: ${RDF_CONNECT_TIMEOUT_MS:-2000}
+  requestTimeoutMs: ${RDF_REQUEST_TIMEOUT_MS:-60000}
+  bulkEntityBatchSize: ${RDF_BULK_ENTITY_BATCH_SIZE:-100}
+  bulkRelationshipSourceBatchSize: ${RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE:-100}
+  bulkLineageEdgeBatchSize: ${RDF_BULK_LINEAGE_EDGE_BATCH_SIZE:-50}
   username: ${RDF_REMOTE_USERNAME:-"admin"}
   password: ${RDF_REMOTE_PASSWORD:-"admin"}
   dataset: ${RDF_DATASET:-"openmetadata"}
+  inferenceEnabled: ${RDF_INFERENCE_ENABLED:-false}
 ```
 
 ### Environment Variables
@@ -154,9 +162,15 @@ rdf:
 | `RDF_STORAGE_TYPE` | Storage backend type | `FUSEKI` |
 | `RDF_BASE_URI` | Base URI for RDF resources | `https://open-metadata.org/` |
 | `RDF_ENDPOINT` | Fuseki SPARQL endpoint URL | `http://localhost:3030/openmetadata` |
+| `RDF_CONNECT_TIMEOUT_MS` | Fuseki connection timeout | `2000` |
+| `RDF_REQUEST_TIMEOUT_MS` | Per-request timeout | `60000` |
+| `RDF_BULK_ENTITY_BATCH_SIZE` | Entity models per bulk write | `100` |
+| `RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE` | Relationship sources per bulk write | `100` |
+| `RDF_BULK_LINEAGE_EDGE_BATCH_SIZE` | Detailed lineage edges per bulk write | `50` |
 | `RDF_REMOTE_USERNAME` | Fuseki admin username | `admin` |
 | `RDF_REMOTE_PASSWORD` | Fuseki admin password | `admin` |
 | `RDF_DATASET` | Fuseki dataset name | `openmetadata` |
+| `RDF_INFERENCE_ENABLED` | Enable in-process full-graph inference | `false` |
 
 ### Docker Compose Configuration
 
@@ -165,16 +179,19 @@ The Fuseki container (`docker/development/docker-compose-fuseki.yml`):
 ```yaml
 services:
   fuseki:
-    image: stain/jena-fuseki:5.0.0
+    build:
+      context: ../rdf-store
+      dockerfile: Dockerfile
+    image: openmetadata-fuseki:5.6.0
     container_name: openmetadata-fuseki
     ports:
       - "3030:3030"
     environment:
-      - ADMIN_PASSWORD=admin
-      - JVM_ARGS=-Xmx4g -Xms2g
-      - FUSEKI_BASE=/fuseki
+      - FUSEKI_ADMIN_PASSWORD=admin
+      - FUSEKI_OPENMETADATA_PASSWORD=openmetadata-secret
+      - JVM_ARGS=-Xmx1500m -Xms256m
     volumes:
-      - fuseki-data:/fuseki
+      - fuseki-tdb2-data:/fuseki-data
 ```
 
 ## API Endpoints

--- a/docs/rdf-local-development.md
+++ b/docs/rdf-local-development.md
@@ -142,7 +142,7 @@ rdf:
   enabled: ${RDF_ENABLED:-false}
   baseUri: ${RDF_BASE_URI:-"https://open-metadata.org/"}
   storageType: ${RDF_STORAGE_TYPE:-"FUSEKI"}
-  remoteEndpoint: ${RDF_ENDPOINT:-"http://localhost:3030/openmetadata"}
+  remoteEndpoint: ${RDF_ENDPOINT:-${RDF_REMOTE_ENDPOINT:-"http://localhost:3030/openmetadata"}}
   connectTimeoutMs: ${RDF_CONNECT_TIMEOUT_MS:-2000}
   requestTimeoutMs: ${RDF_REQUEST_TIMEOUT_MS:-60000}
   bulkEntityBatchSize: ${RDF_BULK_ENTITY_BATCH_SIZE:-100}
@@ -162,6 +162,7 @@ rdf:
 | `RDF_STORAGE_TYPE` | Storage backend type | `FUSEKI` |
 | `RDF_BASE_URI` | Base URI for RDF resources | `https://open-metadata.org/` |
 | `RDF_ENDPOINT` | Fuseki SPARQL endpoint URL | `http://localhost:3030/openmetadata` |
+| `RDF_REMOTE_ENDPOINT` | Deprecated fallback when `RDF_ENDPOINT` is unset | unset |
 | `RDF_CONNECT_TIMEOUT_MS` | Fuseki connection timeout | `2000` |
 | `RDF_REQUEST_TIMEOUT_MS` | Per-request timeout | `60000` |
 | `RDF_BULK_ENTITY_BATCH_SIZE` | Entity models per bulk write | `100` |

--- a/docs/rdf-production-setup.md
+++ b/docs/rdf-production-setup.md
@@ -105,4 +105,6 @@ In-process inference is disabled by default. Enabling `RDF_INFERENCE_ENABLED=tru
 
 Use SPARQL 1.1 property paths for transitive lineage, inverse ownership, and domain or glossary inheritance. These execute inside Fuseki without copying the graph into the OpenMetadata process. Deployments that require persistent RDFS or OWL semantics should configure a Fuseki assembler dataset with an appropriate Jena reasoner and size it independently; server-side materialization or reasoning is operationally safer than per-request full-graph inference in OpenMetadata.
 
+The complete-lineage endpoint intentionally does not impose a row limit on its property-path query. Size `RDF_REQUEST_TIMEOUT_MS`, Fuseki resources, and client response handling for the largest lineage graph operators can request. Semantic search is not an exhaustive traversal: each seed expands at most 100 related graph candidates before reranking to the caller's requested result limit. Use the complete-lineage endpoint or direct SPARQL for exhaustive graph traversal.
+
 For local startup and API examples, see [RDF/Apache Jena Local Development Guide](rdf-local-development.md).

--- a/docs/rdf-production-setup.md
+++ b/docs/rdf-production-setup.md
@@ -22,6 +22,8 @@ TDB2 is a single-writer store. More OpenMetadata indexing threads can prepare an
 
 An RDF indexing run with `recreateIndex: true` clears the graph first and then uses insert-only writes. It does not perform per-entity or per-relationship reconciliation against the empty graph. Entity, relationship, and lineage data are grouped into bounded updates. Incremental runs continue to reconcile existing values.
 
+RDF indexing hydrates every field supported by each entity repository because the RDF mapper preserves fields even when they have no explicit JSON-LD context mapping. It omits only `changeDescription`, `votes`, and the embedded `testCaseResult`, which the mapper intentionally does not emit as triples.
+
 Start with the defaults and tune one setting at a time:
 
 | Environment variable | Default | Purpose |
@@ -74,6 +76,7 @@ The OpenMetadata server reads the following settings from `conf/openmetadata.yam
 | `RDF_BASE_URI` | `https://open-metadata.org/` |
 | `RDF_STORAGE_TYPE` | `FUSEKI` |
 | `RDF_ENDPOINT` | `http://localhost:3030/openmetadata` |
+| `RDF_REMOTE_ENDPOINT` | unset (deprecated fallback) |
 | `RDF_CONNECT_TIMEOUT_MS` | `2000` |
 | `RDF_REQUEST_TIMEOUT_MS` | `60000` |
 | `RDF_WRITE_MAX_RETRIES` | `2` |
@@ -87,7 +90,7 @@ The OpenMetadata server reads the following settings from `conf/openmetadata.yam
 | `RDF_DATASET` | `openmetadata` |
 | `RDF_INFERENCE_ENABLED` | `false` |
 
-Use `RDF_ENDPOINT`, not the deprecated `RDF_REMOTE_ENDPOINT`, for the OpenMetadata server. Override the development credentials in every production deployment.
+Use `RDF_ENDPOINT` for new deployments. `RDF_REMOTE_ENDPOINT` remains a deprecated fallback for backward compatibility, and `RDF_ENDPOINT` takes precedence when both are set. Override the development credentials in every production deployment.
 
 ## Monitoring and failure diagnosis
 

--- a/docs/rdf-production-setup.md
+++ b/docs/rdf-production-setup.md
@@ -1,0 +1,108 @@
+# Setting up Apache Jena Fuseki efficiently
+
+OpenMetadata stores its RDF knowledge graph in a remote Apache Jena Fuseki dataset. Production sizing must account for two different memory consumers: the Fuseki JVM heap and the operating-system page cache used by TDB2's memory-mapped indexes. Giving the JVM all container memory starves the page cache and usually reduces throughput.
+
+## Capacity planning
+
+TDB2 storage varies with URI and literal width. A useful planning range for OpenMetadata graphs is 150-250 bytes per triple before compaction headroom.
+
+| Live triples | Approximate live TDB2 data | Fuseki heap | Suggested total RAM | Suggested persistent disk |
+| ---: | ---: | ---: | ---: | ---: |
+| 1 million | 0.15-0.25 GB | 2 GB | 4-8 GB | 2 GB minimum |
+| 10 million | 1.5-2.5 GB | 4 GB | 8-16 GB | 8 GB minimum |
+| 50 million | 7.5-12.5 GB | 8 GB | 24-48 GB | 40 GB minimum |
+
+Persistent storage should be at least 2-3 times the expected live dataset, plus room for the journal. TDB2 compaction builds a replacement dataset before deleting the old one, so a volume sized only for live data can run out of space during compaction. The 10 GiB PVC in `docker/rdf-store/kubernetes/fuseki-deployment.yaml` is a development default, not a production recommendation.
+
+Keep the Fuseki heap smaller than the container memory limit. Memory beyond `-Xmx` is useful: TDB2 memory-maps its indexes and relies heavily on the OS page cache. The OpenMetadata server does not need additional heap for normal RDF queries because built-in lineage and semantic expansion execute as property-path queries inside Fuseki.
+
+## Write throughput
+
+TDB2 is a single-writer store. More OpenMetadata indexing threads can prepare and read batches concurrently, but Fuseki ultimately serializes write transactions. Throughput therefore depends primarily on the number and size of SPARQL UPDATE transactions, not the number of HTTP clients.
+
+An RDF indexing run with `recreateIndex: true` clears the graph first and then uses insert-only writes. It does not perform per-entity or per-relationship reconciliation against the empty graph. Entity, relationship, and lineage data are grouped into bounded updates. Incremental runs continue to reconcile existing values.
+
+Start with the defaults and tune one setting at a time:
+
+| Environment variable | Default | Purpose |
+| --- | ---: | --- |
+| `RDF_BULK_ENTITY_BATCH_SIZE` | `100` | Entity models per SPARQL update. |
+| `RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE` | `100` | Source entities reconciled per relationship update. |
+| `RDF_BULK_LINEAGE_EDGE_BATCH_SIZE` | `50` | Detailed lineage edges per update. |
+| `RDF_REQUEST_TIMEOUT_MS` | `60000` | Maximum time for one RDF request. |
+
+Larger batches reduce transaction and journal overhead but increase request size, parse time, and retry cost. If a larger batch approaches `RDF_REQUEST_TIMEOUT_MS`, either reduce the batch or raise the timeout. Wide tables can produce tens of megabytes of N-Triples per 100-entity batch, so validate changes against representative catalogs.
+
+## Scheduling
+
+The recommended RDF schedule is a weekly recreate on Saturday at midnight:
+
+```text
+0 0 * * 6
+```
+
+Search indexing defaults to Sunday at 00:30:
+
+```text
+30 0 * * 0
+```
+
+Keep the jobs separated manually. Both scan the metadata database and hydrate entity relationships, so running them together increases database pressure. OpenMetadata does not provide cross-application mutual exclusion between RDF and search indexing.
+
+Upgrades migrate an RDF app that still has the former exact daily default (`0 0 * * *`) to the weekly schedule. Custom schedules and applications with scheduling disabled are not changed.
+
+## Compaction and disk growth
+
+OpenMetadata requests Fuseki compaction after clearing a recreate run and after every successful indexing run. Compaction is best-effort: an indexing run can succeed even if disk reclamation fails.
+
+To compact manually:
+
+```bash
+curl -u admin:<password> -X POST \
+  'http://localhost:3030/$/compact/openmetadata?deleteOld=true'
+```
+
+Fuseki returns an asynchronous task identifier. Inspect active and completed tasks at `/$/tasks` and confirm the data volume has enough space for both the old and replacement datasets. Unexpected journal growth usually indicates failed or skipped compaction, a write-heavy incremental workload, or a volume that filled before compaction completed.
+
+## Configuration reference
+
+The OpenMetadata server reads the following settings from `conf/openmetadata.yaml`:
+
+| Environment variable | Default |
+| --- | --- |
+| `RDF_ENABLED` | `false` |
+| `RDF_BASE_URI` | `https://open-metadata.org/` |
+| `RDF_STORAGE_TYPE` | `FUSEKI` |
+| `RDF_ENDPOINT` | `http://localhost:3030/openmetadata` |
+| `RDF_CONNECT_TIMEOUT_MS` | `2000` |
+| `RDF_REQUEST_TIMEOUT_MS` | `60000` |
+| `RDF_WRITE_MAX_RETRIES` | `2` |
+| `RDF_WRITE_RETRY_INITIAL_BACKOFF_MS` | `250` |
+| `RDF_WRITE_RETRY_MAX_BACKOFF_MS` | `2000` |
+| `RDF_BULK_ENTITY_BATCH_SIZE` | `100` |
+| `RDF_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE` | `100` |
+| `RDF_BULK_LINEAGE_EDGE_BATCH_SIZE` | `50` |
+| `RDF_REMOTE_USERNAME` | `admin` |
+| `RDF_REMOTE_PASSWORD` | `admin` |
+| `RDF_DATASET` | `openmetadata` |
+| `RDF_INFERENCE_ENABLED` | `false` |
+
+Use `RDF_ENDPOINT`, not the deprecated `RDF_REMOTE_ENDPOINT`, for the OpenMetadata server. Override the development credentials in every production deployment.
+
+## Monitoring and failure diagnosis
+
+Useful Fuseki administration endpoints are:
+
+- `/$/ping` for liveness and readiness.
+- `/$/stats` for dataset and operation statistics.
+- `/$/tasks` for compaction and other asynchronous administration work.
+
+Monitor indexing records per second, SPARQL update latency, container RSS, page-cache availability, persistent-volume usage, and journal growth. OpenMetadata logs `RDF circuit breaker is open` after repeated connection failures or request timeouts; check Fuseki health, request latency, credentials, and network reachability before increasing retries.
+
+## Inference
+
+In-process inference is disabled by default. Enabling `RDF_INFERENCE_ENABLED=true` causes general queries to construct the entire graph in the OpenMetadata JVM and should be limited to small graphs. The SPARQL console retains its explicit `inference` option for administrative experiments, but it has the same small-graph constraint.
+
+Use SPARQL 1.1 property paths for transitive lineage, inverse ownership, and domain or glossary inheritance. These execute inside Fuseki without copying the graph into the OpenMetadata process. Deployments that require persistent RDFS or OWL semantics should configure a Fuseki assembler dataset with an appropriate Jena reasoner and size it independently; server-side materialization or reasoning is operationally safer than per-request full-graph inference in OpenMetadata.
+
+For local startup and API examples, see [RDF/Apache Jena Local Development Guide](rdf-local-development.md).

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfReindexInsertOnlyIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/RdfReindexInsertOnlyIT.java
@@ -1,0 +1,273 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.util.RdfTestUtils;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.lineage.AddLineage;
+import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.EntitiesEdge;
+import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.fluent.Tables;
+import org.openmetadata.sdk.fluent.builders.ColumnBuilder;
+import org.openmetadata.sdk.network.HttpClient;
+import org.openmetadata.sdk.network.HttpMethod;
+
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+@ExtendWith(TestNamespaceExtension.class)
+public class RdfReindexInsertOnlyIT {
+
+  private static final String APP_NAME = "RdfIndexApp";
+  private static final String KNOWLEDGE_GRAPH = "https://open-metadata.org/graph/knowledge";
+  private static final String BASE_URI = "https://open-metadata.org/";
+  private static final String SQL_QUERY = "SELECT * FROM insert_only_source";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @Test
+  void recreateRunWritesEntitiesAndDetailedLineageIdempotently(TestNamespace namespace)
+      throws Exception {
+    assumeTrue(
+        RdfTestUtils.isRdfEnabled(),
+        "RDF is disabled. Run this test with an RDF integration-test profile.");
+    assumeFalse(
+        TestSuiteBootstrap.isK8sEnabled(), "App trigger is not compatible with K8s pipelines");
+
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(namespace);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(namespace, service);
+    Table source = createTable(namespace, schema, "insertOnlySource");
+    Table target = createTable(namespace, schema, "insertOnlyTarget");
+    addDetailedLineage(client, source, target);
+
+    HttpClient httpClient = client.getHttpClient();
+    waitForCurrentRunCompletion(httpClient);
+
+    AppRunRecord firstRun = triggerAndWait(httpClient, readLatestRunStartTime(httpClient));
+    assertExpectedTriples(source, target);
+
+    AppRunRecord secondRun = triggerAndWait(httpClient, firstRun.getStartTime());
+    assertExpectedTriples(source, target);
+    assertTrue(secondRun.getStartTime() > firstRun.getStartTime());
+  }
+
+  private static Table createTable(
+      TestNamespace namespace, DatabaseSchema schema, String tableName) {
+    CreateTable request =
+        new CreateTable()
+            .withName(namespace.prefix(tableName))
+            .withDatabaseSchema(schema.getFullyQualifiedName())
+            .withDescription("RDF insert-only reindex integration fixture")
+            .withColumns(
+                List.of(
+                    ColumnBuilder.of("id", "BIGINT").primaryKey().notNull().build(),
+                    ColumnBuilder.of("value", "VARCHAR").dataLength(255).build()));
+    return Tables.create(request);
+  }
+
+  private static void addDetailedLineage(OpenMetadataClient client, Table source, Table target) {
+    LineageDetails details = new LineageDetails().withSqlQuery(SQL_QUERY);
+    AddLineage request =
+        new AddLineage()
+            .withEdge(
+                new EntitiesEdge()
+                    .withFromEntity(source.getEntityReference())
+                    .withToEntity(target.getEntityReference())
+                    .withLineageDetails(details));
+    assertNotNull(client.lineage().addLineage(request));
+  }
+
+  private static AppRunRecord triggerAndWait(HttpClient httpClient, Long previousRunStartTime) {
+    trigger(httpClient);
+    AppRunRecord[] completedRun = new AppRunRecord[1];
+    Awaitility.await("RDF reindex completion")
+        .atMost(Duration.ofMinutes(10))
+        .pollDelay(Duration.ofSeconds(2))
+        .pollInterval(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              AppRunRecord run =
+                  httpClient.execute(
+                      HttpMethod.GET,
+                      "/v1/apps/name/" + APP_NAME + "/runs/latest",
+                      null,
+                      AppRunRecord.class);
+              assertNotNull(run);
+              assertNotNull(run.getStatus());
+              assertNotNull(run.getStartTime());
+              if (previousRunStartTime != null && run.getStartTime() <= previousRunStartTime) {
+                throw new AssertionError("Waiting for the newly triggered RDF reindex run");
+              }
+              assertTrue(isTerminal(run.getStatus().value()));
+              completedRun[0] = run;
+            });
+
+    AppRunRecord run = completedRun[0];
+    assertTrue(
+        "completed".equalsIgnoreCase(run.getStatus().value())
+            || "success".equalsIgnoreCase(run.getStatus().value()),
+        () -> "RDF reindex failed: " + run);
+    return run;
+  }
+
+  private static void trigger(HttpClient httpClient) {
+    Map<String, Object> config = new HashMap<>();
+    // CLEAR ALL affects the shared integration dataset. Reindexing all supported
+    // entity types restores the complete graph for tests that run afterward.
+    config.put("entities", List.of("all"));
+    config.put("recreateIndex", true);
+    config.put("batchSize", 100);
+    config.put("producerThreads", 2);
+    config.put("consumerThreads", 3);
+    config.put("queueSize", 5000);
+    config.put("useDistributedIndexing", false);
+    config.put("partitionSize", 10000);
+
+    Awaitility.await("Trigger " + APP_NAME)
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(3))
+        .ignoreExceptionsMatching(
+            error -> error.getMessage() != null && error.getMessage().contains("already running"))
+        .until(
+            () -> {
+              httpClient.execute(
+                  HttpMethod.POST, "/v1/apps/trigger/" + APP_NAME, config, Void.class);
+              return true;
+            });
+  }
+
+  private static void assertExpectedTriples(Table source, Table target) throws Exception {
+    String sourceUri = entityUri(source);
+    String targetUri = entityUri(target);
+    String detailsUri = BASE_URI + "lineageDetails/" + source.getId() + "/" + target.getId();
+
+    assertEquals(1, countTriples("<" + sourceUri + "> a <http://www.w3.org/ns/dcat#Dataset>"));
+    assertEquals(1, countTriples("<" + targetUri + "> a <http://www.w3.org/ns/dcat#Dataset>"));
+    assertEquals(
+        1,
+        countTriples(
+            "<"
+                + sourceUri
+                + "> <https://open-metadata.org/ontology/UPSTREAM> <"
+                + targetUri
+                + ">"));
+    assertEquals(
+        1,
+        countTriples(
+            "<" + targetUri + "> <http://www.w3.org/ns/prov#wasDerivedFrom> <" + sourceUri + ">"));
+    assertEquals(
+        1,
+        countTriples(
+            "<"
+                + sourceUri
+                + "> <https://open-metadata.org/ontology/hasLineageDetails> <"
+                + detailsUri
+                + ">"));
+    assertEquals(
+        1,
+        countTriples(
+            "<"
+                + detailsUri
+                + "> <https://open-metadata.org/ontology/sqlQuery> \""
+                + SQL_QUERY
+                + "\""));
+  }
+
+  private static long countTriples(String triplePattern) throws Exception {
+    String query =
+        "SELECT (COUNT(*) AS ?count) WHERE { GRAPH <"
+            + KNOWLEDGE_GRAPH
+            + "> { "
+            + triplePattern
+            + " . } }";
+    String response = RdfTestUtils.executeSparqlSelect(query);
+    assertNotNull(response, "Fuseki did not return a SPARQL result");
+    JsonNode bindings = MAPPER.readTree(response).path("results").path("bindings");
+    assertTrue(bindings.isArray() && !bindings.isEmpty(), "SPARQL count result is missing");
+    return bindings.get(0).path("count").path("value").asLong();
+  }
+
+  private static String entityUri(Table table) {
+    return BASE_URI + "entity/table/" + table.getId();
+  }
+
+  private static Long readLatestRunStartTime(HttpClient httpClient) {
+    try {
+      AppRunRecord latest =
+          httpClient.execute(
+              HttpMethod.GET,
+              "/v1/apps/name/" + APP_NAME + "/runs/latest",
+              null,
+              AppRunRecord.class);
+      return latest == null ? null : latest.getStartTime();
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  private static void waitForCurrentRunCompletion(HttpClient httpClient) {
+    Awaitility.await("Wait for an in-flight " + APP_NAME)
+        .atMost(Duration.ofMinutes(10))
+        .pollInterval(Duration.ofSeconds(3))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              AppRunRecord latest =
+                  httpClient.execute(
+                      HttpMethod.GET,
+                      "/v1/apps/name/" + APP_NAME + "/runs/latest",
+                      null,
+                      AppRunRecord.class);
+              return latest == null
+                  || latest.getStatus() == null
+                  || isTerminal(latest.getStatus().value());
+            });
+  }
+
+  private static boolean isTerminal(String status) {
+    return "completed".equalsIgnoreCase(status)
+        || "success".equalsIgnoreCase(status)
+        || "failed".equalsIgnoreCase(status)
+        || "activeError".equalsIgnoreCase(status)
+        || "stopped".equalsIgnoreCase(status);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -775,7 +775,8 @@ public class OpenMetadataApplication extends Application<OpenMetadataApplication
   public void initialize(Bootstrap<OpenMetadataApplicationConfig> bootstrap) {
     bootstrap.setConfigurationSourceProvider(
         new SubstitutingSourceProvider(
-            bootstrap.getConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)));
+            bootstrap.getConfigurationSourceProvider(),
+            new EnvironmentVariableSubstitutor(false, true)));
 
     // Register custom filter factories
     bootstrap

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -32,6 +32,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
 import org.openmetadata.service.rdf.RdfExcludedEntities;
 import org.openmetadata.service.rdf.RdfRepository;
+import org.openmetadata.service.rdf.RdfRepository.LineageEdgeData;
 
 @Slf4j
 public class RdfBatchProcessor {
@@ -54,10 +55,17 @@ public class RdfBatchProcessor {
 
   private final CollectionDAO collectionDAO;
   private final RdfRepository rdfRepository;
+  private final RdfIndexingRunContext runContext;
 
   public RdfBatchProcessor(CollectionDAO collectionDAO, RdfRepository rdfRepository) {
+    this(collectionDAO, rdfRepository, RdfIndexingRunContext.reconcileDefaults());
+  }
+
+  public RdfBatchProcessor(
+      CollectionDAO collectionDAO, RdfRepository rdfRepository, RdfIndexingRunContext runContext) {
     this.collectionDAO = collectionDAO;
     this.rdfRepository = rdfRepository;
+    this.runContext = runContext != null ? runContext : RdfIndexingRunContext.reconcileDefaults();
   }
 
   public BatchProcessingResult processEntities(
@@ -101,7 +109,7 @@ public class RdfBatchProcessor {
     // operator-injected custom predicates are the failure mode to watch.
     if (!effectiveStopRequested.getAsBoolean()) {
       try {
-        rdfRepository.bulkCreateOrUpdate(entities);
+        rdfRepository.bulkCreateOrUpdate(entities, runContext.writeMode());
         indexedEntities.addAll(entities);
         successCount = entities.size();
       } catch (Exception e) {
@@ -125,7 +133,7 @@ public class RdfBatchProcessor {
               break;
             }
             try {
-              rdfRepository.createOrUpdate(entity);
+              rdfRepository.bulkCreateOrUpdate(List.of(entity), runContext.writeMode());
               indexedEntities.add(entity);
               successCount++;
             } catch (Exception ee) {
@@ -254,6 +262,7 @@ public class RdfBatchProcessor {
                   org.openmetadata.schema.type.Include.ALL);
 
       List<org.openmetadata.schema.type.EntityRelationship> allRelationships = new ArrayList<>();
+      List<LineageEdgeData> lineageEdges = new ArrayList<>();
 
       for (EntityRelationshipObject rel : outgoingRelationships) {
         if (shouldSkipRelationship(rel)) {
@@ -261,7 +270,7 @@ public class RdfBatchProcessor {
         }
 
         if (rel.getRelation() == Relationship.UPSTREAM.ordinal() && rel.getJson() != null) {
-          String error = processLineageRelationship(rel);
+          String error = collectLineageRelationship(rel, lineageEdges);
           if (error != null) {
             failures++;
             lastError = error;
@@ -280,9 +289,12 @@ public class RdfBatchProcessor {
         if (shouldSkipRelationship(rel)) {
           continue;
         }
+        if (runContext.entityTypesInRun().contains(rel.getFromEntity())) {
+          continue;
+        }
 
         if (rel.getJson() != null) {
-          String error = processLineageRelationship(rel);
+          String error = collectLineageRelationship(rel, lineageEdges);
           if (error != null) {
             failures++;
             lastError = error;
@@ -315,7 +327,7 @@ public class RdfBatchProcessor {
         // IDs that are outside the batch (the `from` of an UPSTREAM edge
         // where this batch's entity is the `to`); reconciling those would
         // wipe the outside-batch entity's unrelated outgoing edges.
-        rdfRepository.bulkAddRelationships(allRelationships, batchSources);
+        rdfRepository.bulkAddRelationships(allRelationships, batchSources, runContext.writeMode());
       } catch (Exception e) {
         LOG.error(
             "Failed to bulk add {} relationships for entity type {}",
@@ -324,6 +336,12 @@ public class RdfBatchProcessor {
             e);
         failures += allRelationships.size();
         lastError = describeBulkError(entityType, "bulkRelationships", e);
+      }
+
+      RelationshipProcessingResult lineageResult = processLineageEdges(entityType, lineageEdges);
+      failures += lineageResult.failureCount();
+      if (lineageResult.lastError() != null) {
+        lastError = lineageResult.lastError();
       }
     } catch (Exception e) {
       LOG.error("Failed to process batch relationships for entity type {}", entityType, e);
@@ -360,7 +378,8 @@ public class RdfBatchProcessor {
         || RdfExcludedEntities.isExcluded(entityType);
   }
 
-  String processLineageRelationship(EntityRelationshipObject rel) {
+  private String collectLineageRelationship(
+      EntityRelationshipObject rel, List<LineageEdgeData> lineageEdges) {
     UUID fromId;
     UUID toId;
     LineageDetails lineageDetails;
@@ -383,18 +402,90 @@ public class RdfBatchProcessor {
       }
     }
 
+    lineageEdges.add(
+        new LineageEdgeData(rel.getFromEntity(), fromId, rel.getToEntity(), toId, lineageDetails));
+    return null;
+  }
+
+  private RelationshipProcessingResult processLineageEdges(
+      String entityType, List<LineageEdgeData> lineageEdges) {
+    if (lineageEdges.isEmpty()) {
+      return RelationshipProcessingResult.OK;
+    }
+
+    try {
+      rdfRepository.bulkAddLineage(lineageEdges, runContext.writeMode());
+      return RelationshipProcessingResult.OK;
+    } catch (Exception e) {
+      if (isCircuitBreakerOpen(e)) {
+        LOG.warn(
+            "Bulk write of {} lineage edges for {} failed and the RDF circuit breaker is open; "
+                + "skipping per-edge fallback. Reason: {}",
+            lineageEdges.size(),
+            entityType,
+            e.getMessage());
+        return new RelationshipProcessingResult(
+            lineageEdges.size(), describeBulkError(entityType, "bulkLineage", e));
+      }
+
+      LOG.warn(
+          "Bulk write of {} lineage edges for {} failed; falling back to per-edge writes. Reason: {}",
+          lineageEdges.size(),
+          entityType,
+          e.getMessage());
+      int failures = 0;
+      String lastError = null;
+      for (int index = 0; index < lineageEdges.size(); index++) {
+        LineageEdgeData edge = lineageEdges.get(index);
+        try {
+          rdfRepository.bulkAddLineage(List.of(edge), runContext.writeMode());
+        } catch (Exception edgeError) {
+          failures++;
+          lastError = describeLineageError(edge, edgeError);
+          LOG.error(
+              "Failed to add lineage with details for {}->{}",
+              edge.fromId(),
+              edge.toId(),
+              edgeError);
+          if (isCircuitBreakerOpen(edgeError)) {
+            int skippedEdges = lineageEdges.size() - index - 1;
+            failures += skippedEdges;
+            LOG.warn(
+                "RDF circuit breaker opened during lineage fallback for {}; skipping {} remaining edges",
+                entityType,
+                skippedEdges);
+            break;
+          }
+        }
+      }
+      return new RelationshipProcessingResult(failures, lastError);
+    }
+  }
+
+  String processLineageRelationship(EntityRelationshipObject rel) {
+    List<LineageEdgeData> lineageEdges = new ArrayList<>(1);
+    String error = collectLineageRelationship(rel, lineageEdges);
+    if (error != null || lineageEdges.isEmpty()) {
+      return error;
+    }
+
+    LineageEdgeData edge = lineageEdges.get(0);
     try {
       rdfRepository.addLineageWithDetails(
-          rel.getFromEntity(), fromId, rel.getToEntity(), toId, lineageDetails);
+          edge.fromType(), edge.fromId(), edge.toType(), edge.toId(), edge.details());
       return null;
     } catch (Exception e) {
-      LOG.error("Failed to add lineage with details for {}->{}", rel.getFromId(), rel.getToId(), e);
-      return describeLineageError(rel, e);
+      LOG.error("Failed to add lineage with details for {}->{}", edge.fromId(), edge.toId(), e);
+      return describeLineageError(edge, e);
     }
   }
 
   private static String describeLineageError(EntityRelationshipObject rel, Throwable error) {
     return describeError("lineage " + rel.getFromId() + "->" + rel.getToId(), error);
+  }
+
+  private static String describeLineageError(LineageEdgeData edge, Throwable error) {
+    return describeError("lineage " + edge.fromId() + "->" + edge.toId(), error);
   }
 
   RelationshipProcessingResult processGlossaryTermRelations(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java
@@ -289,6 +289,9 @@ public class RdfBatchProcessor {
         if (shouldSkipRelationship(rel)) {
           continue;
         }
+        // Sources included in this run emit the edge from their outgoing pass. This avoids
+        // duplicate writes, but a failed source batch leaves the edge absent until a later run
+        // successfully processes that source.
         if (runContext.entityTypesInRun().contains(rel.getFromEntity())) {
           continue;
         }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexApp.java
@@ -53,6 +53,7 @@ import org.openmetadata.service.jdbi3.EntityDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.rdf.RdfExcludedEntities;
+import org.openmetadata.service.rdf.RdfIndexingFields;
 import org.openmetadata.service.rdf.RdfRepository;
 import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.socket.WebSocketManager;
@@ -78,7 +79,7 @@ public class RdfIndexApp extends AbstractNativeApplication {
       RdfExcludedEntities.EXCLUDED_ENTITY_TYPES;
 
   private final RdfRepository rdfRepository;
-  private final RdfBatchProcessor batchProcessor;
+  private RdfBatchProcessor batchProcessor;
   private volatile boolean stopped = false;
   private volatile long lastWebSocketUpdate = 0;
 
@@ -170,6 +171,14 @@ public class RdfIndexApp extends AbstractNativeApplication {
         throw new IllegalStateException(
             "No repository-backed entity types configured for RDF indexing");
       }
+      // recreateIndex clears the graph before any indexing work starts, so its
+      // batches can use pure INSERT DATA updates. A concurrent live RdfUpdater
+      // write can leave duplicate literal values until the next recreate run;
+      // that accepted race is no worse than the reverse lost-update race in the
+      // previous clear-and-reconcile implementation.
+      batchProcessor =
+          new RdfBatchProcessor(
+              collectionDAO, rdfRepository, RdfIndexingRunContext.forJob(jobData));
 
       LOG.info(
           "RDF Index Job Started for Entities: {}, RecreateIndex: {}",
@@ -655,7 +664,7 @@ public class RdfIndexApp extends AbstractNativeApplication {
               batchSize,
               cursor,
               true,
-              Entity.getFields(entityType, List.of("*")),
+              Entity.getFields(entityType, RdfIndexingFields.forEntityType(entityType)),
               null);
 
       if (!listOrEmpty(result.getData()).isEmpty() && !stopped) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexingRunContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexingRunContext.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.apps.bundles.rdf;
+
+import java.util.Set;
+import org.openmetadata.schema.system.EventPublisherJob;
+import org.openmetadata.service.rdf.RdfWriteMode;
+
+public record RdfIndexingRunContext(RdfWriteMode writeMode, Set<String> entityTypesInRun) {
+
+  public RdfIndexingRunContext {
+    writeMode = writeMode != null ? writeMode : RdfWriteMode.RECONCILE;
+    entityTypesInRun = entityTypesInRun != null ? Set.copyOf(entityTypesInRun) : Set.of();
+  }
+
+  public static RdfIndexingRunContext reconcileDefaults() {
+    return new RdfIndexingRunContext(RdfWriteMode.RECONCILE, Set.of());
+  }
+
+  public static RdfIndexingRunContext forJob(EventPublisherJob job) {
+    if (job == null) {
+      return reconcileDefaults();
+    }
+    RdfWriteMode writeMode =
+        Boolean.TRUE.equals(job.getRecreateIndex())
+            ? RdfWriteMode.INSERT_ONLY
+            : RdfWriteMode.RECONCILE;
+    return new RdfIndexingRunContext(writeMode, job.getEntities());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/DistributedRdfIndexExecutor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/DistributedRdfIndexExecutor.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.system.EventPublisherJob;
 import org.openmetadata.service.apps.bundles.rdf.RdfBatchProcessor;
+import org.openmetadata.service.apps.bundles.rdf.RdfIndexingRunContext;
 import org.openmetadata.service.apps.bundles.searchIndex.distributed.IndexJobStatus;
 import org.openmetadata.service.apps.bundles.searchIndex.distributed.ServerIdentityResolver;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -204,7 +205,10 @@ public class DistributedRdfIndexExecutor {
                 Runtime.getRuntime().availableProcessors() * 2));
     int batchSize = jobConfiguration.getBatchSize() != null ? jobConfiguration.getBatchSize() : 100;
     RdfBatchProcessor batchProcessor =
-        new RdfBatchProcessor(collectionDAO, RdfRepository.getInstance());
+        new RdfBatchProcessor(
+            collectionDAO,
+            RdfRepository.getInstance(),
+            RdfIndexingRunContext.forJob(jobConfiguration));
 
     workerExecutor =
         Executors.newFixedThreadPool(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/RdfPartitionWorker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/distributed/RdfPartitionWorker.java
@@ -28,8 +28,8 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.rdf.RdfBatchProcessor;
 import org.openmetadata.service.exception.SearchIndexException;
 import org.openmetadata.service.jdbi3.ListFilter;
+import org.openmetadata.service.rdf.RdfIndexingFields;
 import org.openmetadata.service.workflows.searchIndex.PaginatedEntitiesSource;
-import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 
 @Slf4j
 public class RdfPartitionWorker {
@@ -245,7 +245,7 @@ public class RdfPartitionWorker {
 
   private ResultList<? extends EntityInterface> readEntitiesKeyset(
       String entityType, String keysetCursor, int limit) throws SearchIndexException {
-    List<String> fields = ReindexingUtil.getSearchIndexFields(entityType);
+    List<String> fields = RdfIndexingFields.forEntityType(entityType);
     PaginatedEntitiesSource source = new PaginatedEntitiesSource(entityType, limit, fields, 0);
     return source.readNextKeyset(keysetCursor);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -9,6 +9,7 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTas
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillSearchRankingSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
+import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateRdfIndexAppScheduleToWeekly;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
 
@@ -36,6 +37,7 @@ public class Migration extends MigrationProcessImpl {
     // runDataMigration() per PR #26571, so this dual-invoke is required to
     // close that path. The helper is idempotent — safe on every run.
     backfillSearchRankingSettings();
+    migrateRdfIndexAppScheduleToWeekly(collectionDAO);
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, MYSQL);
     migrateThreadTasksToTaskEntity(handle, MYSQL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -9,6 +9,7 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.addTas
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillAnnouncementRelationships;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.backfillSearchRankingSettings;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateLegacyActivityThreadsToActivityStream;
+import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateRdfIndexAppScheduleToWeekly;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
 
@@ -36,6 +37,7 @@ public class Migration extends MigrationProcessImpl {
     // runDataMigration() per PR #26571, so this dual-invoke is required to
     // close that path. The helper is idempotent — safe on every run.
     backfillSearchRankingSettings();
+    migrateRdfIndexAppScheduleToWeekly(collectionDAO);
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, POSTGRES);
     migrateThreadTasksToTaskEntity(handle, POSTGRES);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -31,6 +31,8 @@ import org.openmetadata.schema.api.search.RankingConfiguration;
 import org.openmetadata.schema.api.search.RankingStage;
 import org.openmetadata.schema.api.search.SearchSettings;
 import org.openmetadata.schema.entity.activity.ActivityEvent;
+import org.openmetadata.schema.entity.app.App;
+import org.openmetadata.schema.entity.app.ScheduleTimeline;
 import org.openmetadata.schema.entity.feed.Announcement;
 import org.openmetadata.schema.entity.feed.Thread;
 import org.openmetadata.schema.entity.policies.Policy;
@@ -84,6 +86,9 @@ public class MigrationUtil {
   private static final String DATA_CONSUMER_POLICY = "DataConsumerPolicy";
   private static final String TASK_AUTHOR_POLICY = "TaskAuthorPolicy";
   private static final String CREATE_TASK_RULE_NAME = "DataConsumerPolicy-CreateTask-Rule";
+  private static final String RDF_INDEX_APP_NAME = "RdfIndexApp";
+  private static final String RDF_OLD_DAILY_CRON = "0 0 * * *";
+  private static final String RDF_WEEKLY_CRON = "0 0 * * 6";
 
   /**
    * Per-migration cache of {@code (entityType, entityId) -> resolved domains}. Many migrated tasks
@@ -108,6 +113,33 @@ public class MigrationUtil {
       };
 
   private MigrationUtil() {}
+
+  public static void migrateRdfIndexAppScheduleToWeekly(CollectionDAO collectionDAO) {
+    try {
+      List<String> applications =
+          collectionDAO
+              .applicationDAO()
+              .listAfter(new ListFilter(Include.ALL), Integer.MAX_VALUE, "", "");
+      for (String applicationJson : applications) {
+        try {
+          App application = JsonUtils.readValue(applicationJson, App.class);
+          if (RDF_INDEX_APP_NAME.equals(application.getName())
+              && application.getAppSchedule() != null
+              && application.getAppSchedule().getScheduleTimeline() == ScheduleTimeline.CUSTOM
+              && RDF_OLD_DAILY_CRON.equals(application.getAppSchedule().getCronExpression())) {
+            application.getAppSchedule().setCronExpression(RDF_WEEKLY_CRON);
+            collectionDAO.applicationDAO().update(application);
+            LOG.info("Migrated {} schedule from daily to weekly", RDF_INDEX_APP_NAME);
+          }
+        } catch (Exception e) {
+          LOG.warn(
+              "Skipping malformed application while migrating RDF schedule: {}", e.getMessage());
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to migrate the RDF indexing schedule; continuing upgrade", e);
+    }
+  }
 
   public static void backfillSearchRankingSettings() {
     Settings searchSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfIndexingFields.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfIndexingFields.java
@@ -12,22 +12,25 @@
  */
 package org.openmetadata.service.rdf;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
+import org.openmetadata.service.rdf.translator.RdfPropertyMapper;
 
 public final class RdfIndexingFields {
 
   private RdfIndexingFields() {}
 
   public static List<String> forEntityType(String entityType) {
-    List<String> fields = ReindexingUtil.getSearchIndexFields(entityType);
-    if (fields.contains("*")) {
-      return fields;
-    }
-    List<String> rdfFields = new ArrayList<>(fields);
-    rdfFields.remove(Entity.FIELD_VOTES);
-    return rdfFields;
+    return forSupportedFields(Entity.getEntityRepository(entityType).getAllowedFieldsCopy());
+  }
+
+  static List<String> forSupportedFields(Set<String> supportedFields) {
+    // The RDF mapper emits even fields absent from its JSON-LD contexts, so a search-index field
+    // subset can silently remove triples. Start from the repository's complete field contract.
+    return supportedFields.stream()
+        .filter(field -> !RdfPropertyMapper.isIgnoredEntityField(field))
+        .sorted()
+        .toList();
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfIndexingFields.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfIndexingFields.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
+
+public final class RdfIndexingFields {
+
+  private RdfIndexingFields() {}
+
+  public static List<String> forEntityType(String entityType) {
+    List<String> fields = ReindexingUtil.getSearchIndexFields(entityType);
+    if (fields.contains("*")) {
+      return fields;
+    }
+    List<String> rdfFields = new ArrayList<>(fields);
+    rdfFields.remove(Entity.FIELD_VOTES);
+    return rdfFields;
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfRepository.java
@@ -7,6 +7,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringWriter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,6 +39,7 @@ import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EntityRelationship;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.LineageDetails;
 import org.openmetadata.schema.type.Relationship;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.utils.JsonUtils;
@@ -78,8 +80,9 @@ public class RdfRepository {
   private static final int GRAPH_CACHE_MAX_SIZE = 500;
   private static final long GRAPH_CACHE_TTL_SECONDS = 60L;
   private static final long TRUNCATED_GRAPH_CACHE_TTL_SECONDS = 5L;
-  static final int DEFAULT_BULK_ENTITY_BATCH_SIZE = 50;
-  static final int DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE = 25;
+  static final int DEFAULT_BULK_ENTITY_BATCH_SIZE = 100;
+  static final int DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE = 100;
+  static final int DEFAULT_BULK_LINEAGE_EDGE_BATCH_SIZE = 50;
 
   // Fallback predicate URIs for clearAllGlossaryTermRelations when
   // GlossaryTermRelationSettings can't be loaded (e.g. DB blip during startup).
@@ -180,6 +183,10 @@ public class RdfRepository {
   static int resolveBulkRelationshipSourceBatchSize(RdfConfiguration config) {
     return positiveInt(
         config.getBulkRelationshipSourceBatchSize(), DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE);
+  }
+
+  static int resolveBulkLineageEdgeBatchSize(RdfConfiguration config) {
+    return positiveInt(config.getBulkLineageEdgeBatchSize(), DEFAULT_BULK_LINEAGE_EDGE_BATCH_SIZE);
   }
 
   private static int positiveInt(Integer value, int defaultValue) {
@@ -299,9 +306,10 @@ public class RdfRepository {
    * {@link #createOrUpdate}.
    *
    * <p>From the caller's perspective: all-or-nothing — a single thrown
-   * exception means the caller should retry the whole batch (or fall back to
-   * per-entity {@link #createOrUpdate} for per-row error attribution). The
-   * indexer in {@code RdfBatchProcessor.processEntities} does the latter.
+   * exception means the caller should retry the whole batch (or retry singleton
+   * batches for per-row error attribution). The indexer in
+   * {@code RdfBatchProcessor.processEntities} does the latter while preserving
+   * the run's write mode.
    *
    * <p>Implementation note: {@link
    * org.openmetadata.service.rdf.storage.JenaFusekiStorage#bulkStoreEntities}
@@ -313,6 +321,10 @@ public class RdfRepository {
    * row-level failure attribution when a chunk fails.
    */
   public void bulkCreateOrUpdate(List<? extends EntityInterface> entities) {
+    bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
+  }
+
+  public void bulkCreateOrUpdate(List<? extends EntityInterface> entities, RdfWriteMode writeMode) {
     if (!isEnabled() || entities == null || entities.isEmpty()) {
       return;
     }
@@ -324,7 +336,7 @@ public class RdfRepository {
           new RdfStorageInterface.EntityWriteRequest(entityType, entity.getId(), rdfModel));
     }
     try {
-      bulkStoreEntityRequests(requests);
+      bulkStoreEntityRequests(requests, writeMode);
       LOG.debug("Bulk created/updated {} entities in RDF store", entities.size());
     } catch (Exception e) {
       LOG.error("Failed to bulk create/update {} entities in RDF", entities.size(), e);
@@ -333,13 +345,18 @@ public class RdfRepository {
   }
 
   void bulkStoreEntityRequests(List<RdfStorageInterface.EntityWriteRequest> requests) {
+    bulkStoreEntityRequests(requests, RdfWriteMode.RECONCILE);
+  }
+
+  void bulkStoreEntityRequests(
+      List<RdfStorageInterface.EntityWriteRequest> requests, RdfWriteMode writeMode) {
     if (requests == null || requests.isEmpty()) {
       return;
     }
     int chunkSize = resolveBulkEntityBatchSize(config);
     for (int start = 0; start < requests.size(); start += chunkSize) {
       int end = Math.min(start + chunkSize, requests.size());
-      storageService.bulkStoreEntities(requests.subList(start, end));
+      storageService.bulkStoreEntities(requests.subList(start, end), writeMode);
     }
   }
 
@@ -574,6 +591,13 @@ public class RdfRepository {
    */
   public void bulkAddRelationships(
       List<EntityRelationship> relationships, Set<EntitySourceRef> reconcileSources) {
+    bulkAddRelationships(relationships, reconcileSources, RdfWriteMode.RECONCILE);
+  }
+
+  public void bulkAddRelationships(
+      List<EntityRelationship> relationships,
+      Set<EntitySourceRef> reconcileSources,
+      RdfWriteMode writeMode) {
     if (!isEnabled()) {
       return;
     }
@@ -616,7 +640,9 @@ public class RdfRepository {
       } finally {
         tempModel.close();
       }
-      if (reconcileSources != null) {
+      if (writeMode == RdfWriteMode.INSERT_ONLY) {
+        bulkStoreRelationshipData(relationshipDataList, Set.of());
+      } else if (reconcileSources != null) {
         Set<String> sourceUris = new LinkedHashSet<>();
         for (EntitySourceRef ref : reconcileSources) {
           sourceUris.add(
@@ -701,264 +727,26 @@ public class RdfRepository {
    * source table feed into column Z"
    */
   public void addLineageWithDetails(
-      String fromType,
-      UUID fromId,
-      String toType,
-      UUID toId,
-      org.openmetadata.schema.type.LineageDetails lineageDetails) {
+      String fromType, UUID fromId, String toType, UUID toId, LineageDetails lineageDetails) {
     if (!isEnabled()) {
       return;
     }
 
     try {
-      Model model = ModelFactory.createDefaultModel();
-
-      model.setNsPrefix("om", "https://open-metadata.org/ontology/");
-      model.setNsPrefix("prov", "http://www.w3.org/ns/prov#");
-      model.setNsPrefix("dct", "http://purl.org/dc/terms/");
-
-      String fromUri = config.getBaseUri().toString() + "entity/" + fromType + "/" + fromId;
-      String toUri = config.getBaseUri().toString() + "entity/" + toType + "/" + toId;
-
-      Resource fromResource = model.createResource(fromUri);
-      Resource toResource = model.createResource(toUri);
-
-      // PROV-O: to wasDerivedFrom from (reverse direction for semantic correctness)
-      Property derivedFrom = model.createProperty("http://www.w3.org/ns/prov#", "wasDerivedFrom");
-      toResource.addProperty(derivedFrom, fromResource);
-
-      // OpenMetadata-specific upstream for compatibility
-      Property upstream = model.createProperty("https://open-metadata.org/ontology/", "UPSTREAM");
-      fromResource.addProperty(upstream, toResource);
-
-      if (lineageDetails != null) {
-        // Deterministic URI: re-indexing the same lineage produces the same URI,
-        // letting the DELETE+INSERT idempotency below collapse duplicate
-        // LineageDetails resources instead of creating a new one per run.
-        String detailsUri =
-            config.getBaseUri().toString() + "lineageDetails/" + fromId + "/" + toId;
-        Resource detailsResource = model.createResource(detailsUri);
-
-        Property hasLineageDetails =
-            model.createProperty("https://open-metadata.org/ontology/", "hasLineageDetails");
-        fromResource.addProperty(hasLineageDetails, detailsResource);
-
-        detailsResource.addProperty(
-            model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
-            model.createResource("https://open-metadata.org/ontology/LineageDetails"));
-        // detailsResource is the Activity instance for this lineage edge — it
-        // carries Activity-shaped predicates (prov:startedAtTime, endedAtTime,
-        // used, hadPlan, wasGeneratedBy, wasAssociatedWith). Type it as
-        // prov:Activity so PROV-O reasoners and federated SPARQL clients treat
-        // it as one without having to learn the OM-specific type.
-        detailsResource.addProperty(
-            model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
-            model.createResource("http://www.w3.org/ns/prov#Activity"));
-
-        if (lineageDetails.getSqlQuery() != null && !lineageDetails.getSqlQuery().isEmpty()) {
-          detailsResource.addProperty(
-              model.createProperty("https://open-metadata.org/ontology/", "sqlQuery"),
-              lineageDetails.getSqlQuery());
-
-          // PROV-O Plan: model the SQL transformation recipe as a prov:Plan that
-          // the Activity hadPlan. Lets external clients diff/version transformation
-          // logic separately from individual runs.
-          String planUri = detailsUri + "/plan";
-          Resource planResource = model.createResource(planUri);
-          planResource.addProperty(
-              model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
-              model.createResource("http://www.w3.org/ns/prov#Plan"));
-          planResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "value"),
-              lineageDetails.getSqlQuery());
-          detailsResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "hadPlan"), planResource);
-        }
-
-        if (lineageDetails.getSource() != null) {
-          detailsResource.addProperty(
-              model.createProperty("https://open-metadata.org/ontology/", "lineageSource"),
-              lineageDetails.getSource().value());
-        }
-
-        if (lineageDetails.getDescription() != null && !lineageDetails.getDescription().isEmpty()) {
-          detailsResource.addProperty(
-              model.createProperty("http://purl.org/dc/terms/", "description"),
-              lineageDetails.getDescription());
-        }
-
-        if (lineageDetails.getPipeline() != null && lineageDetails.getPipeline().getId() != null) {
-          EntityReference pipeline = lineageDetails.getPipeline();
-          String pipelineType = pipeline.getType() != null ? pipeline.getType() : "pipeline";
-          String pipelineUri =
-              config.getBaseUri().toString() + "entity/" + pipelineType + "/" + pipeline.getId();
-          Resource pipelineResource = model.createResource(pipelineUri);
-
-          detailsResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "wasGeneratedBy"),
-              pipelineResource);
-
-          // PROV-O inverse: pipeline prov:generated lineageDetails. Emitting both
-          // directions lets activity-side queries ("what did this pipeline produce?")
-          // run without needing reverse-property reasoning support in the triple store.
-          pipelineResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "generated"), detailsResource);
-        }
-
-        // PROV-O input: lineageDetails prov:used <upstream entity>. Completes the
-        // standard PROV-O Entity → Activity → Entity chain alongside wasDerivedFrom,
-        // so external SPARQL clients can query "what inputs did this activity use?".
-        detailsResource.addProperty(
-            model.createProperty("http://www.w3.org/ns/prov#", "used"), fromResource);
-
-        if (lineageDetails.getColumnsLineage() != null
-            && !lineageDetails.getColumnsLineage().isEmpty()) {
-          Property hasColumnLineage =
-              model.createProperty("https://open-metadata.org/ontology/", "hasColumnLineage");
-
-          int colLineageIndex = 0;
-          for (org.openmetadata.schema.type.ColumnLineage colLineage :
-              lineageDetails.getColumnsLineage()) {
-            // Deterministic URI per (lineage edge, target column) so re-indexing
-            // doesn't multiply column-lineage resources. The index suffix is a
-            // tiebreaker so distinct toColumn values that normalize to the same
-            // string (e.g. `a-b` and `a_b` both → `a_b` after the
-            // [^A-Za-z0-9]→`_` replacement) don't collapse to one resource.
-            String safeName =
-                colLineage.getToColumn() != null
-                    ? colLineage.getToColumn().replaceAll("[^A-Za-z0-9]", "_")
-                    : "noTarget";
-            String colLineageUri =
-                detailsUri + "/columnLineage/" + safeName + "_" + colLineageIndex;
-            Resource colLineageResource = model.createResource(colLineageUri);
-            colLineageIndex++;
-
-            detailsResource.addProperty(hasColumnLineage, colLineageResource);
-            colLineageResource.addProperty(
-                model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
-                model.createResource("https://open-metadata.org/ontology/ColumnLineage"));
-
-            if (colLineage.getFromColumns() != null) {
-              Property fromColumnProp =
-                  model.createProperty("https://open-metadata.org/ontology/", "fromColumn");
-              for (String fromCol : colLineage.getFromColumns()) {
-                colLineageResource.addProperty(fromColumnProp, fromCol);
-              }
-            }
-
-            if (colLineage.getToColumn() != null) {
-              colLineageResource.addProperty(
-                  model.createProperty("https://open-metadata.org/ontology/", "toColumn"),
-                  colLineage.getToColumn());
-            }
-
-            if (colLineage.getFunction() != null) {
-              colLineageResource.addProperty(
-                  model.createProperty("https://open-metadata.org/ontology/", "transformFunction"),
-                  colLineage.getFunction());
-            }
-          }
-        }
-
-        if (lineageDetails.getCreatedAt() != null) {
-          detailsResource.addProperty(
-              model.createProperty("http://purl.org/dc/terms/", "created"),
-              model.createTypedLiteral(
-                  lineageDetails.getCreatedAt().toString(),
-                  org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong));
-          // PROV-O timing: detailsResource represents the Activity instance, so its
-          // createdAt is when the Activity started.
-          detailsResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "startedAtTime"),
-              model.createTypedLiteral(
-                  java.time.Instant.ofEpochMilli(lineageDetails.getCreatedAt()).toString(),
-                  org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime));
-        }
-        if (lineageDetails.getUpdatedAt() != null) {
-          detailsResource.addProperty(
-              model.createProperty("http://purl.org/dc/terms/", "modified"),
-              model.createTypedLiteral(
-                  lineageDetails.getUpdatedAt().toString(),
-                  org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong));
-          // PROV-O timing: updatedAt is when the Activity last completed (or was
-          // last observed). For instantaneous activities it equals startedAtTime.
-          detailsResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "endedAtTime"),
-              model.createTypedLiteral(
-                  java.time.Instant.ofEpochMilli(lineageDetails.getUpdatedAt()).toString(),
-                  org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime));
-        }
-
-        if (lineageDetails.getCreatedBy() != null) {
-          detailsResource.addProperty(
-              model.createProperty("https://open-metadata.org/ontology/", "lineageCreatedBy"),
-              lineageDetails.getCreatedBy());
-          // PROV-O agency: the Activity was associated with the Agent (user/bot)
-          // that triggered or owns it. We don't know the agent's UUID from a
-          // username string, so use a name-based URI under entity/user/.
-          String associatedAgentUri =
-              config.getBaseUri().toString()
-                  + "entity/user/"
-                  + lineageDetails.getCreatedBy().replaceAll("[^A-Za-z0-9_.-]", "_");
-          detailsResource.addProperty(
-              model.createProperty("http://www.w3.org/ns/prov#", "wasAssociatedWith"),
-              model.createResource(associatedAgentUri));
-        }
-        if (lineageDetails.getUpdatedBy() != null) {
-          detailsResource.addProperty(
-              model.createProperty("https://open-metadata.org/ontology/", "lineageUpdatedBy"),
-              lineageDetails.getUpdatedBy());
-        }
+      Model model = buildLineageModel(fromType, fromId, toType, toId, lineageDetails);
+      String fromUri = entityUri(fromType, fromId);
+      String toUri = entityUri(toType, toId);
+      String detailsUri = lineageDetailsUri(fromId, toId);
+      String triples = serializeModel(model);
+      if (triples.isBlank()) {
+        return;
       }
-
-      // Idempotent delete/insert pattern ensures no duplicate triples
-      java.io.StringWriter writer = new java.io.StringWriter();
-      model.write(writer, "N-TRIPLES");
-      String triples = writer.toString();
-
-      if (!triples.isEmpty()) {
-        String detailsUri =
-            config.getBaseUri().toString() + "lineageDetails/" + fromId + "/" + toId;
-        // Cleanup before re-insert: remove the lineage edge (both directions),
-        // any LineageDetails subtree for THIS specific (fromId, toId) edge — never
-        // touch the source entity's hasLineageDetails links to OTHER downstream
-        // entities — and any prov:generated reference to this details resource.
-        // The hasLineageDetails delete is pinned to <fromUri> hasLineageDetails
-        // <detailsUri> so reindexing one edge doesn't strip the source's other
-        // downstream lineage links. The detailsUri-prefixed delete cleans up the
-        // LineageDetails resource itself plus its child columnLineage resources
-        // (deterministic URI prefix).
-        String deleteQuery =
-            String.format(
-                "DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/UPSTREAM> <%s> . } };"
-                    + " DELETE WHERE { GRAPH <%s> { <%s> <http://www.w3.org/ns/prov#wasDerivedFrom> <%s> . } };"
-                    + " DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/hasLineageDetails> <%s> . } };"
-                    + " DELETE { GRAPH <%s> { ?s ?p ?o } } WHERE { GRAPH <%s> { ?s ?p ?o . FILTER(STRSTARTS(STR(?s), \"%s\")) } };"
-                    + " DELETE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } } WHERE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } }",
-                KNOWLEDGE_GRAPH,
-                fromUri,
-                toUri,
-                KNOWLEDGE_GRAPH,
-                toUri,
-                fromUri,
-                KNOWLEDGE_GRAPH,
-                fromUri,
-                detailsUri,
-                KNOWLEDGE_GRAPH,
-                KNOWLEDGE_GRAPH,
-                detailsUri,
-                KNOWLEDGE_GRAPH,
-                detailsUri,
-                KNOWLEDGE_GRAPH,
-                detailsUri);
-
-        storageService.executeSparqlUpdate(deleteQuery);
-
-        String insertQuery = "INSERT DATA { GRAPH <" + KNOWLEDGE_GRAPH + "> { " + triples + " } }";
-
-        storageService.executeSparqlUpdate(insertQuery);
-        LOG.debug("Added lineage with details from {}/{} to {}/{}", fromType, fromId, toType, toId);
-      }
+      String update =
+          buildLineageDeleteStatements(fromUri, toUri, detailsUri)
+              + ";\n"
+              + buildInsertData(triples);
+      storageService.executeSparqlUpdate(update);
+      LOG.debug("Added lineage with details from {}/{} to {}/{}", fromType, fromId, toType, toId);
     } catch (Exception e) {
       LOG.error(
           "Failed to add lineage with details from {}/{} to {}/{}",
@@ -969,6 +757,311 @@ public class RdfRepository {
           e);
       throw new RuntimeException("Failed to add lineage with details", e);
     }
+  }
+
+  Model buildLineageModel(
+      String fromType, UUID fromId, String toType, UUID toId, LineageDetails lineageDetails) {
+    Model model = ModelFactory.createDefaultModel();
+
+    model.setNsPrefix("om", "https://open-metadata.org/ontology/");
+    model.setNsPrefix("prov", "http://www.w3.org/ns/prov#");
+    model.setNsPrefix("dct", "http://purl.org/dc/terms/");
+
+    String fromUri = entityUri(fromType, fromId);
+    String toUri = entityUri(toType, toId);
+
+    Resource fromResource = model.createResource(fromUri);
+    Resource toResource = model.createResource(toUri);
+
+    // PROV-O: to wasDerivedFrom from (reverse direction for semantic correctness)
+    Property derivedFrom = model.createProperty("http://www.w3.org/ns/prov#", "wasDerivedFrom");
+    toResource.addProperty(derivedFrom, fromResource);
+
+    // OpenMetadata-specific upstream for compatibility
+    Property upstream = model.createProperty("https://open-metadata.org/ontology/", "UPSTREAM");
+    fromResource.addProperty(upstream, toResource);
+
+    if (lineageDetails != null) {
+      // Deterministic URI: re-indexing the same lineage produces the same URI,
+      // letting the DELETE+INSERT idempotency below collapse duplicate
+      // LineageDetails resources instead of creating a new one per run.
+      String detailsUri = lineageDetailsUri(fromId, toId);
+      Resource detailsResource = model.createResource(detailsUri);
+
+      Property hasLineageDetails =
+          model.createProperty("https://open-metadata.org/ontology/", "hasLineageDetails");
+      fromResource.addProperty(hasLineageDetails, detailsResource);
+
+      detailsResource.addProperty(
+          model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
+          model.createResource("https://open-metadata.org/ontology/LineageDetails"));
+      // detailsResource is the Activity instance for this lineage edge — it
+      // carries Activity-shaped predicates (prov:startedAtTime, endedAtTime,
+      // used, hadPlan, wasGeneratedBy, wasAssociatedWith). Type it as
+      // prov:Activity so PROV-O reasoners and federated SPARQL clients treat
+      // it as one without having to learn the OM-specific type.
+      detailsResource.addProperty(
+          model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
+          model.createResource("http://www.w3.org/ns/prov#Activity"));
+
+      if (lineageDetails.getSqlQuery() != null && !lineageDetails.getSqlQuery().isEmpty()) {
+        detailsResource.addProperty(
+            model.createProperty("https://open-metadata.org/ontology/", "sqlQuery"),
+            lineageDetails.getSqlQuery());
+
+        // PROV-O Plan: model the SQL transformation recipe as a prov:Plan that
+        // the Activity hadPlan. Lets external clients diff/version transformation
+        // logic separately from individual runs.
+        String planUri = detailsUri + "/plan";
+        Resource planResource = model.createResource(planUri);
+        planResource.addProperty(
+            model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
+            model.createResource("http://www.w3.org/ns/prov#Plan"));
+        planResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "value"),
+            lineageDetails.getSqlQuery());
+        detailsResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "hadPlan"), planResource);
+      }
+
+      if (lineageDetails.getSource() != null) {
+        detailsResource.addProperty(
+            model.createProperty("https://open-metadata.org/ontology/", "lineageSource"),
+            lineageDetails.getSource().value());
+      }
+
+      if (lineageDetails.getDescription() != null && !lineageDetails.getDescription().isEmpty()) {
+        detailsResource.addProperty(
+            model.createProperty("http://purl.org/dc/terms/", "description"),
+            lineageDetails.getDescription());
+      }
+
+      if (lineageDetails.getPipeline() != null && lineageDetails.getPipeline().getId() != null) {
+        EntityReference pipeline = lineageDetails.getPipeline();
+        String pipelineType = pipeline.getType() != null ? pipeline.getType() : "pipeline";
+        String pipelineUri =
+            config.getBaseUri().toString() + "entity/" + pipelineType + "/" + pipeline.getId();
+        Resource pipelineResource = model.createResource(pipelineUri);
+
+        detailsResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "wasGeneratedBy"), pipelineResource);
+
+        // PROV-O inverse: pipeline prov:generated lineageDetails. Emitting both
+        // directions lets activity-side queries ("what did this pipeline produce?")
+        // run without needing reverse-property reasoning support in the triple store.
+        pipelineResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "generated"), detailsResource);
+      }
+
+      // PROV-O input: lineageDetails prov:used <upstream entity>. Completes the
+      // standard PROV-O Entity → Activity → Entity chain alongside wasDerivedFrom,
+      // so external SPARQL clients can query "what inputs did this activity use?".
+      detailsResource.addProperty(
+          model.createProperty("http://www.w3.org/ns/prov#", "used"), fromResource);
+
+      if (lineageDetails.getColumnsLineage() != null
+          && !lineageDetails.getColumnsLineage().isEmpty()) {
+        Property hasColumnLineage =
+            model.createProperty("https://open-metadata.org/ontology/", "hasColumnLineage");
+
+        int colLineageIndex = 0;
+        for (org.openmetadata.schema.type.ColumnLineage colLineage :
+            lineageDetails.getColumnsLineage()) {
+          // Deterministic URI per (lineage edge, target column) so re-indexing
+          // doesn't multiply column-lineage resources. The index suffix is a
+          // tiebreaker so distinct toColumn values that normalize to the same
+          // string (e.g. `a-b` and `a_b` both → `a_b` after the
+          // [^A-Za-z0-9]→`_` replacement) don't collapse to one resource.
+          String safeName =
+              colLineage.getToColumn() != null
+                  ? colLineage.getToColumn().replaceAll("[^A-Za-z0-9]", "_")
+                  : "noTarget";
+          String colLineageUri = detailsUri + "/columnLineage/" + safeName + "_" + colLineageIndex;
+          Resource colLineageResource = model.createResource(colLineageUri);
+          colLineageIndex++;
+
+          detailsResource.addProperty(hasColumnLineage, colLineageResource);
+          colLineageResource.addProperty(
+              model.createProperty("http://www.w3.org/1999/02/22-rdf-syntax-ns#", "type"),
+              model.createResource("https://open-metadata.org/ontology/ColumnLineage"));
+
+          if (colLineage.getFromColumns() != null) {
+            Property fromColumnProp =
+                model.createProperty("https://open-metadata.org/ontology/", "fromColumn");
+            for (String fromCol : colLineage.getFromColumns()) {
+              colLineageResource.addProperty(fromColumnProp, fromCol);
+            }
+          }
+
+          if (colLineage.getToColumn() != null) {
+            colLineageResource.addProperty(
+                model.createProperty("https://open-metadata.org/ontology/", "toColumn"),
+                colLineage.getToColumn());
+          }
+
+          if (colLineage.getFunction() != null) {
+            colLineageResource.addProperty(
+                model.createProperty("https://open-metadata.org/ontology/", "transformFunction"),
+                colLineage.getFunction());
+          }
+        }
+      }
+
+      if (lineageDetails.getCreatedAt() != null) {
+        detailsResource.addProperty(
+            model.createProperty("http://purl.org/dc/terms/", "created"),
+            model.createTypedLiteral(
+                lineageDetails.getCreatedAt().toString(),
+                org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong));
+        // PROV-O timing: detailsResource represents the Activity instance, so its
+        // createdAt is when the Activity started.
+        detailsResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "startedAtTime"),
+            model.createTypedLiteral(
+                java.time.Instant.ofEpochMilli(lineageDetails.getCreatedAt()).toString(),
+                org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime));
+      }
+      if (lineageDetails.getUpdatedAt() != null) {
+        detailsResource.addProperty(
+            model.createProperty("http://purl.org/dc/terms/", "modified"),
+            model.createTypedLiteral(
+                lineageDetails.getUpdatedAt().toString(),
+                org.apache.jena.datatypes.xsd.XSDDatatype.XSDlong));
+        // PROV-O timing: updatedAt is when the Activity last completed (or was
+        // last observed). For instantaneous activities it equals startedAtTime.
+        detailsResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "endedAtTime"),
+            model.createTypedLiteral(
+                java.time.Instant.ofEpochMilli(lineageDetails.getUpdatedAt()).toString(),
+                org.apache.jena.datatypes.xsd.XSDDatatype.XSDdateTime));
+      }
+
+      if (lineageDetails.getCreatedBy() != null) {
+        detailsResource.addProperty(
+            model.createProperty("https://open-metadata.org/ontology/", "lineageCreatedBy"),
+            lineageDetails.getCreatedBy());
+        // PROV-O agency: the Activity was associated with the Agent (user/bot)
+        // that triggered or owns it. We don't know the agent's UUID from a
+        // username string, so use a name-based URI under entity/user/.
+        String associatedAgentUri =
+            config.getBaseUri().toString()
+                + "entity/user/"
+                + lineageDetails.getCreatedBy().replaceAll("[^A-Za-z0-9_.-]", "_");
+        detailsResource.addProperty(
+            model.createProperty("http://www.w3.org/ns/prov#", "wasAssociatedWith"),
+            model.createResource(associatedAgentUri));
+      }
+      if (lineageDetails.getUpdatedBy() != null) {
+        detailsResource.addProperty(
+            model.createProperty("https://open-metadata.org/ontology/", "lineageUpdatedBy"),
+            lineageDetails.getUpdatedBy());
+      }
+    }
+
+    return model;
+  }
+
+  public record LineageEdgeData(
+      String fromType, UUID fromId, String toType, UUID toId, LineageDetails details) {}
+
+  public void bulkAddLineage(List<LineageEdgeData> edges, RdfWriteMode writeMode) {
+    if (!isEnabled() || edges == null || edges.isEmpty()) {
+      return;
+    }
+
+    try {
+      int chunkSize = resolveBulkLineageEdgeBatchSize(config);
+      for (int start = 0; start < edges.size(); start += chunkSize) {
+        int end = Math.min(start + chunkSize, edges.size());
+        bulkStoreLineageChunk(edges.subList(start, end), writeMode);
+      }
+      LOG.debug("Bulk added {} lineage edges to RDF store", edges.size());
+    } catch (Exception e) {
+      LOG.error("Failed to bulk add {} lineage edges to RDF", edges.size(), e);
+      throw new RuntimeException("Failed to bulk add lineage edges to RDF", e);
+    }
+  }
+
+  void bulkStoreLineageChunk(List<LineageEdgeData> edges, RdfWriteMode writeMode) {
+    if (edges == null || edges.isEmpty()) {
+      return;
+    }
+
+    StringBuilder update = new StringBuilder();
+    Model combinedModel = ModelFactory.createDefaultModel();
+    for (LineageEdgeData edge : edges) {
+      Model edgeModel =
+          buildLineageModel(
+              edge.fromType(), edge.fromId(), edge.toType(), edge.toId(), edge.details());
+      combinedModel.add(edgeModel);
+      edgeModel.close();
+
+      if (writeMode != RdfWriteMode.INSERT_ONLY) {
+        if (!update.isEmpty()) {
+          update.append(";\n");
+        }
+        update.append(
+            buildLineageDeleteStatements(
+                entityUri(edge.fromType(), edge.fromId()),
+                entityUri(edge.toType(), edge.toId()),
+                lineageDetailsUri(edge.fromId(), edge.toId())));
+      }
+    }
+
+    String triples = serializeModel(combinedModel);
+    combinedModel.close();
+    if (!triples.isBlank()) {
+      if (!update.isEmpty()) {
+        update.append(";\n");
+      }
+      update.append(buildInsertData(triples));
+    }
+    if (!update.isEmpty()) {
+      storageService.executeSparqlUpdate(update.toString());
+    }
+  }
+
+  String lineageDetailsUri(UUID fromId, UUID toId) {
+    return config.getBaseUri().toString() + "lineageDetails/" + fromId + "/" + toId;
+  }
+
+  String buildLineageDeleteStatements(String fromUri, String toUri, String detailsUri) {
+    return String.format(
+        "DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/UPSTREAM> <%s> . } };"
+            + " DELETE WHERE { GRAPH <%s> { <%s> <http://www.w3.org/ns/prov#wasDerivedFrom> <%s> . } };"
+            + " DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/hasLineageDetails> <%s> . } };"
+            + " DELETE { GRAPH <%s> { ?s ?p ?o } } WHERE { GRAPH <%s> { ?s ?p ?o . FILTER(STRSTARTS(STR(?s), \"%s\")) } };"
+            + " DELETE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } } WHERE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } }",
+        KNOWLEDGE_GRAPH,
+        fromUri,
+        toUri,
+        KNOWLEDGE_GRAPH,
+        toUri,
+        fromUri,
+        KNOWLEDGE_GRAPH,
+        fromUri,
+        detailsUri,
+        KNOWLEDGE_GRAPH,
+        KNOWLEDGE_GRAPH,
+        detailsUri,
+        KNOWLEDGE_GRAPH,
+        detailsUri,
+        KNOWLEDGE_GRAPH,
+        detailsUri);
+  }
+
+  private String entityUri(String entityType, UUID entityId) {
+    return config.getBaseUri().toString() + "entity/" + entityType + "/" + entityId;
+  }
+
+  private static String serializeModel(Model model) {
+    StringWriter writer = new StringWriter();
+    model.write(writer, "N-TRIPLES");
+    return writer.toString();
+  }
+
+  private static String buildInsertData(String triples) {
+    return "INSERT DATA { GRAPH <" + KNOWLEDGE_GRAPH + "> { " + triples + " } }";
   }
 
   public void removeRelationship(EntityRelationship relationship) {
@@ -1111,6 +1204,11 @@ public class RdfRepository {
 
   public List<Map<String, String>> executeSparqlQueryAsJson(String query) {
     String result = executeSparqlQuery(query, "json");
+    return parseSparqlJsonResults(result);
+  }
+
+  public List<Map<String, String>> executeSparqlQueryDirectAsJson(String query) {
+    String result = executeSparqlQueryDirect(query, "json");
     return parseSparqlJsonResults(result);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfWriteMode.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfWriteMode.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf;
+
+public enum RdfWriteMode {
+  RECONCILE,
+  INSERT_ONLY
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/semantic/SemanticSearchEngine.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/semantic/SemanticSearchEngine.java
@@ -1,6 +1,11 @@
 package org.openmetadata.service.rdf.semantic;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -170,6 +175,7 @@ public class SemanticSearchEngine {
         String sparql =
             """
           PREFIX om: <https://open-metadata.org/ontology/>
+          PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
           SELECT ?predicate ?object ?objectType
           WHERE {
             <%s> ?predicate ?object .
@@ -180,7 +186,8 @@ public class SemanticSearchEngine {
           """
                 .formatted(getEntityUri(result.getEntity()));
 
-        List<Map<String, String>> relationships = rdfRepository.executeSparqlQueryAsJson(sparql);
+        List<Map<String, String>> relationships =
+            rdfRepository.executeSparqlQueryDirectAsJson(sparql);
 
         // Boost score based on relevant relationships
         double contextBoost = calculateContextBoost(relationships, query);
@@ -213,18 +220,38 @@ public class SemanticSearchEngine {
         String sparql =
             """
           PREFIX om: <https://open-metadata.org/ontology/>
+          PREFIX prov: <http://www.w3.org/ns/prov#>
           SELECT ?related ?type ?relationship
           WHERE {
-            <%s> ?relationship ?related .
+            {
+              <%s> ?relationship ?related .
+              FILTER(?relationship IN (om:relatedTo, om:similarTo))
+            } UNION {
+              <%s> (prov:wasDerivedFrom|^om:UPSTREAM)+ ?related .
+              BIND(prov:wasDerivedFrom AS ?relationship)
+            } UNION {
+              <%s> (om:UPSTREAM|^prov:wasDerivedFrom)+ ?related .
+              BIND(om:UPSTREAM AS ?relationship)
+            } UNION {
+              <%s> (om:belongsTo/om:inDomain|om:belongsTo/om:hasGlossaryTerm) ?related .
+              BIND(om:relatedTo AS ?relationship)
+            } UNION {
+              <%s> (^om:owns|^prov:used) ?related .
+              BIND(om:relatedTo AS ?relationship)
+            }
             ?related a ?type .
-            FILTER(?relationship IN (om:relatedTo, om:similarTo, om:derivedFrom))
           }
+          LIMIT 100
           """
-                .formatted(getEntityUri(result.getEntity()));
+                .formatted(
+                    getEntityUri(result.getEntity()),
+                    getEntityUri(result.getEntity()),
+                    getEntityUri(result.getEntity()),
+                    getEntityUri(result.getEntity()),
+                    getEntityUri(result.getEntity()));
 
-        // Execute with custom inference rules
         List<Map<String, String>> inferenceResults =
-            rdfRepository.executeSparqlQueryWithInferenceAsJson(sparql, "custom");
+            rdfRepository.executeSparqlQueryDirectAsJson(sparql);
 
         for (Map<String, String> row : inferenceResults) {
           String relatedUri = row.get("related");
@@ -232,7 +259,8 @@ public class SemanticSearchEngine {
 
           if (relatedUri != null && relationType != null) {
             // Extract relationship type from URI
-            String relationName = relationType.substring(relationType.lastIndexOf("#") + 1);
+            int separator = Math.max(relationType.lastIndexOf('#'), relationType.lastIndexOf('/'));
+            String relationName = relationType.substring(separator + 1);
 
             // Create inferred result
             EntityReference related = getEntityFromUri(relatedUri);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/JenaFusekiStorage.java
@@ -52,6 +52,7 @@ import org.apache.jena.update.UpdateRequest;
 import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
 import org.openmetadata.schema.exception.JsonParsingException;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.rdf.RdfWriteMode;
 import org.openmetadata.service.rdf.translator.RdfPropertyMapper;
 
 /**
@@ -763,9 +764,17 @@ public class JenaFusekiStorage implements RdfStorageInterface {
   }
 
   static String buildEntityUpsertUpdate(String entityUri, Model entityModel) {
+    return buildEntityUpsertUpdate(entityUri, entityModel, RdfWriteMode.RECONCILE);
+  }
+
+  static String buildEntityUpsertUpdate(
+      String entityUri, Model entityModel, RdfWriteMode writeMode) {
+    String triples = serializeModel(entityModel);
+    if (writeMode == RdfWriteMode.INSERT_ONLY) {
+      return triples.isBlank() ? "" : buildInsertData(triples);
+    }
     Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, entityModel);
     String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
-    String triples = serializeModel(entityModel);
     if (triples.isBlank()) {
       return deleteQuery;
     }
@@ -799,6 +808,11 @@ public class JenaFusekiStorage implements RdfStorageInterface {
    */
   @Override
   public void bulkStoreEntities(List<EntityWriteRequest> requests) {
+    bulkStoreEntities(requests, RdfWriteMode.RECONCILE);
+  }
+
+  @Override
+  public void bulkStoreEntities(List<EntityWriteRequest> requests, RdfWriteMode writeMode) {
     if (requests == null || requests.isEmpty()) {
       return;
     }
@@ -808,14 +822,16 @@ public class JenaFusekiStorage implements RdfStorageInterface {
     Model combinedModel = ModelFactory.createDefaultModel();
     boolean first = true;
     for (EntityWriteRequest req : requests) {
-      String entityUri = baseUri + "entity/" + req.entityType() + "/" + req.entityId();
-      Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, req.model());
-      String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
-      if (!first) {
-        combinedDelete.append(";\n");
+      if (writeMode != RdfWriteMode.INSERT_ONLY) {
+        String entityUri = baseUri + "entity/" + req.entityType() + "/" + req.entityId();
+        Set<String> predicatesToDelete = collectTranslatorPredicates(entityUri, req.model());
+        String deleteQuery = buildPredicateScopedDelete(entityUri, predicatesToDelete);
+        if (!first) {
+          combinedDelete.append(";\n");
+        }
+        first = false;
+        combinedDelete.append(deleteQuery);
       }
-      first = false;
-      combinedDelete.append(deleteQuery);
       combinedModel.add(req.model());
     }
 
@@ -826,6 +842,10 @@ public class JenaFusekiStorage implements RdfStorageInterface {
         combined.append(";\n");
       }
       combined.append(buildInsertData(triples));
+    }
+
+    if (combined.isEmpty()) {
+      return;
     }
 
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/storage/RdfStorageInterface.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
 import org.apache.jena.rdf.model.Model;
+import org.openmetadata.service.rdf.RdfWriteMode;
 
 /**
  * Interface for remote RDF storage implementations.
@@ -38,6 +39,14 @@ public interface RdfStorageInterface {
     for (EntityWriteRequest req : requests) {
       storeEntity(req.entityType(), req.entityId(), req.model());
     }
+  }
+
+  /**
+   * Bulk-write entity models using the requested reconciliation mode. Backends that do not support
+   * insert-only writes retain their existing behavior through the one-argument overload.
+   */
+  default void bulkStoreEntities(List<EntityWriteRequest> requests, RdfWriteMode writeMode) {
+    bulkStoreEntities(requests);
   }
 
   /** Payload for {@link #bulkStoreEntities}. */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/rdf/translator/RdfPropertyMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/rdf/translator/RdfPropertyMapper.java
@@ -105,6 +105,10 @@ public class RdfPropertyMapper {
     this.contextCache = contextCache;
   }
 
+  public static boolean isIgnoredEntityField(String fieldName) {
+    return IGNORED_PROPERTIES.contains(fieldName);
+  }
+
   /**
    * Convert all entity properties to RDF triples based on context mappings
    */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/rdf/RdfResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/rdf/RdfResource.java
@@ -608,7 +608,6 @@ public class RdfResource {
             BIND(1 as ?distance)
           }
           ORDER BY ?distance ?name
-          LIMIT 5000
           """,
           entityUri);
 
@@ -624,7 +623,6 @@ public class RdfResource {
             BIND(1 as ?distance)
           }
           ORDER BY ?distance ?name
-          LIMIT 5000
           """,
           entityUri);
 
@@ -645,7 +643,6 @@ public class RdfResource {
             ?entity a ?type .
           }
           ORDER BY ?relationship ?name
-          LIMIT 5000
           """,
           entityUri, entityUri);
     };

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/rdf/RdfResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/rdf/RdfResource.java
@@ -576,8 +576,7 @@ public class RdfResource {
       String query =
           buildLineageQuery(
               entityId, validatedEntityType, direction, getRdfRepository().getBaseUri());
-      String results =
-          getRdfRepository().executeSparqlQueryWithInference(query, SPARQL_JSON, "custom");
+      String results = getRdfRepository().executeSparqlQueryDirect(query, SPARQL_JSON);
       return Response.ok(results).build();
     } catch (IllegalArgumentException e) {
       return Response.status(Response.Status.BAD_REQUEST)
@@ -591,7 +590,7 @@ public class RdfResource {
     }
   }
 
-  private String buildLineageQuery(
+  static String buildLineageQuery(
       UUID entityId, String entityType, String direction, String baseUri) {
     String normalizedBaseUri = baseUri.endsWith("/") ? baseUri : baseUri + "/";
     String entityUri = normalizedBaseUri + "entity/" + entityType + "/" + entityId;
@@ -600,47 +599,53 @@ public class RdfResource {
       case "upstream" -> String.format(
           """
           PREFIX om: <https://open-metadata.org/ontology/>
+          PREFIX prov: <http://www.w3.org/ns/prov#>
           SELECT DISTINCT ?entity ?name ?type ?distance
           WHERE {
-            <%s> om:upstream+ ?entity .
+            <%s> (prov:wasDerivedFrom|^om:UPSTREAM)+ ?entity .
             ?entity om:name ?name .
             ?entity a ?type .
             BIND(1 as ?distance)
           }
           ORDER BY ?distance ?name
+          LIMIT 5000
           """,
           entityUri);
 
       case "downstream" -> String.format(
           """
           PREFIX om: <https://open-metadata.org/ontology/>
+          PREFIX prov: <http://www.w3.org/ns/prov#>
           SELECT DISTINCT ?entity ?name ?type ?distance
           WHERE {
-            <%s> om:downstream+ ?entity .
+            <%s> (om:UPSTREAM|^prov:wasDerivedFrom)+ ?entity .
             ?entity om:name ?name .
             ?entity a ?type .
             BIND(1 as ?distance)
           }
           ORDER BY ?distance ?name
+          LIMIT 5000
           """,
           entityUri);
 
       default -> String.format(
           """
           PREFIX om: <https://open-metadata.org/ontology/>
+          PREFIX prov: <http://www.w3.org/ns/prov#>
           SELECT DISTINCT ?entity ?name ?type ?relationship
           WHERE {
             {
-              <%s> om:upstream+ ?entity .
+              <%s> (prov:wasDerivedFrom|^om:UPSTREAM)+ ?entity .
               BIND("upstream" as ?relationship)
             } UNION {
-              <%s> om:downstream+ ?entity .
+              <%s> (om:UPSTREAM|^prov:wasDerivedFrom)+ ?entity .
               BIND("downstream" as ?relationship)
             }
             ?entity om:name ?name .
             ?entity a ?type .
           }
           ORDER BY ?relationship ?name
+          LIMIT 5000
           """,
           entityUri, entityUri);
     };

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/OpenMetadataOperations.java
@@ -3222,7 +3222,8 @@ public class OpenMetadataOperations implements Callable<Integer> {
     config =
         factory.build(
             new SubstitutingSourceProvider(
-                new FileConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)),
+                new FileConfigurationSourceProvider(),
+                new EnvironmentVariableSubstitutor(false, true)),
             configFilePath);
     IndexMappingLoader.init(config.getElasticSearchConfiguration());
     Fernet.getInstance().setFernetKey(config);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessorTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +48,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipDAO;
 import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
 import org.openmetadata.service.rdf.RdfRepository;
+import org.openmetadata.service.rdf.RdfWriteMode;
 import org.openmetadata.service.rdf.storage.RdfStorageCircuitOpenException;
 
 /**
@@ -109,9 +111,8 @@ class RdfBatchProcessorTest {
     assertEquals(3, result.successCount(), "all entities should be indexed");
     assertEquals(0, result.failedCount(), "no entity-level failure on the happy path");
     assertNull(result.lastError());
-    // Bulk path took the write; per-entity createOrUpdate must NOT fire.
-    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
-    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+    // Bulk path took the write; no singleton bulk fallback must fire.
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
   }
 
   @Test
@@ -125,18 +126,15 @@ class RdfBatchProcessorTest {
 
     // First, the bulk path fails with a payload-shape error (a real
     // SerializationException-style failure, NOT the circuit breaker).
-    doThrow(new RuntimeException("bad RDF model")).when(rdfRepository).bulkCreateOrUpdate(entities);
+    doThrow(new RuntimeException("bad RDF model"))
+        .when(rdfRepository)
+        .bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
 
     // Then in the fallback loop, only entity b fails — a and c succeed.
-    // Use lenient() because MockitoExtension's strict stubbing would
-    // otherwise throw PotentialStubbingProblem on the createOrUpdate(a)
-    // and createOrUpdate(c) calls (no matching stub for those arg values),
-    // which the fallback's catch (Exception) block would treat as entity
-    // failures and skew the success/failure counts.
     lenient()
         .doThrow(new RuntimeException("payload broken on b"))
         .when(rdfRepository)
-        .createOrUpdate(b);
+        .bulkCreateOrUpdate(List.of(b), RdfWriteMode.RECONCILE);
 
     RdfBatchProcessor.BatchProcessingResult result =
         processor.processEntities("table", entities, null);
@@ -150,8 +148,10 @@ class RdfBatchProcessorTest {
     assertTrue(
         result.lastError().contains("payload broken on b"),
         "lastError should carry the underlying message");
-    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
-    verify(rdfRepository, times(3)).createOrUpdate(any(EntityInterface.class));
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(List.of(a), RdfWriteMode.RECONCILE);
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(List.of(b), RdfWriteMode.RECONCILE);
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(List.of(c), RdfWriteMode.RECONCILE);
   }
 
   @Test
@@ -164,7 +164,7 @@ class RdfBatchProcessorTest {
     // attempt would hit the same breaker).
     doThrow(new RdfStorageCircuitOpenException("bulkStoreEntities"))
         .when(rdfRepository)
-        .bulkCreateOrUpdate(entities);
+        .bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
 
     RdfBatchProcessor.BatchProcessingResult result =
         processor.processEntities("table", entities, null);
@@ -175,10 +175,7 @@ class RdfBatchProcessorTest {
     assertTrue(
         result.lastError().contains("table batch"),
         "lastError prefix should identify the failed entity-type batch");
-    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities);
-    // The critical assertion: NO per-entity calls were issued. Pre-fix the
-    // implementation looped 3 times each hitting the same breaker.
-    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
   }
 
   @Test
@@ -192,7 +189,7 @@ class RdfBatchProcessorTest {
     // walk in isCircuitBreakerOpen must still find it.
     Throwable inner = new RdfStorageCircuitOpenException("bulkStoreEntities");
     Throwable wrapped = new RuntimeException("Failed to bulk create/update entities in RDF", inner);
-    doThrow(wrapped).when(rdfRepository).bulkCreateOrUpdate(entities);
+    doThrow(wrapped).when(rdfRepository).bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
 
     RdfBatchProcessor.BatchProcessingResult result =
         processor.processEntities("dashboard", entities, null);
@@ -200,7 +197,7 @@ class RdfBatchProcessorTest {
     // Same as the unwrapped case: NO per-entity fallback.
     assertEquals(0, result.successCount());
     assertEquals(2, result.failedCount());
-    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+    verify(rdfRepository, times(1)).bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
   }
 
   @Test
@@ -214,8 +211,7 @@ class RdfBatchProcessorTest {
 
     assertEquals(0, result.successCount());
     assertEquals(0, result.failedCount());
-    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList());
-    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList(), any(RdfWriteMode.class));
   }
 
   @Test
@@ -225,8 +221,7 @@ class RdfBatchProcessorTest {
         processor.processEntities("table", List.of(), null);
     assertEquals(0, result.successCount());
     assertEquals(0, result.failedCount());
-    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList());
-    verify(rdfRepository, never()).createOrUpdate(any(EntityInterface.class));
+    verify(rdfRepository, never()).bulkCreateOrUpdate(anyList(), any(RdfWriteMode.class));
   }
 
   @Test
@@ -238,10 +233,12 @@ class RdfBatchProcessorTest {
     EntityInterface c = mockEntity();
     List<EntityInterface> entities = List.of(a, b, c);
 
-    doThrow(new RuntimeException("bad model")).when(rdfRepository).bulkCreateOrUpdate(entities);
+    doThrow(new RuntimeException("bad model"))
+        .when(rdfRepository)
+        .bulkCreateOrUpdate(entities, RdfWriteMode.RECONCILE);
 
     // Latch flips to true after the first per-entity attempt succeeds. The
-    // loop must NOT call createOrUpdate for b or c after that.
+    // loop must NOT call the singleton bulk path for b or c after that.
     java.util.concurrent.atomic.AtomicBoolean stop =
         new java.util.concurrent.atomic.AtomicBoolean(false);
     org.mockito.Mockito.doAnswer(
@@ -250,16 +247,17 @@ class RdfBatchProcessorTest {
               return null;
             })
         .when(rdfRepository)
-        .createOrUpdate(eq(a));
+        .bulkCreateOrUpdate(eq(List.of(a)), eq(RdfWriteMode.RECONCILE));
 
     RdfBatchProcessor.BatchProcessingResult result =
         processor.processEntities("table", entities, stop::get);
 
     assertEquals(1, result.successCount(), "only a should have completed before stop");
     assertEquals(0, result.failedCount());
-    verify(rdfRepository, atLeastOnce()).createOrUpdate(eq(a));
-    verify(rdfRepository, never()).createOrUpdate(eq(b));
-    verify(rdfRepository, never()).createOrUpdate(eq(c));
+    verify(rdfRepository, atLeastOnce())
+        .bulkCreateOrUpdate(eq(List.of(a)), eq(RdfWriteMode.RECONCILE));
+    verify(rdfRepository, never()).bulkCreateOrUpdate(eq(List.of(b)), eq(RdfWriteMode.RECONCILE));
+    verify(rdfRepository, never()).bulkCreateOrUpdate(eq(List.of(c)), eq(RdfWriteMode.RECONCILE));
   }
 
   @Test
@@ -291,10 +289,171 @@ class RdfBatchProcessorTest {
 
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<EntityRelationship>> captor = ArgumentCaptor.forClass(List.class);
-    verify(rdfRepository).bulkAddRelationships(captor.capture(), any());
+    verify(rdfRepository).bulkAddRelationships(captor.capture(), any(), eq(RdfWriteMode.RECONCILE));
 
     List<EntityRelationship> stored = captor.getValue();
     assertEquals(1, stored.size(), "aiChart edge filtered; only the table edge remains");
     assertEquals("table", stored.get(0).getToEntity());
+  }
+
+  @Test
+  @DisplayName("insert-only run context is propagated to entity and relationship bulk writes")
+  void insertOnlyContextIsPropagated() {
+    processor =
+        new RdfBatchProcessor(
+            collectionDAO,
+            rdfRepository,
+            new RdfIndexingRunContext(RdfWriteMode.INSERT_ONLY, Set.of("table")));
+    List<EntityInterface> entities = List.of(mockEntity());
+
+    processor.processEntities("table", entities, null);
+
+    verify(rdfRepository).bulkCreateOrUpdate(entities, RdfWriteMode.INSERT_ONLY);
+    verify(rdfRepository).bulkAddRelationships(anyList(), any(), eq(RdfWriteMode.INSERT_ONLY));
+  }
+
+  @Test
+  @DisplayName("insert-only mode is preserved by singleton entity fallback")
+  void insertOnlyModeIsPreservedByEntityFallback() {
+    processor =
+        new RdfBatchProcessor(
+            collectionDAO,
+            rdfRepository,
+            new RdfIndexingRunContext(RdfWriteMode.INSERT_ONLY, Set.of("table")));
+    List<EntityInterface> entities = List.of(mockEntity());
+    doThrow(new RuntimeException("bulk payload rejected"))
+        .doNothing()
+        .when(rdfRepository)
+        .bulkCreateOrUpdate(entities, RdfWriteMode.INSERT_ONLY);
+
+    RdfBatchProcessor.BatchProcessingResult result =
+        processor.processEntities("table", entities, null);
+
+    assertEquals(1, result.successCount());
+    assertEquals(0, result.failedCount());
+    verify(rdfRepository, times(2)).bulkCreateOrUpdate(entities, RdfWriteMode.INSERT_ONLY);
+  }
+
+  @Test
+  @DisplayName("incoming lineage is skipped when its source type is indexed in the same run")
+  void incomingLineageIsDeduplicatedForIndexedSourceType() {
+    processor =
+        new RdfBatchProcessor(
+            collectionDAO,
+            rdfRepository,
+            new RdfIndexingRunContext(RdfWriteMode.INSERT_ONLY, Set.of("table")));
+    UUID fromId = UUID.randomUUID();
+    UUID toId = UUID.randomUUID();
+    EntityInterface from = mock(EntityInterface.class);
+    EntityInterface to = mock(EntityInterface.class);
+    when(from.getId()).thenReturn(fromId);
+    when(to.getId()).thenReturn(toId);
+    EntityRelationshipObject lineage = lineage(fromId, toId);
+    when(relationshipDAO.findToBatchWithRelations(anyList(), anyString(), anyList()))
+        .thenReturn(List.of(lineage));
+    when(relationshipDAO.findFromBatch(anyList(), anyInt(), any(Include.class)))
+        .thenReturn(List.of(lineage));
+
+    processor.processBatchRelationships("table", List.of(from, to));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<RdfRepository.LineageEdgeData>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(rdfRepository).bulkAddLineage(captor.capture(), eq(RdfWriteMode.INSERT_ONLY));
+    assertEquals(1, captor.getValue().size());
+    assertEquals(fromId, captor.getValue().get(0).fromId());
+    assertEquals(toId, captor.getValue().get(0).toId());
+  }
+
+  @Test
+  @DisplayName("legacy run context still processes incoming lineage")
+  void legacyContextProcessesIncomingLineage() {
+    UUID fromId = UUID.randomUUID();
+    UUID toId = UUID.randomUUID();
+    EntityInterface to = mock(EntityInterface.class);
+    when(to.getId()).thenReturn(toId);
+    when(relationshipDAO.findToBatchWithRelations(anyList(), anyString(), anyList()))
+        .thenReturn(List.of());
+    when(relationshipDAO.findFromBatch(anyList(), anyInt(), any(Include.class)))
+        .thenReturn(List.of(lineage(fromId, toId)));
+
+    processor.processBatchRelationships("table", List.of(to));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<RdfRepository.LineageEdgeData>> captor =
+        ArgumentCaptor.forClass(List.class);
+    verify(rdfRepository).bulkAddLineage(captor.capture(), eq(RdfWriteMode.RECONCILE));
+    assertEquals(1, captor.getValue().size());
+  }
+
+  @Test
+  @DisplayName("lineage bulk failure falls back per edge and isolates a bad edge")
+  void lineageFallbackIsolatesBadEdge() {
+    UUID fromId = UUID.randomUUID();
+    UUID goodTargetId = UUID.randomUUID();
+    UUID badTargetId = UUID.randomUUID();
+    EntityInterface source = mock(EntityInterface.class);
+    when(source.getId()).thenReturn(fromId);
+    when(relationshipDAO.findToBatchWithRelations(anyList(), anyString(), anyList()))
+        .thenReturn(List.of(lineage(fromId, goodTargetId), lineage(fromId, badTargetId)));
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              List<RdfRepository.LineageEdgeData> edges = invocation.getArgument(0);
+              if (edges.size() > 1) {
+                throw new RuntimeException("bulk lineage rejected");
+              }
+              if (edges.get(0).toId().equals(badTargetId)) {
+                throw new RuntimeException("bad lineage edge");
+              }
+              return null;
+            })
+        .when(rdfRepository)
+        .bulkAddLineage(anyList(), eq(RdfWriteMode.RECONCILE));
+
+    RdfBatchProcessor.RelationshipProcessingResult result =
+        processor.processBatchRelationships("table", List.of(source));
+
+    assertEquals(1, result.failureCount());
+    assertTrue(result.lastError().contains(badTargetId.toString()));
+    verify(rdfRepository, times(3)).bulkAddLineage(anyList(), eq(RdfWriteMode.RECONCILE));
+  }
+
+  @Test
+  @DisplayName("lineage fallback stops when the RDF circuit breaker opens")
+  void lineageFallbackStopsWhenCircuitBreakerOpens() {
+    UUID fromId = UUID.randomUUID();
+    UUID firstTargetId = UUID.randomUUID();
+    UUID secondTargetId = UUID.randomUUID();
+    EntityInterface source = mock(EntityInterface.class);
+    when(source.getId()).thenReturn(fromId);
+    when(relationshipDAO.findToBatchWithRelations(anyList(), anyString(), anyList()))
+        .thenReturn(List.of(lineage(fromId, firstTargetId), lineage(fromId, secondTargetId)));
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              List<RdfRepository.LineageEdgeData> edges = invocation.getArgument(0);
+              if (edges.size() > 1) {
+                throw new RuntimeException("bulk lineage rejected");
+              }
+              throw new RdfStorageCircuitOpenException("bulkAddLineage");
+            })
+        .when(rdfRepository)
+        .bulkAddLineage(anyList(), eq(RdfWriteMode.RECONCILE));
+
+    RdfBatchProcessor.RelationshipProcessingResult result =
+        processor.processBatchRelationships("table", List.of(source));
+
+    assertEquals(2, result.failureCount());
+    verify(rdfRepository, times(2)).bulkAddLineage(anyList(), eq(RdfWriteMode.RECONCILE));
+  }
+
+  private static EntityRelationshipObject lineage(UUID fromId, UUID toId) {
+    return EntityRelationshipObject.builder()
+        .fromId(fromId.toString())
+        .toId(toId.toString())
+        .fromEntity("table")
+        .toEntity("table")
+        .relation(Relationship.UPSTREAM.ordinal())
+        .json("{\"sqlQuery\":\"SELECT 1\"}")
+        .build();
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexAppTest.java
@@ -39,6 +39,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO.EntityRelationshipObject;
 import org.openmetadata.service.jdbi3.EntityDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.rdf.RdfRepository;
+import org.openmetadata.service.rdf.RdfWriteMode;
 import org.openmetadata.service.search.SearchRepository;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
@@ -543,6 +544,41 @@ class RdfIndexAppTest {
         assertEquals(Set.of("table"), result);
       }
     }
+
+    @Test
+    @DisplayName("Should exclude every time-series entity when expanding all entities")
+    void testResolveEntityTypesExcludesTimeSeriesEntitiesFromAll() throws Exception {
+      Set<String> timeSeriesEntities =
+          Set.of(
+              Entity.TEST_CASE_RESULT,
+              Entity.TEST_CASE_RESOLUTION_STATUS,
+              Entity.QUERY_COST_RECORD,
+              Entity.ENTITY_REPORT_DATA,
+              Entity.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA,
+              Entity.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA,
+              Entity.RAW_COST_ANALYSIS_REPORT_DATA,
+              Entity.AGGREGATED_COST_ANALYSIS_REPORT_DATA);
+      try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+        EntityRepository<?> mockRepository = mock(EntityRepository.class);
+        Set<String> allEntities = new java.util.HashSet<>(timeSeriesEntities);
+        allEntities.add("table");
+        entityMock.when(Entity::getEntityList).thenReturn(allEntities);
+        entityMock.when(() -> Entity.getEntityRepository("table")).thenReturn(mockRepository);
+        for (String timeSeriesEntity : timeSeriesEntities) {
+          entityMock
+              .when(() -> Entity.getEntityRepository(timeSeriesEntity))
+              .thenThrow(new IllegalStateException("Time-series entity"));
+        }
+
+        var method = RdfIndexApp.class.getDeclaredMethod("resolveEntityTypes", Set.class);
+        method.setAccessible(true);
+
+        @SuppressWarnings("unchecked")
+        Set<String> result = (Set<String>) method.invoke(rdfIndexApp, Set.of("all"));
+
+        assertEquals(Set.of("table"), result);
+      }
+    }
   }
 
   @Nested
@@ -1019,7 +1055,8 @@ class RdfIndexAppTest {
       // batchSources (Fix-I — RdfBatchProcessor now passes its batchSources
       // to scope the per-source DELETE inside JenaFusekiStorage).
       var captor = org.mockito.ArgumentCaptor.forClass(List.class);
-      verify(mockRdfRepository).bulkAddRelationships(captor.capture(), anySet());
+      verify(mockRdfRepository)
+          .bulkAddRelationships(captor.capture(), anySet(), eq(RdfWriteMode.RECONCILE));
 
       @SuppressWarnings("unchecked")
       List<org.openmetadata.schema.type.EntityRelationship> storedRelationships = captor.getValue();
@@ -1072,9 +1109,13 @@ class RdfIndexAppTest {
       method.setAccessible(true);
       method.invoke(rdfIndexApp, "table", mockEntities);
 
-      // Verify addLineageWithDetails was called (lineage with JSON should use special method)
-      verify(mockRdfRepository)
-          .addLineageWithDetails(eq("table"), eq(fromId), eq("table"), eq(toId), any());
+      @SuppressWarnings("unchecked")
+      org.mockito.ArgumentCaptor<List<RdfRepository.LineageEdgeData>> captor =
+          org.mockito.ArgumentCaptor.forClass(List.class);
+      verify(mockRdfRepository).bulkAddLineage(captor.capture(), eq(RdfWriteMode.RECONCILE));
+      assertEquals(1, captor.getValue().size());
+      assertEquals(fromId, captor.getValue().get(0).fromId());
+      assertEquals(toId, captor.getValue().get(0).toId());
     }
 
     @Test
@@ -1114,7 +1155,8 @@ class RdfIndexAppTest {
       // SPARQL update. The separate clearOutgoingEntityRelationships call
       // was retired when the clear was folded into bulkAddRelationships'
       // atomic transaction; verify the 2-arg overload instead.
-      verify(mockRdfRepository).bulkAddRelationships(eq(java.util.List.of()), anySet());
+      verify(mockRdfRepository)
+          .bulkAddRelationships(eq(java.util.List.of()), anySet(), eq(RdfWriteMode.RECONCILE));
       verify(mockRdfRepository, never())
           .addRelationship(any(org.openmetadata.schema.type.EntityRelationship.class));
     }
@@ -1153,7 +1195,8 @@ class RdfIndexAppTest {
       // never reach the insert side; bulkAddRelationships is still invoked
       // with an empty list + batchSources so the atomic clear+insert reconciles
       // the source entity's existing RDF state.
-      verify(mockRdfRepository).bulkAddRelationships(eq(java.util.List.of()), anySet());
+      verify(mockRdfRepository)
+          .bulkAddRelationships(eq(java.util.List.of()), anySet(), eq(RdfWriteMode.RECONCILE));
       verify(mockRdfRepository, never())
           .addRelationship(any(org.openmetadata.schema.type.EntityRelationship.class));
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexingRunContextTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/rdf/RdfIndexingRunContextTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.apps.bundles.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.system.EventPublisherJob;
+import org.openmetadata.service.rdf.RdfWriteMode;
+
+class RdfIndexingRunContextTest {
+
+  @Test
+  void recreateJobUsesInsertOnly() {
+    EventPublisherJob job =
+        new EventPublisherJob().withRecreateIndex(true).withEntities(Set.of("table", "dashboard"));
+
+    RdfIndexingRunContext context = RdfIndexingRunContext.forJob(job);
+
+    assertEquals(RdfWriteMode.INSERT_ONLY, context.writeMode());
+    assertEquals(Set.of("table", "dashboard"), context.entityTypesInRun());
+  }
+
+  @Test
+  void falseNullAndMissingJobsReconcile() {
+    assertEquals(
+        RdfWriteMode.RECONCILE,
+        RdfIndexingRunContext.forJob(new EventPublisherJob().withRecreateIndex(false)).writeMode());
+    assertEquals(
+        RdfWriteMode.RECONCILE, RdfIndexingRunContext.forJob(new EventPublisherJob()).writeMode());
+    assertEquals(RdfWriteMode.RECONCILE, RdfIndexingRunContext.forJob(null).writeMode());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/config/LoggingConfigurationYamlTest.java
@@ -76,7 +76,8 @@ class LoggingConfigurationYamlTest {
     if (formatOverride == null) {
       return factory.build(
           new SubstitutingSourceProvider(
-              new FileConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)),
+              new FileConfigurationSourceProvider(),
+              new EnvironmentVariableSubstitutor(false, true)),
           path);
     }
 
@@ -86,7 +87,8 @@ class LoggingConfigurationYamlTest {
           tempFile, Files.readString(Path.of(path)).replace("${LOG_FORMAT:-text}", formatOverride));
       return factory.build(
           new SubstitutingSourceProvider(
-              new FileConfigurationSourceProvider(), new EnvironmentVariableSubstitutor(false)),
+              new FileConfigurationSourceProvider(),
+              new EnvironmentVariableSubstitutor(false, true)),
           tempFile.toString());
     } finally {
       Files.deleteIfExists(tempFile);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/RdfScheduleMigrationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/RdfScheduleMigrationTest.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.migration.utils.v200;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.schema.entity.app.App;
+import org.openmetadata.schema.entity.app.AppSchedule;
+import org.openmetadata.schema.entity.app.ScheduleTimeline;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+import org.openmetadata.service.jdbi3.CollectionDAO.ApplicationDAO;
+import org.openmetadata.service.jdbi3.ListFilter;
+
+class RdfScheduleMigrationTest {
+
+  @Test
+  void migratesOnlyTheFormerRdfDailyDefault() {
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    ApplicationDAO applicationDAO = mock(ApplicationDAO.class);
+    when(collectionDAO.applicationDAO()).thenReturn(applicationDAO);
+    when(applicationDAO.listAfter(any(ListFilter.class), eq(Integer.MAX_VALUE), eq(""), eq("")))
+        .thenReturn(
+            List.of(
+                appJson("RdfIndexApp", ScheduleTimeline.CUSTOM, "0 0 * * *"),
+                appJson("RdfIndexApp", ScheduleTimeline.CUSTOM, "15 2 * * *"),
+                appJson("RdfIndexApp", ScheduleTimeline.NONE, "0 0 * * *"),
+                appJson("RdfIndexApp", ScheduleTimeline.CUSTOM, "0 0 * * 6"),
+                appJson("OtherApp", ScheduleTimeline.CUSTOM, "0 0 * * *")));
+
+    MigrationUtil.migrateRdfIndexAppScheduleToWeekly(collectionDAO);
+
+    ArgumentCaptor<App> appCaptor = ArgumentCaptor.forClass(App.class);
+    verify(applicationDAO, times(1)).update(appCaptor.capture());
+    assertEquals("RdfIndexApp", appCaptor.getValue().getName());
+    assertEquals("0 0 * * 6", appCaptor.getValue().getAppSchedule().getCronExpression());
+  }
+
+  private static String appJson(
+      String name, ScheduleTimeline scheduleTimeline, String cronExpression) {
+    App app =
+        new App()
+            .withName(name)
+            .withAppSchedule(
+                new AppSchedule()
+                    .withScheduleTimeline(scheduleTimeline)
+                    .withCronExpression(cronExpression));
+    return JsonUtils.pojoToJson(app);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfIndexingFieldsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfIndexingFieldsTest.java
@@ -15,33 +15,26 @@ package org.openmetadata.service.rdf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 
 class RdfIndexingFieldsTest {
 
   @Test
-  void removesVotesFromSelectiveSearchFields() {
-    try (MockedStatic<ReindexingUtil> reindexingUtil = Mockito.mockStatic(ReindexingUtil.class)) {
-      reindexingUtil
-          .when(() -> ReindexingUtil.getSearchIndexFields("table"))
-          .thenReturn(List.of("owners", Entity.FIELD_VOTES, "tags"));
+  void usesAllSupportedFieldsExceptPropertiesIgnoredByTheMapper() {
+    Set<String> supportedFields =
+        Set.of(
+            "columns",
+            "domains",
+            "followers",
+            "owners",
+            "changeDescription",
+            "testCaseResult",
+            Entity.FIELD_VOTES);
 
-      assertEquals(List.of("owners", "tags"), RdfIndexingFields.forEntityType("table"));
-    }
-  }
-
-  @Test
-  void preservesWildcardFallback() {
-    try (MockedStatic<ReindexingUtil> reindexingUtil = Mockito.mockStatic(ReindexingUtil.class)) {
-      reindexingUtil
-          .when(() -> ReindexingUtil.getSearchIndexFields("table"))
-          .thenReturn(List.of("*"));
-
-      assertEquals(List.of("*"), RdfIndexingFields.forEntityType("table"));
-    }
+    assertEquals(
+        List.of("columns", "domains", "followers", "owners"),
+        RdfIndexingFields.forSupportedFields(supportedFields));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfIndexingFieldsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfIndexingFieldsTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
+
+class RdfIndexingFieldsTest {
+
+  @Test
+  void removesVotesFromSelectiveSearchFields() {
+    try (MockedStatic<ReindexingUtil> reindexingUtil = Mockito.mockStatic(ReindexingUtil.class)) {
+      reindexingUtil
+          .when(() -> ReindexingUtil.getSearchIndexFields("table"))
+          .thenReturn(List.of("owners", Entity.FIELD_VOTES, "tags"));
+
+      assertEquals(List.of("owners", "tags"), RdfIndexingFields.forEntityType("table"));
+    }
+  }
+
+  @Test
+  void preservesWildcardFallback() {
+    try (MockedStatic<ReindexingUtil> reindexingUtil = Mockito.mockStatic(ReindexingUtil.class)) {
+      reindexingUtil
+          .when(() -> ReindexingUtil.getSearchIndexFields("table"))
+          .thenReturn(List.of("*"));
+
+      assertEquals(List.of("*"), RdfIndexingFields.forEntityType("table"));
+    }
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfLineageBatchingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfLineageBatchingTest.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.StringReader;
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.update.UpdateFactory;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
+import org.openmetadata.schema.type.LineageDetails;
+import org.openmetadata.service.rdf.storage.RdfStorageInterface;
+
+class RdfLineageBatchingTest {
+
+  private static final String BASE_URI = "https://open-metadata.org/";
+  private static final String KNOWLEDGE_GRAPH = "https://open-metadata.org/graph/knowledge";
+
+  @Test
+  void singleLineageWriteUsesOneCombinedTransaction() {
+    RdfStorageInterface storage = mock(RdfStorageInterface.class);
+    RdfRepository repository = repository(storage);
+    UUID fromId = UUID.randomUUID();
+    UUID toId = UUID.randomUUID();
+
+    repository.addLineageWithDetails(
+        "table", fromId, "table", toId, new LineageDetails().withSqlQuery("SELECT * FROM source"));
+
+    ArgumentCaptor<String> updateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(storage, times(1)).executeSparqlUpdate(updateCaptor.capture());
+    String update = updateCaptor.getValue();
+    assertTrue(update.contains("DELETE WHERE"));
+    assertTrue(update.contains("INSERT DATA"));
+    assertTrue(update.indexOf("DELETE") < update.indexOf("INSERT DATA"));
+    assertDoesNotThrow(() -> UpdateFactory.create(update));
+  }
+
+  @Test
+  void lineageDeleteBuilderPreservesTheReconciliationBlock() {
+    RdfRepository repository = repository(mock(RdfStorageInterface.class));
+    UUID fromId = UUID.randomUUID();
+    UUID toId = UUID.randomUUID();
+    String fromUri = BASE_URI + "entity/table/" + fromId;
+    String toUri = BASE_URI + "entity/table/" + toId;
+    String detailsUri = BASE_URI + "lineageDetails/" + fromId + "/" + toId;
+    String expected =
+        String.format(
+            "DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/UPSTREAM> <%s> . } };"
+                + " DELETE WHERE { GRAPH <%s> { <%s> <http://www.w3.org/ns/prov#wasDerivedFrom> <%s> . } };"
+                + " DELETE WHERE { GRAPH <%s> { <%s> <https://open-metadata.org/ontology/hasLineageDetails> <%s> . } };"
+                + " DELETE { GRAPH <%s> { ?s ?p ?o } } WHERE { GRAPH <%s> { ?s ?p ?o . FILTER(STRSTARTS(STR(?s), \"%s\")) } };"
+                + " DELETE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } } WHERE { GRAPH <%s> { ?act <http://www.w3.org/ns/prov#generated> <%s> } }",
+            KNOWLEDGE_GRAPH,
+            fromUri,
+            toUri,
+            KNOWLEDGE_GRAPH,
+            toUri,
+            fromUri,
+            KNOWLEDGE_GRAPH,
+            fromUri,
+            detailsUri,
+            KNOWLEDGE_GRAPH,
+            KNOWLEDGE_GRAPH,
+            detailsUri,
+            KNOWLEDGE_GRAPH,
+            detailsUri,
+            KNOWLEDGE_GRAPH,
+            detailsUri);
+
+    assertEquals(expected, repository.buildLineageDeleteStatements(fromUri, toUri, detailsUri));
+  }
+
+  @Test
+  void insertOnlyBatchContainsTheSameTriplesAsIndividualBuilders() {
+    RdfStorageInterface storage = mock(RdfStorageInterface.class);
+    RdfRepository repository = repository(storage);
+    List<RdfRepository.LineageEdgeData> edges = List.of(edge("SELECT 1"), edge("SELECT 2"));
+    Model expected = ModelFactory.createDefaultModel();
+    for (RdfRepository.LineageEdgeData edge : edges) {
+      expected.add(
+          repository.buildLineageModel(
+              edge.fromType(), edge.fromId(), edge.toType(), edge.toId(), edge.details()));
+    }
+
+    repository.bulkAddLineage(edges, RdfWriteMode.INSERT_ONLY);
+
+    ArgumentCaptor<String> updateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(storage).executeSparqlUpdate(updateCaptor.capture());
+    String update = updateCaptor.getValue();
+    assertFalse(update.contains("DELETE"));
+    Model actual = parseInsertModel(update);
+    assertTrue(expected.isIsomorphicWith(actual));
+  }
+
+  private static RdfRepository repository(RdfStorageInterface storage) {
+    RdfConfiguration config =
+        new RdfConfiguration().withEnabled(true).withBaseUri(URI.create(BASE_URI));
+    return new RdfRepository(config, storage, null);
+  }
+
+  private static RdfRepository.LineageEdgeData edge(String sql) {
+    return new RdfRepository.LineageEdgeData(
+        "table",
+        UUID.randomUUID(),
+        "table",
+        UUID.randomUUID(),
+        new LineageDetails().withSqlQuery(sql));
+  }
+
+  private static Model parseInsertModel(String update) {
+    String prefix = "INSERT DATA { GRAPH <" + KNOWLEDGE_GRAPH + "> { ";
+    int start = update.indexOf(prefix) + prefix.length();
+    int end = update.lastIndexOf(" } }");
+    Model model = ModelFactory.createDefaultModel();
+    model.read(new StringReader(update.substring(start, end)), null, "N-TRIPLES");
+    return model;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfRepositoryBulkChunkingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/RdfRepositoryBulkChunkingTest.java
@@ -13,7 +13,10 @@
 package org.openmetadata.service.rdf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -51,7 +54,7 @@ class RdfRepositoryBulkChunkingTest {
     @SuppressWarnings("unchecked")
     ArgumentCaptor<List<RdfStorageInterface.EntityWriteRequest>> captor =
         ArgumentCaptor.forClass(List.class);
-    verify(storage, times(3)).bulkStoreEntities(captor.capture());
+    verify(storage, times(3)).bulkStoreEntities(captor.capture(), eq(RdfWriteMode.RECONCILE));
     assertEquals(2, captor.getAllValues().get(0).size());
     assertEquals(2, captor.getAllValues().get(1).size());
     assertEquals(1, captor.getAllValues().get(2).size());
@@ -134,6 +137,28 @@ class RdfRepositoryBulkChunkingTest {
     assertEquals(
         RdfRepository.DEFAULT_BULK_RELATIONSHIP_SOURCE_BATCH_SIZE,
         RdfRepository.resolveBulkRelationshipSourceBatchSize(config));
+    assertEquals(
+        RdfRepository.DEFAULT_BULK_LINEAGE_EDGE_BATCH_SIZE,
+        RdfRepository.resolveBulkLineageEdgeBatchSize(config));
+  }
+
+  @Test
+  @DisplayName("lineage edges are split by configured chunk size")
+  void bulkLineageEdgesAreChunked() {
+    RdfStorageInterface storage = storageMock();
+    RdfRepository repository =
+        new RdfRepository(config().withBulkLineageEdgeBatchSize(2), storage, null);
+    List<RdfRepository.LineageEdgeData> edges =
+        List.of(lineageEdge(), lineageEdge(), lineageEdge(), lineageEdge(), lineageEdge());
+
+    repository.bulkAddLineage(edges, RdfWriteMode.INSERT_ONLY);
+
+    ArgumentCaptor<String> updateCaptor = ArgumentCaptor.forClass(String.class);
+    verify(storage, times(3)).executeSparqlUpdate(updateCaptor.capture());
+    for (String update : updateCaptor.getAllValues()) {
+      assertTrue(update.contains("INSERT DATA"));
+      assertFalse(update.contains("DELETE"));
+    }
   }
 
   private static RdfConfiguration config() {
@@ -160,6 +185,11 @@ class RdfRepositoryBulkChunkingTest {
   private static RdfStorageInterface.RelationshipData relationship(UUID fromId, UUID toId) {
     return new RdfStorageInterface.RelationshipData(
         "table", fromId, "database", toId, "CONTAINS", BASE_URI + "ontology/contains");
+  }
+
+  private static RdfRepository.LineageEdgeData lineageEdge() {
+    return new RdfRepository.LineageEdgeData(
+        "table", UUID.randomUUID(), "table", UUID.randomUUID(), null);
   }
 
   private static String entityUri(String entityType, UUID entityId) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/rdf/storage/JenaFusekiStorageTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.api.configuration.rdf.RdfConfiguration;
+import org.openmetadata.service.rdf.RdfWriteMode;
 
 /**
  * Unit tests for the package-private helpers on {@link JenaFusekiStorage}.
@@ -68,6 +69,10 @@ class JenaFusekiStorageTest {
       assertEquals(
           JenaFusekiStorage.DEFAULT_WRITE_RETRY_MAX_BACKOFF_MS,
           JenaFusekiStorage.resolveWriteRetryMaxBackoffMs(config));
+      assertFalse(config.getInferenceEnabled());
+      assertEquals(100, config.getBulkEntityBatchSize());
+      assertEquals(100, config.getBulkRelationshipSourceBatchSize());
+      assertEquals(50, config.getBulkLineageEdgeBatchSize());
     }
 
     @Test
@@ -199,6 +204,25 @@ class JenaFusekiStorageTest {
       assertTrue(
           update.contains("INSERT DATA { GRAPH <https://open-metadata.org/graph/knowledge>"));
       assertTrue(update.indexOf("DELETE") < update.indexOf("INSERT DATA"));
+      assertTrue(update.contains("orders"));
+    }
+
+    @Test
+    @DisplayName("insert-only entity helper emits no delete reconciliation")
+    void insertOnlyEntityUpsertSkipsDelete() {
+      UUID entityId = UUID.randomUUID();
+      String entityUri = "https://open-metadata.org/entity/table/" + entityId;
+      Model model = ModelFactory.createDefaultModel();
+      model
+          .createResource(entityUri)
+          .addProperty(
+              model.createProperty("http://www.w3.org/2000/01/rdf-schema#label"), "orders");
+
+      String update =
+          JenaFusekiStorage.buildEntityUpsertUpdate(entityUri, model, RdfWriteMode.INSERT_ONLY);
+
+      assertFalse(update.contains("DELETE"));
+      assertTrue(update.startsWith("INSERT DATA"));
       assertTrue(update.contains("orders"));
     }
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceLineageQueryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceLineageQueryTest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.resources.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.apache.jena.query.QueryFactory;
+import org.junit.jupiter.api.Test;
+
+class RdfResourceLineageQueryTest {
+
+  @Test
+  void lineageQueriesUseStoredPredicatesAndAreBounded() {
+    UUID entityId = UUID.randomUUID();
+
+    String upstream =
+        RdfResource.buildLineageQuery(entityId, "table", "upstream", "https://open-metadata.org/");
+    String downstream =
+        RdfResource.buildLineageQuery(
+            entityId, "table", "downstream", "https://open-metadata.org/");
+    String both =
+        RdfResource.buildLineageQuery(entityId, "table", "both", "https://open-metadata.org/");
+
+    assertTrue(upstream.contains("(prov:wasDerivedFrom|^om:UPSTREAM)+"));
+    assertTrue(downstream.contains("(om:UPSTREAM|^prov:wasDerivedFrom)+"));
+    assertTrue(both.contains("LIMIT 5000"));
+    assertFalse(both.contains("om:upstream"));
+    QueryFactory.create(upstream);
+    QueryFactory.create(downstream);
+    QueryFactory.create(both);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceLineageQueryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/rdf/RdfResourceLineageQueryTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 class RdfResourceLineageQueryTest {
 
   @Test
-  void lineageQueriesUseStoredPredicatesAndAreBounded() {
+  void lineageQueriesUseStoredPredicatesWithoutTruncation() {
     UUID entityId = UUID.randomUUID();
 
     String upstream =
@@ -35,7 +35,9 @@ class RdfResourceLineageQueryTest {
 
     assertTrue(upstream.contains("(prov:wasDerivedFrom|^om:UPSTREAM)+"));
     assertTrue(downstream.contains("(om:UPSTREAM|^prov:wasDerivedFrom)+"));
-    assertTrue(both.contains("LIMIT 5000"));
+    assertFalse(upstream.contains("LIMIT"));
+    assertFalse(downstream.contains("LIMIT"));
+    assertFalse(both.contains("LIMIT"));
     assertFalse(both.contains("om:upstream"));
     QueryFactory.create(upstream);
     QueryFactory.create(downstream);

--- a/openmetadata-spec/src/main/resources/json/schema/api/configuration/rdfConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/configuration/rdfConfiguration.json
@@ -63,13 +63,19 @@
     "bulkEntityBatchSize": {
       "description": "Maximum number of entity models written to RDF storage in a single bulk request.",
       "type": "integer",
-      "default": 50,
+      "default": 100,
       "minimum": 1
     },
     "bulkRelationshipSourceBatchSize": {
       "description": "Maximum number of source entities reconciled in a single RDF relationship bulk request.",
       "type": "integer",
-      "default": 25,
+      "default": 100,
+      "minimum": 1
+    },
+    "bulkLineageEdgeBatchSize": {
+      "description": "Maximum number of lineage edges written to RDF storage in a single SPARQL update.",
+      "type": "integer",
+      "default": 50,
       "minimum": 1
     },
     "username": {
@@ -94,7 +100,7 @@
     "inferenceEnabled": {
       "description": "Enable inference/reasoning on SPARQL queries. When enabled, SPARQL queries will use the inference engine to derive additional triples based on the reasoning level.",
       "type": "boolean",
-      "default": true
+      "default": false
     },
     "defaultInferenceLevel": {
       "description": "Default reasoning level for SPARQL queries when inference is enabled. CUSTOM provides OpenMetadata-specific inference rules including transitive lineage traversal and inverse relationships.",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/rdfConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/rdfConfiguration.ts
@@ -23,6 +23,10 @@ export interface RDFConfiguration {
      */
     bulkEntityBatchSize?: number;
     /**
+     * Maximum number of lineage edges written to RDF storage in a single SPARQL update.
+     */
+    bulkLineageEdgeBatchSize?: number;
+    /**
      * Maximum number of source entities reconciled in a single RDF relationship bulk request.
      */
     bulkRelationshipSourceBatchSize?: number;


### PR DESCRIPTION
### Describe your changes:

Fixes #30115

This change scales RDF/Fuseki indexing by batching entity, relationship, and detailed-lineage writes and by using insert-only writes after a recreate clears the graph, while preserving reconciliation for incremental indexing. It also deduplicates lineage traversal, hydrates the complete repository field contract needed by RDF translation, moves built-in lineage and semantic expansion to Fuseki property paths, disables full-graph in-process inference by default, migrates only the former daily RDF schedule to weekly, corrects deployment configuration, and adds production sizing and operations guidance.

#
### Type of change:

- [x] Improvement

#
### High-level design:

`RdfIndexingRunContext` derives `INSERT_ONLY` only for a recreate run after graph clearing and propagates the mode through local and distributed processors; all live and incremental callers retain `RECONCILE`. `RdfRepository` and `JenaFusekiStorage` group entity models, relationship sources, and deterministic lineage-detail models into bounded SPARQL updates with singleton fallback for payload isolation, while lineage reads and semantic expansion execute as property-path queries inside Fuseki without application-level result caps. The configuration additions are backward-compatible and require no database schema migration; the v200 data migration updates only an application still using the exact former default schedule, preserving custom and disabled schedules.

#
### Tests:

#### Use cases covered

- Recreate runs emit insert-only entity, relationship, and detailed-lineage writes.
- Repeated full reindexes preserve exact RDF entity and lineage counts without duplicate lineage details.
- Incremental and legacy paths retain reconciliation and singleton fallback behavior.
- Time-series entities remain excluded, only the old default schedule migrates, and lineage queries use stored predicates without application-level result caps.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated: `RdfBatchProcessorTest`, `RdfIndexAppTest`, `RdfIndexingRunContextTest`, `RdfScheduleMigrationTest`, `RdfIndexingFieldsTest`, `RdfLineageBatchingTest`, `RdfRepositoryBulkChunkingTest`, `JenaFusekiStorageTest`, `RdfResourceLineageQueryTest`, and `LoggingConfigurationYamlTest`.
- Validation: 102 focused RDF service tests passed with no failures; 77 field/config-focused tests passed after the review fixes.

#### Backend integration tests

- [x] I added an integration test in `openmetadata-integration-tests/` for the changed RDF reindex behavior.
- Files added/updated: `RdfReindexInsertOnlyIT`.
- Validation: the Fuseki-backed test passed two full recreate runs with exact entity, lineage, and lineage-detail counts and successful compaction.

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

1. Built the changed backend modules with `mvn -pl openmetadata-spec,openmetadata-service install -DskipTests`.
2. Ran Spotless checks for the service and integration-test Java sources.
3. Validated the changed JSON/YAML files and RDF Docker Compose endpoint precedence for preferred and legacy variables.
4. Ran `git diff --check` against `origin/main`.

No million-scale performance benchmark was run; the real-Fuseki integration fixture validates correctness and idempotency rather than throughput.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

#### Improvement

- [x] I have added tests around the new logic.
- [x] I have updated the RDF documentation.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scales RDF indexing for large catalogs and moves graph traversal work into Fuseki. The main changes are:

- Batched entity, relationship, and detailed-lineage writes.
- Insert-only writes after recreate runs clear the graph.
- Complete lineage and semantic expansion through Fuseki property paths.
- Full repository-supported field hydration for RDF translation.
- Backward-compatible RDF endpoint configuration and new tuning options.
- Updated scheduling, deployment sizing, operations guidance, and tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The complete-lineage query no longer applies the fixed result cap.
- RDF indexing now requests the repository-supported field set instead of search-only fields.
- The legacy RDF endpoint variable remains available as a fallback.
- No blocking issue was confirmed in the updated code.


</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/rdf/RdfResource.java | Removes the fixed row cap from complete-lineage property-path queries. |
| openmetadata-service/src/main/java/org/openmetadata/service/rdf/RdfIndexingFields.java | Uses repository-supported entity fields for complete RDF hydration. |
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/rdf/RdfBatchProcessor.java | Adds batched writes, insert-only mode propagation, and singleton fallback for RDF indexing. |
| conf/openmetadata.yaml | Adds RDF batching and inference settings while preserving the legacy endpoint fallback. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `conf/openmetadata.yaml`, line 841 ([link](https://github.com/open-metadata/openmetadata/blob/84eebbbbf62786d82f15c069620c3e45498d580e/conf/openmetadata.yaml#L841)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Legacy Endpoint Variable Is Ignored**

   Existing deployments that export `RDF_REMOTE_ENDPOINT` will now silently use `http://localhost:3030/openmetadata`. In a container, this usually targets the OpenMetadata service rather than Fuseki, so RDF requests fail and the circuit breaker can open after an upgrade. Keep the former variable as a compatibility fallback while deprecating it.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Preserve RDF fields and endpoint compati..."](https://github.com/open-metadata/openmetadata/commit/4f8a6b333e6ace10dbab0b6d2bb8dfba14b24542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44723438)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->