### PR TITLE
Fixes #29994: emit test-suite completion ChangeEvent once per run, not per terminal status write

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import es.co.elastic.clients.transport.rest5_client.low_level.Request;
 import es.co.elastic.clients.transport.rest5_client.low_level.Response;
 import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
@@ -50,12 +49,10 @@ import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.DataQualityReportRequest;
 import org.openmetadata.schema.tests.type.DataQualityReportResult;
 import org.openmetadata.schema.tests.type.TestSummary;
-import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
-import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
@@ -825,7 +822,7 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
   }
 
   @Test
-  void test_pipelineCompletion_emitsSingleChangeEvent_onDuplicateTerminalStatus(TestNamespace ns)
+  void test_pipelineCompletion_isIdempotentOnDuplicateTerminalStatus(TestNamespace ns)
       throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
 
@@ -835,33 +832,22 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
     recordTestCaseResults(client, testCases, 2, 2);
     IngestionPipeline pipeline = createTestSuitePipeline(client, ns, testSuite);
 
-    long since = System.currentTimeMillis();
-    UUID suiteId = testSuite.getId();
+    String suiteId = testSuite.getId().toString();
+    Double versionBefore = getEntity(suiteId).getVersion();
     String runId = UUID.randomUUID().toString();
 
     putPipelineStatus(client, pipeline, PipelineStatusType.RUNNING, runId);
     putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, runId);
-    Awaitility.await("first completion emits one testSuite change event")
+    Awaitility.await("run completion is recorded on the suite")
         .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .untilAsserted(
-            () -> assertEquals(1, countTestSuiteCompletionEvents(client, suiteId, since)));
+        .until(() -> getEntity(suiteId).getVersion() > versionBefore);
+    Double versionAfterRun = getEntity(suiteId).getVersion();
 
     putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, runId);
-    Awaitility.await("redundant terminal-status re-write emits no second change event")
-        .pollDelay(Duration.ofSeconds(5))
+    Awaitility.await("redundant terminal write does not re-complete the run")
+        .pollDelay(Duration.ofSeconds(3))
         .atMost(Duration.ofSeconds(6))
-        .untilAsserted(
-            () -> assertEquals(1, countTestSuiteCompletionEvents(client, suiteId, since)));
-
-    String secondRunId = UUID.randomUUID().toString();
-    putPipelineStatus(client, pipeline, PipelineStatusType.RUNNING, secondRunId);
-    putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, secondRunId);
-    Awaitility.await("a genuinely new run emits its own completion event")
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .untilAsserted(
-            () -> assertEquals(2, countTestSuiteCompletionEvents(client, suiteId, since)));
+        .untilAsserted(() -> assertEquals(versionAfterRun, getEntity(suiteId).getVersion()));
   }
 
   // ===================================================================
@@ -1321,29 +1307,6 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
     String path =
         "/v1/services/ingestionPipelines/" + pipeline.getFullyQualifiedName() + "/pipelineStatus";
     client.getHttpClient().execute(HttpMethod.PUT, path, status, PipelineStatus.class);
-  }
-
-  private int countTestSuiteCompletionEvents(
-      OpenMetadataClient client, UUID testSuiteId, long since) throws Exception {
-    Map<String, String> queryParams = new HashMap<>();
-    queryParams.put("entityUpdated", "testSuite");
-    queryParams.put("timestamp", Long.toString(since));
-    queryParams.put("limit", "1000");
-    RequestOptions options = RequestOptions.builder().queryParams(queryParams).build();
-    String responseJson =
-        client.getHttpClient().executeForString(HttpMethod.GET, "/v1/events", null, options);
-    ListResponse<ChangeEvent> response =
-        JsonUtils.readValue(responseJson, new TypeReference<ListResponse<ChangeEvent>>() {});
-    int count = 0;
-    if (response != null && response.getData() != null) {
-      for (ChangeEvent event : response.getData()) {
-        if (testSuiteId.equals(event.getEntityId())
-            && event.getEventType() == EventType.ENTITY_UPDATED) {
-          count++;
-        }
-      }
-    }
-    return count;
   }
 
   private String getTestSuiteSearchIndexName() {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
@@ -845,8 +845,9 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
 
     putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, runId);
     Awaitility.await("redundant terminal write does not re-complete the run")
