### PR TITLE
fix(observability): DQ UI feedback — pipeline gap, test-type truncation, profiler summary cards

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/field-doc-popover.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/field-doc-popover.tsx
@@ -24,6 +24,12 @@ export interface FieldDocPopoverProps {
    * this to their layout (e.g. to clear a modal's padding). Defaults to 16.
    */
   offset?: number;
+  /**
+   * Max height in px of the popover card; the doc body scrolls internally
+   * beyond it so a long hint never grows to the full page height. Defaults
+   * to 480.
+   */
+  maxHeight?: number;
 }
 
 const defaultRenderDoc = (doc: string): ReactNode => (
@@ -42,6 +48,7 @@ export const FieldDocPopover: FC<FieldDocPopoverProps> = ({
   renderDoc,
   header,
   offset = 16,
+  maxHeight = 480,
 }) => {
   const { entry, name } = useActiveFieldDoc();
   const anchorRef = useRef<HTMLElement | null>(null);
@@ -62,7 +69,12 @@ export const FieldDocPopover: FC<FieldDocPopoverProps> = ({
     <Popover
       isNonModal
       isOpen
-      className="tw:flex tw:max-h-[85vh] tw:w-75 tw:flex-col tw:overflow-hidden tw:rounded-xl tw:border tw:border-secondary tw:bg-primary tw:shadow-lg"
+      className="tw:flex tw:w-75 tw:flex-col tw:overflow-hidden tw:rounded-xl tw:border tw:border-secondary tw:bg-primary tw:shadow-lg"
+      // react-aria sets its own inline maxHeight from available space, which
+      // overrides any CSS max-h-* class; use the prop so the hint card stays a
+      // fixed, bounded height and scrolls internally instead of growing to the
+      // full page height.
+      maxHeight={maxHeight}
       offset={offset}
       placement="right top"
       triggerRef={anchorRef}>

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/form/hook-form.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/form/hook-form.tsx
@@ -20,6 +20,7 @@ interface FormProps<TFieldValues extends FieldValues = FieldValues>
   renderFieldDoc?: (doc: string) => ReactNode;
   fieldDocHeader?: ReactNode;
   fieldDocOffset?: number;
+  fieldDocMaxHeight?: number;
 }
 
 interface FormFieldProps<
@@ -71,6 +72,7 @@ export const HookForm = <TFieldValues extends FieldValues = FieldValues>({
   renderFieldDoc,
   fieldDocHeader,
   fieldDocOffset,
+  fieldDocMaxHeight,
   ...props
 }: FormProps<TFieldValues>) => {
   // Always keep the same tree shape (FormProvider > FieldDocProvider > AriaForm)
@@ -83,6 +85,7 @@ export const HookForm = <TFieldValues extends FieldValues = FieldValues>({
         {showFieldDocs ? (
           <FieldDocPopover
             header={fieldDocHeader}
+            maxHeight={fieldDocMaxHeight}
             offset={fieldDocOffset}
             renderDoc={renderFieldDoc}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/IncidentManagerPageHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/IncidentManagerPageHeader.component.tsx
@@ -172,6 +172,20 @@ const IncidentManagerPageHeader = ({
     );
   }, [testCaseStatusData, isLoading, taskLinkInfo, hasEditStatusPermission]);
 
+  const testDefinitionName = getEntityName(testCaseData?.testDefinition);
+  const testDefinitionDescription = testCaseData?.testDefinition?.description;
+
+  // The value is truncated to keep the header on one row, so reveal the full
+  // test type name (plus its description when present) on hover.
+  const testTypeTooltip = testDefinitionDescription ? (
+    <div className="tw:flex tw:flex-col tw:gap-1.5">
+      <div className="tw:font-medium">{testDefinitionName}</div>
+      <div>{testDefinitionDescription}</div>
+    </div>
+  ) : (
+    testDefinitionName
+  );
+
   return (
     <div className="incident-manager-header w-full">
       <DomainLabel
@@ -245,13 +259,15 @@ const IncidentManagerPageHeader = ({
       <HeaderDotSeparator />
       <HeaderField label={t('label.test-type')}>
         <Tooltip
-          isDisabled={!testCaseData?.testDefinition?.description}
+          isDisabled={!testDefinitionName}
           placement="bottom"
-          title={testCaseData?.testDefinition?.description}>
-          <TooltipTrigger className="tw:w-fit">
-            <HeaderFieldValue dataTestId="test-definition-name">
-              {getEntityName(testCaseData?.testDefinition)}
-            </HeaderFieldValue>
+          title={testTypeTooltip}>
+          <TooltipTrigger className="tw:w-fit tw:max-w-full">
+            <span
+              className="tw:block tw:max-w-[176px] tw:truncate tw:text-sm tw:font-medium tw:text-primary"
+              data-testid="test-definition-name">
+              {testDefinitionName}
+            </span>
           </TooltipTrigger>
         </Tooltip>
       </HeaderField>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/incident-manager.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/incident-manager.less
@@ -18,7 +18,7 @@
 .incident-manager-header {
   display: flex;
   align-items: flex-start;
-  gap: 18px;
+  gap: 12px;
   justify-content: flex-start;
   flex-wrap: wrap;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
@@ -479,7 +479,7 @@ const TestSuitePipelineTab = ({
                     data-row-key={record.fullyQualifiedName}
                     id={record.id}
                     key={record.id}>
-                    <Table.Cell className="tw:align-middle tw:w-72 tw:min-w-56">
+                    <Table.Cell className="tw:align-middle tw:w-full tw:min-w-56">
                       {renderNameField()(record.name, record)}
                     </Table.Cell>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/SummaryCard/SummaryCardV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/SummaryCard/SummaryCardV1.tsx
@@ -35,19 +35,19 @@ const SummaryCardV1 = ({
 
   return (
     <div>
-      <div className="tw:flex tw:w-full tw:min-w-52 tw:items-center tw:gap-4 tw:rounded-lg tw:border tw:border-secondary tw:px-5 tw:py-4 tw:shadow-xs">
+      <div className="tw:flex tw:w-full tw:min-w-52 tw:items-center tw:gap-3 tw:rounded-lg tw:border tw:border-secondary tw:px-2.5 tw:py-4 tw:shadow-xs">
         <Icon height={40} width={40} />
         <div>
-          <p className="tw:m-0 tw:text-lg tw:font-semibold tw:text-primary">
+          <p className="tw:m-0 tw:text-base tw:font-semibold tw:text-primary">
             {value}
           </p>
-          <p className="tw:m-0 tw:text-sm tw:font-medium tw:text-secondary">
+          <p className="tw:m-0 tw:text-xs tw:font-medium tw:text-secondary">
             {title}
           </p>
         </div>
       </div>
       {extra && (
-        <div className="tw:mx-4 tw:rounded-b-lg tw:bg-secondary tw:px-2 tw:py-2">
+        <div className="tw:mx-4 tw:rounded-b-lg tw:bg-secondary tw:px-2 tw:py-1">
           <p className="tw:m-0 tw:text-[10px] tw:font-medium tw:text-primary">
             {extra}
           </p>


### PR DESCRIPTION
## Summary

Addresses a batch of Data Observability / Data Quality UI feedback from the team.

### 1. Test case header — long test type name + one-row layout
The **Test Type** value could overflow when the definition name was long. Truncate it (max-width + ellipsis) with a hover tooltip that shows the **full name and its description**, and tighten the header field gap (18px → 12px) so the labelled fields (Domains / Owners / Incident Status / Assignee / Severity / Table / Test Type) fit on a **single row** at laptop widths.

### 2. Test suite pipeline table — right-side blank space
On wide screens the pipeline table (`table-layout: auto`, `width: 100%`) distributed leftover width across every column, leaving blank space to the right of the Actions column. Make the **Name** column flexible (`w-full`) so it absorbs the slack and the data/Actions columns stay snug. Applies to the AI experience too (same shared component).

### 3. Table Profile summary cards — laptop-width polish
Tighten the profiler summary cards: value `18→16px`, label `14→12px`, card padding `px-5→px-2.5`, `gap-4→gap-3`, and reduce the Created Date footer padding. Keeps the five cards aligned and stops the long "Profile Sample type" label from wrapping/misaligning (verified equal-height down to ~1180px).

### 4. Add Test Case — Form Hint popover height (core-components)
The field-doc "Form Hint" popover grew to nearly full page height on long hints (e.g. the SQL Expression doc), reading as a detached full-height card beside the modal. react-aria sets its own inline `max-height` from available space, which overrode the CSS `max-h-*` class — so cap it via the `Popover` **`maxHeight` prop** instead. The card now stays bounded and scrolls internally. Configurable via `HookForm`'s `fieldDocMaxHeight` (default **480px**).
> Note: touches the shared `openmetadata-ui-core-components` `FieldDocPopover` / `HookForm`, so it applies to every HookForm field-doc.

## Notes
- **Assignee icon alignment** (reported separately) was already resolved on current `main` by the `owner-avatar-stack` header refactor — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR polishes several Data Quality and observability interfaces. The main changes are:

- Makes the pipeline name column absorb unused table width.
- Truncates long test-type names and shows the full name in a tooltip.
- Tightens profiler summary card spacing and typography.
- Caps field-documentation popovers and keeps long content scrollable.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The popover height fix retains viewport-aware sizing and internal scrolling.
- Empty descriptions now fall back to the full test-type name.
- No blocking issue remains in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/field-doc-popover.tsx | Adds a configurable popover height cap while preserving internal scrolling. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/base/form/hook-form.tsx | Exposes and forwards the field-documentation height setting. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/IncidentManagerPageHeader.component.tsx | Truncates long test-type names and provides a full-name tooltip fallback. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/incident-manager.less | Reduces spacing between incident header fields. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx | Makes the pipeline name cell use the remaining table width. |
| openmetadata-ui/src/main/resources/ui/src/components/common/SummaryCard/SummaryCardV1.tsx | Reduces summary card spacing, typography, and footer padding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(core-components): bound the form-hin..."](https://github.com/open-metadata/openmetadata/commit/bc02b155913b6db3a956e55a4edfbb44133f440e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44816521)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->