### PR TITLE
Backport database, schema, and container lazy-loading updates to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
@@ -104,6 +104,15 @@ jest.mock('../../Customization/GenericProvider/GenericContext', () => ({
   }),
 }));
 
+jest.mock('../../../utils/TablePureUtils', () => {
+  const actual = jest.requireActual('../../../utils/TablePureUtils');
+
+  return {
+    ...actual,
+    pruneEmptyChildren: jest.fn().mockImplementation((value) => value),
+  };
+});
+
 jest.mock('../../../utils/TableUtils', () => {
   const actual = jest.requireActual('../../../utils/TableUtils');
 
@@ -121,7 +130,6 @@ jest.mock('../../../utils/TableUtils', () => {
         'glossary',
       ]),
     handleUpdateTableColumnSelections: jest.fn(),
-    pruneEmptyChildren: jest.fn().mockImplementation((value) => value),
   };
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
@@ -46,7 +46,7 @@ import { useTreeTagFilter } from '../../../hooks/useTreeTagFilter';
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from '../../../utils/ContainerDetailUtils';
+} from '../../../utils/ContainerDetailPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { columnFilterIcon } from '../../../utils/TableColumn.util';
 import {
@@ -65,7 +65,6 @@ import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component
 import TableDescription from '../../Database/TableDescription/TableDescription.component';
 import TableTags from '../../Database/TableTags/TableTags.component';
 import { ContainerDataModelProps } from './ContainerDataModel.interface';
-
 const ModalWithMarkdownEditor = withSuspenseFallback(
   lazy(() =>
     import('../../Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor').then(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerVersion/ContainerVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerVersion/ContainerVersion.component.tsx
@@ -33,7 +33,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPartialNameFromTableFQN } from '../../../utils/FqnUtils';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVers
 import VersionTable from '../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { ContainerVersionProp } from './ContainerVersion.interface';
-
 const ContainerVersion: React.FC<ContainerVersionProp> = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
@@ -38,7 +38,7 @@ import { listTestCases } from '../../../rest/testAPI';
 import { calculateTestCaseStatusCounts } from '../../../utils/DataQuality/DataQualityPureUtils';
 import EntityLink from '../../../utils/EntityLink';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import { toEntityData } from '../../../utils/EntitySummaryPanelUtils';
+import { toEntityData } from '../../../utils/EntitySummaryPanelPureUtils';
 import { getErrorText, stringToHTML } from '../../../utils/StringUtils';
 import {
   buildColumnBreadcrumbPath,
@@ -76,7 +76,6 @@ import {
 import './ColumnDetailPanel.less';
 import { KeyProfileMetrics } from './KeyProfileMetrics';
 import { NestedColumnsSection } from './NestedColumnsSection';
-
 const isColumn = (item: ColumnOrTask | null): item is Column => {
   return item !== null && 'dataType' in item;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
@@ -407,7 +407,7 @@ jest.mock('../../../utils/StringUtils', () => ({
   getDecodedFqn: jest.fn().mockImplementation((fqn: string) => fqn),
 }));
 
-jest.mock('../../../utils/TableUtils', () => ({
+jest.mock('../../../utils/TablePureUtils', () => ({
   flattenColumns: jest.fn().mockImplementation((columns) => columns || []),
   generateEntityLink: jest.fn().mockImplementation((fqn) => fqn),
   getDataTypeDisplay: jest.fn().mockReturnValue('VARCHAR'),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
@@ -77,7 +77,6 @@ import {
   TestCasePermission,
 } from '../ProfilerDashboard/profilerDashboard.interface';
 import './data-quality-tab.less';
-
 const DataQualityTab: React.FC<DataQualityTabProps> = ({
   isLoading = false,
   testCases,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -88,8 +88,7 @@ jest.mock('../../../../../utils/CommonUtils', () => ({
     ),
 }));
 
-jest.mock('../../../../../utils/TableUtils', () => ({
-  getTableExpandableConfig: jest.fn().mockReturnValue({}),
+jest.mock('../../../../../utils/TablePureUtils', () => ({
   pruneEmptyChildren: jest.fn().mockImplementation((data) => data),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
@@ -48,10 +48,8 @@ import {
   getListTestCaseBySearch,
   ListTestCaseParamsBySearch,
 } from '../../../../rest/testAPI';
-import {
-  aggregateTestResultsByEntity,
-  TestCaseCountByStatus,
-} from '../../../../utils/DataQuality/DataQualityPureUtils';
+import type { TestCaseCountByStatus } from '../../../../utils/DataQuality/DataQualityPureUtils';
+import { aggregateTestResultsByEntity } from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { formatNumberWithComma } from '../../../../utils/NumberUtils';
 import { bytesToSize } from '../../../../utils/StringUtils';
 import { generateEntityLink } from '../../../../utils/TablePureUtils';
@@ -65,7 +63,6 @@ import {
   TableProfilerContextInterface,
   TableProfilerProviderProps,
 } from './TableProfiler.interface';
-
 const TestCaseFormV1 = withSuspenseFallback(
   lazy(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -117,7 +117,6 @@ import { ColumnFilter } from '../ColumnFilter/ColumnFilter.component';
 import TableDescription from '../TableDescription/TableDescription.component';
 import TableTags from '../TableTags/TableTags.component';
 import { TableCellRendered } from './SchemaTable.interface';
-
 const ModalWithMarkdownEditor = withSuspenseFallback(
   lazy(() =>
     import('../../Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor').then(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
@@ -26,7 +26,7 @@ import {
   getCommonExtraInfoForVersionDetails,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
@@ -40,7 +40,6 @@ import DataProductsContainer from '../../DataProducts/DataProductsContainer/Data
 import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { StoredProcedureVersionProp } from './StoredProcedureVersion.interface';
-
 const StoredProcedureVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDataCardBody/TableDataCardBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDataCardBody/TableDataCardBody.tsx
@@ -20,7 +20,6 @@ import { getTagValue } from '../../../utils/TagsPureUtils';
 import EntitySummaryDetails from '../../common/EntitySummaryDetails/EntitySummaryDetails';
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import TagsViewer from '../../Tag/TagsViewer/TagsViewer';
-
 type Props = {
   description: string;
   extraInfo: Array<ExtraInfo>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableVersion/TableVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableVersion/TableVersion.component.tsx
@@ -34,7 +34,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
 import { pruneEmptyChildren } from '../../../utils/TablePureUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVers
 import VersionTable from '../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { TableVersionProp } from './TableVersion.interface';
-
 const TableVersion: React.FC<TableVersionProp> = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
@@ -72,7 +72,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { DirectoryDetailsProps } from './DirectoryDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
@@ -37,7 +37,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
@@ -54,7 +54,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { DirectoryVersionProps } from './DirectoryVersion.interface';
-
 const DirectoryVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
@@ -70,7 +70,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { FileDetailsProps } from './FileDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileVersion/FileVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileVersion/FileVersion.tsx
@@ -28,7 +28,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../../utils/useRequiredParams';
@@ -42,7 +42,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { FileVersionProps } from './FileVersion.interface';
-
 const FileVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
@@ -27,7 +27,6 @@ import { useRequiredParams } from '../../../utils/useRequiredParams';
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import SpreadsheetDetails from './SpreadsheetDetails';
 import { SpreadsheetDetailsProps } from './SpreadsheetDetails.interface';
-
 jest.mock('../../../hooks/useApplicationStore');
 jest.mock('../../../hooks/useCustomPages');
 jest.mock('../../../hooks/useFqn');

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
@@ -70,7 +70,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { SpreadsheetDetailsProps } from './SpreadsheetDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
@@ -37,7 +37,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
@@ -54,7 +54,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { SpreadsheetVersionProps } from './SpreadsheetVersion.interface';
-
 const SpreadsheetVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.test.tsx
@@ -31,12 +31,16 @@ jest.mock('../../../../utils/TableTags/TableTags.utils', () => ({
   getAllTags: jest.fn(() => []),
   getFilteredTagsData: jest.fn((data) => data),
 }));
-jest.mock('../../../../utils/TableUtils', () => ({
-  ...jest.requireActual('../../../../utils/TableUtils'),
+jest.mock('../../../../utils/TablePureUtils', () => ({
+  ...jest.requireActual('../../../../utils/TablePureUtils'),
   pruneEmptyChildren: jest.fn().mockImplementation((columns) => columns),
-  prepareConstraintIcon: jest.fn(() => null),
   updateFieldDescription: jest.fn(),
   updateFieldTags: jest.fn(),
+}));
+
+jest.mock('../../../../utils/TableUtils', () => ({
+  ...jest.requireActual('../../../../utils/TableUtils'),
+  prepareConstraintIcon: jest.fn(() => null),
   getTableExpandableConfig: jest.fn(() => ({})),
 }));
 jest.mock(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
@@ -69,7 +69,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { WorksheetDetailsProps } from './WorksheetDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
@@ -53,8 +53,10 @@ jest.mock('../../../../utils/EntityVersionUtils', () => ({
 jest.mock('../../../../utils/FqnUtils', () => ({
   getPartialNameFromTableFQN: jest.fn(() => 'Column'),
 }));
-jest.mock('../../../../utils/TableUtils', () => ({
+jest.mock('../../../../utils/TablePureUtils', () => ({
   pruneEmptyChildren: jest.fn((columns) => columns),
+  getTagsWithoutTier: jest.fn((tags) => tags),
+  getTierTags: jest.fn(() => []),
 }));
 jest.mock('../../../common/CustomPropertyTable/CustomPropertyTable', () => ({
   CustomPropertyTable: jest.fn(() => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
@@ -31,7 +31,7 @@ import { WorksheetVersionProps } from './WorksheetVersion.interface';
 
 jest.mock('../../../../utils/useRequiredParams');
 jest.mock('../../../../utils/RouterUtils');
-jest.mock('../../../../utils/EntityVersionUtils', () => ({
+jest.mock('../../../../utils/EntityVersionUtilsPure', () => ({
   getCommonExtraInfoForVersionDetails: jest.fn(() => ({
     ownerDisplayName: 'Test Owner',
     ownerRef: { id: 'owner-1', name: 'test-owner' },

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.tsx
@@ -33,7 +33,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPartialNameFromTableFQN } from '../../../../utils/FqnUtils';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityV
 import VersionTable from '../../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { WorksheetVersionProps } from './WorksheetVersion.interface';
-
 const WorksheetVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
@@ -124,6 +124,28 @@ jest.mock(
   () => jest.fn().mockReturnValue(<span>ContainerDataModel</span>)
 );
 
+jest.mock('../../components/Customization/GenericTab/GenericTab', () => ({
+  GenericTab: jest.fn().mockImplementation(() => {
+    const { getContainerByName } = jest.requireMock('../../rest/storageAPI');
+
+    getContainerByName('s3_storage_sample.transactions', {
+      fields: 'children',
+    });
+
+    return (
+      <>
+        <span>DescriptionV1</span>
+        <span>ContainerDataModel</span>
+        <span>CustomPropertyTable</span>
+        <span>label.glossary-term</span>
+        <span>label.tag-plural</span>
+        <span>label.data-product-plural</span>
+        <span>ContainerChildren</span>
+      </>
+    );
+  }),
+}));
+
 jest.mock(
   '../../components/DataAssets/DataAssetsHeader/DataAssetsHeader.component',
   () => ({
@@ -256,6 +278,26 @@ jest.mock('../../utils/ToastUtils', () => ({
   showSuccessToast: jest.fn(),
 }));
 
+jest.mock(
+  '../../components/Customization/GenericProvider/GenericProvider',
+  () => ({
+    GenericProvider: jest
+      .fn()
+      .mockImplementation(({ children }) => <>{children}</>),
+    useGenericContext: jest.fn().mockReturnValue({
+      data: {},
+      permissions: {
+        EditAll: true,
+        EditDescription: true,
+        EditGlossaryTerms: true,
+        EditTags: true,
+      },
+      isVersionView: false,
+      deleted: false,
+    }),
+  })
+);
+
 const mockUseParams = jest.fn().mockReturnValue({
   fqn: MOCK_CONTAINER_DATA.fullyQualifiedName,
   tab: 'schema',
@@ -302,6 +344,14 @@ jest.mock('../../hooks/useEntityRules', () => ({
 
 describe('Container Page Component', () => {
   beforeEach(() => {
+    mockGetEntityPermissionByFqn.mockResolvedValue({
+      ViewBasic: true,
+    });
+    mockUseParams.mockReturnValue({
+      fqn: MOCK_CONTAINER_DATA.fullyQualifiedName,
+      tab: 'schema',
+    });
+
     const { getPrioritizedEditPermission, getPrioritizedViewPermission } =
       jest.requireMock('../../utils/PermissionsUtils');
     getPrioritizedEditPermission.mockReturnValue(true);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
@@ -89,7 +89,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const ContainerPage = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
@@ -189,12 +189,15 @@ jest.mock('../../rest/feedsAPI', () => ({
   postThread: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 
-jest.mock('../../utils/TableUtils', () => ({
+jest.mock('../../utils/TablePureUtils', () => ({
   getUsagePercentile: jest.fn().mockReturnValue('Medium - 45th pctile'),
   getTierTags: jest.fn().mockImplementation(() => ({})),
   getTagsWithoutTier: jest.fn().mockImplementation(() => []),
-  getTableExpandableConfig: jest.fn().mockReturnValue({}),
   extractColumnsFromData: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../utils/TableUtils', () => ({
+  getTableExpandableConfig: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('../../components/common/NextPrevious/NextPrevious', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
@@ -97,7 +97,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const DatabaseDetails: FunctionComponent = () => {
   const { t } = useTranslation();
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -95,7 +95,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const DatabaseSchemaPage: FunctionComponent = () => {
   const { t } = useTranslation();
   const { getEntityPermissionByFqn } = usePermissionProvider();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
@@ -25,7 +25,6 @@ import {
   mockPatchDatabaseSchemaDetailsData,
   mockPostThreadData,
 } from './mocks/DatabaseSchemaPage.mock';
-
 const mockEntityPermissionByFqn = jest
   .fn()
   .mockImplementation(() => DEFAULT_ENTITY_PERMISSION);
@@ -122,9 +121,13 @@ jest.mock('../../utils/CommonUtils', () => ({
   getEntityMissingError: jest.fn().mockImplementation((error) => error),
   getFeedCounts: jest.fn().mockImplementation(() => FEED_COUNT_INITIAL_DATA),
 }));
+
 jest.mock('../../utils/FeedUtilsPure', () => ({
   fetchEntityActivityCountInto: jest.fn(),
   fetchEntityTaskCountsInto: jest.fn(),
+}));
+
+jest.mock('../../utils/TagsUtils', () => ({
   sortTagsCaseInsensitive: jest.fn(),
 }));
 
@@ -132,7 +135,7 @@ jest.mock('../../utils/RouterUtils', () => ({
   getDatabaseSchemaVersionPath: jest.fn().mockImplementation((path) => path),
 }));
 
-jest.mock('../../utils/TableUtils', () => ({
+jest.mock('../../utils/TablePureUtils', () => ({
   getTierTags: jest.fn(),
   getTagsWithoutTier: jest.fn(),
   extractColumnsFromData: jest.fn().mockReturnValue([]),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
@@ -106,6 +106,9 @@ jest.mock('../../pages/DatabaseSchemaPage/SchemaTablesTab', () =>
 jest.mock(
   '../../components/Customization/GenericProvider/GenericContext',
   () => ({
+    ...jest.requireActual(
+      '../../components/Customization/GenericProvider/GenericContext'
+    ),
     useGenericContext: jest.fn().mockImplementation(() => ({
       data: {
         tableDetails: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
@@ -147,7 +147,7 @@ jest.mock('../../utils/EntityNameUtils', () => ({
   getEntityName: jest.fn().mockReturnValue('entityName'),
 }));
 
-jest.mock('../../utils/EntityVersionUtils', () => ({
+jest.mock('../../utils/EntityVersionUtilsPure', () => ({
   getBasicEntityInfoFromVersionData: jest.fn().mockReturnValue({}),
   getCommonDiffsFromVersionData: jest.fn().mockReturnValue({}),
   getCommonExtraInfoForVersionDetails: jest.fn().mockReturnValue({}),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.tsx
@@ -56,7 +56,7 @@ import {
   getBasicEntityInfoFromVersionData,
   getCommonDiffsFromVersionData,
   getCommonExtraInfoForVersionDetails,
-} from '../../utils/EntityVersionUtils';
+} from '../../utils/EntityVersionUtilsPure';
 import {
   DEFAULT_ENTITY_PERMISSION,
   getPrioritizedViewPermission,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseVersionPage/DatabaseVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseVersionPage/DatabaseVersionPage.tsx
@@ -52,7 +52,7 @@ import {
   getBasicEntityInfoFromVersionData,
   getCommonDiffsFromVersionData,
   getCommonExtraInfoForVersionDetails,
-} from '../../utils/EntityVersionUtils';
+} from '../../utils/EntityVersionUtilsPure';
 import {
   DEFAULT_ENTITY_PERMISSION,
   getPrioritizedViewPermission,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
@@ -80,7 +80,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const StoredProcedurePage = () => {
   const { t } = useTranslation();
   const { currentUser } = useApplicationStore();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.test.tsx
@@ -38,8 +38,8 @@ import {
 import type { EntityDataMapValue } from './ColumnUpdateUtils.interface';
 
 // Mock dependencies
-jest.mock('./TableUtils', () => {
-  const actual = jest.requireActual('./TableUtils');
+jest.mock('./TablePureUtils', () => {
+  const actual = jest.requireActual('./TablePureUtils');
 
   return {
     ...actual,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.ts
@@ -37,7 +37,7 @@ import {
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from './ContainerDetailUtils';
+} from './ContainerDetailPureUtils';
 import {
   findFieldByFQN,
   normalizeTags,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.ts
@@ -16,9 +16,8 @@ import { Column, DataType } from '../generated/entity/data/container';
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from './ContainerDetailUtils';
+} from './ContainerDetailPureUtils';
 import { getEntityDetailsPath } from './RouterUtils';
-
 const mockTagOptions = [
   {
     tagFQN: 'PII.Sensitive',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.tsx
@@ -18,7 +18,7 @@ import {
 } from '../generated/entity/data/container';
 import { EntityReference } from '../generated/type/entityReference';
 import { LabelType, State } from '../generated/type/tagLabel';
-import { extractContainerColumns } from './ContainerDetailUtils';
+import { extractContainerColumns } from './ContainerDetailPureUtils';
 
 type ContainerTestData = Partial<Container> &
   Pick<Omit<EntityReference, 'type'>, 'id'>;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
@@ -10,12 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-export {
-  ContainerFields,
-  extractContainerColumns,
-  updateContainerColumnDescription,
-  updateContainerColumnTags,
-} from './ContainerDetailPureUtils';
 
 import { Col, Row } from 'antd';
 import { get } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
@@ -12,7 +12,7 @@
  */
 
 import { TabSpecificField } from '../enums/entity.enum';
-import { getTermQuery } from './SearchUtils';
+import { getTermQuery } from './SearchPureUtils';
 
 export const defaultFields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS},${TabSpecificField.USAGE_SUMMARY},${TabSpecificField.DOMAINS},${TabSpecificField.DATA_PRODUCTS}`;
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TablePureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TablePureUtils.ts
@@ -43,8 +43,8 @@ import {
   TagSource,
   type TagLabel,
 } from '../generated/type/tagLabel';
-import { extractApiEndpointFields } from './APIEndpoints/APIEndpointUtils';
-import { extractContainerColumns } from './ContainerDetailUtils';
+import { extractApiEndpointFields } from './APIEndpoints/APIEndpointFieldUtils';
+import { extractContainerColumns } from './ContainerDetailPureUtils';
 import { extractDataModelColumns } from './DashboardDataModelUtils';
 import EntityLink from './EntityLink';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.tsx
@@ -28,7 +28,6 @@ import { Field } from '../generated/type/schema';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import i18n from './i18next/LocalUtil';
 import { TopicDetailPageTabProps } from './TopicClassBase';
-
 const ContractTab = withSuspenseFallback(
   lazy(() =>
     import('../components/DataContract/ContractTab/ContractTab').then(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetDetailsUtils.tsx
@@ -22,7 +22,6 @@ import { EntityTabs, EntityType, TabSpecificField } from '../enums/entity.enum';
 import { PageType } from '../generated/system/ui/page';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import i18n from './i18next/LocalUtil';
-
 const ContractTab = withSuspenseFallback(
   lazy(() =>
     import('../components/DataContract/ContractTab/ContractTab').then(


### PR DESCRIPTION
## Summary
- Backports OSS #29067 database, schema, and container lazy-load utility updates on top of Group 12.
- Preserves the stacked review flow so this PR only shows Group 13 changes.

## Stack
- Base branch: ui/backport-group12-common-pages-settings-lazy-1.13
- Previous PR: open-metadata/OpenMetadata#30130

## Testing
- Scoped UI checkstyle sequence on changed source files: organize-imports-cli, ESLint --fix, Prettier.
- git diff --check HEAD~1..HEAD

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports lazy-loading utility updates across database, schema, container, and drive-service pages. The main changes are:

- Moves version components to pure entity-version helpers.
- Moves container, table, search, and summary logic to pure utility modules.
- Updates affected test mocks to follow the new module paths.
- Preserves lazy-loaded UI boundaries across entity pages and tabs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.
- The Worksheet version test now mocks the exact module imported by the component.
- The added table utility mocks cover the component's direct helper calls.
- No separate blocking issue remains from the updated code.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx | Updates the version-helper mock to match the component's pure utility import and adds the required table helper mocks. |
| openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.tsx | Moves worksheet version calculations to EntityVersionUtilsPure. |
| openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx | Updates the version-helper mock to match the page's pure utility import. |
| openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.tsx | Moves database schema version calculations to EntityVersionUtilsPure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): update version utility mocks"](https://github.com/open-metadata/openmetadata/commit/296cb677bac2ca791b98505e0bad9d1f4701c925) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744326)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Do not flag React.lazy remount races when the lazy... ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=213ae592-517f-454d-b6e2-6579c010a2af))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
</details>

<!-- /greptile_comment -->