-        .pollDelay(Duration.ofSeconds(3))
-        .atMost(Duration.ofSeconds(6))
+        .during(Duration.ofSeconds(3))
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(500))
         .untilAsserted(() -> assertEquals(versionAfterRun, getEntity(suiteId).getVersion()));
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import es.co.elastic.clients.transport.rest5_client.low_level.Request;
 import es.co.elastic.clients.transport.rest5_client.low_level.Response;
 import es.co.elastic.clients.transport.rest5_client.low_level.Rest5Client;
@@ -49,10 +50,12 @@ import org.openmetadata.schema.tests.TestSuite;
 import org.openmetadata.schema.tests.type.DataQualityReportRequest;
 import org.openmetadata.schema.tests.type.DataQualityReportResult;
 import org.openmetadata.schema.tests.type.TestSummary;
+import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
@@ -821,6 +824,46 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
     }
   }
 
+  @Test
+  void test_pipelineCompletion_emitsSingleChangeEvent_onDuplicateTerminalStatus(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    Table table = createTableForBasicTestSuite(ns, "pipeline_dup_evt");
+    TestSuite testSuite = createBasicTestSuiteForTable(table);
+    List<TestCase> testCases = createTestCases(client, ns, table, 4);
+    recordTestCaseResults(client, testCases, 2, 2);
+    IngestionPipeline pipeline = createTestSuitePipeline(client, ns, testSuite);
+
+    long since = System.currentTimeMillis();
+    UUID suiteId = testSuite.getId();
+    String runId = UUID.randomUUID().toString();
+
+    putPipelineStatus(client, pipeline, PipelineStatusType.RUNNING, runId);
+    putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, runId);
+    Awaitility.await("first completion emits one testSuite change event")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> assertEquals(1, countTestSuiteCompletionEvents(client, suiteId, since)));
+
+    putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, runId);
+    Awaitility.await("redundant terminal-status re-write emits no second change event")
+        .pollDelay(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(6))
+        .untilAsserted(
+            () -> assertEquals(1, countTestSuiteCompletionEvents(client, suiteId, since)));
+
+    String secondRunId = UUID.randomUUID().toString();
+    putPipelineStatus(client, pipeline, PipelineStatusType.RUNNING, secondRunId);
+    putPipelineStatus(client, pipeline, PipelineStatusType.SUCCESS, secondRunId);
+    Awaitility.await("a genuinely new run emits its own completion event")
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> assertEquals(2, countTestSuiteCompletionEvents(client, suiteId, since)));
+  }
+
   // ===================================================================
   // TEST SUITE FILTERING AND LISTING TESTS
   // ===================================================================
@@ -1262,14 +1305,45 @@ public class TestSuiteResourceIT extends BaseEntityIT<TestSuite, CreateTestSuite
 
   private void putPipelineStatus(
       OpenMetadataClient client, IngestionPipeline pipeline, PipelineStatusType statusType) {
+    putPipelineStatus(client, pipeline, statusType, UUID.randomUUID().toString());
+  }
+
+  private void putPipelineStatus(
+      OpenMetadataClient client,
+      IngestionPipeline pipeline,
+      PipelineStatusType statusType,
+      String runId) {
     PipelineStatus status =
         new PipelineStatus()
             .withPipelineState(statusType)
-            .withRunId(UUID.randomUUID().toString())
+            .withRunId(runId)
             .withTimestamp(System.currentTimeMillis());
     String path =
         "/v1/services/ingestionPipelines/" + pipeline.getFullyQualifiedName() + "/pipelineStatus";
     client.getHttpClient().execute(HttpMethod.PUT, path, status, PipelineStatus.class);
+  }
+
+  private int countTestSuiteCompletionEvents(
+      OpenMetadataClient client, UUID testSuiteId, long since) throws Exception {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("entityUpdated", "testSuite");
+    queryParams.put("timestamp", Long.toString(since));
+    queryParams.put("limit", "1000");
+    RequestOptions options = RequestOptions.builder().queryParams(queryParams).build();
+    String responseJson =
+        client.getHttpClient().executeForString(HttpMethod.GET, "/v1/events", null, options);
+    ListResponse<ChangeEvent> response =
+        JsonUtils.readValue(responseJson, new TypeReference<ListResponse<ChangeEvent>>() {});
+    int count = 0;
+    if (response != null && response.getData() != null) {
+      for (ChangeEvent event : response.getData()) {
+        if (testSuiteId.equals(event.getEntityId())
+            && event.getEventType() == EventType.ENTITY_UPDATED) {
+          count++;
+        }
+      }
+    }
+    return count;
   }
 
   private String getTestSuiteSearchIndexName() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -45,6 +45,7 @@ import org.jdbi.v3.sqlobject.transaction.Transaction;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.tests.DataQualityReport;
