### PR TITLE
Backport ActivityFeed and Announcement lazy-loading updates to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
@@ -89,7 +89,7 @@ jest.mock('../../../utils/useRequiredParams', () => ({
   }),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.test.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../../generated/entity/feed/thread';
 import ActivityFeedCard from './ActivityFeedCard';
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getEntityField: jest.fn(),
   getEntityFQN: jest.fn(),
   getEntityType: jest.fn(),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.tsx
@@ -25,7 +25,7 @@ import {
   getEntityField,
   getEntityFQN,
   getEntityType,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import UserPopOverCard from '../../common/PopOverCard/UserPopOverCard';
 import EditAnnouncementModal from '../../Modals/AnnouncementModal/EditAnnouncementModal';
 import { ActivityFeedCardProp } from './ActivityFeedCard.interface';
@@ -33,7 +33,6 @@ import FeedCardBody from './FeedCardBody/FeedCardBody';
 import FeedCardFooter from './FeedCardFooter/FeedCardFooter';
 import FeedCardHeader from './FeedCardHeader/FeedCardHeader';
 import PopoverContent from './PopoverContent';
-
 const ActivityFeedCard: FC<ActivityFeedCardProp> = ({
   feed,
   feedType,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.test.tsx
@@ -25,11 +25,7 @@ const mockCancel = jest.fn();
 
 const mockUpdate = jest.fn();
 
-jest.mock('../../../../utils/FeedUtils', () => ({
-  formatDateTime: jest.fn().mockReturnValue('Jan 1, 1970, 12:00 AM'),
-}));
-
-jest.mock('../../../../utils/FeedUtils', () => ({
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
   getFrontEndFormat: jest.fn(),
   MarkdownToHTMLConverter: {
     makeHtml: jest.fn().mockReturnValue('html string'),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.tsx
@@ -20,12 +20,11 @@ import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
 import {
   getFrontEndFormat,
   MarkdownToHTMLConverter,
-} from '../../../../utils/FeedUtils';
+} from '../../../../utils/FeedUtilsPure';
 import RichTextEditorPreviewerV1 from '../../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import ActivityFeedEditor from '../../ActivityFeedEditor/ActivityFeedEditor';
 import Reactions from '../../Reactions/Reactions';
 import { FeedBodyProp } from '../ActivityFeedCard.interface';
-
 const FeedCardBody: FC<FeedBodyProp> = ({
   message,
   announcementDetails,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyNew.tsx
@@ -23,14 +23,13 @@ import {
   getEntityType,
   getFrontEndFormat,
   MarkdownToHTMLConverter,
-} from '../../../../utils/FeedUtils';
+} from '../../../../utils/FeedUtilsPure';
 import RichTextEditorPreviewerNew from '../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import DescriptionFeedNew from '../../ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeedNew';
 import OwnersFeed from '../../ActivityFeedCardV2/FeedCardBody/OwnerFeed/OwnersFeed';
 import TagsFeed from '../../ActivityFeedCardV2/FeedCardBody/TagsFeed/TagsFeed';
 import './feed-card-body-v1.less';
 import { FeedCardBodyV1Props } from './FeedCardBodyV1.interface';
-
 const ActivityFeedEditor = withSuspenseFallback(
   lazy(() => import('../../ActivityFeedEditor/ActivityFeedEditor'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyV1.tsx
@@ -32,7 +32,7 @@ import {
   getEntityType,
   getFrontEndFormat,
   MarkdownToHTMLConverter,
-} from '../../../../utils/FeedUtils';
+} from '../../../../utils/FeedUtilsPure';
 import RichTextEditorPreviewerV1 from '../../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import ExploreSearchCard from '../../../ExploreV1/ExploreSearchCard/ExploreSearchCard';
 import DescriptionFeed from '../../ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardFooter/FeedCardFooter.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardFooter/FeedCardFooter.test.tsx
@@ -20,7 +20,7 @@ import {
 import { MemoryRouter } from 'react-router-dom';
 import FeedCardFooter from './FeedCardFooter';
 
-jest.mock('../../../../utils/FeedUtils', () => ({
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
   getReplyText: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardFooter/FeedCardFooter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardFooter/FeedCardFooter.tsx
@@ -15,10 +15,9 @@ import { Button, Divider } from 'antd';
 import { isUndefined } from 'lodash';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { getReplyText } from '../../../../utils/FeedUtils';
+import { getReplyText } from '../../../../utils/FeedUtilsPure';
 import ProfilePicture from '../../../common/ProfilePicture/ProfilePicture';
 import { FeedFooterProp } from '../ActivityFeedCard.interface';
-
 const FeedCardFooter: FC<FeedFooterProp> = ({
   repliedUsers,
   replies,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.test.tsx
@@ -34,6 +34,7 @@ const mockProps2 = {
 
 jest.mock('../../../../utils/RouterUtils', () => ({
   getUserPath: jest.fn().mockReturnValue('user-profile-path'),
+  getEntityDetailsPath: jest.fn().mockReturnValue('/entity/path'),
 }));
 
 jest.mock('../../../../hooks/user-profile/useUserProfile', () => ({
@@ -43,6 +44,10 @@ jest.mock('../../../../hooks/user-profile/useUserProfile', () => ({
 jest.mock('../../../../utils/date-time/DateTimeUtils', () => ({
   formatDateTime: jest.fn().mockImplementation((date) => date),
   getRelativeTime: jest.fn().mockImplementation((date) => date),
+  getEpochMillisForPastDays: jest.fn().mockImplementation((days) => days),
+  getStartOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getEndOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getCurrentMillis: jest.fn().mockReturnValue(0),
 }));
 
 jest.mock('../../../../utils/EntityNameUtils', () => ({
@@ -50,10 +55,12 @@ jest.mock('../../../../utils/EntityNameUtils', () => ({
 }));
 
 jest.mock('../../../../utils/FeedUtils', () => ({
-  entityDisplayName: jest.fn().mockReturnValue('database.schema.table'),
   getEntityFieldDisplay: jest
     .fn()
     .mockImplementation((entityField) => entityField),
+}));
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
+  entityDisplayName: jest.fn().mockReturnValue('database.schema.table'),
   prepareFeedLink: jest.fn().mockReturnValue('entity-link'),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader.tsx
@@ -24,18 +24,17 @@ import {
   getRelativeTime,
 } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
+import { getEntityFieldDisplay } from '../../../../utils/FeedUtils';
 import {
   entityDisplayName,
-  getEntityFieldDisplay,
   prepareFeedLink,
-} from '../../../../utils/FeedUtils';
+} from '../../../../utils/FeedUtilsPure';
 import { getUserPath } from '../../../../utils/RouterUtils';
 import { getTaskDetailPath } from '../../../../utils/TasksUtils';
 import EntityPopOverCard from '../../../common/PopOverCard/EntityPopOverCard';
 import UserPopOverCard from '../../../common/PopOverCard/UserPopOverCard';
 import { FeedHeaderProp } from '../ActivityFeedCard.interface';
 import './feed-card-header-v1.style.less';
-
 const FeedCardHeader: FC<FeedHeaderProp> = ({
   className,
   createdBy,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/ActivityFeedcardNew.component.tsx
@@ -29,12 +29,12 @@ import {
 } from '../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import entityUtilClassBase from '../../../utils/EntityUtilClassBase';
+import { getFeedHeaderTextFromCardStyle } from '../../../utils/FeedUtils';
 import {
   entityDisplayName,
   getEntityFQN,
   getEntityType,
-  getFeedHeaderTextFromCardStyle,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import { getUserPath } from '../../../utils/RouterUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
 import EntityPopOverCard from '../../common/PopOverCard/EntityPopOverCard';
@@ -45,7 +45,6 @@ import FeedCardFooterNew from '../ActivityFeedCardV2/FeedCardFooter/FeedCardFoot
 import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
 import '../ActivityFeedTab/activity-feed-tab.less';
 import CommentCard from './CommentCard.component';
-
 const ActivityFeedEditorNew = withSuspenseFallback(
   lazy(() => import('../ActivityFeedEditor/ActivityFeedEditorNew'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/CommentCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/CommentCard.component.tsx
@@ -26,7 +26,7 @@ import { getEntityName } from '../../../utils/EntityNameUtils';
 import {
   getFrontEndFormat,
   MarkdownToHTMLConverter,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import { getUserPath } from '../../../utils/RouterUtils';
 import UserPopOverCard from '../../common/PopOverCard/UserPopOverCard';
 import ProfilePicture from '../../common/ProfilePicture/ProfilePicture';
@@ -34,7 +34,6 @@ import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEdito
 import FeedCardFooterNew from '../ActivityFeedCardV2/FeedCardFooter/FeedCardFooterNew';
 import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
 import ActivityFeedActions from '../Shared/ActivityFeedActions';
-
 const ActivityFeedEditor = withSuspenseFallback(
   lazy(() => import('../ActivityFeedEditor/ActivityFeedEditorNew'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed.test.tsx
@@ -24,8 +24,10 @@ jest.mock('../../../../common/RichTextEditor/RichTextEditorPreviewerV1', () => {
 });
 
 jest.mock('../../../../../utils/FeedUtils', () => ({
-  getFeedChangeFieldLabel: jest.fn(),
   getFieldOperationIcon: jest.fn(),
+}));
+jest.mock('../../../../../utils/FeedUtilsPure', () => ({
+  getFeedChangeFieldLabel: jest.fn(),
   getFrontEndFormat: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeed.tsx
@@ -14,11 +14,11 @@
 import { Col, Row } from 'antd';
 import { useMemo } from 'react';
 import { EntityField } from '../../../../../constants/Feeds.constants';
+import { getFieldOperationIcon } from '../../../../../utils/FeedUtils';
 import {
   getFeedChangeFieldLabel,
-  getFieldOperationIcon,
   getFrontEndFormat,
-} from '../../../../../utils/FeedUtils';
+} from '../../../../../utils/FeedUtilsPure';
 import RichTextEditorPreviewerV1 from '../../../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import { DescriptionFeedProps } from './DescriptionFeed.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeedNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/DescriptionFeed/DescriptionFeedNew.tsx
@@ -14,11 +14,11 @@
 import { Col, Row } from 'antd';
 import { useMemo } from 'react';
 import { EntityField } from '../../../../../constants/Feeds.constants';
+import { getFieldOperationIcon } from '../../../../../utils/FeedUtils';
 import {
   getFeedChangeFieldLabel,
-  getFieldOperationIcon,
   getFrontEndFormat,
-} from '../../../../../utils/FeedUtils';
+} from '../../../../../utils/FeedUtilsPure';
 import RichTextEditorPreviewNew from '../../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import { DescriptionFeedProps } from './DescriptionFeed.interface';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/TestCaseFeed/TestCaseFeed.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardBody/TestCaseFeed/TestCaseFeed.tsx
@@ -21,7 +21,7 @@ import {
   EntityTestResultSummaryObject,
   TestCaseStatus,
 } from '../../../../../generated/entity/feed/thread';
-import { formatTestStatusData } from '../../../../../utils/FeedUtils';
+import { formatTestStatusData } from '../../../../../utils/FeedUtilsPure';
 import { translateWithNestedKeys } from '../../../../../utils/i18next/LocalUtil';
 import { getTestCaseResultCount } from '../../../../../utils/TestCaseUtils';
 import TestSummaryGraph from '../../../../Database/Profiler/TestSummary/TestSummaryGraph';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardHeader/FeedCardHeaderV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardHeader/FeedCardHeaderV2.test.tsx
@@ -29,12 +29,15 @@ jest.mock('../../../../utils/date-time/DateTimeUtils', () => ({
 }));
 
 jest.mock('../../../../utils/FeedUtils', () => ({
-  entityDisplayName: jest.fn().mockReturnValue('entityDisplayName'),
-  getEntityFQN: jest.fn().mockImplementation((data) => data),
-  getEntityType: jest.fn().mockImplementation((data) => data),
   getFeedHeaderTextFromCardStyle: jest
     .fn()
     .mockReturnValue('getFeedHeaderTextFromCardStyle'),
+}));
+
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
+  entityDisplayName: jest.fn().mockReturnValue('entityDisplayName'),
+  getEntityFQN: jest.fn().mockImplementation((data) => data),
+  getEntityType: jest.fn().mockImplementation((data) => data),
 }));
 
 jest.mock('../../../../utils/EntityNameUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardHeader/FeedCardHeaderV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardV2/FeedCardHeader/FeedCardHeaderV2.tsx
@@ -15,28 +15,27 @@ import { Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { ASSET_CARD_STYLES } from '../../../../constants/Feeds.constants';
+import { EntityType } from '../../../../enums/entity.enum';
+import { CardStyle } from '../../../../generated/entity/feed/thread';
 import { useUserProfile } from '../../../../hooks/user-profile/useUserProfile';
 import {
   formatDateTime,
   getRelativeTime,
 } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
+import entityUtilClassBase from '../../../../utils/EntityUtilClassBase';
+import { getFeedHeaderTextFromCardStyle } from '../../../../utils/FeedUtils';
 import {
   entityDisplayName,
   getEntityFQN,
   getEntityType,
-  getFeedHeaderTextFromCardStyle,
-} from '../../../../utils/FeedUtils';
-import EntityPopOverCard from '../../../common/PopOverCard/EntityPopOverCard';
-
-import { useTranslation } from 'react-i18next';
-import { ASSET_CARD_STYLES } from '../../../../constants/Feeds.constants';
-import { EntityType } from '../../../../enums/entity.enum';
-import { CardStyle } from '../../../../generated/entity/feed/thread';
-import entityUtilClassBase from '../../../../utils/EntityUtilClassBase';
+} from '../../../../utils/FeedUtilsPure';
 import { getUserPath } from '../../../../utils/RouterUtils';
 import searchClassBase from '../../../../utils/SearchClassBase';
+import EntityPopOverCard from '../../../common/PopOverCard/EntityPopOverCard';
 import UserPopOverCard from '../../../common/PopOverCard/UserPopOverCard';
 import './feed-card-header-v2.less';
 import { FeedCardHeaderV2Props } from './FeedCardHeaderV2.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor.test.tsx
@@ -22,7 +22,7 @@ const onSaveHandler = jest.fn().mockImplementation(() => {
   onSave();
 });
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getBackendFormat: jest.fn(),
   HTMLToMarkdown: jest.fn().mockReturnValue({ turndown: jest.fn() }),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditor.tsx
@@ -23,11 +23,10 @@ import {
   useState,
 } from 'react';
 import withSuspenseFallback from '../../../components/AppRouter/withSuspenseFallback';
-import { getBackendFormat, HTMLToMarkdown } from '../../../utils/FeedUtils';
+import { getBackendFormat, HTMLToMarkdown } from '../../../utils/FeedUtilsPure';
 import { EditorContentRef } from '../../common/RichTextEditor/RichTextEditor.interface';
 import { KeyHelp } from './KeyHelp';
 import { SendButton } from './SendButton';
-
 const FeedEditor = withSuspenseFallback(
   lazy(() =>
     import('../FeedEditor/FeedEditor').then((m) => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditorNew.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedEditor/ActivityFeedEditorNew.tsx
@@ -23,11 +23,10 @@ import {
   useState,
 } from 'react';
 import withSuspenseFallback from '../../../components/AppRouter/withSuspenseFallback';
-import { getBackendFormat, HTMLToMarkdown } from '../../../utils/FeedUtils';
+import { getBackendFormat, HTMLToMarkdown } from '../../../utils/FeedUtilsPure';
 import { EditorContentRef } from '../../common/RichTextEditor/RichTextEditor.interface';
 import { KeyHelp } from './KeyHelp';
 import { SendButton } from './SendButton';
-
 const FeedEditor = withSuspenseFallback(
   lazy(() =>
     import('../FeedEditor/FeedEditor').then((m) => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx
@@ -17,11 +17,10 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as FeedEmptyIcon } from '../../../assets/svg/ic-task-empty.svg';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
 import { Thread } from '../../../generated/entity/feed/thread';
-import { getFeedListWithRelativeDays } from '../../../utils/FeedUtils';
+import { getFeedListWithRelativeDays } from '../../../utils/FeedUtilsPure';
 import ErrorPlaceHolderNew from '../../common/ErrorWithPlaceholder/ErrorPlaceHolderNew';
 import Loader from '../../common/Loader/Loader';
 import FeedPanelBodyV1New from '../ActivityFeedPanel/FeedPanelBodyV1New';
-
 interface ActivityFeedListV1Props {
   feedList: Thread[];
   isLoading: boolean;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/FeedPanelBodyV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/FeedPanelBodyV1.tsx
@@ -17,7 +17,7 @@ import { FC, useCallback, useMemo } from 'react';
 import { EntityType } from '../../../enums/entity.enum';
 import { Post, ThreadType } from '../../../generated/entity/feed/thread';
 import { ENTITY_LINK_SEPARATOR } from '../../../utils/EntityPureUtils';
-import { getEntityType } from '../../../utils/FeedUtils';
+import { getEntityType } from '../../../utils/FeedUtilsPure';
 import { TaskTabNew } from '../../Entity/Task/TaskTab/TaskTabNew.component';
 import ActivityFeedCardNew from '../ActivityFeedCardNew/ActivityFeedcardNew.component';
 import '../ActivityFeedTab/activity-feed-tab.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/FeedPanelHeader.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedPanel/FeedPanelHeader.tsx
@@ -20,16 +20,15 @@ import { Link } from 'react-router-dom';
 import CloseIcon from '../../../components/Modals/CloseIcon.component';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import entityUtilClassBase from '../../../utils/EntityUtilClassBase';
+import { getEntityFieldDisplay } from '../../../utils/FeedUtils';
 import {
   entityDisplayName,
   getEntityField,
-  getEntityFieldDisplay,
   getEntityFQN,
   getEntityType,
   getFeedPanelHeaderText,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import { FeedPanelHeaderProp } from './ActivityFeedPanel.interface';
-
 const FeedPanelHeader: FC<FeedPanelHeaderProp> = ({
   className,
   entityLink,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider.test.tsx
@@ -44,6 +44,13 @@ jest.mock('../../../rest/feedsAPI', () => ({
   postFeedById: jest.fn(),
   updatePost: jest.fn(),
   updateThread: jest.fn(),
+  getMyActivityFeed: jest.fn().mockResolvedValue({ data: [], paging: {} }),
+  getEntityActivityByFqn: jest.fn().mockResolvedValue({ data: [], paging: {} }),
+  addActivityReaction: jest.fn().mockResolvedValue({
+    id: 'activity-123',
+    reactions: [{ reactionType: 'thumbsUp', user: { id: 'user-1' } }],
+  }),
+  removeActivityReaction: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../rest/incidentManagerAPI', () => ({
@@ -62,8 +69,12 @@ jest.mock('../../../utils/ToastUtils', () => ({
   showErrorToast: jest.fn(),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
-  getUpdatedThread: jest.fn(),
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  getUpdatedThread: jest.fn().mockResolvedValue({
+    id: '123',
+    posts: [],
+    postsCount: 0,
+  }),
 }));
 
 describe('ActivityFeedProvider', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedProvider/ActivityFeedProvider.tsx
@@ -52,11 +52,10 @@ import {
 } from '../../../rest/feedsAPI';
 import { getListTestCaseIncidentByStateId } from '../../../rest/incidentManagerAPI';
 import { getEntityFeedLink } from '../../../utils/EntityPureUtils';
-import { getUpdatedThread } from '../../../utils/FeedUtils';
+import { getUpdatedThread } from '../../../utils/FeedUtilsPure';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import { ActivityFeedProviderContextType } from './ActivityFeedProviderContext.interface';
-
 const ActivityFeedDrawer = withSuspenseFallback(
   lazy(() => import('../ActivityFeedDrawer/ActivityFeedDrawer'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -85,7 +85,6 @@ import {
   ActivityFeedTabProps,
   ActivityFeedTabs,
 } from './ActivityFeedTab.interface';
-
 const TaskTabNew = withSuspenseFallback(
   lazy(() =>
     import('../../Entity/Task/TaskTab/TaskTabNew.component').then((m) => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThread.tsx
@@ -21,12 +21,11 @@ import {
   ThreadType,
 } from '../../../generated/entity/feed/thread';
 import { getFeedById } from '../../../rest/feedsAPI';
-import { getReplyText } from '../../../utils/FeedUtils';
+import { getReplyText } from '../../../utils/FeedUtilsPure';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import ActivityFeedCard from '../ActivityFeedCard/ActivityFeedCard';
 import ActivityFeedEditor from '../ActivityFeedEditor/ActivityFeedEditor';
 import { ActivityThreadProp } from './ActivityThreadPanel.interface';
-
 const ActivityThread: FC<ActivityThreadProp> = ({
   className,
   selectedThread,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadList.test.tsx
@@ -21,7 +21,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { mockThreadData } from './ActivityThread.mock';
 import ActivityThreadList from './ActivityThreadList';
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getFeedListWithRelativeDays: jest.fn().mockReturnValue({
     updatedFeedList: mockThreadData,
     relativeDays: ['Today', 'Yesterday'],

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityThreadPanel/ActivityThreadList.tsx
@@ -27,7 +27,7 @@ import {
   ThreadTaskStatus,
   ThreadType,
 } from '../../../generated/entity/feed/thread';
-import { getFeedListWithRelativeDays } from '../../../utils/FeedUtils';
+import { getFeedListWithRelativeDays } from '../../../utils/FeedUtilsPure';
 import { getTaskDetailPath } from '../../../utils/TasksUtils';
 import { OwnerLabel } from '../../common/OwnerLabel/OwnerLabel.component';
 import ActivityFeedCard from '../ActivityFeedCard/ActivityFeedCard';
@@ -37,7 +37,6 @@ import FeedListSeparator from '../FeedListSeparator/FeedListSeparator';
 import AnnouncementBadge from '../Shared/AnnouncementBadge';
 import TaskBadge from '../Shared/TaskBadge';
 import { ActivityThreadListProp } from './ActivityThreadPanel.interface';
-
 const ActivityThreadList: FC<ActivityThreadListProp> = ({
   className,
   threads,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
@@ -42,10 +42,10 @@ import { TabSpecificField } from '../../../enums/entity.enum';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { getUserByName } from '../../../rest/userAPI';
 import {
-  HTMLToMarkdown,
   suggestions,
   userMentionItemWithAvatar,
 } from '../../../utils/FeedUtils';
+import { HTMLToMarkdown } from '../../../utils/FeedUtilsPure';
 import { LinkBlot } from '../../../utils/QuillLink/QuillLink';
 import { insertMention, insertRef } from '../../../utils/QuillUtils';
 import { getSanitizeContent } from '../../../utils/sanitize.utils';
@@ -54,7 +54,6 @@ import { EditorContentRef } from '../../common/RichTextEditor/RichTextEditor.int
 import './feed-editor.less';
 import { FeedEditorProp, MentionSuggestionsItem } from './FeedEditor.interface';
 import './quill-emoji.css';
-
 Quill.register('modules/markdownOptions', QuillMarkdown);
 Quill.register(LinkBlot as unknown as Parchment.RegistryDefinition);
 Quill.register('modules/emoji-textarea', TextAreaEmoji, true);

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCard.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCard.component.test.tsx
@@ -58,7 +58,7 @@ jest.mock('../../../utils/TasksUtils', () => ({
   getTaskDetailPath: jest.fn().mockReturnValue('/'),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getEntityFQN: jest.fn().mockReturnValue('entityFQN'),
   getEntityType: jest.fn().mockReturnValue('entityType'),
 }));
@@ -66,6 +66,10 @@ jest.mock('../../../utils/FeedUtils', () => ({
 jest.mock('../../../utils/date-time/DateTimeUtils', () => ({
   formatDateTime: jest.fn().mockReturnValue('formatDateTime'),
   getRelativeTime: jest.fn().mockReturnValue('getRelativeTime'),
+  getEpochMillisForPastDays: jest.fn().mockImplementation((days) => days),
+  getStartOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getEndOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getCurrentMillis: jest.fn().mockReturnValue(0),
 }));
 
 jest.mock('../../../utils/FqnUtils', () => ({
@@ -77,6 +81,8 @@ jest.mock('../../../utils/EntityLink', () => {
     __esModule: true,
     default: {
       getTableColumnName: jest.fn().mockReturnValue('getTableColumnName'),
+      getEntityType: jest.fn().mockReturnValue('table'),
+      getEntityFqn: jest.fn().mockReturnValue('db.schema.table'),
     },
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCard.component.tsx
@@ -33,7 +33,7 @@ import {
   getRelativeTime,
 } from '../../../utils/date-time/DateTimeUtils';
 import EntityLink from '../../../utils/EntityLink';
-import { getEntityFQN, getEntityType } from '../../../utils/FeedUtils';
+import { getEntityFQN, getEntityType } from '../../../utils/FeedUtilsPure';
 import { getNameFromFQN } from '../../../utils/FqnUtils';
 import { getTaskDetailPath } from '../../../utils/TasksUtils';
 import { OwnerLabel } from '../../common/OwnerLabel/OwnerLabel.component';
@@ -41,7 +41,6 @@ import ProfilePicture from '../../common/ProfilePicture/ProfilePicture';
 import { useActivityFeedProvider } from '../ActivityFeedProvider/ActivityFeedProvider';
 import ActivityFeedActions from '../Shared/ActivityFeedActions';
 import './task-feed-card.less';
-
 interface TaskFeedCardProps {
   post: Post;
   feed: Thread;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.test.tsx
@@ -87,9 +87,11 @@ jest.mock('../../../utils/TasksUtils', () => ({
   isDescriptionTask: jest.fn().mockReturnValue(false),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getEntityFQN: jest.fn().mockReturnValue('entityFQN'),
+  getEntityFQNFromAbout: jest.fn().mockReturnValue('entityFQN'),
   getEntityType: jest.fn().mockReturnValue('table'),
+  getEntityTypeFromAbout: jest.fn().mockReturnValue('table'),
 }));
 
 jest.mock('../../../utils/date-time/DateTimeUtils', () => ({
@@ -110,6 +112,8 @@ jest.mock('../../../utils/EntityLink', () => {
     __esModule: true,
     default: {
       getTableColumnName: jest.fn().mockReturnValue(null),
+      getEntityType: jest.fn().mockReturnValue('table'),
+      getEntityFqn: jest.fn().mockReturnValue('test.entity.fqn'),
     },
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/TaskFeedCard/TaskFeedCardNew.component.tsx
@@ -33,7 +33,7 @@ import {
   getRelativeTime,
 } from '../../../utils/date-time/DateTimeUtils';
 import EntityLink from '../../../utils/EntityLink';
-import { getEntityFQN, getEntityType } from '../../../utils/FeedUtils';
+import { getEntityFQN, getEntityType } from '../../../utils/FeedUtilsPure';
 
 import { AxiosError } from 'axios';
 import { TaskOperation } from '../../../constants/Feeds.constants';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementFeedCardBody.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementFeedCardBody.component.tsx
@@ -30,7 +30,7 @@ import {
   getEntityField,
   getEntityFQN,
   getEntityType,
-} from '../../utils/FeedUtils';
+} from '../../utils/FeedUtilsPure';
 import FeedCardBody from '../ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody';
 import FeedCardHeader from '../ActivityFeed/ActivityFeedCard/FeedCardHeader/FeedCardHeader';
 import PopoverContent from '../ActivityFeed/ActivityFeedCard/PopoverContent';
@@ -39,7 +39,6 @@ import ProfilePicture from '../common/ProfilePicture/ProfilePicture';
 import EditAnnouncementModal from '../Modals/AnnouncementModal/EditAnnouncementModal';
 import { AnnouncementFeedCardBodyProp } from './Announcement.interface';
 import './announcement.less';
-
 const AnnouncementFeedCardBody = ({
   feed,
   entityLink,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementFeedCardBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementFeedCardBody.test.tsx
@@ -18,10 +18,21 @@ import { MOCK_ANNOUNCEMENT_DATA } from '../../mocks/Announcement.mock';
 import { mockUserData } from '../../mocks/MyDataPage.mock';
 import AnnouncementFeedCardBody from './AnnouncementFeedCardBody.component';
 
-jest.mock('../../utils/FeedUtils', () => ({
-  getEntityField: jest.fn(),
-  getEntityFQN: jest.fn(),
-  getEntityType: jest.fn(),
+jest.mock('../../utils/date-time/DateTimeUtils', () => ({
+  formatDateTime: jest.fn(() => 'formatted-time'),
+}));
+
+jest.mock('../../utils/EntityUtilClassBase', () => ({
+  __esModule: true,
+  default: {
+    getEntityLink: jest.fn(() => '/entity-link'),
+  },
+}));
+
+jest.mock('../../utils/FeedUtilsPure', () => ({
+  getEntityField: jest.fn(() => 'columns.name'),
+  getEntityFQN: jest.fn(() => 'service.database.table'),
+  getEntityType: jest.fn(() => 'table'),
 }));
 
 jest.mock('../../hooks/useApplicationStore', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementThreads.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementThreads.tsx
@@ -16,7 +16,7 @@ import { FC, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Post, Thread } from '../../generated/entity/feed/thread';
 import { isActiveAnnouncement } from '../../utils/AnnouncementsUtils';
-import { getFeedListWithRelativeDays } from '../../utils/FeedUtils';
+import { getFeedListWithRelativeDays } from '../../utils/FeedUtilsPure';
 import { AnnouncementThreadListProp } from './Announcement.interface';
 import './announcement.less';
 import AnnouncementFeedCard from './AnnouncementFeedCard.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/hashtagSuggestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/hashtagSuggestion.ts
@@ -17,7 +17,7 @@ import tippy, { Instance, Props } from 'tippy.js';
 import { EntityType } from '../../../../enums/entity.enum';
 import { SearchIndex } from '../../../../enums/search.enum';
 import { searchQuery } from '../../../../rest/searchAPI';
-import { buildMentionLink } from '../../../../utils/FeedUtils';
+import { buildMentionLink } from '../../../../utils/FeedUtilsPure';
 import searchClassBase from '../../../../utils/SearchClassBase';
 import { ExtensionRef } from '../../BlockEditor.interface';
 import HashList from './HashList';

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/mention/mentionSuggestions.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/mention/mentionSuggestions.ts
@@ -19,7 +19,7 @@ import {
   ENTITY_URL_MAP,
 } from '../../../../constants/Feeds.constants';
 import { getUserAndTeamSearch } from '../../../../rest/miscAPI';
-import { buildMentionLink } from '../../../../utils/FeedUtils';
+import { buildMentionLink } from '../../../../utils/FeedUtilsPure';
 import { ExtensionRef } from '../../BlockEditor.interface';
 import MentionList from './MentionList';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
@@ -93,7 +93,9 @@ jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
   }),
 }));
 
-jest.mock('../../../utils/CommonUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
@@ -94,7 +94,9 @@ jest.mock('../../../context/PermissionProvider/PermissionProvider', () => ({
   }),
 }));
 
-jest.mock('../../../utils/CommonUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
@@ -84,7 +84,9 @@ jest.mock('../../../../utils/useRequiredParams', () => ({
   }),
 }));
 
-jest.mock('../../../../utils/CommonUtils', () => ({
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/AnnouncementsWidgetV2/AnnouncementItemV2.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/AnnouncementsWidgetV2/AnnouncementItemV2.component.tsx
@@ -12,8 +12,7 @@
  */
 
 import { useMemo } from 'react';
-import { Thread } from '../../../generated/entity/feed/thread';
-import { getEntityFQN, getEntityType } from '../../../utils/FeedUtils';
+import { getEntityFQN, getEntityType } from '../../../utils/FeedUtilsPure';
 import { getEntityIcon } from '../../../utils/TableUtils';
 import AnnouncementCardV1Content from '../../MyData/Widgets/AnnouncementsWidgetV1/AnnouncementCardV1/AnnouncementCardV1Content.component';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/AnnouncementsWidgetV2/AnnouncementsWidgetV2.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/AnnouncementsWidgetV2/AnnouncementsWidgetV2.component.tsx
@@ -24,7 +24,7 @@ import {
   getEntityFQN,
   getEntityType,
   prepareFeedLink,
-} from '../../../utils/FeedUtils';
+} from '../../../utils/FeedUtilsPure';
 import Loader from '../../common/Loader/Loader';
 import AnnouncementItemV2 from './AnnouncementItemV2.component';
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddTestCaseList/AddTestCaseList.component.test.tsx
@@ -50,7 +50,7 @@ jest.mock('../../../utils/StringUtils', () => {
     replacePlus: jest.fn().mockImplementation((fqn) => fqn),
   };
 });
-jest.mock('../../../utils/FeedUtils', () => {
+jest.mock('../../../utils/FeedUtilsPure', () => {
   return {
     getEntityFQN: jest.fn().mockImplementation((fqn) => fqn),
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
@@ -50,7 +50,7 @@ import { removeTestCaseFromTestSuite } from '../../../../rest/testAPI';
 import { getNameFromFQN } from '../../../../utils/CommonUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { getColumnNameFromEntityLink } from '../../../../utils/EntityPureUtils';
-import { getEntityFQN } from '../../../../utils/FeedUtils';
+import { getEntityFQN } from '../../../../utils/FeedUtilsPure';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';
 import {
   getEntityDetailsPath,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -84,7 +84,7 @@ import {
   highlightSearchArrayElement,
   highlightSearchText,
 } from '../../../utils/EntitySearchUtils';
-import { getEntityColumnFQN } from '../../../utils/FeedUtils';
+import { getEntityColumnFQN } from '../../../utils/FeedUtilsPure';
 import { stringToHTML } from '../../../utils/StringUtils';
 import { columnFilterIcon } from '../../../utils/TableColumn.util';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.test.tsx
@@ -335,7 +335,7 @@ jest.mock('../../../utils/StringUtils', () => ({
   stringToHTML: jest.fn((text) => text),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getEntityColumnFQN: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.test.tsx
@@ -42,6 +42,10 @@ jest.mock('../../../utils/CommonUtils', () => ({
   getFeedCounts: (...args: [EntityType, string, (data: FeedCounts) => void]) =>
     mockGetFeedCounts(...args),
 }));
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
+}));
 jest.mock('../../../utils/RouterUtils');
 jest.mock('../../../utils/ToastUtils');
 jest.mock('../../../utils/DirectoryClassBase', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.test.tsx
@@ -38,7 +38,11 @@ const mockGetFeedCounts = jest.fn();
 jest.mock('../../../utils/CommonUtils', () => ({
   ...jest.requireActual('../../../utils/CommonUtils'),
   getEntityMissingError: jest.fn(),
-  getFeedCounts: (...args: any[]) => mockGetFeedCounts(...args),
+  getFeedCounts: (...args: unknown[]) => mockGetFeedCounts(...args),
+}));
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
 }));
 jest.mock('../../../utils/RouterUtils');
 jest.mock('../../../utils/ToastUtils');

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
@@ -22,7 +22,6 @@ import { useCustomPages } from '../../../hooks/useCustomPages';
 import { useFqn } from '../../../hooks/useFqn';
 import { ENTITY_PERMISSIONS } from '../../../mocks/Permissions.mock';
 import { restoreDriveAsset } from '../../../rest/driveAPI';
-import { getFeedCounts } from '../../../utils/CommonUtils';
 import { getEntityDetailsPath } from '../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
@@ -34,7 +33,17 @@ jest.mock('../../../hooks/useCustomPages');
 jest.mock('../../../hooks/useFqn');
 jest.mock('../../../utils/useRequiredParams');
 jest.mock('../../../rest/driveAPI');
-jest.mock('../../../utils/CommonUtils');
+const mockGetFeedCounts = jest.fn();
+
+jest.mock('../../../utils/CommonUtils', () => ({
+  ...jest.requireActual('../../../utils/CommonUtils'),
+  getEntityMissingError: jest.fn(),
+  getFeedCounts: (...args: unknown[]) => mockGetFeedCounts(...args),
+}));
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityTaskCountsInto: jest.fn(),
+  fetchEntityActivityCountInto: jest.fn(),
+}));
 jest.mock('../../../utils/RouterUtils');
 jest.mock('../../../utils/ToastUtils');
 jest.mock('../../../utils/SpreadsheetClassBase', () => ({
@@ -120,7 +129,6 @@ const mockUseCustomPages = useCustomPages as jest.Mock;
 const mockUseFqn = useFqn as jest.Mock;
 const mockUseRequiredParams = useRequiredParams as jest.Mock;
 const mockRestoreDriveAsset = restoreDriveAsset as jest.Mock;
-const mockGetFeedCounts = getFeedCounts as jest.Mock;
 const mockGetEntityDetailsPath = getEntityDetailsPath as jest.Mock;
 
 const mockSpreadsheetDetails: Spreadsheet = {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.test.tsx
@@ -38,7 +38,11 @@ const mockGetFeedCounts = jest.fn();
 jest.mock('../../../utils/CommonUtils', () => ({
   ...jest.requireActual('../../../utils/CommonUtils'),
   getEntityMissingError: jest.fn(),
-  getFeedCounts: (...args: any[]) => mockGetFeedCounts(...args),
+  getFeedCounts: (...args: unknown[]) => mockGetFeedCounts(...args),
+}));
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
 }));
 jest.mock('../../../utils/RouterUtils');
 jest.mock('../../../utils/ToastUtils');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
@@ -81,7 +81,9 @@ jest.mock('../../../utils/useRequiredParams', () => ({
   }),
 }));
 
-jest.mock('../../../utils/CommonUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/RightSidebar/AnnouncementsWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/RightSidebar/AnnouncementsWidget.tsx
@@ -19,7 +19,7 @@ import { ReactComponent as AnnouncementsEmptyIcon } from '../../../assets/svg/an
 import { ERROR_PLACEHOLDER_TYPE, SIZE } from '../../../enums/common.enum';
 import { Thread } from '../../../generated/entity/feed/thread';
 import { WidgetCommonProps } from '../../../pages/CustomizablePage/CustomizablePage.interface';
-import { getEntityFQN } from '../../../utils/FeedUtils';
+import { getEntityFQN } from '../../../utils/FeedUtilsPure';
 import FeedCardBodyV1 from '../../ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBodyV1';
 import FeedCardHeaderV2 from '../../ActivityFeed/ActivityFeedCardV2/FeedCardHeader/FeedCardHeaderV2';
 import ErrorPlaceHolder from '../../common/ErrorWithPlaceholder/ErrorPlaceHolder';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementCardV1/AnnouncementCardV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementCardV1/AnnouncementCardV1.component.tsx
@@ -13,8 +13,10 @@
 import { Card } from 'antd';
 import classNames from 'classnames';
 import { useMemo } from 'react';
-import { Thread } from '../../../../../generated/entity/feed/thread';
-import { getEntityFQN, getEntityType } from '../../../../../utils/FeedUtils';
+import {
+  getEntityFQN,
+  getEntityType,
+} from '../../../../../utils/FeedUtilsPure';
 import { getEntityIcon } from '../../../../../utils/TableUtils';
 import './announcement-card-v1.less';
 import AnnouncementCardV1Content from './AnnouncementCardV1Content.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementCardV1/AnnouncementCardV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementCardV1/AnnouncementCardV1.test.tsx
@@ -37,9 +37,9 @@ jest.mock('../../../../../utils/EntityUtilClassBase', () => ({
   },
 }));
 
-jest.mock('../../../../../utils/FeedUtils', () => ({
-  getEntityFQN: jest.fn((about) => about.split('::').pop() || ''),
-  getEntityType: jest.fn((about) => about.split('::')[1] || ''),
+jest.mock('../../../../../utils/FeedUtilsPure', () => ({
+  getEntityFQN: jest.fn(() => 'service::entity'),
+  getEntityType: jest.fn(() => 'table'),
 }));
 
 jest.mock('../../../../../utils/RouterUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementsWidgetV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementsWidgetV1.component.tsx
@@ -22,7 +22,7 @@ import {
   getEntityFQN,
   getEntityType,
   prepareFeedLink,
-} from '../../../../utils/FeedUtils';
+} from '../../../../utils/FeedUtilsPure';
 import WidgetWrapper from '../Common/WidgetWrapper/WidgetWrapper';
 import AnnouncementCardV1 from './AnnouncementCardV1/AnnouncementCardV1.component';
 import './announcements-widget-v1.less';

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementsWidgetV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/AnnouncementsWidgetV1/AnnouncementsWidgetV1.test.tsx
@@ -30,9 +30,11 @@ jest.mock('react-i18next', () => ({
 }));
 
 // Mock utility functions
-jest.mock('../../../../utils/FeedUtils', () => ({
-  getEntityFQN: jest.fn((about) => about.split('::').pop() || ''),
-  getEntityType: jest.fn((about) => about.split('::')[1] || ''),
+jest.mock('../../../../utils/FeedUtilsPure', () => ({
+  getEntityFQN: jest.fn(
+    () => 'sample_data.ecommerce_db.shopify.raw_product_catalog'
+  ),
+  getEntityType: jest.fn(() => 'table'),
   prepareFeedLink: jest.fn(() => '/test-feed-link'),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.test.tsx
@@ -77,7 +77,7 @@ jest.mock('../../utils/RouterUtils', () => ({
   refreshPage: jest.fn(),
   getEntityDetailLink: jest.fn(),
 }));
-jest.mock('../../utils/FeedUtils', () => ({
+jest.mock('../../utils/FeedUtilsPure', () => ({
   getEntityFQN: jest.fn().mockReturnValue('entityFQN'),
   getEntityType: jest.fn().mockReturnValue('entityType'),
   prepareFeedLink: jest.fn().mockReturnValue('entity-link'),

--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
@@ -70,7 +70,7 @@ import {
   getEntityFQN,
   getEntityType,
   prepareFeedLink,
-} from '../../utils/FeedUtils';
+} from '../../utils/FeedUtilsPure';
 import { languageSelectOptions } from '../../utils/i18next/i18nextUtil';
 import i18n from '../../utils/i18next/LocalUtil';
 import localUtilClassBase from '../../utils/i18next/LocalUtilClassBase';

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.component.tsx
@@ -28,7 +28,7 @@ import { ThreadType } from '../../generated/api/feed/createThread';
 import { Post, Thread } from '../../generated/entity/feed/thread';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { getFeedsWithFilter } from '../../rest/feedsAPI';
-import { getEntityFQN, getEntityType } from '../../utils/FeedUtils';
+import { getEntityFQN, getEntityType } from '../../utils/FeedUtilsPure';
 import { getUserPath } from '../../utils/RouterUtils';
 import { showErrorToast } from '../../utils/ToastUtils';
 import Loader from '../common/Loader/Loader';

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationBox.test.tsx
@@ -79,7 +79,7 @@ jest.mock('../../rest/feedsAPI', () => ({
   })),
 }));
 
-jest.mock('../../utils/FeedUtils', () => ({
+jest.mock('../../utils/FeedUtilsPure', () => ({
   getEntityFQN: jest.fn().mockReturnValue('entityFQN'),
   getEntityType: jest.fn().mockReturnValue('entityType'),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../utils/date-time/DateTimeUtils';
 import { getEntityLinkFromType } from '../../utils/EntityBreadcrumbUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
-import { entityDisplayName, prepareFeedLink } from '../../utils/FeedUtils';
+import { entityDisplayName, prepareFeedLink } from '../../utils/FeedUtilsPure';
 import Fqn from '../../utils/Fqn';
 import { getTaskDetailPath } from '../../utils/TasksUtils';
 import { ActivityFeedTabs } from '../ActivityFeed/ActivityFeedTab/ActivityFeedTab.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../../utils/date-time/DateTimeUtils', () => ({
 const mockPrepareFeedLink = jest.fn();
 const mockGetTaskDetailPath = jest.fn();
 
-jest.mock('../../utils/FeedUtils', () => ({
+jest.mock('../../utils/FeedUtilsPure', () => ({
   entityDisplayName: jest.fn().mockReturnValue('database.schema.table'),
   prepareFeedLink: (...args: any[]) => mockPrepareFeedLink(...args),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/PipelineDetails/PipelineDetails.test.tsx
@@ -174,7 +174,7 @@ jest.mock('../../common/CustomPropertyTable/CustomPropertyTable', () => ({
     .mockReturnValue(<p>CustomPropertyTable.component</p>),
 }));
 
-jest.mock('../../../utils/FeedUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
   getFeedCounts: jest.fn().mockReturnValue({}),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
@@ -95,7 +95,9 @@ jest.mock('../../../utils/useRequiredParams', () => ({
   }),
 }));
 
-jest.mock('../../../utils/CommonUtils', () => ({
+jest.mock('../../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.test.tsx
@@ -44,7 +44,7 @@ jest.mock('../../utils/EntityNameUtils', () => ({
 jest.mock('../../utils/CommonUtils', () => ({
   getFeedCounts: jest.fn(),
 }));
-jest.mock('../../utils/FeedUtils', () => ({
+jest.mock('../../utils/FeedUtilsPure', () => ({
   fetchEntityActivityCountInto: jest.fn(),
   fetchEntityTaskCountsInto: jest.fn(),
   getEntityMissingError: jest.fn(),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
@@ -181,8 +181,14 @@ jest.mock('../../rest/storageAPI');
 
 jest.mock('../../utils/CommonUtils', () => ({
   addToRecentViewed: jest.fn(),
-  getEntityMissingError: jest.fn().mockImplementation(() => <div>Error</div>),
+  getEntityMissingError: jest
+    .fn()
+    .mockImplementation((entity: string, fqn: string) => `${entity} ${fqn}`),
   getFeedCounts: jest.fn().mockReturnValue(0),
+}));
+jest.mock('../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   sortTagsCaseInsensitive: jest.fn().mockImplementation((tags) => tags),
 }));
 
@@ -392,7 +398,7 @@ describe('Container Page Component', () => {
 
     await waitFor(() => expect(getContainerByName).toHaveBeenCalledTimes(1));
 
-    expect(screen.getByText('ErrorPlaceHolder')).toBeInTheDocument();
+    expect(await screen.findByText('ErrorPlaceHolder')).toBeInTheDocument();
   });
 
   it('should render the page container data, with the schema tab selected', async () => {
@@ -430,7 +436,7 @@ describe('Container Page Component', () => {
       )
     );
 
-    expect(screen.getByTestId('data-asset-header')).toBeInTheDocument();
+    expect(await screen.findByTestId('data-asset-header')).toBeInTheDocument();
 
     const tabs = screen.getAllByRole('tab');
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
@@ -121,6 +121,10 @@ jest.mock('../../rest/tableAPI', () => ({
 jest.mock('../../utils/CommonUtils', () => ({
   getEntityMissingError: jest.fn().mockImplementation((error) => error),
   getFeedCounts: jest.fn().mockImplementation(() => FEED_COUNT_INITIAL_DATA),
+}));
+jest.mock('../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   sortTagsCaseInsensitive: jest.fn(),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.test.tsx
@@ -44,7 +44,13 @@ jest.mock('../../rest/storedProceduresAPI', () => ({
   restoreStoredProcedures: jest.fn(),
 }));
 
-jest.mock('../../utils/CommonUtils', () => ({
+jest.mock('../../utils/RecentActivityUtils', () => ({
+  ...jest.requireActual('../../utils/RecentActivityUtils'),
+  addToRecentViewed: jest.fn(),
+}));
+jest.mock('../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
   sortTagsCaseInsensitive: jest.fn(),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
@@ -138,7 +138,13 @@ jest.mock('../../rest/suggestionsAPI', () => ({
   getSuggestionsList: jest.fn().mockImplementation(() => Promise.resolve([])),
 }));
 
-jest.mock('../../utils/CommonUtils', () => ({
+jest.mock('../../utils/RecentActivityUtils', () => ({
+  ...jest.requireActual('../../utils/RecentActivityUtils'),
+  addToRecentViewed: jest.fn(),
+}));
+jest.mock('../../utils/FeedUtilsPure', () => ({
+  fetchEntityActivityCountInto: jest.fn(),
+  fetchEntityTaskCountsInto: jest.fn(),
   getFeedCounts: jest.fn(),
   getPartialNameFromTableFQN: jest.fn().mockImplementation(() => 'fqn'),
   getTableFQNFromColumnFQN: jest.fn(),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/DescriptionTabs.tsx
@@ -19,10 +19,9 @@ import { useTranslation } from 'react-i18next';
 import withSuspenseFallback from '../../../components/AppRouter/withSuspenseFallback';
 import { EditorContentRef } from '../../../components/common/RichTextEditor/RichTextEditor.interface';
 import RichTextEditorPreviewerV1 from '../../../components/common/RichTextEditor/RichTextEditorPreviewerV1';
-import { isDescriptionContentEmpty } from '../../../utils/BlockEditorUtils';
+import { isDescriptionContentEmpty } from '../../../utils/BlockEditorPureUtils';
 import { getDescriptionDiff } from '../../../utils/TasksUtils';
 import DiffView from './DiffView/DiffView';
-
 const RichTextEditor = withSuspenseFallback(
   lazy(() => import('../../../components/common/RichTextEditor/RichTextEditor'))
 );

--- a/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/BlockEditorUtils.ts
@@ -28,7 +28,11 @@ import { FileType } from '../components/BlockEditor/BlockEditor.interface';
 import { ENTITY_URL_MAP } from '../constants/Feeds.constants';
 import blockEditorExtensionsClassBase from './BlockEditorExtensionsClassBase';
 import { ENTITY_LINK_SEPARATOR } from './EntityPureUtils';
-import { getEntityDetail, getHashTagList, getMentionList } from './FeedUtils';
+import {
+  getEntityDetail,
+  getHashTagList,
+  getMentionList,
+} from './FeedUtilsPure';
 import { getSanitizeContent } from './sanitize.utils';
 
 export const getSelectedText = (state: EditorState) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -72,8 +72,12 @@ jest.mock('../TablePureUtils', () => ({
   }),
 }));
 
-jest.mock('../FeedUtils', () => ({
-  getEntityFQN: jest.fn((link: string) => link),
+jest.mock('../FeedUtilsPure', () => ({
+  getEntityFQN: jest.fn((link: string) => {
+    const match = link?.match(/^<#E::table::(.+?)(?:::columns::[^>]+)?>$/);
+
+    return match ? match[1] : link;
+  }),
 }));
 
 jest.mock('../EntityPureUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.test.tsx
@@ -14,17 +14,18 @@ import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import { CardStyle, FieldOperation } from '../generated/entity/feed/thread';
 import {
+  getFeedHeaderTextFromCardStyle,
+  getFieldOperationIcon,
+  suggestions,
+} from './FeedUtils';
+import {
   entityDisplayName,
   getBackendFormat,
   getEntityField,
   getEntityFQN,
   getEntityType,
-  getFeedHeaderTextFromCardStyle,
-  getFieldOperationIcon,
   getFrontEndFormat,
-  suggestions,
-} from './FeedUtils';
-
+} from './FeedUtilsPure';
 jest.mock('../rest/searchAPI', () => ({
   searchQuery: jest.fn().mockResolvedValue({
     hits: {
@@ -55,24 +56,25 @@ jest.mock('./EntityDisplayUtils', () => ({
 
 jest.mock('./FeedUtils', () => ({
   ...jest.requireActual('./FeedUtils'),
-  getEntityField: jest.fn().mockReturnValue('entityField'),
-  getEntityFQN: jest.fn().mockReturnValue('123'),
-  getEntityType: jest.fn().mockReturnValue('entityType'),
   buildMentionLink: jest.fn().mockReturnValue('buildMentionLink'),
   getEntityBreadcrumbs: jest.fn().mockReturnValue('entityBreadcrumbs'),
 }));
 
 describe('Feed Utils', () => {
   it('should getEntityType return the correct entity type', () => {
-    expect(getEntityType('#E::Type::123')).toBe('entityType');
+    expect(getEntityType('<#E::table::db.schema.table>')).toBe('table');
   });
 
   it('should getEntityFQN return the correct entity FQN', () => {
-    expect(getEntityFQN('#E::Type::123')).toBe('123');
+    expect(getEntityFQN('<#E::table::db.schema.table>')).toBe(
+      'db.schema.table'
+    );
   });
 
   it('should getEntityField return the correct entity field', () => {
-    expect(getEntityField('entityField')).toBe('entityField');
+    expect(getEntityField('<#E::table::db.schema.table::description>')).toBe(
+      'description'
+    );
   });
 
   it('should return mention suggestions for "@" mentionChar', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FeedUtils.tsx
@@ -37,40 +37,7 @@ import {
   getImageWithResolutionAndFallback,
   ImageQuality,
 } from './ProfilerUtils';
-import { getTermQuery } from './SearchUtils';
-
-// Re-exports from FeedUtilsPure (backward compat)
-export {
-  buildMentionLink,
-  deletePost,
-  entityDisplayName,
-  fetchEntityActivityCountInto,
-  fetchEntityTaskCountsInto,
-  formatTestStatusData,
-  getBackendFormat,
-  getEntityColumnFQN,
-  getEntityDetail,
-  getEntityField,
-  getEntityFQN,
-  getEntityFQNFromAbout,
-  getEntityType,
-  getEntityTypeFromAbout,
-  getFeedChangeFieldLabel,
-  getFeedCounts,
-  getFeedListWithRelativeDays,
-  getFeedPanelHeaderText,
-  getFrontEndFormat,
-  getHashTagList,
-  getMentionList,
-  getReplyText,
-  getTestCaseNameListForResult,
-  getUpdatedThread,
-  HTMLToMarkdown,
-  isEntityReferenceAbout,
-  MarkdownToHTMLConverter,
-  prepareFeedLink,
-  updateThreadData,
-} from './FeedUtilsPure';
+import { getTermQuery } from './SearchPureUtils';
 
 export async function suggestions(
   searchTerm: string,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TasksUtils.ts
@@ -76,8 +76,7 @@ import { getContainerByFQN } from '../rest/storageAPI';
 import { getStoredProceduresByFqn } from '../rest/storedProceduresAPI';
 import { getTableDetailsByFQN } from '../rest/tableAPI';
 import { getTopicByFqn } from '../rest/topicsAPI';
-import { getPartialNameFromTableFQN } from './CommonUtils';
-import { ContainerFields } from './ContainerDetailUtils';
+import { ContainerFields } from './ContainerDetailPureUtils';
 import {
   defaultFields as DashboardFields,
   fetchCharts,
@@ -88,8 +87,9 @@ import { defaultFields as DataModelFields } from './DataModelsUtils';
 import { defaultFields as TableFields } from './DatasetDetailsUtils';
 import { getEntityName } from './EntityNameUtils';
 import entityUtilClassBase from './EntityUtilClassBase';
-import { getEntityFQN, getEntityType } from './FeedUtils';
-import { getGlossaryBreadcrumbs } from './GlossaryUtils';
+import { getEntityFQN, getEntityType } from './FeedUtilsPure';
+import { getPartialNameFromTableFQN } from './FqnUtils';
+import { getGlossaryBreadcrumbs } from './GlossaryPureUtils';
 import { t } from './i18next/LocalUtil';
 import { defaultFields as MlModelFields } from './MlModelDetailsUtils';
 import { defaultFields as PipelineFields } from './PipelineDetailsUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TestCaseUtils.tsx
@@ -14,6 +14,7 @@
 import { Typography } from 'antd';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
 import { lowerCase } from 'lodash';
+import type { ReactNode } from 'react';
 import { NavigateFunction } from 'react-router-dom';
 import { ReactComponent as IconEdit } from '../assets/svg/edit-new.svg';
 import { ReactComponent as ExportIcon } from '../assets/svg/ic-export.svg';
@@ -31,7 +32,7 @@ import { t } from './i18next/LocalUtil';
 export const getTestCaseResultCount = (
   count: number,
   status: TestCaseStatus
-) => (
+): ReactNode => (
   <div
     className={`test-result-container ${lowerCase(status)}`}
     data-testid={`test-${status}`}>


### PR DESCRIPTION
## Summary
- Backports OSS #29062 ActivityFeed and Announcement lazy-load utility updates on top of Group 9.
- Keeps deleted 1.13 task API/form-schema files deleted and preserves current task-panel behavior where the newer task API path is not present.
- Preserves the stacked review flow so this PR only shows Group 10 changes.

## Stack
- Base branch: ui/backport-group9-dataquality-incident-lazy-1.13
- Previous PR: open-metadata/OpenMetadata#30126

## Testing
- Scoped UI checkstyle sequence on changed source files: organize-imports-cli, ESLint --fix, Prettier.
- git diff --check HEAD~1..HEAD

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports the ActivityFeed and Announcement lazy-loading updates to the 1.13 branch. The main changes are:

- Moves pure activity-feed helpers to `FeedUtilsPure`.
- Lazily loads ActivityFeed and Announcement components.
- Updates affected components and tests to use the new utility imports.
- Preserves the existing 1.13 task-panel behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.
- The updated announcement, widget, and notification imports resolve to compatible exports.
- No blocking issues remain in the reviewed fixes.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Announcement/AnnouncementFeedCardBody.component.tsx | Moves entity-link helper imports to compatible exports from FeedUtilsPure. |
| openmetadata-ui/src/main/resources/ui/src/components/MyData/RightSidebar/AnnouncementsWidget.tsx | Keeps the announcement card component imports and migrates getEntityFQN to FeedUtilsPure. |
| openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx | Restores the notification link helpers and uses the pure feed utility exports. |

</details>

<sub>Reviews (4): Last reviewed commit: ["feat(ui): update ActivityFeed &amp; Announce..."](https://github.com/open-metadata/openmetadata/commit/f35b408ebe301897a699845158331122209bae2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44741971)</sub>

**Context used:**

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->