### PR TITLE
Fixes #30117: never surface soft-deleted users as owners/followers/experts/reviewers under include=all

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
@@ -17,6 +17,10 @@ import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.Include.ALL;
 import static org.openmetadata.schema.type.Include.NON_DELETED;
+import static org.openmetadata.service.Entity.FIELD_EXPERTS;
+import static org.openmetadata.service.Entity.FIELD_FOLLOWERS;
+import static org.openmetadata.service.Entity.FIELD_OWNERS;
+import static org.openmetadata.service.Entity.FIELD_REVIEWERS;
 import static org.openmetadata.service.jdbi3.ListFilter.NULL_PARAM;
 import static org.openmetadata.service.jdbi3.RoleRepository.DOMAIN_ONLY_ACCESS_ROLE;
 import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
@@ -630,6 +634,12 @@ public final class EntityUtil {
    */
   @Getter
   public static class RelationIncludes {
+    // Soft-deleted users must never surface as owners/followers/experts/reviewers, even under
+    // include=all: returning them desyncs the client's PATCH base (fetched with include=all) from
+    // the server's NON_DELETED patch load, causing "array item index out of range" on owner edits.
+    private static final Set<String> USER_IDENTITY_RELATION_FIELDS =
+        Set.of(FIELD_OWNERS, FIELD_FOLLOWERS, FIELD_EXPERTS, FIELD_REVIEWERS);
+
     private final Include defaultInclude;
     private final Map<String, Include> fieldIncludes;
 
@@ -649,7 +659,14 @@ public final class EntityUtil {
     }
 
     public Include getIncludeFor(String fieldName) {
-      return fieldIncludes.getOrDefault(fieldName, defaultInclude);
+      Include explicitInclude = fieldIncludes.get(fieldName);
+      if (explicitInclude != null) {
+        return explicitInclude;
+      }
+      if (USER_IDENTITY_RELATION_FIELDS.contains(fieldName)) {
+        return NON_DELETED;
+      }
+      return defaultInclude;
     }
 
     public boolean hasFieldSpecificInclude(String fieldName) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityUtilTest.java
@@ -283,6 +283,26 @@ class EntityUtilTest {
   }
 
   @Test
+  void testUserIdentityRelationFieldsForceNonDeletedUnderIncludeAll() {
+    // Under include=all, soft-deleted users must not leak into owners/followers/experts/reviewers,
+    // otherwise the client's include=all PATCH base desyncs from the server's NON_DELETED patch
+    // load and owner edits fail with "array item index out of range".
+    EntityUtil.RelationIncludes includeAll = EntityUtil.RelationIncludes.fromInclude(Include.ALL);
+    assertEquals(Include.NON_DELETED, includeAll.getIncludeFor("owners"));
+    assertEquals(Include.NON_DELETED, includeAll.getIncludeFor("followers"));
+    assertEquals(Include.NON_DELETED, includeAll.getIncludeFor("experts"));
+    assertEquals(Include.NON_DELETED, includeAll.getIncludeFor("reviewers"));
+    // Non-user relationship fields still honor the requested include.
+    assertEquals(Include.ALL, includeAll.getIncludeFor("domains"));
+    assertEquals(Include.ALL, includeAll.getIncludeFor("dataProducts"));
+    assertEquals(Include.ALL, includeAll.getIncludeFor("unknown"));
+    // An explicit per-field override remains authoritative.
+    EntityUtil.RelationIncludes explicitOwners =
+        new EntityUtil.RelationIncludes(Include.ALL, "owners:all");
+    assertEquals(Include.ALL, explicitOwners.getIncludeFor("owners"));
+  }
+
+  @Test
   void testVersionAndFieldNameHelpers() {
     Column column = new Column().withName("amount");
     Topic topic = new Topic().withFullyQualifiedName("service.topic");


### PR DESCRIPTION
Fixes #30117

## Problem

Editing the **owners** of an entity fails when one of the current owners is a **soft-deleted user**:

```
PATCH /api/v1/dataQuality/testSuites/{id}
[JsonException] An array item index is out of range. Index: 6, Size: 6
```

The soft-deleted user also keeps showing in the owner list, so the user can't remove them. Reported by a customer on 1.13.1 for a Test Suite, but it is generic — it hits **any entity** edited from a detail page that fetches with `include=all` (Database, Database Schema, Service, Team, Persona, Test Suite, …).

## Root cause

A client ↔ server **owner-array size mismatch**:

- The UI loads the entity with `include=all`; under `include=all` the server resolves owners **including soft-deleted users**, so the JSON-Patch base (`compare(entity, updated)`) has *N* owners.
- `EntityRepository.patch()` loads the patch `original` with `NON_DELETED`, which **drops** the soft-deleted owner → *N-1* owners.
- Applying the client patch (which references `/owners/{N-1}`) against the *N-1*-sized array throws `array item index out of range`.

This is the same class of bug as #27107 / #27120 (soft-deleted users leaking into experts/reviewers/owners). #27120 fixed the bulk-list and default-include paths, but the **single-entity GET path still honored `include=all`** for owner/expert/reviewer/follower resolution, so soft-deleted users still leaked there.

## Fix

Soft-deleted users are never valid owners/followers/experts/reviewers, so these **user-identity relationship fields always resolve with `NON_DELETED`, regardless of the entity-level `include`** — completing #27120 for the single-entity read path. This is done at the single choke point both the read planner and `setFieldsInternal` route through: `RelationIncludes.getIncludeFor`.

- An explicit per-field override (`include-relations=owners:all`) remains authoritative.
- Non-user relationship fields (`domains`, `dataProducts`, `children`, …) are unchanged.

With this, the UI's `include=all` view and the server's `NON_DELETED` patch load agree, so owner edits succeed and soft-deleted users no longer appear as owners.

## Test plan

- Unit: `EntityUtilTest.testUserIdentityRelationFieldsForceNonDeletedUnderIncludeAll` — owners/followers/experts/reviewers force `NON_DELETED` under `include=all`; non-user fields keep the requested include; explicit override wins.
- Existing `RelationIncludes` / `ReadPlanner` tests remain green (their differing values come from explicit per-field overrides).
- Manual repro (before → after): create a logical Test Suite with ≥2 owners, soft-delete the last-sorting owner, then remove owners via `PATCH`. Before: `400 array item index out of range`. After: succeeds and the deleted user no longer shows as owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents soft-deleted user identities from appearing through the default `include=all` relation path. The main changes are:

- Forces owners, followers, experts, and reviewers to use `NON_DELETED` by default.
- Keeps explicit per-field relation overrides authoritative.
- Adds unit coverage for identity fields, other relations, and override precedence.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The explicit owner include override can still trigger the PATCH array mismatch.

- The default `include=all` path now filters soft-deleted user identities.
- `owners:all` still exposes deleted owners while PATCH reconstructs the entity with `NON_DELETED`.
- The resulting arrays can have different sizes and reject a valid client patch.

openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java | Adds a default non-deleted include policy for user-identity relations, but explicit overrides can restore the GET/PATCH mismatch. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/EntityUtilTest.java | Adds focused tests for identity relation filtering, unaffected relation fields, and explicit override precedence. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(entity): never surface soft-deleted ..."](https://github.com/open-metadata/openmetadata/commit/2c3222f32b760fb78b15292d40294178aff093b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44718282)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->