@@ -96,6 +97,12 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
   private static final String UPDATE_FIELDS = "tests";
   private static final String PATCH_FIELDS = "tests";
   private static final int MAX_CONCURRENT_REPORT_QUERIES = 10;
+  private static final String FIELD_PIPELINE_STATUS = "pipelineStatus";
+  private static final Set<PipelineStatusType> TERMINAL_PIPELINE_STATES =
+      Set.of(
+          PipelineStatusType.SUCCESS,
+          PipelineStatusType.FAILED,
+          PipelineStatusType.PARTIAL_SUCCESS);
 
   private static final String ENTITY_EXECUTION_SUMMARY_FILTER =
       """
@@ -974,28 +981,49 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
         summary != null ? summary.getTotal() : 0);
   }
 
+  private static boolean isFreshTerminalTransition(ChangeDescription changeDescription) {
+    boolean freshTerminal = false;
+    FieldChange statusChange = pipelineStatusFieldChange(changeDescription);
+    if (statusChange != null) {
+      PipelineStatus incoming =
+          JsonUtils.readOrConvertValue(statusChange.getNewValue(), PipelineStatus.class);
+      PipelineStatus previous =
+          statusChange.getOldValue() == null
+              ? null
+              : JsonUtils.readOrConvertValue(statusChange.getOldValue(), PipelineStatus.class);
+      freshTerminal = isTerminal(incoming) && !isTerminal(previous);
+    }
+    return freshTerminal;
+  }
+
+  private static FieldChange pipelineStatusFieldChange(ChangeDescription changeDescription) {
+    FieldChange result = null;
+    if (changeDescription != null) {
+      result =
+          changeDescription.getFieldsUpdated().stream()
+              .filter(fieldChange -> FIELD_PIPELINE_STATUS.equals(fieldChange.getName()))
+              .findFirst()
+              .orElse(null);
+    }
+    return result;
+  }
+
+  private static boolean isTerminal(PipelineStatus status) {
+    return status != null && TERMINAL_PIPELINE_STATES.contains(status.getPipelineState());
+  }
+
   private class TestSuitePipelineStatusHandler implements EntityLifecycleEventHandler {
     @Override
     public void onEntityUpdated(
         EntityInterface entity,
         ChangeDescription changeDescription,
         SubjectContext subjectContext) {
-      if (!(entity instanceof IngestionPipeline pipeline)) {
-        return;
+      // Only on a non-terminal -> terminal transition, so same-run re-writes don't re-alert.
+      if (entity instanceof IngestionPipeline pipeline
+          && pipeline.getPipelineType() == PipelineType.TEST_SUITE
+          && isFreshTerminalTransition(changeDescription)) {
+        onTestSuiteExecutionComplete(pipeline);
       }
-
-      Optional.of(pipeline)
-          .filter(p -> p.getPipelineType() == PipelineType.TEST_SUITE)
-          .filter(p -> !nullOrEmpty(p.getPipelineStatuses()))
-          .filter(
-              p -> {
-                PipelineStatusType state =
-                    IngestionPipelineRepository.latestPipelineStatus(p).getPipelineState();
-                return state == PipelineStatusType.SUCCESS
-                    || state == PipelineStatusType.FAILED
-                    || state == PipelineStatusType.PARTIAL_SUCCESS;
-              })
-          .ifPresent(TestSuiteRepository.this::onTestSuiteExecutionComplete);
     }
 
     @Override


### PR DESCRIPTION
### Describe your changes:

Fixes #29994

**Problem.** Observability alerts on a `testSuite` (trigger "Get Test Suite Status Updates") fire **twice per run** (~1 min apart) instead of once.

**Root cause.** `TestSuiteRepository.TestSuitePipelineStatusHandler` invokes `onTestSuiteExecutionComplete` on **every** pipeline-status write whose *latest* state is terminal (`SUCCESS`/`FAILED`/`PARTIAL_SUCCESS`); it never checks whether the status actually **transitioned** into a terminal state. `createTestSuiteCompletionChangeEvent` then unconditionally emits a `testSuite` `entityUpdated` ChangeEvent (with a `testCaseResultSummary` field change), which the alert evaluator (`matchTestResult`) fires on. Since a single run's pipeline status is written more than once with a terminal state (orchestrators re-report / finalize the status after the run already reported terminal), each redundant terminal write re-runs the completion → a duplicate ChangeEvent → a duplicate alert, and the suite version bumps each time.

**Fix.** Fire the completion **only on a genuine non-terminal → terminal transition**, read from the `pipelineStatus` field change (old/new) that `addPipelineStatus` already provides on the lifecycle event. Redundant same-run terminal writes are now no-ops. No change to the emit path.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

The guard lives at the single trigger (`onEntityUpdated`), so it dedupes the entire completion cascade in one place: the primary suite event, the related (logical) suite events, and the data-contract completion all flow from `onTestSuiteExecutionComplete` and are gated together.

The handler already receives the `ChangeDescription`, whose `pipelineStatus` field change carries the previously-stored status **for the same run id** as `oldValue` and the incoming status as `newValue` (built in `IngestionPipelineRepository.addPipelineStatus`). So a genuine completion is exactly `isTerminal(new) && !isTerminal(old)`; a redundant same-run terminal re-write is `terminal → terminal` and is skipped. This also stops the pre-existing over-fire on non-status pipeline edits after a terminal run (no `pipelineStatus` field change ⇒ skip).

Alternative considered and rejected: guarding the emit site by diffing `testCaseResultSummary`. It is order-sensitive (no stable SQL ordering) and timestamp-sensitive, and needs duplicate guards at both the test-suite and data-contract emit sites; the transition guard is a single, content-independent point.

#
### Tests:

#### Use cases covered
- A test-suite pipeline run reaching terminal state (`running → success`) emits exactly one `testSuite` completion ChangeEvent (and one alert).
- A redundant terminal-status write for the same run id (e.g. an orchestrator re-reporting/finalizing) emits **no** additional ChangeEvent.
- A genuinely new run (fresh run id) emits its own completion ChangeEvent.

- [x] Added `TestSuiteResourceIT#test_pipelineCompletion_isIdempotentOnDuplicateTerminalStatus` in `openmetadata-integration-tests/`.
- Asserts: a run reaching terminal state bumps the suite version once; re-posting `success` for the same run id does not bump it again. The suite version is 1:1 with the completion ChangeEvent, so it is the direct signal for "a completion fired".

#### Manual testing performed
1. Built a server with the change and created a basic test suite + test cases + results, a `TestSuite` ingestion pipeline, and an Observability alert on `testSuite` with a webhook destination.
2. `PUT` terminal `success` for run `R1`, then `PUT` `success` again for the **same** `R1`, then `PUT` `success` for a new run `R2`.
3. Observed webhook deliveries: `R1` ⇒ 1, redundant `R1` write ⇒ **still 1 (no duplicate)**, `R2` ⇒ 2. Suite version bumped only once per genuine run.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR emits test-suite completion events once per pipeline run. The main changes are:

- Gate completion on a non-terminal-to-terminal status transition.
- Ignore repeated terminal writes for the same run ID.
- Add integration coverage using suite version changes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Repeated terminal writes for the same run ID are suppressed.
- New run IDs can still trigger their own completion.
- No blocking issue remains in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java | Gates the completion cascade on a fresh terminal pipeline-status transition. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestSuiteResourceIT.java | Verifies that a repeated terminal status for one run ID does not bump the suite version again. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Assert version stability with Awaitility..."](https://github.com/open-metadata/openmetadata/commit/e96bdcb7678fe87d7259121ca9f145cd2b82dffb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44754922)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->