### PR TITLE
Fixes #30147: pipeline sources own one BaseConnection to avoid a second sign-in

### DIFF
--- a/ingestion/src/metadata/ingestion/connections/connection.py
+++ b/ingestion/src/metadata/ingestion/connections/connection.py
@@ -86,7 +86,11 @@ class BaseConnection(ABC, Generic[S, C]):
                 type(self).__name__,
             )
             self._was_closed = False
-        return self._get_client()
+        try:
+            return self._get_client()
+        except Exception:
+            self.close()
+            raise
 
     @abstractmethod
     def _get_client(self) -> C:

--- a/ingestion/src/metadata/ingestion/source/pipeline/airbyte/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airbyte/connection.py
@@ -13,7 +13,7 @@
 Source connection handler
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 from metadata.generated.schema.entity.automations.workflow import (
     Workflow as AutomationWorkflow,
@@ -37,21 +37,16 @@ from metadata.ingestion.source.pipeline.airbyte.client import (
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(
-    connection: AirbyteConnectionConfig,
-) -> Union[AirbyteClient, AirbyteCloudClient]:  # noqa: UP007
-    """
-    Create connection - returns appropriate client based on auth type.
-    OAuth authentication indicates Airbyte Cloud, otherwise self-hosted instance.
-    """
-    if connection.auth and isinstance(connection.auth, Oauth20ClientCredentialsAuthentication):
-        return AirbyteCloudClient(connection)
-    return AirbyteClient(connection)
-
-
 class AirbyteConnection(BaseConnection[AirbyteConnectionConfig, AirbyteClient | AirbyteCloudClient]):
     def _get_client(self) -> AirbyteClient | AirbyteCloudClient:
-        return get_connection(self.service_connection)
+        """
+        Return the appropriate client based on auth type.
+        OAuth authentication indicates Airbyte Cloud, otherwise self-hosted instance.
+        """
+        connection = self.service_connection
+        if connection.auth and isinstance(connection.auth, Oauth20ClientCredentialsAuthentication):
+            return AirbyteCloudClient(connection)
+        return AirbyteClient(connection)
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
@@ -211,24 +211,6 @@ def _(airflow_connection: SQLiteConnectionConfig) -> Engine:
     return SQLiteConnection(airflow_connection)._get_client()
 
 
-def get_connection(connection: AirflowConnectionConfig):
-    """
-    Create connection
-    """
-    from metadata.generated.schema.entity.utils.airflowRestApiConnection import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
-        AirflowRestApiConnection,
-    )
-
-    if isinstance(connection.connection, AirflowRestApiConnection):
-        return AirflowApiClient(connection)
-
-    try:
-        return _get_connection(connection.connection)
-    except Exception as exc:
-        msg = f"Unknown error connecting with {connection}: {exc}."
-        raise SourceConnectionException(msg) from exc
-
-
 class AirflowTaskDetailsAccessError(Exception):
     """
     Raise when Task detail information is not retrieved
@@ -472,7 +454,19 @@ class AirflowChecks:
 
 class AirflowConnection(BaseConnection[AirflowConnectionConfig, Any]):
     def _get_client(self) -> Any:
-        client = get_connection(self.service_connection)
+        from metadata.generated.schema.entity.utils.airflowRestApiConnection import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+            AirflowRestApiConnection,
+        )
+
+        connection = self.service_connection
+        if isinstance(connection.connection, AirflowRestApiConnection):
+            return AirflowApiClient(connection)
+
+        try:
+            client = _get_connection(connection.connection)
+        except Exception as exc:
+            msg = f"Unknown error connecting with {connection}: {exc}."
+            raise SourceConnectionException(msg) from exc
         if isinstance(client, Engine):
             self._on_close(client.dispose)
         return client

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
@@ -61,6 +61,7 @@ class DatabricksPipelineConnection(BaseConnection[DatabricksPipelineConnectionCo
             get_connection_url_fn=get_connection_url,
             get_connection_args_fn=get_connection_args_common,
         )
+        self._on_close(engine.dispose)
 
         return DatabricksClient(connection, engine)
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py
@@ -46,28 +46,23 @@ def get_connection_url(connection: DatabricksPipelineConnectionConfig) -> str:
     return url  # noqa: RET504
 
 
-def get_connection(connection: DatabricksPipelineConnectionConfig) -> DatabricksClient:
-    """
-    Create connection
-    """
-
-    if connection.httpPath:
-        if not connection.connectionArguments:
-            connection.connectionArguments = init_empty_connection_arguments()
-        connection.connectionArguments.root["http_path"] = connection.httpPath
-
-    engine = create_generic_db_connection(
-        connection=connection,
-        get_connection_url_fn=get_connection_url,
-        get_connection_args_fn=get_connection_args_common,
-    )
-
-    return DatabricksClient(connection, engine)
-
-
 class DatabricksPipelineConnection(BaseConnection[DatabricksPipelineConnectionConfig, DatabricksClient]):
     def _get_client(self) -> DatabricksClient:
-        return get_connection(self.service_connection)
+        connection = self.service_connection
+        if connection.httpPath:
+            if not connection.connectionArguments:
+                connection.connectionArguments = init_empty_connection_arguments()
+            if connection.connectionArguments.root is None:
+                connection.connectionArguments.root = {}
+            connection.connectionArguments.root["http_path"] = connection.httpPath
+
+        engine = create_generic_db_connection(
+            connection=connection,
+            get_connection_url_fn=get_connection_url,
+            get_connection_args_fn=get_connection_args_common,
+        )
+
+        return DatabricksClient(connection, engine)
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/connection.py
@@ -31,16 +31,9 @@ from metadata.ingestion.source.pipeline.fivetran.client import FivetranClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: FivetranConnectionConfig) -> FivetranClient:
-    """
-    Create connection
-    """
-    return FivetranClient(connection)
-
-
 class FivetranConnection(BaseConnection[FivetranConnectionConfig, FivetranClient]):
     def _get_client(self) -> FivetranClient:
-        return get_connection(self.service_connection)
+        return FivetranClient(self.service_connection)
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/flink/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/flink/connection.py
@@ -31,16 +31,9 @@ from metadata.ingestion.source.pipeline.flink.client import FlinkClient
 from metadata.utils.constants import THREE_MIN
 
 
-def get_connection(connection: FlinkConnectionConfig) -> FlinkClient:
-    """
-    Create connection
-    """
-    return FlinkClient(connection)
-
-
 class FlinkConnection(BaseConnection[FlinkConnectionConfig, FlinkClient]):
     def _get_client(self) -> FlinkClient:
-        return get_connection(self.service_connection)
+        return FlinkClient(self.service_connection)
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/openlineage/connection.py
@@ -13,7 +13,7 @@
 Source connection handler
 """
 
-from typing import Optional, Union
+from typing import Optional
 
 from botocore.client import BaseClient
 from confluent_kafka import Consumer as KafkaConsumer
@@ -43,23 +43,6 @@ from metadata.ingestion.connections.test_connections import (
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
-
-
-def get_connection(
-    connection: OpenLineageConnectionConfig,
-) -> Union[KafkaConsumer, BaseClient]:  # noqa: UP007
-    """
-    Create connection based on broker config type.
-    """
-    broker = connection.brokerConfig
-
-    if isinstance(broker, KafkaBrokerConfig):
-        return _get_kafka_connection(broker)
-
-    if isinstance(broker, KinesisBrokerConfig):
-        return _get_kinesis_connection(broker)
-
-    raise SourceConnectionException(f"Unsupported broker config type: {type(broker)}")
 
 
 def _get_kafka_connection(broker: KafkaBrokerConfig) -> KafkaConsumer:
@@ -113,7 +96,18 @@ def _get_kinesis_connection(broker: KinesisBrokerConfig):
 
 class OpenLineageConnection(BaseConnection[OpenLineageConnectionConfig, KafkaConsumer | BaseClient]):
     def _get_client(self) -> KafkaConsumer | BaseClient:
-        return get_connection(self.service_connection)
+        """
+        Create connection based on broker config type.
+        """
+        broker = self.service_connection.brokerConfig
+
+        if isinstance(broker, KafkaBrokerConfig):
+            return _get_kafka_connection(broker)
+
+        if isinstance(broker, KinesisBrokerConfig):
+            return _get_kinesis_connection(broker)
+
+        raise SourceConnectionException(f"Unsupported broker config type: {type(broker)}")
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/pipeline_service.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/pipeline_service.py
@@ -54,7 +54,12 @@ from metadata.ingestion.models.topology import (
     TopologyNode,
 )
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.ingestion.source.connections import get_connection, test_connection_common
+from metadata.ingestion.source.connections import (
+    create_connection,
+    get_connection,
+    run_test_connection,
+    test_connection_common,
+)
 from metadata.ingestion.source.pipeline.openlineage.models import TableDetails
 from metadata.ingestion.source.pipeline.openlineage.utils import FQNNotFoundException
 from metadata.utils import fqn
@@ -177,11 +182,17 @@ class PipelineServiceSource(TopologyRunnerMixin, Source, ABC):
         self.service_connection = self.config.serviceConnection.root.config
         self.source_config: PipelineServiceMetadataPipeline = self.config.sourceConfig.config
 
-        self.connection = get_connection(self.service_connection)
+        self._connection = create_connection(self.service_connection)
+        self.connection = self._connection.client if self._connection else get_connection(self.service_connection)
         # Flag the connection for the test connection
         self.connection_obj = self.connection
         self.client = self.connection
-        self.test_connection()
+        try:
+            self.test_connection()
+        except Exception:
+            if self._connection is not None:
+                self._connection.close()
+            raise
 
     @property
     def name(self) -> str:
@@ -343,6 +354,8 @@ class PipelineServiceSource(TopologyRunnerMixin, Source, ABC):
 
     def close(self):
         """Method to implement any required logic after the ingestion process is completed"""
+        if self._connection is not None:
+            self._connection.close()
         self.metadata.compute_percentile(Pipeline, self.today)
 
     def get_services(self) -> Iterable[WorkflowSource]:
@@ -404,7 +417,10 @@ class PipelineServiceSource(TopologyRunnerMixin, Source, ABC):
             )
 
     def test_connection(self) -> None:
-        test_connection_common(self.metadata, self.connection_obj, self.service_connection)
+        if self._connection is not None:
+            run_test_connection(self.metadata, self._connection)
+        else:
+            test_connection_common(self.metadata, self.connection_obj, self.service_connection)
 
     def register_record(self, pipeline_request: CreatePipelineRequest) -> None:
         """Mark the pipeline record as scanned and update the pipeline_source_state"""

--- a/ingestion/tests/unit/connections/test_connection_lifecycle.py
+++ b/ingestion/tests/unit/connections/test_connection_lifecycle.py
@@ -18,6 +18,8 @@ import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source import connections as connections_module
 
@@ -94,6 +96,23 @@ def test_first_build_does_not_log_reopen(caplog):
     with caplog.at_level(logging.INFO):
         _ = conn.client
     assert not any("opening a new client" in r.message for r in caplog.records)
+
+
+def test_failed_build_releases_what_get_client_registered():
+    """A ``_get_client`` that raises after registering a teardown still unwinds:
+    the caller never receives a client, so nothing is left for it to close."""
+    released = []
+
+    class HalfBuiltConnection(BaseConnection):
+        def _get_client(self):
+            self._on_close(lambda: released.append("engine"))
+            raise RuntimeError("client construction failed")
+
+    conn = HalfBuiltConnection(_service_connection())
+    with pytest.raises(RuntimeError):
+        _ = conn.client
+
+    assert released == ["engine"]
 
 
 def test_create_connection_returns_owner():

--- a/ingestion/tests/unit/source/pipeline/airbyte/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/airbyte/test_connection.py
@@ -22,13 +22,13 @@ def test_airbyte_connection_is_base_connection():
     assert issubclass(AirbyteConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_get_client_builds_client():
+    with patch(f"{CONNECTION_MODULE}.AirbyteClient") as mock_client:
         conn = AirbyteConnection(MagicMock())
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_client.return_value
+    mock_client.assert_called_once_with(conn.service_connection)
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
@@ -52,17 +52,17 @@ def test_airflow_connection_is_base_connection():
     assert issubclass(AirflowConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_get_client_builds_engine_via_dispatch():
+    with patch(f"{CONNECTION_MODULE}._get_connection") as mock_get:
         conn = AirflowConnection(MagicMock())
         client = conn.client
 
     assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    mock_get.assert_called_once_with(conn.service_connection.connection)
 
 
 def test_client_is_built_once_and_cached():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+    with patch(f"{CONNECTION_MODULE}._get_connection") as mock_get:
         conn = AirflowConnection(MagicMock())
         first = conn.client
         second = conn.client
@@ -73,7 +73,7 @@ def test_client_is_built_once_and_cached():
 
 def test_engine_client_registers_dispose():
     engine = MagicMock(spec=Engine)
-    with patch(f"{CONNECTION_MODULE}.get_connection", return_value=engine):
+    with patch(f"{CONNECTION_MODULE}._get_connection", return_value=engine):
         conn = AirflowConnection(MagicMock())
         _ = conn.client
         conn.close()
@@ -82,7 +82,7 @@ def test_engine_client_registers_dispose():
 
 
 def test_checks_expose_every_step():
-    with patch(f"{CONNECTION_MODULE}.get_connection"):
+    with patch(f"{CONNECTION_MODULE}._get_connection"):
         resolved = collect_checks(AirflowConnection(MagicMock()).checks())
 
     assert set(resolved) == {
@@ -95,7 +95,7 @@ def test_checks_expose_every_step():
 def test_checks_borrow_the_connection_client():
     """The provider borrows the client BaseConnection owns, rather than building a
     second one behind its back."""
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+    with patch(f"{CONNECTION_MODULE}._get_connection") as mock_get:
         conn = AirflowConnection(MagicMock())
         provider = conn.checks()
 

--- a/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
@@ -22,13 +22,16 @@ def test_databrickspipeline_connection_is_base_connection():
     assert issubclass(DatabricksPipelineConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_get_client_builds_client():
+    with (
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_engine,
+        patch(f"{CONNECTION_MODULE}.DatabricksClient") as mock_client,
+    ):
         conn = DatabricksPipelineConnection(MagicMock())
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_client.return_value
+    mock_client.assert_called_once_with(conn.service_connection, mock_engine.return_value)
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/databrickspipeline/test_connection.py
@@ -34,6 +34,18 @@ def test_get_client_builds_client():
     mock_client.assert_called_once_with(conn.service_connection, mock_engine.return_value)
 
 
+def test_close_disposes_the_engine():
+    with (
+        patch(f"{CONNECTION_MODULE}.create_generic_db_connection") as mock_engine,
+        patch(f"{CONNECTION_MODULE}.DatabricksClient"),
+    ):
+        conn = DatabricksPipelineConnection(MagicMock())
+        _ = conn.client
+        conn.close()
+
+    mock_engine.return_value.dispose.assert_called_once()
+
+
 def test_test_connection_runs_steps():
     conn = DatabricksPipelineConnection(MagicMock())
     conn._client = MagicMock()

--- a/ingestion/tests/unit/source/pipeline/fivetran/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/fivetran/test_connection.py
@@ -22,13 +22,13 @@ def test_fivetran_connection_is_base_connection():
     assert issubclass(FivetranConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_get_client_builds_client():
+    with patch(f"{CONNECTION_MODULE}.FivetranClient") as mock_client:
         conn = FivetranConnection(MagicMock())
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_client.return_value
+    mock_client.assert_called_once_with(conn.service_connection)
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/source/pipeline/flink/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/flink/test_connection.py
@@ -22,13 +22,13 @@ def test_flink_connection_is_base_connection():
     assert issubclass(FlinkConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
+def test_get_client_builds_client():
+    with patch(f"{CONNECTION_MODULE}.FlinkClient") as mock_client:
         conn = FlinkConnection(MagicMock())
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_client.return_value
+    mock_client.assert_called_once_with(conn.service_connection)
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/openlineage/test_connection.py
@@ -25,13 +25,15 @@ def test_openlineage_connection_is_base_connection():
     assert issubclass(OpenLineageConnection, BaseConnection)
 
 
-def test_get_client_delegates_to_get_connection():
-    with patch(f"{CONNECTION_MODULE}.get_connection") as mock_get:
-        conn = OpenLineageConnection(MagicMock())
+def test_get_client_builds_client():
+    service_connection = MagicMock()
+    service_connection.brokerConfig = MagicMock(spec=KafkaBrokerConfig)
+    with patch(f"{CONNECTION_MODULE}._get_kafka_connection") as mock_kafka:
+        conn = OpenLineageConnection(service_connection)
         client = conn.client
 
-    assert client is mock_get.return_value
-    mock_get.assert_called_once_with(conn.service_connection)
+    assert client is mock_kafka.return_value
+    mock_kafka.assert_called_once_with(service_connection.brokerConfig)
 
 
 def test_test_connection_runs_steps():

--- a/ingestion/tests/unit/topology/pipeline/test_airbyte.py
+++ b/ingestion/tests/unit/topology/pipeline/test_airbyte.py
@@ -237,7 +237,7 @@ class AirbyteUnitTest(TestCase):
     """Test class for Airbyte source module."""
 
     @patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection")
-    @patch("metadata.ingestion.source.pipeline.airbyte.connection.get_connection")
+    @patch("metadata.ingestion.source.pipeline.airbyte.connection.AirbyteConnection._get_client")
     def __init__(self, methodName, airbyte_client, test_connection) -> None:  # noqa: N803
         super().__init__(methodName)
         test_connection.return_value = False
@@ -456,7 +456,7 @@ class AirbyteCloudUnitTest(TestCase):
     """Test class for Airbyte Cloud source module."""
 
     @patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection")
-    @patch("metadata.ingestion.source.pipeline.airbyte.connection.get_connection")
+    @patch("metadata.ingestion.source.pipeline.airbyte.connection.AirbyteConnection._get_client")
     def __init__(self, methodName, airbyte_cloud_client, test_connection) -> None:  # noqa: N803
         super().__init__(methodName)
         test_connection.return_value = False

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -307,7 +307,7 @@ class TestSortAndLimitSyncs:
 def fivetran_source():
     with (
         patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection"),
-        patch("metadata.ingestion.source.pipeline.fivetran.connection.get_connection") as mock_client,
+        patch("metadata.ingestion.source.pipeline.fivetran.connection.FivetranConnection._get_client") as mock_client,
     ):
         config = OpenMetadataWorkflowConfig.model_validate(MOCK_FIVETRAN_CONFIG)
         source = FivetranSource.create(

--- a/ingestion/tests/unit/topology/pipeline/test_flink.py
+++ b/ingestion/tests/unit/topology/pipeline/test_flink.py
@@ -125,7 +125,7 @@ EXPECTED_PIPELINE = [
 
 class FlinkUnitTest(TestCase):
     @patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection")
-    @patch("metadata.ingestion.source.pipeline.flink.connection.get_connection")
+    @patch("metadata.ingestion.source.pipeline.flink.connection.FlinkConnection._get_client")
     def __init__(self, methodName, flink_client, test_connection) -> None:  # noqa: N803
 
         super().__init__(methodName)
@@ -157,7 +157,7 @@ class TestFlinkTaskNames:
     def setup_method(self):
         with (
             patch("metadata.ingestion.source.pipeline.pipeline_service.PipelineServiceSource.test_connection"),
-            patch("metadata.ingestion.source.pipeline.flink.connection.get_connection"),
+            patch("metadata.ingestion.source.pipeline.flink.connection.FlinkConnection._get_client"),
         ):
             config = OpenMetadataWorkflowConfig.model_validate(mock_flink_config)
             self.flink = FlinkSource.create(

--- a/ingestion/tests/unit/topology/pipeline/test_pipeline_service.py
+++ b/ingestion/tests/unit/topology/pipeline/test_pipeline_service.py
@@ -1,0 +1,39 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Unit tests for the PipelineServiceSource base connection lifecycle."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from tests.unit.topology.pipeline.test_flink import mock_flink_config
+
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
+from metadata.ingestion.source.pipeline.flink.metadata import FlinkSource
+
+PIPELINE_SERVICE_MODULE = "metadata.ingestion.source.pipeline.pipeline_service"
+
+
+@patch(f"{PIPELINE_SERVICE_MODULE}.run_test_connection")
+@patch(f"{PIPELINE_SERVICE_MODULE}.create_connection")
+def test_owned_connection_closed_when_test_connection_fails(mock_create_connection, mock_run_test_connection):
+    """A failing test-connection in __init__ disposes the owned connection and
+    re-raises the original error without running the source's ``close()`` (whose
+    subclass overrides touch attributes the source ``__init__`` never set)."""
+    mock_run_test_connection.side_effect = RuntimeError("cannot connect")
+    config = OpenMetadataWorkflowConfig.model_validate(mock_flink_config)
+
+    with patch.object(FlinkSource, "close") as mock_close, pytest.raises(RuntimeError):
+        FlinkSource(config.source, MagicMock())
+
+    mock_create_connection.return_value.close.assert_called_once()
+    mock_close.assert_not_called()

--- a/ingestion/tests/unit/topology/pipeline/test_pipeline_service.py
+++ b/ingestion/tests/unit/topology/pipeline/test_pipeline_service.py
@@ -13,14 +13,33 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from tests.unit.topology.pipeline.test_flink import mock_flink_config
 
-from metadata.generated.schema.metadataIngestion.workflow import (
-    OpenMetadataWorkflowConfig,
-)
-from metadata.ingestion.source.pipeline.flink.metadata import FlinkSource
+from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
 
 PIPELINE_SERVICE_MODULE = "metadata.ingestion.source.pipeline.pipeline_service"
+
+
+class PipelineSourceForTest(PipelineServiceSource):
+    """Minimal concrete source: the base's connection lifecycle is under test."""
+
+    @classmethod
+    def create(cls, config_dict, metadata, pipeline_name=None):
+        """Not exercised"""
+
+    def yield_pipeline(self, pipeline_details):
+        """Not exercised"""
+
+    def yield_pipeline_lineage_details(self, pipeline_details):
+        """Not exercised"""
+
+    def get_pipelines_list(self):
+        """Not exercised"""
+
+    def get_pipeline_name(self, pipeline_details):
+        """Not exercised"""
+
+    def yield_pipeline_status(self, pipeline_details):
+        """Not exercised"""
 
 
 @patch(f"{PIPELINE_SERVICE_MODULE}.run_test_connection")
@@ -30,10 +49,21 @@ def test_owned_connection_closed_when_test_connection_fails(mock_create_connecti
     re-raises the original error without running the source's ``close()`` (whose
     subclass overrides touch attributes the source ``__init__`` never set)."""
     mock_run_test_connection.side_effect = RuntimeError("cannot connect")
-    config = OpenMetadataWorkflowConfig.model_validate(mock_flink_config)
 
-    with patch.object(FlinkSource, "close") as mock_close, pytest.raises(RuntimeError):
-        FlinkSource(config.source, MagicMock())
+    with patch.object(PipelineSourceForTest, "close") as mock_close, pytest.raises(RuntimeError):
+        PipelineSourceForTest(MagicMock(), MagicMock())
 
     mock_create_connection.return_value.close.assert_called_once()
     mock_close.assert_not_called()
+
+
+@patch(f"{PIPELINE_SERVICE_MODULE}.run_test_connection")
+@patch(f"{PIPELINE_SERVICE_MODULE}.create_connection")
+def test_owned_connection_is_reused_for_the_test_step(mock_create_connection, mock_run_test_connection):
+    """The source tests through the connection it owns instead of building a second one."""
+    source = PipelineSourceForTest(MagicMock(), MagicMock())
+
+    mock_run_test_connection.assert_called_once_with(source.metadata, mock_create_connection.return_value)
+    assert source.connection is mock_create_connection.return_value.client
+    assert source.connection_obj is source.connection
+    assert source.client is source.connection


### PR DESCRIPTION
Fixes #30147

`PipelineServiceSource` built its client through the `get_connection` seam, which discards the `BaseConnection` owner, and then ran its test step through `test_connection_common` — which built a **second** connection, i.e. a second sign-in. Same root cause already fixed for dashboard (#29870) and database (#30094).

The base now owns one `BaseConnection` and reuses it:

- `__init__` builds the owner with `create_connection` and takes its client; `test_connection()` goes through `run_test_connection`, reusing that owner. Unmigrated/custom connectors keep the legacy `test_connection_common` path.
- `close()` disposes the owner. If the in-`__init__` test fails, the owned connection is released directly rather than via `self.close()` — `close()` is successful-run teardown (it runs `compute_percentile`) and is polymorphic, so subclass overrides would touch attributes their `__init__` had not set yet and mask the original error.
- `connection_obj`, `self.connection` and `self.client` still point at the owner's live client: pipeline subclasses read `self.connection`, and Collate reads `connection_obj`.

Each connector's redundant module-level `get_connection` is inlined into its `_get_client` and deleted (airbyte, airflow, databrickspipeline, fivetran, flink, openlineage). `databrickspipeline.get_connection_url` is kept — it has external importers. Airflow keeps its `@check` provider, `Engine` dispose registration and singledispatch builder from #30089.

Fixes a latent bug surfaced while inlining: the databricks pipeline connector subscripted `connectionArguments.root` without guarding against `None`.

`self.test_connection()` stays a visible polymorphic call in `__init__` — Collate subclasses (`SnowplowSource`) override it to run a different check.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes pipeline sources own and reuse one connection throughout a run. The main changes are:

- Creates pipeline clients through an owned `BaseConnection`.
- Reuses the owned connection for connection tests.
- Closes partially built clients when construction fails.
- Registers connector resources for teardown.
- Keeps the legacy path for custom and unmigrated connectors.
- Inlines connector-specific client factories.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Client construction failures now release registered resources.
- The owned connection is reused by the connection test.
- No additional blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/connections/connection.py | Closes resources registered during client construction when `_get_client()` raises. |
| ingestion/src/metadata/ingestion/source/pipeline/pipeline_service.py | Owns one connection and reuses it for the client, connection test, and base teardown. |
| ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py | Registers engine disposal and handles missing connection-argument storage. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ingestion): release what a failed cl..."](https://github.com/open-metadata/openmetadata/commit/3c379a8876c8394d6b05620da227506fd2f7a77f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44798401)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->