### PR TITLE
Backport explore, search, and alerts lazy-loading updates to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertDiagnosticInfo/AlertDiagnosticInfoTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertDiagnosticInfo/AlertDiagnosticInfoTab.tsx
@@ -19,7 +19,7 @@ import { GRAYED_OUT_COLOR } from '../../../../constants/constants';
 import { EventSubscriptionDiagnosticInfo } from '../../../../generated/events/api/eventSubscriptionDiagnosticInfo';
 import { useFqn } from '../../../../hooks/useFqn';
 import { getDiagnosticInfo } from '../../../../rest/observabilityAPI';
-import { getDiagnosticItems } from '../../../../utils/Alerts/AlertsUtil';
+import { getDiagnosticItems } from '../../../../utils/Alerts/AlertsUtilPure';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 
 function AlertDiagnosticInfoTab() {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertRecentEventsTab/AlertRecentEventsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertRecentEventsTab/AlertRecentEventsTab.tsx
@@ -37,12 +37,14 @@ import {
 import { usePaging } from '../../../../hooks/paging/usePaging';
 import { getAlertEventsFromId } from '../../../../rest/alertsAPI';
 import {
-  getAlertEventsFilterLabels,
   getAlertRecentEventsFilterOptions,
   getAlertStatusIcon,
+} from '../../../../utils/Alerts/AlertsUtil';
+import {
+  getAlertEventsFilterLabels,
   getChangeEventDataFromTypedEvent,
   getLabelsForEventDetails,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.component.tsx
@@ -26,10 +26,12 @@ import { Destination } from '../../../generated/events/eventSubscription';
 import { testAlertDestination } from '../../../rest/alertsAPI';
 import {
   getConnectionTimeoutField,
-  getFormattedDestinations,
   getReadTimeoutField,
-  listLengthValidator,
 } from '../../../utils/Alerts/AlertsUtil';
+import {
+  getFormattedDestinations,
+  listLengthValidator,
+} from '../../../utils/Alerts/AlertsUtilPure';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import './destination-form-item.less';
 import { DestinationFormItemProps } from './DestinationFormItem.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.test.tsx
@@ -39,19 +39,23 @@ jest.mock('../../../utils/Alerts/AlertsUtil', () => ({
   getDestinationConfigField: jest
     .fn()
     .mockReturnValue(<div data-testid="destination-field" />),
-  getSubscriptionTypeOptions: jest.fn().mockReturnValue([]),
-  listLengthValidator: jest.fn().mockImplementation(() => Promise.resolve()),
-  getFilteredDestinationOptions: jest
-    .fn()
-    .mockImplementation((key) => DESTINATION_SOURCE_ITEMS[key]),
   getConnectionTimeoutField: jest
     .fn()
     .mockReturnValue(<div data-testid="connection-timeout" />),
   getReadTimeoutField: jest
     .fn()
     .mockReturnValue(<div data-testid="read-timeout" />),
+}));
+
+jest.mock('../../../utils/Alerts/AlertsUtilPure', () => ({
+  listLengthValidator: jest.fn().mockImplementation(() => Promise.resolve()),
   getFormattedDestinations: (...args: unknown[]) =>
     mockGetFormattedDestinations(...args),
+  getSubscriptionTypeOptions: jest.fn().mockReturnValue([]),
+  getFilteredDestinationOptions: jest
+    .fn()
+    .mockImplementation((key) => DESTINATION_SOURCE_ITEMS[key]),
+  normalizeDestinationConfig: jest.fn().mockImplementation((config) => config),
 }));
 
 jest.mock('../../../utils/ObservabilityUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationSelectItem/DestinationSelectItem.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationSelectItem/DestinationSelectItem.tsx
@@ -44,10 +44,12 @@ import { ModifiedDestination } from '../../../../pages/AddObservabilityPage/AddO
 import {
   getDestinationConfigField,
   getDestinationStatusAlertData,
+} from '../../../../utils/Alerts/AlertsUtil';
+import {
   getFilteredDestinationOptions,
   getSubscriptionTypeOptions,
   normalizeDestinationConfig,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';
 import { checkIfDestinationIsInternal } from '../../../../utils/ObservabilityUtils';
 import { DestinationSelectItemProps } from './DestinationSelectItem.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
@@ -17,10 +17,9 @@ import type { CustomTagProps } from 'rc-select/lib/BaseSelect';
 import React, { useEffect, useState } from 'react';
 import { SearchIndex } from '../../../enums/search.enum';
 import { searchQuery } from '../../../rest/searchAPI';
-import { getTermQuery } from '../../../utils/SearchUtils';
+import { getTermQuery } from '../../../utils/SearchPureUtils';
 import { AsyncSelect } from '../../common/AsyncSelect/AsyncSelect';
 import { AsyncSelectListProps } from '../../common/AsyncSelect/AsyncSelectList.interface';
-
 interface FQNListSelectProps
   extends SelectProps,
     Pick<AsyncSelectListProps, 'api'> {

--- a/openmetadata-ui/src/main/resources/ui/src/components/AuditLog/AuditLogFilters.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AuditLog/AuditLogFilters.component.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../utils/AuditLogUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { translateWithNestedKeys } from '../../utils/i18next/LocalUtil';
-import { getTermQuery } from '../../utils/SearchUtils';
+import { getTermQuery } from '../../utils/SearchPureUtils';
 import DatePickerMenu from '../common/DatePickerMenu/DatePickerMenu.component';
 import SearchDropdown from '../SearchDropdown/SearchDropdown';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
@@ -42,7 +42,6 @@ import {
   AuditLogFiltersProps,
   FilterOption,
 } from './AuditLogFilters.interface';
-
 const ENTITY_TYPE_OPTIONS: FilterOption[] = [
   // Data Assets
   { label: 'Table', value: 'table' },

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.component.tsx
@@ -58,7 +58,7 @@ import { useFqn } from '../../../hooks/useFqn';
 import { useLineageStore } from '../../../hooks/useLineageStore';
 import { QueryFieldInterface } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { exportLineageByEntityCountAsync } from '../../../rest/lineageAPI';
-import { getQuickFilterQuery } from '../../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../../utils/ExplorePureUtils';
 import { getSearchNameEsQuery } from '../../../utils/Lineage/LineageUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import Searchbar from '../../common/SearchBarComponent/SearchBar.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
@@ -33,8 +33,8 @@ import { SearchIndex } from '../../../enums/search.enum';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
 import { TabsInfoData } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { getAllCustomProperties } from '../../../rest/metadataTypeAPI';
+import { getEmptyJsonTree } from '../../../utils/AdvancedSearchPureUtils';
 import {
-  getEmptyJsonTree,
   getTreeConfig,
   processEntityTypeFields,
 } from '../../../utils/AdvancedSearchUtils';
@@ -49,7 +49,6 @@ import {
   AdvanceSearchProviderProps,
   SearchOutputType,
 } from './AdvanceSearchProvider.interface';
-
 const AdvancedSearchContext = createContext<AdvanceSearchContext>(
   {} as AdvanceSearchContext
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CustomPropertiesSection/CustomPropertiesSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CustomPropertiesSection/CustomPropertiesSection.test.tsx
@@ -75,7 +75,7 @@ jest.mock('../../../common/ErrorWithPlaceholder/ErrorPlaceHolderNew', () => ({
 }));
 
 // Mock utility functions
-jest.mock('../../../../utils/EntityBreadcrumbUtils', () => ({
+jest.mock('../../../../utils/EntityLinkUtils', () => ({
   getEntityLinkFromType: jest.fn().mockReturnValue('/test-entity-link'),
 }));
 jest.mock('../../../../utils/EntityNameUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DataProductSummary/DataProductSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DataProductSummary/DataProductSummary.component.tsx
@@ -16,7 +16,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EntityType } from '../../../../enums/entity.enum';
 import { DataProduct } from '../../../../generated/entity/domains/dataProduct';
-import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelUtils';
+import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelPureUtils';
 import { DomainLabel } from '../../../common/DomainLabel/DomainLabel.component';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DomainSummary/DomainSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DomainSummary/DomainSummary.component.tsx
@@ -15,7 +15,7 @@ import { get } from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Domain } from '../../../../generated/entity/domains/domain';
-import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelUtils';
+import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelPureUtils';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import SummaryTagsDescription from '../../../common/SummaryTagsDescription/SummaryTagsDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
@@ -20,7 +20,6 @@ import AppBadge from '../../../../common/Badge/Badge.component';
 import RichTextEditorPreviewerV1 from '../../../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import TagsViewer from '../../../../Tag/TagsViewer/TagsViewer';
 import { SummaryListItemProps } from './SummaryListItems.interface';
-
 const { Text, Paragraph } = Typography;
 
 function SummaryListItem({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SearchIndex } from '../../../../enums/search.enum';
 import { searchQuery } from '../../../../rest/searchAPI';
-import { getTermQuery } from '../../../../utils/SearchUtils';
+import { getTermQuery } from '../../../../utils/SearchPureUtils';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import TableDataCardV2 from '../../../common/TableDataCardV2/TableDataCardV2';
 import { SourceType } from '../../../SearchedData/SearchedData.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -21,7 +21,7 @@ import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
 import { useSearchStore } from '../../hooks/useSearchStore';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
-import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchUtils';
+import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchPureUtils';
 import {
   getCombinedQueryFilterObject,
   getQuickFilterWithDeletedFlag,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreTree/ExploreTree.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreTree/ExploreTree.tsx
@@ -37,7 +37,7 @@ import {
   getSubLevelHierarchyKey,
   updateTreeData,
   updateTreeDataWithCounts,
-} from '../../../utils/ExploreUtils';
+} from '../../../utils/ExplorePureUtils';
 import { Transi18next } from '../../../utils/i18next/LocalUtil';
 import searchClassBase from '../../../utils/SearchClassBase';
 import serviceUtilClassBase from '../../../utils/ServiceUtilClassBase';
@@ -53,7 +53,6 @@ import {
   ExploreTreeProps,
   TreeNodeData,
 } from './ExploreTree.interface';
-
 const ExploreTreeTitle = ({ node }: { node: ExploreTreeNode }) => {
   const tooltipText = node.tooltip ?? node.title;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -22,7 +22,7 @@ import { debounce, isUndefined } from 'lodash';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
-import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchUtils';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
 import Loader from '../common/Loader/Loader';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
 import { QuickFilterDropdownProps } from './QuickFilterDropdown.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -58,7 +58,7 @@ import { getCombinedQueryFilterObject } from '../../utils/ExplorePage/ExplorePag
 import {
   getExploreQueryFilterMust,
   getSelectedValuesFromQuickFilter,
-} from '../../utils/ExploreUtils';
+} from '../../utils/ExplorePureUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import withSuspenseFallback from '../AppRouter/withSuspenseFallback';
 import FilterErrorPlaceHolder from '../common/ErrorWithPlaceholder/FilterErrorPlaceHolder';
@@ -76,7 +76,6 @@ import { ReactComponent as IconAscending } from './../../assets/svg/ic-ascending
 import { ReactComponent as IconDescending } from './../../assets/svg/ic-descending.svg';
 import './exploreV1.less';
 import { IndexNotFoundBanner } from './IndexNotFoundBanner';
-
 const EntitySummaryPanel = withSuspenseFallback(
   lazy(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -58,7 +58,7 @@ import {
 import { getEntityLinkFromType } from '../../utils/EntityLinkUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { highlightSearchText } from '../../utils/EntitySearchUtils';
-import { getQuickFilterQuery } from '../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../utils/ExplorePureUtils';
 import Fqn from '../../utils/Fqn';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
@@ -30,7 +30,6 @@ import { ActivityFeedTabs } from '../ActivityFeed/ActivityFeedTab/ActivityFeedTa
 import ProfilePicture from '../common/ProfilePicture/ProfilePicture';
 import { SourceType } from '../SearchedData/SearchedData.interface';
 import { NotificationFeedProp } from './NotificationFeedCard.interface';
-
 const NotificationFeedCard: FC<NotificationFeedProp> = ({
   createdBy,
   entityFQN,

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
@@ -19,6 +19,10 @@ import NotificationFeedCard from './NotificationFeedCard.component';
 jest.mock('../../utils/date-time/DateTimeUtils', () => ({
   formatDateTime: jest.fn().mockImplementation((date) => date),
   getRelativeTime: jest.fn().mockImplementation((date) => date),
+  getEpochMillisForPastDays: jest.fn().mockImplementation((days) => days),
+  getStartOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getEndOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getCurrentMillis: jest.fn().mockReturnValue(0),
 }));
 
 const mockPrepareFeedLink = jest.fn();

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -40,10 +40,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DropDown } from '../../assets/svg/drop-down.svg';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
 import {
   generateSearchDropdownLabel,
   getSearchDropdownLabels,
-  getSelectedOptionLabelString,
 } from '../../utils/AdvancedSearchUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import Loader from '../common/Loader/Loader';
@@ -52,7 +52,6 @@ import {
   SearchDropdownOption,
   SearchDropdownProps,
 } from './SearchDropdown.interface';
-
 const SearchDropdown: FC<SearchDropdownProps> = ({
   dropdownClassName,
   isSuggestionsLoading,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.component.tsx
@@ -22,16 +22,15 @@ import {
   Effect,
   EventSubscription,
 } from '../../../../generated/events/eventSubscription';
+import { EDIT_LINK_PATH } from '../../../../utils/Alerts/AlertsUtil';
 import {
-  EDIT_LINK_PATH,
   getDisplayNameForEntities,
   getFunctionDisplayName,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import TitleBreadcrumb from '../../../common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../../common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../../PageHeader/PageHeader.component';
 import { HeaderProps } from '../../../PageHeader/PageHeader.interface';
-
 interface AlertDetailsComponentProps {
   alerts: EventSubscription;
   onDelete: () => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.test.tsx
@@ -23,6 +23,9 @@ import { AlertDetailsComponent } from './AlertDetails.component';
 
 jest.mock('../../../../utils/Alerts/AlertsUtil', () => ({
   EDIT_LINK_PATH: 'Edit Alert Link',
+}));
+
+jest.mock('../../../../utils/Alerts/AlertsUtilPure', () => ({
   getDisplayNameForEntities: jest.fn().mockImplementation((entity) => entity),
   getFunctionDisplayName: jest
     .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
@@ -20,7 +20,6 @@ import { ReactComponent as CopyLeft } from '../../../../../assets/svg/copy-left.
 import { useClipboard } from '../../../../../hooks/useClipBoard';
 import { splitCSV } from '../../../../../utils/CSV/CSVPureUtils';
 import './workflow-array-field-template.less';
-
 const WorkflowArrayFieldTemplate = (props: FieldProps) => {
   const { t } = useTranslation();
   const isFilterPatternField = (id: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
@@ -41,7 +41,7 @@ import { searchQuery } from '../../../../../../rest/searchAPI';
 import {
   getEmptyJsonTree,
   getEmptyJsonTreeForQueryBuilder,
-} from '../../../../../../utils/AdvancedSearchUtils';
+} from '../../../../../../utils/AdvancedSearchPureUtils';
 import { elasticSearchFormat } from '../../../../../../utils/QueryBuilderElasticsearchFormatUtils';
 import {
   addEntityTypeFilter,
@@ -50,14 +50,13 @@ import {
   getJsonTreeFromQueryFilter,
   migrateJsonLogic,
   READONLY_SETTINGS,
-} from '../../../../../../utils/QueryBuilderUtils';
+} from '../../../../../../utils/QueryBuilderPureUtils';
 import { getExplorePath } from '../../../../../../utils/RouterUtils';
 import searchClassBase from '../../../../../../utils/SearchClassBase';
 import { withAdvanceSearch } from '../../../../../AppRouter/withAdvanceSearch';
 import { useAdvanceSearch } from '../../../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.component';
 import { SearchOutputType } from '../../../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import './query-builder-widget.less';
-
 const QueryBuilderWidget: FC<
   WidgetProps & {
     fields?: Config['fields'];

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/SelectWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/SelectWidget.tsx
@@ -17,7 +17,6 @@ import { FC } from 'react';
 import { filterSelectOptions } from '../../../../../utils/FilterQueryUtils';
 import { getPopupContainer } from '../../../../../utils/formPureUtils';
 import TreeSelectWidget from './TreeSelectWidget';
-
 const getDisplayLabel = (
   label: string | number | boolean | null,
   shouldCapitalize: boolean

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.test.tsx
@@ -23,7 +23,7 @@ import { EntityType } from '../../../enums/entity.enum';
 import { searchQuery } from '../../../rest/searchAPI';
 import { getTreeConfig } from '../../../utils/AdvancedSearchUtils';
 import * as QueryBuilderElasticsearchFormatUtils from '../../../utils/QueryBuilderElasticsearchFormatUtils';
-import * as QueryBuilderUtils from '../../../utils/QueryBuilderUtils';
+import * as QueryBuilderUtils from '../../../utils/QueryBuilderPureUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
 import { SearchOutputType } from '../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import QueryBuilderWidgetV1 from './QueryBuilderWidgetV1';
@@ -48,6 +48,7 @@ jest.mock('../../../utils/AdvancedSearchUtils', () => ({
 }));
 
 jest.mock('../../../utils/QueryBuilderUtils');
+jest.mock('../../../utils/QueryBuilderPureUtils');
 jest.mock('../../../utils/QueryBuilderElasticsearchFormatUtils');
 jest.mock('../../../utils/RouterUtils', () => {
   return {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
@@ -50,22 +50,19 @@ import { EntityType } from '../../../enums/entity.enum';
 import { SearchIndex } from '../../../enums/search.enum';
 import { QueryFilterInterface } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { searchQuery } from '../../../rest/searchAPI';
-import {
-  getEmptyJsonTreeForQueryBuilder,
-  getTreeConfig,
-} from '../../../utils/AdvancedSearchUtils';
+import { getEmptyJsonTreeForQueryBuilder } from '../../../utils/AdvancedSearchPureUtils';
+import { getTreeConfig } from '../../../utils/AdvancedSearchUtils';
 import { elasticSearchFormat } from '../../../utils/QueryBuilderElasticsearchFormatUtils';
 import {
   addEntityTypeFilter,
   getEntityTypeAggregationFilter,
   getJsonTreeFromQueryFilter,
   READONLY_SETTINGS,
-} from '../../../utils/QueryBuilderUtils';
+} from '../../../utils/QueryBuilderPureUtils';
 import { getExplorePath } from '../../../utils/RouterUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
 import { SearchOutputType } from '../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import './query-builder-widget-v1.less';
-
 const QueryBuilderWidgetV1: FC<{
   fields?: Config['fields'];
   onChange?: (value: string, tree?: JsonTree) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -134,7 +134,7 @@ import {
 import { getLoadingStatusValue } from '../../utils/EntityLineageUtils';
 import { updateNodeType } from '../../utils/EntityPureUtils';
 import { getEntityReferenceFromEntity } from '../../utils/EntityReferenceUtils';
-import { getQuickFilterQuery } from '../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../utils/ExplorePureUtils';
 import { addBaseNodeDepthToNodes } from '../../utils/Lineage/LineageUtils';
 import tableClassBase from '../../utils/TableClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -41,11 +41,10 @@ import { useSearchStore } from '../../hooks/useSearchStore';
 import { Aggregations, SearchResponse } from '../../interface/search.interface';
 import {
   extractTermKeys,
-  fetchEntityData,
   findActiveSearchIndex,
-  generateTabItems,
   parseSearchParams,
-} from '../../utils/ExploreUtils';
+} from '../../utils/ExplorePureUtils';
+import { fetchEntityData, generateTabItems } from '../../utils/ExploreUtils';
 import { getExplorePath } from '../../utils/RouterUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import { useRequiredParams } from '../../utils/useRequiredParams';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -37,11 +37,13 @@ import {
   getEmptyJsonTreeForQueryBuilder,
   getOptionsFromAggregationBucket,
   getSchemaFieldOptions,
-  getSearchDropdownLabels,
   getSearchLabel,
   getSelectedOptionLabelString,
   getServiceOptions,
   getTasksOptions,
+} from './AdvancedSearchPureUtils';
+import {
+  getSearchDropdownLabels,
   processCustomPropertyField,
   processEntityTypeFields,
 } from './AdvancedSearchUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
@@ -39,23 +39,6 @@ import { t } from './i18next/LocalUtil';
 import jsonLogicSearchClassBase from './JSONLogicSearchClassBase';
 import searchClassBase from './SearchClassBase';
 
-export {
-  formatQueryValueBasedOnType,
-  getAssetsPageQuickFilters,
-  getChartsOptions,
-  getColumnsOptions,
-  getCustomPropertyAdvanceSearchEnumOptions,
-  getDataModelOptions,
-  getEmptyJsonTree,
-  getEmptyJsonTreeForQueryBuilder,
-  getOptionsFromAggregationBucket,
-  getSchemaFieldOptions,
-  getSearchLabel,
-  getSelectedOptionLabelString,
-  getServiceOptions,
-  getTasksOptions,
-} from './AdvancedSearchPureUtils';
-
 export const getDropDownItems = (index: string): ExploreQuickFilterField[] => {
   return searchClassBase.getDropDownItems(index);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -38,32 +38,34 @@ import {
 import { ModifiedDestination } from '../../pages/AddObservabilityPage/AddObservabilityPage.interface';
 import { searchContracts } from '../../rest/contractAPI';
 import { searchQuery } from '../../rest/searchAPI';
-import { getTermQuery } from '../SearchUtils';
+import { getTermQuery } from '../SearchPureUtils';
 import {
-  getAlertActionTypeDisplayName,
-  getAlertEventsFilterLabels,
   getAlertExtraInfo,
   getAlertRecentEventsFilterOptions,
   getAlertsActionTypeIcon,
   getAlertStatusIcon,
+  getConnectionTimeoutField,
+  getDestinationConfigField,
+  getFieldByArgumentType,
+  getFqnSearchIndexes,
+  searchEntity,
+} from './AlertsUtil';
+import {
+  getAlertActionTypeDisplayName,
+  getAlertEventsFilterLabels,
   getChangeEventDataFromTypedEvent,
   getConfigHeaderArrayFromObject,
   getConfigHeaderObjectFromArray,
   getConfigQueryParamsArrayFromObject,
   getConfigQueryParamsObjectFromArray,
-  getConnectionTimeoutField,
-  getDestinationConfigField,
   getDisplayNameForEntities,
-  getFieldByArgumentType,
   getFilteredDestinationOptions,
   getFormattedDestinations,
-  getFqnSearchIndexes,
   getFunctionDisplayName,
   getLabelsForEventDetails,
   listLengthValidator,
   normalizeDestinationConfig,
-  searchEntity,
-} from './AlertsUtil';
+} from './AlertsUtilPure';
 
 jest.mock('antd', () => ({
   ...jest.requireActual('antd'),

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -11,28 +11,6 @@
  *  limitations under the License.
  */
 
-export {
-  getAlertActionTypeDisplayName,
-  getAlertEventsFilterLabels,
-  getChangeEventDataFromTypedEvent,
-  getConfigHeaderArrayFromObject,
-  getConfigHeaderObjectFromArray,
-  getConfigQueryParamsArrayFromObject,
-  getConfigQueryParamsObjectFromArray,
-  getDiagnosticItems,
-  getDisplayNameForEntities,
-  getFilteredDestinationOptions,
-  getFormattedDestinations,
-  getFunctionDisplayName,
-  getLabelsForEventDetails,
-  getMessageFromArgumentName,
-  getRandomizedAlertName,
-  getSelectOptionsFromEnum,
-  getSubscriptionTypeOptions,
-  listLengthValidator,
-  normalizeDestinationConfig,
-} from './AlertsUtilPure';
-
 import {
   CheckCircleOutlined,
   CloseOutlined,
@@ -104,7 +82,7 @@ import { getEntityName, getEntityNameLabel } from '../EntityNameUtils';
 import { t } from '../i18next/LocalUtil';
 import { getConfigFieldFromDestinationType } from '../ObservabilityUtils';
 import searchClassBase from '../SearchClassBase';
-import { getTermQuery } from '../SearchUtils';
+import { getTermQuery } from '../SearchPureUtils';
 import { showErrorToast } from '../ToastUtils';
 import './alerts-util.less';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
@@ -22,7 +22,7 @@ import {
   getSelectedValuesFromQuickFilter,
   getSubLevelHierarchyKey,
   updateTreeData,
-} from './ExploreUtils';
+} from './ExplorePureUtils';
 
 describe('Explore Utils', () => {
   it('should return undefined if data is empty', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -41,24 +41,6 @@ import {
 import { escapeESReservedCharacters } from './StringUtils';
 import { showErrorToast } from './ToastUtils';
 
-export {
-  extractTermKeys,
-  findActiveSearchIndex,
-  getAggregations,
-  getExploreQueryFilterMust,
-  getParseValueFromLocation,
-  getQuickFilterObject,
-  getQuickFilterObjectForEntities,
-  getQuickFilterQuery,
-  getSelectedValuesFromQuickFilter,
-  getSubLevelHierarchyKey,
-  isElasticsearchError,
-  parseSearchParams,
-  updateCountsInTreeData,
-  updateTreeData,
-  updateTreeDataWithCounts,
-} from './ExplorePureUtils';
-
 export const getAggregationOptions = async (
   index: SearchIndex | SearchIndex[],
   key: string,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
@@ -23,8 +23,7 @@ import {
   getJsonTreeFromQueryFilter,
   jsonLogicToElasticsearch,
   resolveFieldType,
-} from './QueryBuilderUtils';
-
+} from './QueryBuilderPureUtils';
 jest.mock('./StringUtils', () => ({
   generateUUID: jest.fn(),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
@@ -15,30 +15,6 @@ import type { RenderSettings } from '@react-awesome-query-builder/antd';
 import { Button } from 'antd';
 import { t } from './i18next/LocalUtil';
 
-export {
-  addEntityTypeFilter,
-  buildExploreUrlParams,
-  elasticsearchToJsonLogic,
-  getCommonFieldProperties,
-  getEntityTypeAggregationFilter,
-  getEqualFieldProperties,
-  getFieldsByKeys,
-  getJsonTreeFromQueryFilter,
-  getJsonTreePropertyFromQueryFilter,
-  getOperator,
-  getSelectAnyInProperties,
-  getSelectEqualsNotEqualsProperties,
-  getSelectNotAnyInProperties,
-  jsonLogicToElasticsearch,
-  JSONLOGIC_FIELDS_TO_IGNORE_SPLIT,
-  JSONLOGIC_OPERATORS,
-  migrateJsonLogic,
-  READONLY_SETTINGS,
-  resolveFieldType,
-  type ElasticsearchQuery,
-  type JsonLogic,
-} from './QueryBuilderPureUtils';
-
 export const renderQueryBuilderFilterButtons: RenderSettings['renderButton'] = (
   props
 ) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
@@ -14,11 +14,10 @@ import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import {
   getEntityTypeFromSearchIndex,
-  getGroupLabel,
   getTermQuery,
   parseBucketsData,
-} from './SearchUtils';
-
+} from './SearchPureUtils';
+import { getGroupLabel } from './SearchUtils';
 // Add type definition for ESQueryClause to fix type errors
 type ESQueryClause = {
   term?: Record<string, string | number | boolean>;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.tsx
@@ -42,12 +42,6 @@ import i18n from './i18next/LocalUtil';
 import searchClassBase from './SearchClassBase';
 import serviceUtilClassBase from './ServiceUtilClassBase';
 
-export {
-  getEntityTypeFromSearchIndex,
-  getTermQuery,
-  parseBucketsData,
-} from './SearchPureUtils';
-
 export const getGroupLabel = (index: string) => {
   let label = '';
   let GroupIcon;


### PR DESCRIPTION
## Summary
- Backports OSS #29068 explore, search, and alerts lazy-load utility updates on top of Group 13.
- Preserves the stacked review flow so this PR only shows Group 14 changes.

## Stack
- Base branch: ui/backport-group13-database-schema-container-lazy-1.13
- Previous PR: open-metadata/OpenMetadata#30132

## Testing
- Scoped UI checkstyle sequence on changed source files: organize-imports-cli, ESLint --fix, Prettier.
- git diff --check HEAD~1..HEAD

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports lazy-loading utility updates for Explore, Search, Query Builder, and Alerts. The main changes are:

- Moves pure utility imports to dedicated `*PureUtils` modules.
- Removes compatibility re-exports from the original utility modules.
- Updates affected components and tests to use the new import paths.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.
- The remaining `QuickFilterDropdown` import now uses the correct pure utility module.
- No blocking issue remains in the updated import paths.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx | Imports `getSelectedOptionLabelString` directly from `AdvancedSearchPureUtils`. |
| openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx | Removes pure utility compatibility re-exports after consumer imports were migrated. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): update quick filter helper impo..."](https://github.com/open-metadata/openmetadata/commit/38d2b65431105f9c592216dce49b392748ac724e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44744998)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->