### PR TITLE
fix(security-scan): count vulnerable libraries, not dependency paths, in Snyk Slack totals

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -366,7 +366,7 @@ jobs:
         if: env.SEND_SLACK_NOTIFICATION == 'true'
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: C0B6Q6KDMJN
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: header.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -421,7 +421,7 @@ jobs:
         if: always() && env.SEND_SLACK_NOTIFICATION == 'true' && steps.send-header.outputs.ts != '' && steps.build-thread.outcome == 'success'
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: C0B6Q6KDMJN
+          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
           payload-file-path: thread.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -366,7 +366,7 @@ jobs:
         if: env.SEND_SLACK_NOTIFICATION == 'true'
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
+          channel-id: C0B6Q6KDMJN
           payload-file-path: header.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -421,7 +421,7 @@ jobs:
         if: always() && env.SEND_SLACK_NOTIFICATION == 'true' && steps.send-header.outputs.ts != '' && steps.build-thread.outcome == 'success'
         uses: slackapi/slack-github-action@v1.27.1
         with:
-          channel-id: ${{ secrets.SLACK_CHANNEL_IDS }}
+          channel-id: C0B6Q6KDMJN
           payload-file-path: thread.json
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/scripts/retire_slack_summary.py
+++ b/scripts/retire_slack_summary.py
@@ -92,7 +92,9 @@ def collect_libs(data):
                     continue
                 entry["seen"].add(vid)
                 entry["vulns"].append(v)
-    return libs
+    # Drop libraries whose results carried no vulnerabilities — otherwise a
+    # per-library count reports a phantom low-risk finding that isn't real.
+    return {key: info for key, info in libs.items() if info["vulns"]}
 
 
 def lib_top_severity(info):

--- a/scripts/retire_slack_summary.py
+++ b/scripts/retire_slack_summary.py
@@ -105,12 +105,14 @@ def lib_top_severity(info):
 
 
 def count_severities(libs):
+    """Count each vulnerable library once at its highest severity, mirroring
+    snyk_summary's per-library counting — not per-CVE, which over-counts a
+    library that bundles several advisories."""
     counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
     for info in libs.values():
-        for v in info["vulns"]:
-            sev = (v.get("severity") or "low").lower()
-            if sev in counts:
-                counts[sev] += 1
+        sev = lib_top_severity(info).lower()
+        if sev in counts:
+            counts[sev] += 1
     return counts
 
 

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -162,7 +162,7 @@ def count_severities(libs, by_rule):
     for info in libs.values():
         sev = (info["sev"] or "low").lower()
         if sev in counts:
-            counts[sev] += info["paths"]
+            counts[sev] += 1
     for rid, items in by_rule.items():
         for uri, level, lines in items:
             mapped = {"error": "high", "warning": "medium", "note": "low"}.get(level, "medium")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## What
The security-scan Slack summary reported wildly inflated per-severity totals.
The Snyk header showed **100 critical · 256 high**, and the Retire.js header
showed **13 medium · 3 low**, while the actual reports had only a handful of
vulnerable libraries per severity.

## Root cause
Both summary scripts over-counted:

- **Snyk** (`scripts/snyk_summary.py`) summed each library's **dependency-path
  count** — `counts[sev] += info["paths"]`. One CVE reachable through 30 paths
  added 30. Proof: the "Paths" column across all critical rows summed to exactly
  100, matching the bogus "100 critical".
- **Retire.js** (`scripts/retire_slack_summary.py`) counted **every CVE** a
  library bundles — a single vulnerable jQuery counted as 4–5, so 5 vulnerable
  libraries reported 13 medium · 3 low.

## Fix
Count each vulnerable **library once, at its highest severity** — consistent
across both scanners:

- Snyk: `counts[sev] += 1` per `(package, version)` row.
- Retire.js: `counts[sev] += 1` using the existing `lib_top_severity(info)`.

Snyk Code (SARIF) counting is unchanged — it already counts one per location.

These functions feed the Slack header totals, the `_*_slack.txt` section
headers, and the CI `high_critical` gate (`jq '.high + .critical'`), so all are
corrected together. No workflow YAML change. The Markdown/Slack detail sections
still show the full "N libraries · M CVEs" breakdown.

## Result
- Snyk — critical count drops from 100 to the real per-library total; high from 256.
- Retire.js — medium **4** (was 13), low **1** (was 3).

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the library totals produced by the security-scan summary scripts. The main changes are:

- Count each Snyk package and version once instead of counting dependency paths.
- Count each Retire.js library once using its most serious finding.
- Exclude Retire.js entries that contain no vulnerabilities.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The Retire.js filter resolves the previously reported phantom finding.
- The Snyk change matches the package-and-version aggregation model.
- No blocking issues were found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/retire_slack_summary.py | Counts vulnerable libraries once and removes entries with no collected vulnerabilities. |
| scripts/snyk_summary.py | Counts each aggregated package and version once instead of using its dependency-path count. |

</details>

<sub>Reviews (2): Last reviewed commit: ["address comment"](https://github.com/open-metadata/openmetadata/commit/e5126be411f729c652679b11bb2f888c8c9ba046) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44724897)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->