### PR TITLE
fix(ci): bound integration-test peak disk and rebalance shards

### DIFF
--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -86,6 +86,7 @@ jobs:
               tests/integration/mysql
               tests/integration/profiler
               tests/integration/data_quality
+              tests/integration/sql_server
           - name: "shard-2"
             nox-args: >-
               --ignore=tests/integration/ometa
@@ -93,6 +94,7 @@ jobs:
               --ignore=tests/integration/mysql
               --ignore=tests/integration/profiler
               --ignore=tests/integration/data_quality
+              --ignore=tests/integration/sql_server
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -64,6 +64,7 @@ jobs:
               tests/integration/mysql
               tests/integration/profiler
               tests/integration/data_quality
+              tests/integration/sql_server
           - name: "shard-2"
             nox-args: >-
               --ignore=tests/integration/ometa
@@ -71,6 +72,7 @@ jobs:
               --ignore=tests/integration/mysql
               --ignore=tests/integration/profiler
               --ignore=tests/integration/data_quality
+              --ignore=tests/integration/sql_server
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -143,6 +143,7 @@ jobs:
               tests/integration/mysql
               tests/integration/profiler
               tests/integration/data_quality
+              tests/integration/sql_server
           - name: "shard-2"
             nox-args: >-
               --ignore=tests/integration/ometa
@@ -150,6 +151,7 @@ jobs:
               --ignore=tests/integration/mysql
               --ignore=tests/integration/profiler
               --ignore=tests/integration/data_quality
+              --ignore=tests/integration/sql_server
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/ingestion/tests/integration/conftest.py
+++ b/ingestion/tests/integration/conftest.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import shutil
 import time
 from typing import List, Tuple, Type  # noqa: UP035
 
@@ -22,6 +24,51 @@ from metadata.workflow.ingestion import IngestionWorkflow
 def configure_logging():
     logging.getLogger("sqlfluff").setLevel(logging.CRITICAL)
     logging.getLogger("pytds").setLevel(logging.CRITICAL)
+
+
+_last_package: dict = {"name": None}
+
+
+def _package_of(item) -> str | None:
+    """Top-level package under tests/integration, e.g. 'tests/integration/trino'."""
+    parts = item.nodeid.split("/")
+    return "/".join(parts[:3]) if len(parts) > 3 else None
+
+
+def _prune_docker_images() -> None:
+    import docker
+    from docker.errors import DockerException
+
+    try:
+        reclaimed = docker.from_env().images.prune(filters={"dangling": False}).get("SpaceReclaimed", 0)
+    except DockerException:
+        logging.exception("Failed to prune docker images")
+        return
+    logging.info(
+        "Pruned docker images: reclaimed %.1f GiB, %.1f GiB now free",
+        reclaimed / 2**30,
+        shutil.disk_usage("/").free / 2**30,
+    )
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_setup(item):
+    """Reclaim the previous package's images before the next one pulls its own.
+
+    Testcontainers stops containers at fixture teardown but never removes images, so a
+    shard's peak disk grows with the number of packages it runs rather than its heaviest
+    one. Runners in the ubuntu-latest pool ship either a 72G or a 145G root disk, and the
+    unpruned total only fits the latter. Pruning here keeps peak at one package's images.
+
+    CI only: this removes every image not held by a running container, which on a
+    developer machine would wipe their local cache.
+    """
+    if not os.environ.get("CI"):
+        return
+    package = _package_of(item)
+    if _last_package["name"] not in (None, package):
+        _prune_docker_images()
+    _last_package["name"] = package
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Key finding

The `Integration Tests (shard-2)` failures are not flaky tests — they are disk exhaustion, and they are deterministic per runner SKU.

Every failure is a fixture `ERROR`, never a failed assertion:

```
docker.errors.BuildError: failed to register layer:
write /opt/mssql/lib/system.netfx.sfp: no space left on device
```

`ubuntu-latest` is a heterogeneous pool. Correlation across every shard-2 job in [run 29507587291](https://github.com/open-metadata/OpenMetadata/actions/runs/29507587291) (both attempts, no exceptions):

| Job | Root disk | Free after `free-disk-space` | Result |
|---|---|---|---|
| shard-2, 3.10 | 145G | 89G | 280 passed |
| shard-2, 3.11 | 145G | 88G | 280 passed |
| shard-2, 3.12 | 72G | **38G** | 218 passed, **65 errors** |

Both attempts of the 3.12 job are byte-identical (same 218/65, same 96 `no space` hits), and the errors land only in `sql_server`, `superset`, `trino` — the last container-heavy packages to run. Peak disk grows monotonically and only fits the 145G SKU. Re-running just re-rolls the runner, which is what makes it look flaky.

## What

- Prune unused Docker images at each test-package boundary, so peak disk is one package's images rather than the whole shard's.
- Move `sql_server` from shard-2 to shard-1.

## How

Testcontainers stops containers at fixture teardown but never removes images, so a shard's peak footprint is the *sum* of every image it touches. Pruning on package transition makes it the *max* instead — `O(1)` in the number of packages, so the runner SKU stops mattering.

This uses a `pytest_runtest_setup` transition hook rather than a package-scoped fixture: under `pytest==7.0.1`, a package-scoped fixture defined in a parent conftest is cached at the parent and fires **once for the whole tree**, reclaiming nothing during the run. `tryfirst=True` orders the prune after the previous package's containers stop and before the next package pulls its images.

The prune is gated on `CI` — it removes every image not held by a running container, which on a developer machine would wipe their local cache.

The shard move rebalances the suite from 27.4/50.0 min to 40.5/36.9 min, taking the critical path from ~70 to ~61 min. The same shard split exists in `py-tests.yml`, `py-tests-postgres.yml` and `py-sonarcloud-nightly.yml`, so all three are updated.

## Note on verification

Runner SKU can't be pinned, so a green run doesn't by itself prove the fix — it may just be a 145G draw. The hook logs `Pruned docker images: reclaimed X GiB, Y GiB now free` at each boundary; **Y staying flat across packages** (rather than descending toward zero) is the real signal that peak is bounded.

## Follow-ups (not in this PR)

- `tests/integration/sql_server/conftest.py` builds with `tag=self.image`, retagging the mssql base onto the derived image; `tests/integration/trino/conftest.py` has the correct pattern. Hygiene only — negligible space impact.
- The shard-1 list ↔ shard-2 ignore-list invariant is hand-maintained. A desync silently runs tests twice, or zero times.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR bounds integration-test disk use and rebalances the test shards. The main changes are:

- Prune unused Docker images between top-level integration-test packages in CI.
- Move SQL Server integration tests from shard 2 to shard 1.
- Apply the shard change consistently across all three integration workflows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Package transitions are detected correctly for the current integration-test layout.
- Pytest completes the previous item's teardown before starting the next item, allowing stopped-container images to be pruned.
- SQL Server tests remain covered exactly once in each workflow.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/tests/integration/conftest.py | Adds CI-only Docker image pruning when pytest moves between top-level integration packages. |
| .github/workflows/py-tests.yml | Moves SQL Server tests to shard 1 while excluding them from shard 2. |
| .github/workflows/py-tests-postgres.yml | Applies the same SQL Server shard reassignment to the PostgreSQL workflow. |
| .github/workflows/py-sonarcloud-nightly.yml | Applies the same SQL Server shard reassignment to the nightly SonarCloud workflow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): bound integration-test peak dis..."](https://github.com/open-metadata/openmetadata/commit/48ff0ae70de96d082036c0c7e1ac229dda6acde4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44872080)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->