### PR TITLE
fix(ingestion): bind the test-connection diagnoses to errors drivers really raise

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/client.py
+++ b/ingestion/src/metadata/ingestion/ometa/client.py
@@ -347,6 +347,10 @@ class REST:
         except Exception as exc:
             logger.debug(traceback.format_exc())
             logger.warning(f"Unexpected error calling [{url}] with method [{method}]: {exc}")
+            # A raw caller asked for the response; swallowing to None would strand it
+            # with an AttributeError. Re-raise so the real cause reaches the caller.
+            if raw:
+                raise
 
         return None
 
@@ -370,16 +374,19 @@ class REST:
         data: Any = None,
         headers: Optional[dict] = None,  # noqa: UP045
         retry_wait: Optional[int] = None,  # noqa: UP045
+        retries: Optional[int] = None,  # noqa: UP045
     ) -> requests.Response:
         """GET returning the raw ``Response`` so the caller can read its status.
 
         ``get`` drops the status and returns ``None`` for an error body it cannot
         classify; a caller that needs the status uses this instead. Same pipeline as
-        ``get`` (auth, retries); ``retry_wait`` overrides the between-retry sleep.
+        ``get`` (auth, retries); ``retries`` and ``retry_wait`` override the client's
+        retry count and between-retry sleep - the sleep grows per attempt, so a
+        caller on a budget must bound both.
         """
         return cast(
             "requests.Response",
-            self._request("GET", path, data, headers=headers, retry_wait=retry_wait, raw=True),
+            self._request("GET", path, data, headers=headers, retry_wait=retry_wait, retries=retries, raw=True),
         )
 
     def post(

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -160,10 +160,8 @@ LOOKER_ERRORS = ErrorPack(
         fix=f"This connector uses API {SDK_API_VERSION}, which the instance does not list as supported.",
         doc=API_SDK_DOC,
     ),
-    # Matched on text, not type: the transport flattens every IOError into an
-    # SDKError message (see the note on NETWORK_ERRORS below), so these are the only
-    # rules that can diagnose reachability here. Guarded so a structured Looker error
-    # is not read as a transport failure.
+    # Matched on text, not type: the SDK transport flattens every IOError to a
+    # string (see NETWORK_ERRORS below), so type-based matching cannot work here.
     when(
         _transport_text("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
@@ -201,10 +199,9 @@ LOOKER_ERRORS = ErrorPack(
         fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
     ),
 )
-# NETWORK_ERRORS is deliberately not folded in: it matches by exception type, and
-# looker_sdk/rtl/requests_transport.py RequestsTransport.request catches IOError
-# (which every socket error and requests exception is) and returns its str() as a
-# response body, so no type survives. _transport_text above reads those strings.
+# NETWORK_ERRORS not folded in: it matches by type, but the SDK transport
+# (requests_transport.py) catches every IOError and returns its str() as a body,
+# so no exception type survives - _transport_text reads those strings instead.
 
 
 class LookerChecks:

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -39,7 +39,6 @@ from metadata.core.connections.test_connection.checks.rest import (
     verify_access,
 )
 from metadata.core.connections.test_connection.classifier import chain_text, exception_chain
-from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.dashboard.lookerConnection import (
     LookerConnection as LookerConnectionConfig,
 )
@@ -161,9 +160,10 @@ LOOKER_ERRORS = ErrorPack(
         fix=f"This connector uses API {SDK_API_VERSION}, which the instance does not list as supported.",
         doc=API_SDK_DOC,
     ),
-    # Matched on text: the transport flattens these into an SDKError message. Guarded
-    # so a structured Looker error is not read as a transport failure; the type-based
-    # NETWORK_ERRORS below only fires outside the transport.
+    # Matched on text, not type: the transport flattens every IOError into an
+    # SDKError message (see the note on NETWORK_ERRORS below), so these are the only
+    # rules that can diagnose reachability here. Guarded so a structured Looker error
+    # is not read as a transport failure.
     when(
         _transport_text("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
@@ -200,7 +200,11 @@ LOOKER_ERRORS = ErrorPack(
         "The host is not serving the Looker API",
         fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
     ),
-).including(NETWORK_ERRORS)
+)
+# NETWORK_ERRORS is deliberately not folded in: it matches by exception type, and
+# looker_sdk/rtl/requests_transport.py RequestsTransport.request catches IOError
+# (which every socket error and requests exception is) and returns its str() as a
+# response body, so no type survives. _transport_text above reads those strings.
 
 
 class LookerChecks:

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
@@ -17,7 +17,7 @@ import math
 import traceback
 from copy import deepcopy
 from time import sleep
-from typing import List, Optional, Tuple  # noqa: UP035
+from typing import Any, List, Optional, Tuple  # noqa: UP035
 
 import msal
 from pydantic import BaseModel, ConfigDict
@@ -28,7 +28,7 @@ from metadata.generated.schema.entity.services.connections.dashboard.powerBIConn
 from metadata.generated.schema.type.filterPattern import FilterPattern
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.connections.source_api_client import TrackedREST
-from metadata.ingestion.ometa.client import ClientConfig
+from metadata.ingestion.ometa.client import ClientConfig, LimitsException
 from metadata.ingestion.source.dashboard.powerbi.file_client import PowerBiFileClient
 from metadata.ingestion.source.dashboard.powerbi.models import (
     DashboardsResponse,
@@ -61,6 +61,26 @@ GETGROUPS_DEFAULT_PARAMS = {"$top": "1", "$skip": "0"}
 API_RESPONSE_MESSAGE_KEY = "message"
 AUTH_TOKEN_MAX_RETRIES = 5
 AUTH_TOKEN_RETRY_WAIT = 120
+
+# Bounds the error body kept in the step's error log.
+ERROR_DETAIL_LIMIT = 200
+
+# Retry budget for the test calls, summing to 6s. Both must be capped: the client is
+# retry=100/retry_wait=30 for ingestion throughput and the sleep grows per attempt,
+# so a rate-limited call sleeps ~42h - and ~2.8h if only the wait is capped.
+TEST_MAX_RETRIES = 2
+TEST_RETRY_WAIT_SECONDS = 2
+
+HTTP_TOO_MANY_REQUESTS = 429
+
+
+class PowerBiApiError(Exception):
+    """A Power BI REST API call answered with a non-success HTTP status."""
+
+    def __init__(self, status_code: int, path: str, detail: str) -> None:
+        super().__init__(f"Power BI API returned HTTP {status_code} for {path}: {detail}")
+        self.status_code = status_code
+        self.path = path
 
 
 # Similar inner methods with mode client. That's fine.
@@ -172,6 +192,60 @@ class PowerBiApiClient:
             return response.value
         group = self.fetch_all_workspaces()[0]
         return self.fetch_all_org_dashboards(group_id=group.id)
+
+    def _test_get(self, path: str, params: Optional[dict] = None) -> Any:  # noqa: UP045
+        """Authenticated GET that raises PowerBiApiError on a non-success status.
+
+        Test-connection's accessor. ``get`` decides a body is an error by looking for
+        a TOP-LEVEL ``code``, but Power BI nests it under ``error``, so ``get``
+        neither raises nor returns a body - it returns None and the caller does
+        ``Response(**None)``. ``get_raw`` keeps the status.
+
+        An exhausted 429 surfaces as ``LimitsException``, which is raised with no
+        message - ``str()`` is empty, so the step's errorLog would be blank. Re-raised
+        as a 429 to carry the status and a readable message.
+        """
+        try:
+            response = self.client.get_raw(
+                path,
+                data=params,
+                retry_wait=TEST_RETRY_WAIT_SECONDS,
+                retries=TEST_MAX_RETRIES,
+            )
+        except LimitsException as limit_reached:
+            raise PowerBiApiError(HTTP_TOO_MANY_REQUESTS, path, str(limit_reached)) from limit_reached
+        if not response.ok:
+            raise PowerBiApiError(response.status_code, path, response.text[:ERROR_DETAIL_LIMIT])
+        return self._test_json(response, path)
+
+    @staticmethod
+    def _test_json(response, path: str) -> Any:
+        """Decode a success body, rejecting the 200-with-``message`` error shape.
+
+        Power BI can answer 200 with a bare ``{"message": ...}`` instead of the
+        expected payload; without this the caller's model would raise an
+        unclassifiable ValidationError.
+        """
+        data = response.json()
+        if isinstance(data, dict) and API_RESPONSE_MESSAGE_KEY in data and "value" not in data:
+            raise PowerBiApiError(response.status_code, path, str(data[API_RESPONSE_MESSAGE_KEY])[:ERROR_DETAIL_LIMIT])
+        return data
+
+    def test_fetch_dashboards(self) -> Optional[List[PowerBIDashboard]]:  # noqa: UP006, UP045
+        """Fetch dashboards for the test-connection GetDashboards step.
+
+        Separate from ``fetch_dashboards``, which is the ingestion path: that one
+        swallows failures and returns None by design, which as a check would report
+        "0 dashboards" for an outright error.
+        """
+        if self.config.useAdminApis:
+            response = DashboardsResponse(**self._test_get("/myorg/admin/dashboards"))
+            return response.value
+        groups = GroupsResponse(**self._test_get("/myorg/groups", params=GETGROUPS_DEFAULT_PARAMS))
+        if not groups.value:
+            return []
+        group_id = groups.value[0].id
+        return DashboardsResponse(**self._test_get(f"/myorg/groups/{group_id}/dashboards")).value
 
     def fetch_all_org_dashboards(self, group_id: str) -> Optional[List[PowerBIDashboard]]:  # noqa: UP006, UP045
         """Method to fetch all powerbi dashboards within the group

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
@@ -65,7 +65,42 @@ def _contains_any(*tokens: str) -> Matcher:
     return match
 
 
+ENTRA_ERRORS_DOC = "https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes"
+
+
+def _token_error(code: str) -> Matcher:
+    """Match an AADSTS code in a token-acquisition failure.
+
+    Gated on InvalidSourceException so a status-coded REST error echoing an AADSTS
+    code still classifies by its status.
+    """
+    lowered = code.lower()
+    return lambda error: Matchers.exception(InvalidSourceException)(error) and lowered in chain_text(error)
+
+
 POWERBI_ERRORS = ErrorPack(
+    # MSAL returns its error as a dict, which the client interpolates into the
+    # InvalidSourceException message - that is what makes the code matchable text.
+    # Codes: ENTRA_ERRORS_DOC.
+    when(_token_error("AADSTS7000215")).diagnose(
+        "Invalid client secret",
+        fix="Microsoft Entra rejected the Client Secret (AADSTS7000215). Check it was copied "
+        "whole, has not expired, and is the secret *value* rather than the secret ID.",
+        doc=ENTRA_ERRORS_DOC,
+    ),
+    when(_token_error("AADSTS700016")).diagnose(
+        "Application not found in this tenant",
+        fix="The app registration was not found in this directory (AADSTS700016). Check the "
+        "Client ID and Tenant ID match the same tenant, and that an administrator has "
+        "installed or consented to the application there.",
+        doc=ENTRA_ERRORS_DOC,
+    ),
+    when(_token_error("AADSTS90002")).diagnose(
+        "Tenant not found",
+        fix="Microsoft Entra does not know this tenant (AADSTS90002). Check the Tenant ID is the "
+        "correct GUID or tenant name for your organization.",
+        doc=ENTRA_ERRORS_DOC,
+    ),
     # CheckAccess acquires the OAuth token, so a bad secret fails there as an
     # InvalidSourceException - not here. Any 401/403 from a REST call therefore
     # means the token was accepted but Power BI would not authorize the call, so
@@ -95,6 +130,11 @@ POWERBI_ERRORS = ErrorPack(
         "Resource not found",
         fix="The requested resource was not found (404). Check the API URL and that the configured "
         "tenant/workspace exists and is visible to the service principal.",
+    ),
+    when(http_status(429)).diagnose(
+        "Rate limited by Power BI",
+        fix="Power BI is throttling this service principal (429). Retry once the current window "
+        "has elapsed; the admin APIs throttle per user per time window.",
     ),
     # Kept last: authority/instance-discovery failures are MSAL ValueErrors that
     # carry no HTTP status, so a broad substring match here must not shadow a
@@ -136,7 +176,7 @@ class PowerBIChecks:
     @check(DashboardStep.GetDashboards)
     def get_dashboards(self) -> Evidence:
         return fetch_list(
-            lambda: self._client().fetch_dashboards(),
+            lambda: self._client().test_fetch_dashboards(),
             noun="dashboard",
             command="fetch dashboards",
             empty_caveat=Diagnosis(

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -53,6 +53,7 @@ from metadata.ingestion.connections.builders import (
     init_empty_connection_arguments,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.databricks.auth import (
     catalog_url,
     get_auth_config,
@@ -90,9 +91,19 @@ DEFAULT_CATALOG = "main"
 SYSTEM_SCHEMAS = frozenset({"information_schema", "performance_schema", "sys"})
 
 
+# The listing checks raise a message carrying this token when no catalog/schema was
+# resolved; the pack matches on it. Shared so producer and matcher cannot drift.
+UNRESOLVED_TARGET_TOKEN = "Could not resolve a catalog and schema"
+
+
 # databricks-sql/thrift reports failures as message tokens, not numeric codes, so
 # rules key on tokens; specific ones precede broad ones (first match wins).
 DATABRICKS_ERRORS = ErrorPack(
+    when(Matchers.contains(UNRESOLVED_TARGET_TOKEN)).diagnose(
+        "Could not resolve a catalog and schema to probe",
+        fix="The earlier steps found no catalog/schema this user can use. Verify the configured "
+        "catalog and schema exist and that the user has USE CATALOG and USE SCHEMA on them.",
+    ),
     when(Matchers.contains("invalid access token")).diagnose(
         "Authentication failed",
         fix="Check the access token - the workspace rejected it. Verify the token is valid, "
@@ -102,11 +113,9 @@ DATABRICKS_ERRORS = ErrorPack(
         "Access token expired",
         fix="The access token has expired. Generate a new token and update the connection.",
     ),
-    when(Matchers.contains("forbidden")).diagnose(
-        "Access denied",
-        fix="The workspace returned 403 Forbidden. Verify the token's user is entitled to the "
-        "workspace and the configured HTTP path / SQL warehouse.",
-    ),
+    # No 403 rule: databricks-sql keeps the status in error.context["http-code"] and
+    # Error.__str__ returns only self.message (databricks/sql/exc.py), so no status
+    # reaches the text; "Forbidden" appears nowhere in the driver (4.2.6).
     when(Matchers.contains("malformed_request")).diagnose(
         "Invalid HTTP path",
         fix="The HTTP Path is malformed. Copy it from the SQL warehouse (or cluster) Connection "
@@ -195,25 +204,35 @@ class DatabricksEngineWrapper:
                     self.first_schema = self.schemas[0]
         return self.schemas
 
+    def _require_resolved_catalog_and_schema(self) -> tuple[str, str]:
+        """Fail loudly when the earlier steps resolved no catalog or schema.
+
+        Returning an empty list would be indistinguishable from "the schema is
+        genuinely empty", so a mandatory step would pass having proved nothing.
+        """
+        if not (self.first_catalog and self.first_schema):
+            raise SourceConnectionException(
+                f"{UNRESOLVED_TARGET_TOKEN}: catalog={self.first_catalog}, schema={self.first_schema}"
+            )
+        return self.first_catalog, self.first_schema
+
     def get_tables(self):
         """Get tables using the cached first schema"""
         if self.first_schema is None:
             self.get_schemas()
-        if self.first_catalog and self.first_schema:
-            with self.engine.connect() as connection:
-                tables = connection.execute(text(f"SHOW TABLES IN `{self.first_catalog}`.`{self.first_schema}`"))
-                return tables.fetchmany(DEFAULT_SAMPLE_ROWS)
-        return []
+        catalog, schema = self._require_resolved_catalog_and_schema()
+        with self.engine.connect() as connection:
+            tables = connection.execute(text(f"SHOW TABLES IN `{catalog}`.`{schema}`"))
+            return tables.fetchmany(DEFAULT_SAMPLE_ROWS)
 
     def get_views(self):
         """Get views using the cached first schema"""
         if self.first_schema is None:
             self.get_schemas()
-        if self.first_catalog and self.first_schema:
-            with self.engine.connect() as connection:
-                views = connection.execute(text(f"SHOW VIEWS IN `{self.first_catalog}`.`{self.first_schema}`"))
-                return views.fetchmany(DEFAULT_SAMPLE_ROWS)
-        return []
+        catalog, schema = self._require_resolved_catalog_and_schema()
+        with self.engine.connect() as connection:
+            views = connection.execute(text(f"SHOW VIEWS IN `{catalog}`.`{schema}`"))
+            return views.fetchmany(DEFAULT_SAMPLE_ROWS)
 
     def get_catalogs(self, catalog_name: Optional[str] = None):  # noqa: UP045
         """Get catalogs"""

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -59,24 +59,12 @@ if TYPE_CHECKING:
     from metadata.core.connections.test_connection.records import Evidence
 
 
-# --- SQL Server error pack ---------------------------------------------------
-# Grouped and self-contained so the Fabric (Database) connector, which speaks the
-# same SQL Server protocol, can lift it verbatim later.
-#
-# Error numbers are from the SQL Server system error message reference
-# (https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors).
-
-
 def _mssql_number(error: BaseException) -> int | None:
-    """The SQL Server error number, however the raising driver carries it.
+    """The SQL Server error number, wherever the driver puts it.
 
-    ``Matchers.errno`` cannot find it: it wants an ``int`` at ``args[0]`` and no
-    supported driver puts one there. pytds sets ``.number``/``.msg_no``
-    (``tds_base._create_exception_by_message``); pymssql leaves a ``(number, message)``
-    tuple at ``args[0]`` (``_pymssql.pyx``, ``connect``); pyodbc exposes no number at
-    all, only ``(sqlstate, message)``.
-
-    Only ever the number of pytds' LAST server message - see SQLSERVER_ERRORS.
+    ``Matchers.errno`` misses it: no supported driver leaves an ``int`` at
+    ``args[0]``. pytds uses ``.number``/``.msg_no``, pymssql a ``(number, message)``
+    tuple at ``args[0]``, pyodbc none at all.
     """
     for current in exception_chain(error):
         for attribute in ("number", "msg_no"):
@@ -95,25 +83,16 @@ def _sqlserver_errno(*codes: int) -> Matcher:
     return lambda error: _mssql_number(error) in wanted
 
 
-# --- SQL Server error pack ---------------------------------------------------
+# pytds folds a multi-message failure unevenly (tds_session.raise_db_exception):
+# the text joins every message, but the number is the LAST message's only. So a
+# number is keyable only when it arrives last (observed live, pinned by tests):
+#   missing database [4060,18456]->18456 ; no VIEW SERVER STATE [300,297]->297 ;
+#   bad password [18456] ; denied SELECT [229]. Hence no 4060/300 rule.
 # Numbers: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
-#
-# SQL Server answers one failure with several messages, and pytds folds them
-# unevenly (tds_session._TdsSession.raise_db_exception): the text is every message
-# joined, the number is the LAST message's only. So a number is matchable only where
-# it arrives last. Observed live, and pinned by the tests:
-#
-#   missing database     -> [4060, 18456] -> number 18456
-#   bad password         -> [18456]       -> number 18456
-#   denied SELECT        -> [229]         -> number 229
-#   no VIEW SERVER STATE -> [300, 297]    -> number 297
-#
-# Hence no 4060 or 300 rule. 911 arrives alone but only from USE, which no check
-# issues; 262 is a statement permission and these checks only SELECT.
 SQLSERVER_ERRORS = ErrorPack(
-    # Must precede the login rules: the joined text ends "Login failed for user ..."
-    # and the number is 18456, so both signals point at auth. No number to key on
-    # here, so a non-English server reads this as an auth failure.
+    # Precedes the login rules: 4060's joined text ends "Login failed", and its
+    # number (18456) also points at auth - so on a non-English server this reads
+    # as an auth failure, the only signal available.
     when(Matchers.contains("Cannot open database")).diagnose(
         "Database not found or not accessible",
         fix="Verify the configured database exists and the login is allowed to open it.",
@@ -127,9 +106,7 @@ SQLSERVER_ERRORS = ErrorPack(
         "Authentication failed",
         fix="Check the username and password, and that the login is allowed to connect.",
     ),
-    # 229 denied SELECT on an object GetTables/GetViews reads; 297 the tail of the
-    # VIEW SERVER STATE denial GetQueries provokes via sys.dm_exec_query_stats.
-    # 297's own text lacks "permission was denied", so its number is the only signal.
+    # 297's text lacks "permission was denied", so its number is the only signal.
     when(
         Matchers.any_of(
             _sqlserver_errno(229, 297),

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -30,6 +30,7 @@ from metadata.core.connections.test_connection.checks.database import (
     run_sql,
 )
 from metadata.core.connections.test_connection.checks.summary import enumerated
+from metadata.core.connections.test_connection.classifier import exception_chain
 from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection as MssqlConnectionConfig,
@@ -54,6 +55,7 @@ from metadata.ingestion.source.database.mssql.utils import is_query_store_enable
 if TYPE_CHECKING:
     from metadata.core.connections.lifetime import Borrowed
     from metadata.core.connections.test_connection import ChecksProvider
+    from metadata.core.connections.test_connection.classifier import Matcher
     from metadata.core.connections.test_connection.records import Evidence
 
 
@@ -61,44 +63,76 @@ if TYPE_CHECKING:
 # Grouped and self-contained so the Fabric (Database) connector, which speaks the
 # same SQL Server protocol, can lift it verbatim later.
 #
-# The two supported drivers surface SQL Server errors differently:
-#   * pymssql exposes the numeric SQL Server error in ``args[0]`` -> Matchers.errno
-#   * pyodbc exposes a string SQLSTATE + message text -> Matchers.contains
-# Both shapes are covered per failure mode; first match wins, so the errno and the
-# message rule fold to the same diagnosis whichever driver raised.
-#
 # Error numbers are from the SQL Server system error message reference
 # (https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors).
+
+
+def _mssql_number(error: BaseException) -> int | None:
+    """The SQL Server error number, however the raising driver carries it.
+
+    ``Matchers.errno`` cannot find it: it wants an ``int`` at ``args[0]`` and no
+    supported driver puts one there. pytds sets ``.number``/``.msg_no``
+    (``tds_base._create_exception_by_message``); pymssql leaves a ``(number, message)``
+    tuple at ``args[0]`` (``_pymssql.pyx``, ``connect``); pyodbc exposes no number at
+    all, only ``(sqlstate, message)``.
+
+    Only ever the number of pytds' LAST server message - see SQLSERVER_ERRORS.
+    """
+    for current in exception_chain(error):
+        for attribute in ("number", "msg_no"):
+            value = getattr(current, attribute, None)
+            if isinstance(value, int):
+                return value
+        args = getattr(current, "args", ())
+        if args and isinstance(args[0], tuple) and args[0] and isinstance(args[0][0], int):
+            return args[0][0]
+    return None
+
+
+def _sqlserver_errno(*codes: int) -> Matcher:
+    """Match a SQL Server error by number, across the cause chain."""
+    wanted = frozenset(codes)
+    return lambda error: _mssql_number(error) in wanted
+
+
+# --- SQL Server error pack ---------------------------------------------------
+# Numbers: https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors
+#
+# SQL Server answers one failure with several messages, and pytds folds them
+# unevenly (tds_session._TdsSession.raise_db_exception): the text is every message
+# joined, the number is the LAST message's only. So a number is matchable only where
+# it arrives last. Observed live, and pinned by the tests:
+#
+#   missing database     -> [4060, 18456] -> number 18456
+#   bad password         -> [18456]       -> number 18456
+#   denied SELECT        -> [229]         -> number 229
+#   no VIEW SERVER STATE -> [300, 297]    -> number 297
+#
+# Hence no 4060 or 300 rule. 911 arrives alone but only from USE, which no check
+# issues; 262 is a statement permission and these checks only SELECT.
 SQLSERVER_ERRORS = ErrorPack(
-    # Database missing / not accessible MUST be matched before the login rules: SQL
-    # Server's 4060 message is "Cannot open database "X" requested by the login. The
-    # login failed." - it contains "login failed", so a login-first ordering would
-    # misclassify a missing database as an auth failure (confirmed live on pytds).
-    # 4060 (cannot open database requested by the login), 911 (database does not exist).
-    when(
-        Matchers.any_of(
-            Matchers.errno(4060, 911),
-            Matchers.contains("Cannot open database"),
-        )
-    ).diagnose(
+    # Must precede the login rules: the joined text ends "Login failed for user ..."
+    # and the number is 18456, so both signals point at auth. No number to key on
+    # here, so a non-English server reads this as an auth failure.
+    when(Matchers.contains("Cannot open database")).diagnose(
         "Database not found or not accessible",
         fix="Verify the configured database exists and the login is allowed to open it.",
     ),
-    # Login failed (auth). SQL Server error 18456; message "Login failed for user".
     when(
         Matchers.any_of(
-            Matchers.errno(18456),
+            _sqlserver_errno(18456),
             Matchers.contains("Login failed"),
         )
     ).diagnose(
         "Authentication failed",
         fix="Check the username and password, and that the login is allowed to connect.",
     ),
-    # Permission denied. 229 (permission denied on object), 297 (no permission for the
-    # action), 262 (statement permission denied); message "permission was denied".
+    # 229 denied SELECT on an object GetTables/GetViews reads; 297 the tail of the
+    # VIEW SERVER STATE denial GetQueries provokes via sys.dm_exec_query_stats.
+    # 297's own text lacks "permission was denied", so its number is the only signal.
     when(
         Matchers.any_of(
-            Matchers.errno(229, 297, 262),
+            _sqlserver_errno(229, 297),
             Matchers.contains("permission was denied"),
         )
     ).diagnose(

--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -252,10 +252,9 @@ REDSHIFT_ERRORS = ErrorPack(
         "Authentication failed",
         fix="Check the username and password, and that the user is allowed to connect.",
     ),
-    when(_sqlstate("28000", "28P01")).diagnose(  # invalid_authorization / invalid_password
-        "Authentication failed",
-        fix="Check the username and password, and that the user is allowed to connect.",
-    ),
+    # No _sqlstate("28000", "28P01") rule: those are connect-phase codes, and libpq
+    # reports a failed connection with no PGresult, so .pgcode is None (verified on
+    # PostgreSQL 15). The message rule above is what catches auth failures.
     when(_database_not_found).diagnose(
         "Database not found",
         fix="Verify the configured database exists and the user is allowed to connect to it.",

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -191,12 +191,21 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
     and are caught by the TCP preflight in CheckAccess via NETWORK_ERRORS; a wrong
     *account* is not - Snowflake's wildcard DNS resolves any
     ``<account>.snowflakecomputing.com`` and accepts TCP on 443, so it is only
-    rejected at the HTTP login layer (errno 290404), handled here."""
+    rejected at the HTTP login layer, handled here."""
     return ErrorPack(
-        when(_sf_errno(290404)).diagnose(
-            "Snowflake account not found",
-            fix="Check the account identifier - the login endpoint returned 404. Use the account "
-            "from your Snowflake URL (e.g. <org>-<account> or <locator>.<region>.<cloud>).",
+        # snowflake/connector/auth/_auth.py turns ANY 403 at the login endpoint into
+        # this message, so it means "rejected at login", not specifically a bad
+        # account - a proxy, an IP allowlist or a network policy lands here too; the
+        # remediation says so. Keyed on the message, not the errno: this path's errno
+        # is 540001 (ForbiddenError.__init__ adds ER_HTTP_GENERAL_ERROR to the
+        # ER_FAILED_TO_CONNECT_TO_DB it is passed), an accidental sum, and never the
+        # 290404 once matched here - a number absent from the connector entirely.
+        when(Matchers.contains("verify the account name is correct")).diagnose(
+            "Snowflake rejected the login endpoint request",
+            fix="Snowflake answered 403 before authenticating. Most often the account identifier is "
+            "wrong - use the one from your Snowflake URL (e.g. <org>-<account> or "
+            "<locator>.<region>.<cloud>). If it is correct, check whether a network policy, IP "
+            "allowlist, or proxy is blocking this host.",
         ),
         when(Matchers.contains("multi-factor authentication")).diagnose(
             "Multi-factor authentication required",

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -193,13 +193,9 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
     ``<account>.snowflakecomputing.com`` and accepts TCP on 443, so it is only
     rejected at the HTTP login layer, handled here."""
     return ErrorPack(
-        # snowflake/connector/auth/_auth.py turns ANY 403 at the login endpoint into
-        # this message, so it means "rejected at login", not specifically a bad
-        # account - a proxy, an IP allowlist or a network policy lands here too; the
-        # remediation says so. Keyed on the message, not the errno: this path's errno
-        # is 540001 (ForbiddenError.__init__ adds ER_HTTP_GENERAL_ERROR to the
-        # ER_FAILED_TO_CONNECT_TO_DB it is passed), an accidental sum, and never the
-        # 290404 once matched here - a number absent from the connector entirely.
+        # Any login-endpoint 403 yields this message (snowflake _auth.py), so it
+        # means "rejected at login" - proxy, IP allowlist, network policy too, per
+        # the fix. Keyed on the message: this path's errno is an accidental 540001.
         when(Matchers.contains("verify the account name is correct")).diagnose(
             "Snowflake rejected the login endpoint request",
             fix="Snowflake answered 403 before authenticating. Most often the account identifier is "

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
@@ -182,14 +182,9 @@ class AirflowApiClient:
     def test_get_version(self) -> dict:
         """Prove the host really is Airflow, for the test-connection gate.
 
-        ``get_version`` cannot gate anything on either flavour: over REST it is
-        lenient by design (``_parse_response`` turns a reply it cannot parse into
-        ``{}``, so a 200 text/html page passes), and over MWAA it is a hardcoded stub
-        that never calls AWS. Both need an accessor that actually fails.
-
-        REST uses ``get_raw`` so the status survives and ``JSONDecodeError`` escapes
-        to the classifier, mirroring dbt Cloud's ``_test_get``; MWAA makes a real
-        ``invoke_rest_api`` call.
+        Unlike ``get_version``, which is lenient over REST (parses to ``{}``, so a
+        200 HTML page passes) and a stub over MWAA: REST reads via ``get_raw`` so a
+        bad status/body raises, MWAA makes a real ``invoke_rest_api`` call.
         """
         if self.mwaa_client:
             return self.mwaa_client.test_get_version()

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py
@@ -31,7 +31,8 @@ from metadata.generated.schema.entity.utils.common.mwaaAuthConfig import (
     MwaaAuthentication,
 )
 from metadata.ingestion.connections.source_api_client import TrackedREST
-from metadata.ingestion.ometa.client import ClientConfig
+from metadata.ingestion.connections.test_connections import SourceConnectionException
+from metadata.ingestion.ometa.client import ClientConfig, LimitsException
 from metadata.ingestion.source.pipeline.airflow.api.auth import (
     build_access_token_callback,
     build_basic_auth_callback,
@@ -48,6 +49,11 @@ from metadata.utils.helpers import clean_uri
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+# Retry budget for the test call, summing to 6s. The client defaults (retry=3,
+# retry_wait=30) sleep ~180s on a 504, over the step budget.
+TEST_MAX_RETRIES = 2
+TEST_RETRY_WAIT_SECONDS = 2
 
 
 class AirflowApiClient:
@@ -100,6 +106,15 @@ class AirflowApiClient:
                 verify=verify_ssl,
             )
             self.client = TrackedREST(client_config, source_name="airflow_api")
+
+    @property
+    def _rest(self) -> TrackedREST:
+        """The REST client. ``client`` is None on the MWAA flavour, which reaches
+        Airflow through the AWS SDK instead - callers must branch on ``mwaa_client``
+        before reading this."""
+        if self.client is None:
+            raise SourceConnectionException("No Airflow REST client: this is an MWAA connection")
+        return self.client
 
     @property
     def api_version(self) -> str:
@@ -163,6 +178,35 @@ class AirflowApiClient:
 
         response = self.client.get(f"{self._prefix}/version")
         return self._parse_response(response)
+
+    def test_get_version(self) -> dict:
+        """Prove the host really is Airflow, for the test-connection gate.
+
+        ``get_version`` cannot gate anything on either flavour: over REST it is
+        lenient by design (``_parse_response`` turns a reply it cannot parse into
+        ``{}``, so a 200 text/html page passes), and over MWAA it is a hardcoded stub
+        that never calls AWS. Both need an accessor that actually fails.
+
+        REST uses ``get_raw`` so the status survives and ``JSONDecodeError`` escapes
+        to the classifier, mirroring dbt Cloud's ``_test_get``; MWAA makes a real
+        ``invoke_rest_api`` call.
+        """
+        if self.mwaa_client:
+            return self.mwaa_client.test_get_version()
+
+        try:
+            response = self._rest.get_raw(
+                f"{self._prefix}/version", retry_wait=TEST_RETRY_WAIT_SECONDS, retries=TEST_MAX_RETRIES
+            )
+        except LimitsException as rate_limited:
+            # A 429 surfaces as LimitsException, raised with no message, so its
+            # errorLog would be blank. Its cause is the driver's real HTTPError,
+            # which carries the status and a readable message - surface that.
+            if rate_limited.__cause__ is not None:
+                raise rate_limited.__cause__ from None
+            raise
+        response.raise_for_status()
+        return response.json()
 
     def list_dags(self, limit: int = 100, offset: int = 0) -> dict:
         if self.mwaa_client:

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py
@@ -94,6 +94,17 @@ class MWAAClient:
         # Return a simple response to indicate connectivity
         return {"version": "MWAA", "status": "connected"}
 
+    def test_get_version(self) -> Dict:  # noqa: UP006
+        """Prove the environment is reachable and the credentials work.
+
+        ``get_version`` is a hardcoded stub - MWAA exposes no version endpoint - so
+        it proves nothing and cannot gate a connection. Listing one DAG is the
+        smallest call that really exercises the IAM credentials, the environment
+        name and the route; ``_invoke_rest_api`` re-raises whatever AWS returns.
+        """
+        self._invoke_rest_api("/dags", query={"limit": "1"})
+        return {"version": "MWAA", "status": "connected"}
+
     def list_dags(self, limit: int = 100, offset: int = 0) -> Dict:  # noqa: UP006
         """List DAGs with pagination"""
         query = {"limit": str(limit), "offset": str(offset)}

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
@@ -248,10 +248,13 @@ def _test_task_detail_access(session) -> Optional[Any]:  # noqa: UP045
 
 def _decorated_check_access(client, host, auth_config, verify: bool) -> Any:  # pyright: ignore[reportMissingParameterType]
     """
-    Call client.get_version(); on failure, attempt a managed-flavor-specific
+    Call client.test_get_version(); on failure, attempt a managed-flavor-specific
     diagnostic and raise SourceConnectionException with a combined message
     ("<original error>\\n\\n<hint>"). When no hint applies, the original
     exception is re-raised unchanged.
+
+    Uses the strict accessor, not get_version: the latter tolerates a reply it
+    cannot parse, which would pass the gate against any web server.
     """
     from metadata.ingestion.source.pipeline.airflow.api.diagnostics import (  # noqa: PLC0415
         diagnose,
@@ -259,7 +262,7 @@ def _decorated_check_access(client, host, auth_config, verify: bool) -> Any:  # 
 
     result = None
     try:
-        result = client.get_version()
+        result = client.test_get_version()
     except Exception as exc:
         hint = diagnose(host, auth_config, verify, exc)
         if hint:
@@ -302,6 +305,11 @@ AIRFLOW_ERRORS = ErrorPack(
         "Endpoint not found",
         fix="Airflow returned 404 for this URL. Check the Host and Port point to the Airflow web "
         "server, not a UI or console page.",
+    ),
+    when(http_status(429)).diagnose(
+        "Rate limited",
+        fix="Airflow (or a gateway in front of it) is throttling the request. Retry in a few "
+        "minutes, or raise the rate limit for the account ingestion uses.",
     ),
     # A URL that is not the Airflow REST API (an SSO login page, the marketing
     # site) answers with HTML that fails to decode as JSON.

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
@@ -34,7 +34,6 @@ from metadata.core.connections.test_connection.checks.rest import (
     http_status,
     verify_access,
 )
-from metadata.core.connections.test_connection.network import NETWORK_ERRORS
 from metadata.generated.schema.entity.services.connections.pipeline.dbtCloudConnection import (
     DBTCloudConnection as DBTCloudConnectionConfig,
 )
@@ -124,7 +123,13 @@ DBTCLOUD_ERRORS = ErrorPack(
         fix="Check Host for typos and that it resolves from where ingestion runs. dbt Cloud is "
         "regional - the access URL differs per region.",
     ),
-).including(NETWORK_ERRORS)
+)
+# NETWORK_ERRORS is deliberately not folded in: `including` appends at lower
+# precedence, so the requests-typed rules above claim every network failure first
+# (a DNS gaierror arrives wrapped in requests' ConnectionError), and
+# NetworkUnreachableError needs a tcp_probe this connector never runs. No preflight
+# is added because requests honours HTTPS_PROXY and a raw TCP probe does not, which
+# would fail a proxied setup - see `ping`.
 
 
 class DBTCloudChecks:

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
@@ -124,12 +124,10 @@ DBTCLOUD_ERRORS = ErrorPack(
         "regional - the access URL differs per region.",
     ),
 )
-# NETWORK_ERRORS is deliberately not folded in: `including` appends at lower
-# precedence, so the requests-typed rules above claim every network failure first
-# (a DNS gaierror arrives wrapped in requests' ConnectionError), and
-# NetworkUnreachableError needs a tcp_probe this connector never runs. No preflight
-# is added because requests honours HTTPS_PROXY and a raw TCP probe does not, which
-# would fail a proxied setup - see `ping`.
+# NETWORK_ERRORS not folded in: the requests-typed rules above already claim every
+# network failure, and NetworkUnreachableError needs a tcp_probe this connector
+# never runs. No preflight added - it would break a proxied setup (requests honours
+# HTTPS_PROXY, a raw probe does not).
 
 
 class DBTCloudChecks:

--- a/ingestion/tests/unit/source/dashboard/looker/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/looker/test_connection.py
@@ -11,10 +11,13 @@
 """Unit tests for Looker test-connection checks."""
 
 import socket
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 from looker_sdk.error import SDKError
+from looker_sdk.rtl.requests_transport import RequestsTransport
+from looker_sdk.rtl.transport import HttpMethod
 
 from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
@@ -37,6 +40,20 @@ DASHBOARDS_429 = "https://cloud.google.com/looker/docs/r/err/4.0/429/get/api/4.0
 DASHBOARDS_400 = "https://cloud.google.com/looker/docs/r/err/4.0/400/get/api/4.0/dashboards"
 DASHBOARDS_401 = "https://cloud.google.com/looker/docs/r/err/4.0/401/get/api/4.0/dashboards"
 DASHBOARDS_403 = "https://cloud.google.com/looker/docs/r/err/4.0/403/get/api/4.0/dashboards"
+
+
+class _TransportSettings:
+    """The transport's settings contract, as looker_sdk.rtl.transport defines it.
+
+    Duck-typed rather than mocked: RequestsTransport reads these attributes at
+    configure() time, and a MagicMock would silently satisfy any shape.
+    """
+
+    base_url = "https://looker.example.com:19999"
+    verify_ssl = True
+    timeout = 10
+    agent_tag = "test"
+    headers: ClassVar[dict] = {}
 
 
 def _sdk_error(message: str, documentation_url: str = "") -> SDKError:
@@ -415,13 +432,44 @@ def test_an_unreachable_host_is_diagnosed_from_the_flattened_message():
     assert diagnosis.title == "Cannot reach the host"
 
 
-def test_the_shared_network_pack_still_classifies_a_raw_socket_error():
-    # Anything raised outside the SDK's transport keeps its type, so the folded
-    # NETWORK_ERRORS rules remain the fallback.
-    diagnosis = LOOKER_ERRORS.classify(socket.gaierror("nodename nor servname provided"))
+@pytest.mark.parametrize(
+    ("raised", "title"),
+    [
+        (ConnectionRefusedError(61, "Connection refused"), "Connection refused"),
+        (socket.gaierror(8, "nodename nor servname provided"), "Host could not be resolved"),
+        (TimeoutError("timed out"), "Connection timed out"),
+    ],
+)
+def test_a_socket_error_is_flattened_by_the_sdk_and_diagnosed_from_its_text(raised, title):
+    """Drives the real transport: the type is destroyed, the text still diagnoses.
 
-    assert diagnosis is not None
-    assert diagnosis.title == "Host could not be resolved"
+    This is why NETWORK_ERRORS (which matches by type) is not folded into the pack.
+    """
+    transport_ = RequestsTransport.configure(_TransportSettings())
+
+    with patch.object(transport_.session, "request", side_effect=raised):
+        response = transport_.request(HttpMethod.GET, "/api/4.0/user")
+
+    assert response.ok is False
+    assert isinstance(response.value, bytes)
+
+    # What the SDK hands the classifier: the flattened text, not the exception.
+    flattened = _sdk_error(response.value.decode())
+    assert LOOKER_ERRORS.classify(flattened).title == title
+
+
+@pytest.mark.parametrize(
+    ("raised", "title"),
+    [
+        (ConnectionRefusedError(61, "Connection refused"), "Connection refused"),
+        (socket.gaierror(8, "nodename nor servname provided"), "Host could not be resolved"),
+        (TimeoutError("timed out"), "Connection timed out"),
+    ],
+)
+def test_dropping_the_network_fold_changes_no_diagnosis(raised, title):
+    """_transport_text returns the same titles NETWORK_ERRORS would, so dropping the
+    fold is behaviour-preserving even where it could have been reached."""
+    assert LOOKER_ERRORS.classify(raised).title == title
 
 
 def test_an_unknown_error_is_not_classified():

--- a/ingestion/tests/unit/source/dashboard/powerbi/test_connection.py
+++ b/ingestion/tests/unit/source/dashboard/powerbi/test_connection.py
@@ -10,19 +10,24 @@
 #  limitations under the License.
 """Unit tests for Power BI test-connection checks."""
 
+import json
 import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from requests.exceptions import HTTPError
 
 from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import CheckError, collect_checks
 from metadata.core.connections.test_connection.checks.dashboard import DashboardStep
+from metadata.core.connections.test_connection.constants import STEP_TIMEOUT_SECONDS
+from metadata.generated.schema.entity.services.connections.dashboard.powerBIConnection import (
+    PowerBIConnection as PowerBIConnectionConfig,
+)
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.connections.connection import BaseConnection
-from metadata.ingestion.ometa.client import APIError
-from metadata.ingestion.source.dashboard.powerbi.client import PowerBiApiClient
+from metadata.ingestion.source.dashboard.powerbi.client import PowerBiApiClient, PowerBiApiError
 from metadata.ingestion.source.dashboard.powerbi.connection import (
     POWERBI_ERRORS,
     PowerBIChecks,
@@ -32,10 +37,16 @@ from metadata.ingestion.source.dashboard.powerbi.connection import (
 CONNECTION_MODULE = "metadata.ingestion.source.dashboard.powerbi.connection"
 
 
-def _api_error(status_code: int, message: str = "boom") -> APIError:
-    http_error = MagicMock()
-    http_error.response.status_code = status_code
-    return APIError({"message": message, "code": "x"}, http_error)
+def _api_error(status_code: int, message: str = "boom") -> PowerBiApiError:
+    """The error the test-connection path really raises on a non-success status.
+
+    Previously this built an ometa APIError from {"code": ..., "message": ...} - a
+    TOP-LEVEL code, which is the OM server's own error contract, not Power BI's wire
+    format. Power BI nests code under "error", so ometa never builds an APIError for
+    it; the shape was unreachable. PowerBiApiError is what _test_get raises, and it
+    carries the status on .status_code where the http_status matcher reads it.
+    """
+    return PowerBiApiError(status_code, "/myorg/admin/dashboards", message)
 
 
 def _raw_http_error(status_code: int) -> HTTPError:
@@ -112,7 +123,7 @@ def test_check_access_wraps_failure_as_check_error():
 
 def test_get_dashboards_counts_results():
     provider, client = _checks()
-    client.fetch_dashboards.return_value = [object(), object(), object()]
+    client.test_fetch_dashboards.return_value = [object(), object(), object()]
 
     evidence = provider.get_dashboards()
 
@@ -122,7 +133,7 @@ def test_get_dashboards_counts_results():
 
 def test_get_dashboards_caps_the_count():
     provider, client = _checks()
-    client.fetch_dashboards.return_value = [object()] * 250
+    client.test_fetch_dashboards.return_value = [object()] * 250
 
     evidence = provider.get_dashboards()
 
@@ -132,7 +143,7 @@ def test_get_dashboards_caps_the_count():
 
 def test_get_dashboards_at_cap_shows_plus():
     provider, client = _checks()
-    client.fetch_dashboards.return_value = [object()] * 100
+    client.test_fetch_dashboards.return_value = [object()] * 100
 
     evidence = provider.get_dashboards()
 
@@ -141,7 +152,7 @@ def test_get_dashboards_at_cap_shows_plus():
 
 def test_get_dashboards_empty_passes_with_caveat():
     provider, client = _checks()
-    client.fetch_dashboards.return_value = None
+    client.test_fetch_dashboards.return_value = None
 
     evidence = provider.get_dashboards()
 
@@ -152,7 +163,7 @@ def test_get_dashboards_empty_passes_with_caveat():
 
 def test_get_dashboards_wraps_failure_as_check_error():
     provider, client = _checks()
-    client.fetch_dashboards.side_effect = _api_error(403)
+    client.test_fetch_dashboards.side_effect = _api_error(403)
 
     with pytest.raises(CheckError) as exc_info:
         provider.get_dashboards()
@@ -207,3 +218,277 @@ def test_error_pack_classifies(error, title):
 
 def test_error_pack_ignores_unknown_error():
     assert POWERBI_ERRORS.classify(ValueError("something else")) is None
+
+
+# ── Driving the real PowerBiApiClient against Power BI's real error envelope ──
+#
+# Everything above mocks the api_client, so it proves only that the provider calls
+# it. These drive the real client and the real ometa REST plumbing, stubbing only
+# requests.Session.request, against the envelope Microsoft documents.
+
+
+@pytest.fixture
+def real_api_client():
+    """A real PowerBiApiClient over the real ometa REST plumbing.
+
+    Only the two things that would really dial out are stubbed: MSAL (whose
+    ConfidentialClientApplication does authority discovery at construction) and the
+    token acquisition. The subject under test is what the client does with Power
+    BI's *reply*, so everything from the request down is real. get_auth_token is
+    patched on the class because ClientConfig captures the bound method at
+    construction, before an instance attribute could take effect.
+    """
+    config = PowerBIConnectionConfig(clientId="cid", clientSecret="secret", tenantId="tid")
+    with (
+        patch("metadata.ingestion.source.dashboard.powerbi.client.msal.ConfidentialClientApplication"),
+        patch.object(PowerBiApiClient, "get_auth_token", return_value=("token", 3600)),
+    ):
+        yield PowerBiApiClient(config)
+
+
+def _powerbi_error_response(status_code: int, code: str, message: str) -> requests.Response:
+    """A real Power BI error reply.
+
+    The envelope is the one Microsoft documents for the Power BI REST API:
+        {"error":{"code":"TokenExpired","message":"Access token has expired, ..."}}
+    quoted verbatim against a 403 in
+    https://learn.microsoft.com/en-us/power-bi/developer/embedded/troubleshoot-rest-api
+
+    This shape is exactly what defeats ometa's REST._request: it tests for a
+    TOP-LEVEL "code" key, but Power BI nests code under "error", so neither branch
+    raises and the request decays to None.
+    """
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps({"error": {"code": code, "message": message}}).encode()
+    response.headers["content-type"] = "application/json"
+    response.url = "https://api.powerbi.com/v1.0/myorg/admin/dashboards"
+    return response
+
+
+@pytest.mark.parametrize(
+    ("status_code", "code", "title"),
+    [
+        (401, "PowerBINotAuthorizedException", "Power BI did not authorize the service principal"),
+        (403, "TokenExpired", "Insufficient permissions"),
+        (404, "ItemNotFound", "Resource not found"),
+    ],
+)
+def test_a_real_powerbi_error_envelope_reaches_the_status_rules(real_api_client, status_code, code, title):
+    """Regression: ometa's REST._request looks for a TOP-LEVEL "code"; Power BI nests
+    it under "error", so the request decayed to None and the step died with a bare
+    TypeError carrying no status. The status must reach the classifier."""
+    provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=real_api_client)))
+
+    with (
+        patch.object(requests.Session, "request", return_value=_powerbi_error_response(status_code, code, "denied")),
+        pytest.raises(CheckError) as failure,
+    ):
+        provider.get_dashboards()
+
+    diagnosis = POWERBI_ERRORS.classify(failure.value.cause)
+    assert diagnosis is not None, f"a {status_code} produced no diagnosis: {failure.value.cause!r}"
+    assert diagnosis.title == title
+
+
+# Real MSAL client-credentials error payloads. MSAL returns the token endpoint's
+# error document as a dict rather than raising, and PowerBiApiClient interpolates
+# that dict into the InvalidSourceException message - which is what makes the
+# AADSTS code matchable text. Code meanings verified against
+# https://learn.microsoft.com/en-us/entra/identity-platform/reference-error-codes
+_MSAL_BAD_SECRET = {
+    "error": "invalid_client",
+    "error_description": (
+        "AADSTS7000215: Invalid client secret provided. Ensure the secret being sent in the request "
+        "is the client secret value, not the client secret ID, for a secret added to app "
+        "'11111111-1111-1111-1111-111111111111'."
+    ),
+    "error_codes": [7000215],
+}
+_MSAL_APP_NOT_IN_TENANT = {
+    "error": "unauthorized_client",
+    "error_description": (
+        "AADSTS700016: Application with identifier '11111111-1111-1111-1111-111111111111' was not "
+        "found in the directory 'contoso'. This can happen if the application has not been installed "
+        "by the administrator of the tenant or consented to by any user in the tenant."
+    ),
+    "error_codes": [700016],
+}
+_MSAL_TENANT_NOT_FOUND = {
+    "error": "invalid_request",
+    "error_description": "AADSTS90002: Tenant 'nope' not found. Check to make sure you have the correct tenant ID.",
+    "error_codes": [90002],
+}
+
+
+@pytest.mark.parametrize(
+    ("msal_response", "title"),
+    [
+        (_MSAL_BAD_SECRET, "Invalid client secret"),
+        (_MSAL_APP_NOT_IN_TENANT, "Application not found in this tenant"),
+        (_MSAL_TENANT_NOT_FOUND, "Tenant not found"),
+    ],
+)
+def test_a_token_failure_is_diagnosed_by_its_aadsts_code(msal_response, title):
+    """Drive the real get_auth_token so the AADSTS code reaches the pack the way it
+    really does: MSAL hands back an error dict, the client interpolates it into the
+    InvalidSourceException message."""
+    config = PowerBIConnectionConfig(clientId="cid", clientSecret="secret", tenantId="tid")
+    with patch("metadata.ingestion.source.dashboard.powerbi.client.msal.ConfidentialClientApplication") as msal_app:
+        msal_app.return_value.acquire_token_silent.return_value = None
+        msal_app.return_value.acquire_token_for_client.return_value = msal_response
+        client = PowerBiApiClient(config)
+        provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=client)))
+
+        with pytest.raises(CheckError) as failure:
+            provider.check_access()
+
+    diagnosis = POWERBI_ERRORS.classify(failure.value.cause)
+    assert diagnosis is not None
+    assert diagnosis.title == title
+    assert diagnosis.remediation
+
+
+def test_the_non_admin_path_resolves_a_group_then_lists_its_dashboards():
+    """useAdminApis=False takes the /myorg/groups -> /myorg/groups/<id>/dashboards
+    route; both hops must go through the strict accessor."""
+    config = PowerBIConnectionConfig(clientId="cid", clientSecret="secret", tenantId="tid", useAdminApis=False)
+    groups = requests.Response()
+    groups.status_code = 200
+    groups._content = json.dumps(
+        {
+            "@odata.context": "http://api.powerbi.com/v1.0/myorg/$metadata#groups",
+            "@odata.count": 1,
+            "value": [{"id": "g1", "name": "Workspace 1"}],
+        }
+    ).encode()
+    dashboards = requests.Response()
+    dashboards.status_code = 200
+    dashboards._content = json.dumps(
+        {
+            "@odata.context": "http://api.powerbi.com/v1.0/myorg/$metadata#dashboards",
+            "value": [{"id": "d1"}, {"id": "d2"}],
+        }
+    ).encode()
+
+    with (
+        patch("metadata.ingestion.source.dashboard.powerbi.client.msal.ConfidentialClientApplication"),
+        patch.object(PowerBiApiClient, "get_auth_token", return_value=("token", 3600)),
+    ):
+        client = PowerBiApiClient(config)
+        provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=client)))
+        with patch.object(requests.Session, "request", side_effect=[groups, dashboards]):
+            evidence = provider.get_dashboards()
+
+    assert evidence.summary == "2 dashboards enumerated"
+
+
+def test_the_non_admin_path_surfaces_a_group_listing_failure():
+    """A 403 on the first hop must fail the step, not decay into "no dashboards"."""
+    config = PowerBIConnectionConfig(clientId="cid", clientSecret="secret", tenantId="tid", useAdminApis=False)
+
+    with (
+        patch("metadata.ingestion.source.dashboard.powerbi.client.msal.ConfidentialClientApplication"),
+        patch.object(PowerBiApiClient, "get_auth_token", return_value=("token", 3600)),
+    ):
+        client = PowerBiApiClient(config)
+        provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=client)))
+        with (
+            patch.object(
+                requests.Session,
+                "request",
+                return_value=_powerbi_error_response(403, "TokenExpired", "denied"),
+            ),
+            pytest.raises(CheckError) as failure,
+        ):
+            provider.get_dashboards()
+
+    assert POWERBI_ERRORS.classify(failure.value.cause).title == "Insufficient permissions"
+
+
+def test_an_unrecognised_token_failure_keeps_the_generic_auth_diagnosis():
+    """The AADSTS rules are additive: a token failure with no code we know must
+    still be diagnosed, not fall through to nothing."""
+    error = InvalidSourceException("Failed to generate the PowerBi access token. Please check provided config {}")
+    assert POWERBI_ERRORS.classify(error).title == "Authentication failed"
+
+
+def test_an_aadsts_code_in_a_rest_error_does_not_shadow_its_status():
+    """The AADSTS rules are gated on InvalidSourceException, so a status-coded REST
+    failure whose body echoes a code still classifies by status."""
+    error = _api_error(403, "AADSTS700016 mentioned in a proxy error body")
+    assert POWERBI_ERRORS.classify(error).title == "Insufficient permissions"
+
+
+def test_a_rate_limited_call_is_bounded_in_time(real_api_client):
+    """Regression: an exhausted 429 slept ~42h (~2.8h with only retry_wait capped) -
+    the sleep grows per attempt, so the retry count dominates."""
+    provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=real_api_client)))
+    slept: list[float] = []
+
+    with (
+        patch.object(requests.Session, "request", return_value=_powerbi_error_response(429, "TooManyRequests", "slow")),
+        patch("metadata.ingestion.ometa.client.time.sleep", side_effect=slept.append),
+        pytest.raises(CheckError),
+    ):
+        provider.get_dashboards()
+
+    assert sum(slept) <= STEP_TIMEOUT_SECONDS, f"a rate-limited step slept {sum(slept)}s"
+
+
+def test_a_rate_limited_call_reports_a_diagnosis_and_a_readable_error(real_api_client):
+    """An exhausted 429 arrives as LimitsException, raised with no message - so
+    str() is empty and the step's errorLog would be blank. It must still name the
+    status and say something."""
+    provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=real_api_client)))
+
+    with (
+        patch.object(requests.Session, "request", return_value=_powerbi_error_response(429, "TooManyRequests", "slow")),
+        patch("metadata.ingestion.ometa.client.time.sleep"),
+        pytest.raises(CheckError) as failure,
+    ):
+        provider.get_dashboards()
+
+    cause = failure.value.cause
+    assert POWERBI_ERRORS.classify(cause).title == "Rate limited by Power BI"
+    assert str(cause), "the step's errorLog would be empty"
+    assert "429" in str(cause)
+
+
+def test_a_two_hundred_carrying_only_a_message_is_diagnosed(real_api_client):
+    """Power BI can answer 200 with a bare {"message": ...}. response.ok is True, so
+    without a guard the model raises an unclassifiable ValidationError."""
+    provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=real_api_client)))
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps({"message": "API is not accessible for application"}).encode()
+    response.headers["content-type"] = "application/json"
+
+    with (
+        patch.object(requests.Session, "request", return_value=response),
+        pytest.raises(CheckError) as failure,
+    ):
+        provider.get_dashboards()
+
+    assert isinstance(failure.value.cause, PowerBiApiError)
+    assert "API is not accessible" in str(failure.value.cause)
+
+
+def test_a_successful_dashboard_listing_is_counted(real_api_client):
+    """The counterpart: a real 200 payload still passes and is counted."""
+    provider = PowerBIChecks(powerbi=Borrowed.of(MagicMock(api_client=real_api_client)))
+    response = requests.Response()
+    response.status_code = 200
+    # The shape Power BI returns for GET /admin/dashboards: an OData envelope.
+    response._content = json.dumps(
+        {
+            "@odata.context": "http://api.powerbi.com/v1.0/myorg/$metadata#dashboards",
+            "value": [{"id": "d1", "displayName": "D1"}],
+        }
+    ).encode()
+    response.headers["content-type"] = "application/json"
+
+    with patch.object(requests.Session, "request", return_value=response):
+        evidence = provider.get_dashboards()
+
+    assert evidence.summary == "1 dashboard enumerated"

--- a/ingestion/tests/unit/source/database/databricks/test_connection.py
+++ b/ingestion/tests/unit/source/database/databricks/test_connection.py
@@ -25,8 +25,10 @@ from metadata.generated.schema.entity.services.connections.database.databricksCo
     DatabricksConnection as DatabricksConnectionConfig,
 )
 from metadata.ingestion.connections.connection import BaseConnection
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.databricks.connection import (
     DATABRICKS_ERRORS,
+    UNRESOLVED_TARGET_TOKEN,
     DatabricksChecks,
     DatabricksConnection,
 )
@@ -97,9 +99,12 @@ def test_expired_token_message_is_classified():
     assert DATABRICKS_ERRORS.classify(error).title == "Access token expired"
 
 
-def test_forbidden_message_is_classified():
-    error = _SqlAlchemyError(Exception("HTTP Response code: 403, Forbidden"))
-    assert DATABRICKS_ERRORS.classify(error).title == "Access denied"
+def test_a_not_found_object_is_not_misread_as_access_denied():
+    """Regression: a `contains("forbidden")` rule used to sit ahead of every
+    not-found rule, so any object whose name contained "forbidden" was diagnosed as
+    "Access denied". The rule is gone; this keeps it gone."""
+    error = _SqlAlchemyError(Exception("[TABLE_OR_VIEW_NOT_FOUND] The table `forbidden_items` does not exist"))
+    assert DATABRICKS_ERRORS.classify(error).title == "Table or view not found"
 
 
 def test_malformed_http_path_is_classified():
@@ -336,7 +341,11 @@ def test_schema_scoped_get_schemas_skips_use_catalog_when_catalog_unresolved():
     engine.connect.assert_not_called()
 
 
-def test_get_tables_returns_empty_when_catalog_unresolved():
+@pytest.mark.parametrize("listing", ["get_tables", "get_views"])
+def test_listing_raises_when_the_catalog_never_resolved(listing):
+    """GetTables/GetViews are mandatory steps. Returning [] here would be
+    indistinguishable from "the schema is empty", so the step would pass having
+    resolved nothing and proved nothing - it must fail instead."""
     from metadata.ingestion.source.database.databricks.connection import (
         DatabricksEngineWrapper,
     )
@@ -345,5 +354,26 @@ def test_get_tables_returns_empty_when_catalog_unresolved():
     wrapper = DatabricksEngineWrapper(Borrowed.of(engine))
     wrapper.first_catalog = None
     wrapper.first_schema = "my_schema"
-    assert wrapper.get_tables() == []
+
+    with pytest.raises(SourceConnectionException) as failure:
+        getattr(wrapper, listing)()
+
+    assert UNRESOLVED_TARGET_TOKEN in str(failure.value)
+    assert DATABRICKS_ERRORS.classify(failure.value).title == "Could not resolve a catalog and schema to probe"
     engine.connect.assert_not_called()
+
+
+@pytest.mark.parametrize("listing", ["get_tables", "get_views"])
+def test_listing_raises_when_the_schema_never_resolved(listing):
+    from metadata.ingestion.source.database.databricks.connection import (
+        DatabricksEngineWrapper,
+    )
+
+    engine = MagicMock()
+    wrapper = DatabricksEngineWrapper(Borrowed.of(engine))
+    wrapper.first_catalog = "my_catalog"
+    wrapper.schemas = []  # get_schemas() ran and found nothing usable
+    wrapper.first_schema = None
+
+    with pytest.raises(SourceConnectionException):
+        getattr(wrapper, listing)()

--- a/ingestion/tests/unit/source/database/mssql/test_connection.py
+++ b/ingestion/tests/unit/source/database/mssql/test_connection.py
@@ -15,26 +15,40 @@ tests/unit/test_source_url.py and tests/unit/test_source_connection.py.
 """
 
 import socket
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pyodbc
+import pytest
+from pytds.tds_base import Message
+from pytds.tds_session import _TdsSession
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError as SqlAlchemyOperationalError
 from sqlalchemy.pool import StaticPool
 
 from metadata.core.connections.lifetime import Borrowed
-from metadata.core.connections.test_connection import collect_checks
+from metadata.core.connections.test_connection import Matchers, collect_checks
 from metadata.core.connections.test_connection.checks.database import DEFAULT_SAMPLE_ROWS, DatabaseStep
+from metadata.core.connections.test_connection.runner import TestConnectionRunner
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection as MssqlConnectionConfig,
 )
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlScheme,
 )
+from metadata.generated.schema.entity.services.connections.testConnectionDefinition import (
+    TestConnectionDefinition,
+)
+from metadata.generated.schema.entity.services.connections.testConnectionResult import (
+    TestConnectionResult,
+)
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.database.mssql.connection import (
     MSSQL_ERRORS,
     MssqlChecks,
     MssqlConnection,
+    _mssql_number,
     get_connection_url,
 )
 from metadata.ingestion.source.database.mssql.queries import (
@@ -126,34 +140,186 @@ def test_get_databases_statement_uses_all_dbs_when_ingest_all():
     assert handler._get_databases_statement() == MSSQL_GET_DATABASE
 
 
+# ── Driver error fixtures ────────────────────────────────────────────────────
+
+
+def _message(number: int, text: str) -> Message:
+    return {
+        "marker": 0xAA,
+        "msgno": number,
+        "state": 1,
+        "severity": 16,
+        "sql_state": None,
+        "priv_msg_type": 0,
+        "message": text,
+        "server": "sql1",
+        "proc_name": "",
+        "line_number": 1,
+    }
+
+
+class _Session:
+    """The only attribute raise_db_exception touches."""
+
+    def __init__(self, messages: list[Message]) -> None:
+        self.messages = messages
+
+
+def _pytds_error(*messages: tuple[int, str]) -> Exception:
+    """The error pytds raises for a sequence of server messages.
+
+    Goes through the driver's own _TdsSession.raise_db_exception, where the
+    number/text asymmetry lives, so it cannot drift from it.
+    """
+    session = _Session([_message(number, text) for number, text in messages])
+    try:
+        _TdsSession.raise_db_exception(session)
+    except Exception as raised:
+        return raised
+    raise AssertionError("raise_db_exception did not raise")
+
+
 def _pymssql_error(number: int, message: str) -> Exception:
-    """A pymssql-style driver error: numeric SQL Server code in ``args[0]``,
-    wrapped by SQLAlchemy which preserves the original on ``.orig``."""
-    orig = Exception(number, message)
-    wrapper = Exception(f"({number}) {message}")
-    wrapper.orig = orig  # type: ignore[attr-defined]
-    return wrapper
+    """pymssql's DBAPI shape: args[0] is the (number, message) tuple.
+
+    Hand-rolled - pymssql is in its own extra, not installed. Shape from v2.3.9
+    _pymssql.pyx, connect: `raise OperationalError(e.args[0])`.
+    """
+    return Exception((number, message))
 
 
 def _pyodbc_error(sqlstate: str, message: str) -> Exception:
-    """A pyodbc-style driver error: SQLSTATE + message text, no numeric code."""
-    return Exception(f"('{sqlstate}', \"[{sqlstate}] {message}\")")
+    """pyodbc's shape: ``args`` is ``(sqlstate, message)`` (src/errors.cpp, GetError).
+    The number appears only inside the message text."""
+    return pyodbc.ProgrammingError(sqlstate, f"[{sqlstate}] [Microsoft][ODBC Driver 18 for SQL Server]{message}")
 
 
-def test_pymssql_login_failure_classifies_as_auth():
-    diagnosis = MSSQL_ERRORS.classify(_pymssql_error(18456, "Login failed for user 'x'"))
+def _wrapped(orig: Exception) -> Exception:
+    """The driver error as SQLAlchemy re-raises it.
+
+    ``__cause__`` is the driver error, which is also what ``.orig`` holds - verified
+    on both the connect and execute paths, they are the same object.
+    """
+    error = SqlAlchemyOperationalError("SELECT 1", {}, orig)
+    error.__cause__ = orig
+    return error
+
+
+# The message sequences SQL Server really sends, captured from a live server
+# (Azure SQL Edge, pytds). The pairs are the whole point: pytds joins every
+# message's TEXT but keeps only the LAST message's NUMBER.
+_MISSING_DATABASE = (
+    (4060, 'Cannot open database "no_such_db" requested by the login. The login failed.'),
+    (18456, "Login failed for user 'sa'."),
+)
+_BAD_PASSWORD = ((18456, "Login failed for user 'sa'."),)
+_DENIED_SELECT = ((229, "The SELECT permission was denied on the object 'secret_t', database 'probe', schema 'dbo'."),)
+_NO_VIEW_SERVER_STATE = (
+    (300, "VIEW SERVER STATE permission was denied on object 'server', database 'master'."),
+    (297, "The user does not have permission to perform this action."),
+)
+
+
+@pytest.mark.parametrize(
+    ("messages", "expected_number"),
+    [
+        (_MISSING_DATABASE, 18456),  # NOT 4060 - the pair's last message wins
+        (_BAD_PASSWORD, 18456),
+        (_DENIED_SELECT, 229),
+        (_NO_VIEW_SERVER_STATE, 297),  # NOT 300 - same reason
+    ],
+)
+def test_pytds_reproduces_the_live_server_message_pairs(messages, expected_number):
+    """Each expected_number was read off a live Azure SQL Edge through this driver.
+    If pytds changes which message it takes the number from, this fails rather than
+    the rules silently going dead."""
+    assert _mssql_number(_pytds_error(*messages)) == expected_number
+
+
+def test_matchers_errno_cannot_read_any_supported_driver():
+    """Why this connector needs its own accessor: Matchers.errno wants an int at
+    args[0]; pytds puts the message there, pymssql a tuple, pyodbc a SQLSTATE."""
+    assert not Matchers.errno(18456)(_pytds_error(*_BAD_PASSWORD))
+    assert not Matchers.errno(18456)(_pymssql_error(18456, "Login failed for user 'x'."))
+    assert not Matchers.errno(4060)(_pyodbc_error("42000", "Cannot open database."))
+
+
+def test_mssql_number_reads_each_driver_shape():
+    assert _mssql_number(_pytds_error(*_BAD_PASSWORD)) == 18456
+    assert _mssql_number(_pymssql_error(4060, "Cannot open database.")) == 4060
+    assert _mssql_number(_wrapped(_pytds_error(*_DENIED_SELECT))) == 229
+    # pyodbc carries no number anywhere the accessor can reach.
+    assert _mssql_number(_pyodbc_error("42000", "Cannot open database. (4060)")) is None
+    assert _mssql_number(Exception("no number here")) is None
+
+
+def test_mssql_number_reads_through_sqlalchemys_cause():
+    """SQLAlchemy chains the driver error onto __cause__, which is the same object
+    it exposes as .orig - so walking the cause chain alone suffices."""
+    driver_error = _pytds_error(*_DENIED_SELECT)
+    wrapper = _wrapped(driver_error)
+    assert wrapper.orig is wrapper.__cause__ is driver_error
+    assert _mssql_number(wrapper) == 229
+
+
+# SQL Server localizes message text but never the number, so a German message can
+# only be diagnosed via the number. This is what proves a code is really bound.
+@pytest.mark.parametrize(
+    ("messages", "title"),
+    [
+        (((18456, "Fehler bei der Anmeldung für den Benutzer 'y'."),), "Authentication failed"),
+        (((229, "Die SELECT-Berechtigung wurde für das Objekt 'x' verweigert."),), "Insufficient privileges"),
+        (
+            (
+                (300, "Die VIEW SERVER STATE-Berechtigung wurde verweigert."),
+                (297, "Der Benutzer hat keine Berechtigung zum Ausführen dieser Aktion."),
+            ),
+            "Insufficient privileges",
+        ),
+    ],
+)
+def test_error_numbers_classify_independently_of_message_text(messages, title):
+    diagnosis = MSSQL_ERRORS.classify(_wrapped(_pytds_error(*messages)))
+    assert diagnosis is not None, "unbound: no rule matched"
+    assert diagnosis.title == title
+
+
+def test_a_localized_missing_database_has_no_number_to_key_on():
+    """The documented limitation, pinned so nobody re-adds a 4060 rule expecting it
+    to fire. pytds reports the [4060, 18456] pair's number as 18456, so on a
+    non-English server a missing database is diagnosed as an auth failure. English
+    survives only via the "Cannot open database" text rule."""
+    localized = (
+        (4060, 'Die Datenbank "x" kann nicht geöffnet werden. Fehler bei der Anmeldung.'),
+        (18456, "Fehler bei der Anmeldung für den Benutzer 'y'."),
+    )
+    error = _wrapped(_pytds_error(*localized))
+
+    assert _mssql_number(error) == 18456
+    assert MSSQL_ERRORS.classify(error).title == "Authentication failed"
+
+
+def test_pymssql_tuple_shape_classifies_by_number():
+    diagnosis = MSSQL_ERRORS.classify(_wrapped(_pymssql_error(18456, "Fehler bei der Anmeldung.")))
     assert diagnosis is not None
     assert diagnosis.title == "Authentication failed"
 
 
-def test_pyodbc_login_failure_classifies_as_auth():
+def test_pytds_login_failure_classifies_as_auth():
+    diagnosis = MSSQL_ERRORS.classify(_wrapped(_pytds_error(*_BAD_PASSWORD)))
+    assert diagnosis is not None
+    assert diagnosis.title == "Authentication failed"
+
+
+def test_pyodbc_login_failure_classifies_as_auth_on_message_text():
+    # pyodbc exposes no number, so this rides the `Login failed` message rule.
     diagnosis = MSSQL_ERRORS.classify(_pyodbc_error("28000", "Login failed for user 'x'."))
     assert diagnosis is not None
     assert diagnosis.title == "Authentication failed"
 
 
-def test_pymssql_database_not_found_classifies():
-    diagnosis = MSSQL_ERRORS.classify(_pymssql_error(4060, 'Cannot open database "x" requested by the login.'))
+def test_pytds_database_not_found_classifies():
+    diagnosis = MSSQL_ERRORS.classify(_wrapped(_pytds_error(*_MISSING_DATABASE)))
     assert diagnosis is not None
     assert diagnosis.title == "Database not found or not accessible"
 
@@ -165,14 +331,19 @@ def test_pyodbc_cannot_open_database_classifies():
 
 
 def test_cannot_open_database_wins_over_login_failed():
-    """The SQL Server 4060 message embeds 'The login failed.', so the database
-    rule must be ordered before the login rule (regression for live-found bug)."""
-    message = "Cannot open database \"x\" requested by the login. The login failed. Login failed for user 'y'."
-    assert MSSQL_ERRORS.classify(Exception(message)).title == "Database not found or not accessible"
+    """4060's text ends "The login failed." and pytds appends "Login failed for
+    user ..." - and the number is 18456. Both signals point at auth; only rule order
+    saves this case."""
+    error = _wrapped(_pytds_error(*_MISSING_DATABASE))
+
+    assert "Login failed for user" in str(error)
+    assert _mssql_number(error) == 18456
+    assert MSSQL_ERRORS.classify(error).title == "Database not found or not accessible"
 
 
-def test_pymssql_permission_denied_classifies():
-    diagnosis = MSSQL_ERRORS.classify(_pymssql_error(229, "The SELECT permission was denied on the object 'x'."))
+def test_pytds_permission_denied_classifies():
+    error = _wrapped(_pytds_error(*_DENIED_SELECT))
+    diagnosis = MSSQL_ERRORS.classify(error)
     assert diagnosis is not None
     assert diagnosis.title == "Insufficient privileges"
 
@@ -183,6 +354,14 @@ def test_pyodbc_permission_denied_classifies():
     assert diagnosis.title == "Insufficient privileges"
 
 
+def test_statement_permission_denied_is_not_diagnosed():
+    """262 is a statement permission (CREATE DATABASE / TABLE / SHOWPLAN); these
+    checks only SELECT. Its text says "permission denied", not "permission was
+    denied", so the message rule misses it too."""
+    error = _wrapped(_pytds_error((262, "CREATE DATABASE permission denied in database 'master'.")))
+    assert MSSQL_ERRORS.classify(error) is None
+
+
 def test_network_pack_is_folded_in():
     diagnosis = MSSQL_ERRORS.classify(socket.gaierror("Name or service not known"))
     assert diagnosis is not None
@@ -191,6 +370,96 @@ def test_network_pack_is_folded_in():
 
 def test_unknown_error_is_not_classified():
     assert MSSQL_ERRORS.classify(Exception("something unexpected")) is None
+
+
+# ── API level: TestConnectionRunner.run() -> TestConnectionResult ────────────
+#
+# The product surface. Everything above asserts on the pack in isolation; these
+# drive the runner end to end against an engine that raises a real pytds error and
+# assert on the TestConnectionResult the backend and UI actually consume.
+
+
+MSSQL_DEFINITION_JSON = (
+    Path(__file__).parents[6] / "openmetadata-service/src/main/resources/json/data/testConnections/database/mssql.json"
+)
+
+
+def _mssql_definition() -> TestConnectionDefinition:
+    """The MSSQL definition the server seeds, loaded from the resource itself.
+
+    Read rather than transcribed so step order, gate category and mandatory flags
+    cannot drift from what production runs.
+    """
+    return TestConnectionDefinition.model_validate_json(MSSQL_DEFINITION_JSON.read_text())
+
+
+def _run_against(engine) -> TestConnectionResult:
+    """Drive the runner as BaseConnection.test_connection does. tcp_probe is stubbed
+    so the gate's preflight passes and the test reaches the driver error."""
+    metadata = MagicMock()
+    metadata.get_by_name.return_value = _mssql_definition()
+    checks = MssqlChecks(db=Borrowed.of(engine), get_databases_statement="SELECT 1")
+    with patch("metadata.core.connections.test_connection.network.tcp_probe"):
+        return TestConnectionRunner(checks, "Mssql", timeout_seconds=None).run(metadata)
+
+
+def _engine_failing_with(error: Exception) -> Engine:
+    """A real mssql+pytds Engine whose DBAPI connect raises `error`, so SQLAlchemy
+    does the wrapping and the classifier sees the production shape."""
+
+    def connect_raises():
+        raise error
+
+    return create_engine("mssql+pytds://user:pass@sql1.example.com:1433/mydb", creator=connect_raises)
+
+
+def test_bad_login_fails_the_whole_test_with_an_auth_diagnosis():
+    result = _run_against(_engine_failing_with(_pytds_error(*_BAD_PASSWORD)))
+
+    assert result.status.value == "Failed"
+    gate = result.steps[0]
+    assert gate.name == "CheckAccess"
+    assert gate.passed is False
+    assert gate.status.value == "Failed"
+    assert gate.diagnosis.title == "Authentication failed"
+    assert gate.diagnosis.remediation
+
+
+def test_a_failed_gate_short_circuits_every_later_step():
+    result = _run_against(_engine_failing_with(_pytds_error(*_BAD_PASSWORD)))
+
+    later = result.steps[1:]
+    assert [step.status.value for step in later] == ["Skipped"] * 5
+    assert {step.skipReason.value for step in later} == {"ConnectionNotEstablished"}
+
+
+def test_missing_database_is_reported_as_a_database_problem_not_an_auth_one():
+    """Both of 4060's signals point at auth - the joined text ends "Login failed for
+    user ..." and the number is 18456 - so only rule order gets this right."""
+    result = _run_against(_engine_failing_with(_pytds_error(*_MISSING_DATABASE)))
+
+    assert result.status.value == "Failed"
+    assert result.steps[0].diagnosis.title == "Database not found or not accessible"
+
+
+def test_a_localized_permission_denial_is_diagnosed_at_the_api_level():
+    """End-to-end proof a number, not the English text, can drive the diagnosis."""
+    localized = (
+        (300, "Die VIEW SERVER STATE-Berechtigung wurde verweigert."),
+        (297, "Der Benutzer hat keine Berechtigung zum Ausführen dieser Aktion."),
+    )
+    result = _run_against(_engine_failing_with(_pytds_error(*localized)))
+
+    assert result.steps[0].diagnosis.title == "Insufficient privileges"
+
+
+def test_an_unclassified_failure_still_reports_its_raw_error_log():
+    result = _run_against(_engine_failing_with(RuntimeError("something we have never seen")))
+
+    gate = result.steps[0]
+    assert gate.passed is False
+    assert gate.diagnosis is None
+    assert "something we have never seen" in gate.errorLog
 
 
 def _engine_returning(rows: int) -> Engine:

--- a/ingestion/tests/unit/source/database/redshift/test_connection.py
+++ b/ingestion/tests/unit/source/database/redshift/test_connection.py
@@ -39,6 +39,7 @@ from metadata.ingestion.source.database.redshift.connection import (
     REDSHIFT_ERRORS,
     RedshiftChecks,
     RedshiftConnection,
+    _pgcode,
     _summarize_databases,
 )
 from metadata.ingestion.source.database.redshift.models import RedshiftInstanceType
@@ -112,8 +113,12 @@ def test_auth_failure_message_is_classified():
     assert REDSHIFT_ERRORS.classify(error).title == "Authentication failed"
 
 
-def test_auth_failure_sqlstate_is_classified():
-    error = _SqlAlchemyError(_Psycopg2Error("authorization not valid", pgcode="28000"))
+def test_a_connect_phase_auth_failure_carries_no_sqlstate_to_match_on():
+    """Pins why there is no 28000/28P01 rule: a connect-phase failure has no
+    PGresult, so .pgcode is None (verified on PostgreSQL 15) and only the message
+    rule can fire. The old test fabricated pgcode="28000" here."""
+    error = _SqlAlchemyError(_Psycopg2Error(_AUTH_FAILED_MSG))
+    assert _pgcode(error) is None
     assert REDSHIFT_ERRORS.classify(error).title == "Authentication failed"
 
 

--- a/ingestion/tests/unit/source/database/snowflake/test_connection.py
+++ b/ingestion/tests/unit/source/database/snowflake/test_connection.py
@@ -18,6 +18,11 @@ the intended diagnosis).
 from unittest.mock import MagicMock, patch
 
 import pytest
+from snowflake.connector.errorcode import (
+    ER_FAILED_TO_CONNECT_TO_DB,
+    ER_HTTP_GENERAL_ERROR,
+)
+from snowflake.connector.errors import ForbiddenError
 
 from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import Evidence
@@ -69,14 +74,40 @@ def test_auth_failure_message_is_classified():
     assert SNOWFLAKE_ERRORS.classify(error).title == "Authentication failed"
 
 
-def test_bad_account_login_404_is_classified():
-    error = _SqlAlchemyError(
-        _SnowflakeError(
-            "None: 404 Not Found: post nope99999.us-east-1.snowflakecomputing.com:443/session/v1/login-request",
-            errno=290404,
-        )
+def _bad_account_error() -> ForbiddenError:
+    """A login-endpoint 403, reproducing snowflake/connector/auth/_auth.py's
+    `except ForbiddenError` re-raise verbatim (message + errno)."""
+    return ForbiddenError(
+        msg=(
+            "Failed to connect to DB. Verify the account name is correct: "
+            "nope99999.us-east-1.snowflakecomputing.com:443. 403 Forbidden: "
+            "post nope99999.us-east-1.snowflakecomputing.com:443/session/v1/login-request"
+        ),
+        errno=ER_FAILED_TO_CONNECT_TO_DB,
+        sqlstate="08001",
     )
-    assert SNOWFLAKE_ERRORS.classify(error).title == "Snowflake account not found"
+
+
+def test_a_login_endpoint_403_is_classified():
+    assert (
+        SNOWFLAKE_ERRORS.classify(_SqlAlchemyError(_bad_account_error())).title
+        == "Snowflake rejected the login endpoint request"
+    )
+
+
+def test_the_bad_account_errno_is_not_290404():
+    """Pins why the rule is keyed on the message: 290404 appears nowhere in the
+    connector, and this path's errno is 540001 only because ForbiddenError.__init__
+    adds ER_HTTP_GENERAL_ERROR to the errno it is passed."""
+    error = _bad_account_error()
+    assert error.errno != 290404
+    assert error.errno == ER_HTTP_GENERAL_ERROR + ER_FAILED_TO_CONNECT_TO_DB == 540001
+
+
+def test_a_login_endpoint_403_is_not_read_as_a_generic_auth_failure():
+    """The 403 path carries errno 540001, not the overloaded 250001, but the
+    message rule must still win regardless of ordering."""
+    assert SNOWFLAKE_ERRORS.classify(_SqlAlchemyError(_bad_account_error())).title != "Authentication failed"
 
 
 def test_mfa_required_beats_generic_auth():

--- a/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/airflow/test_connection.py
@@ -13,6 +13,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
+from botocore.exceptions import ClientError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import HTTPError, JSONDecodeError, SSLError, Timeout
 from sqlalchemy import create_engine
@@ -23,7 +25,21 @@ from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import collect_checks
 from metadata.core.connections.test_connection.check import CheckError
 from metadata.core.connections.test_connection.checks.pipeline import PipelineStep
+from metadata.core.connections.test_connection.classifier import exception_chain
 from metadata.core.connections.test_connection.network import NetworkUnreachableError
+from metadata.generated.schema.entity.services.connections.pipeline.airflowConnection import (
+    AirflowConnection as AirflowConnectionConfig,
+)
+from metadata.generated.schema.entity.utils.airflowRestApiConnection import (
+    AirflowRestApiConnection,
+    ApiVersion,
+)
+from metadata.generated.schema.entity.utils.common.accessTokenConfig import AccessToken
+from metadata.generated.schema.entity.utils.common.mwaaAuthConfig import (
+    MwaaAuthentication,
+    MwaaConfig,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.pipeline.airflow.api.client import AirflowApiClient
 from metadata.ingestion.source.pipeline.airflow.connection import (
@@ -107,20 +123,23 @@ def test_checks_borrow_the_connection_client():
 
 
 @patch("metadata.core.connections.test_connection.network.tcp_probe")
-def test_rest_check_access_reads_the_version(_mock_probe):
+def test_rest_check_access_reads_the_version_via_the_strict_accessor(_mock_probe):
+    """The gate must read the version through test_get_version, not get_version:
+    the latter tolerates an unparseable reply and would pass against any host."""
     client = _rest_client()
-    client.get_version.return_value = {"version": "2.9.0"}
+    client.test_get_version.return_value = {"version": "2.9.0"}
 
     evidence = _rest_checks(client).check_access()
 
-    client.get_version.assert_called_once_with()
+    client.test_get_version.assert_called_once_with()
+    client.get_version.assert_not_called()
     assert evidence.summary == "authenticated"
 
 
 @patch("metadata.core.connections.test_connection.network.tcp_probe")
 def test_rest_check_access_failure_reports_a_check_error(_mock_probe):
     client = _rest_client()
-    client.get_version.side_effect = RuntimeError("transport closed")
+    client.test_get_version.side_effect = RuntimeError("transport closed")
 
     with (
         patch(
@@ -179,6 +198,197 @@ def test_rest_task_detail_access_is_a_noop_pass():
     evidence = _rest_checks(client).task_detail_access()
 
     assert "per-DAG" in evidence.summary
+
+
+# ── REST path, driving the real AirflowApiClient ─────────────────────────────
+#
+# The tests above mock AirflowApiClient wholesale, so they prove only that the
+# provider calls it - never that the client surfaces a non-Airflow host. These
+# drive the real client (and the real REST plumbing under it) by stubbing only
+# the outermost seam, requests.Session.request.
+
+
+def _real_rest_client(host="https://airflow.example.com:8080") -> AirflowApiClient:
+    """A real AirflowApiClient. apiVersion is pinned so the gate makes exactly one
+    HTTP call and the test is not coupled to version auto-detection."""
+    config = AirflowConnectionConfig(
+        hostPort=host,
+        connection=AirflowRestApiConnection(
+            authConfig=AccessToken(token="a-token"),
+            apiVersion=ApiVersion.v2,
+        ),
+    )
+    return AirflowApiClient(config)
+
+
+def _html_response(status_code: int = 200) -> requests.Response:
+    """A real Response with an HTML body - what a host that is not the Airflow REST
+    API answers with. Real, so response.json() raises the genuine JSONDecodeError."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = b"<!doctype html><html><body>Sign in</body></html>"
+    response.headers["content-type"] = "text/html; charset=utf-8"
+    response.url = "https://airflow.example.com:8080/api/v2/version"
+    return response
+
+
+@patch("metadata.core.connections.test_connection.network.tcp_probe")
+def test_rest_gate_fails_against_a_host_that_is_not_airflow(_mock_probe):
+    """Regression: REST.get returns the raw Response when the body will not decode,
+    and _parse_response swallowed that into {} - so the gate went green against any
+    web server answering 200 text/html."""
+    client = _real_rest_client()
+
+    with (
+        patch.object(requests.Session, "request", return_value=_html_response()),
+        pytest.raises(CheckError) as failure,
+    ):
+        _rest_checks(client).check_access()
+
+    assert AIRFLOW_ERRORS.classify(failure.value.cause).title == "Host is not the Airflow REST API"
+
+
+@patch("metadata.core.connections.test_connection.network.tcp_probe")
+def test_rest_gate_passes_against_a_real_airflow_version_payload(_mock_probe):
+    """The counterpart: a genuine Airflow /version JSON body still passes the gate."""
+    client = _real_rest_client()
+    response = requests.Response()
+    response.status_code = 200
+    response._content = b'{"version": "2.9.0", "git_version": "abc"}'
+    response.headers["content-type"] = "application/json"
+
+    with patch.object(requests.Session, "request", return_value=response):
+        evidence = _rest_checks(client).check_access()
+
+    assert evidence.summary == "authenticated"
+
+
+@patch("metadata.core.connections.test_connection.network.tcp_probe")
+def test_rest_gate_fails_on_an_unauthorized_reply(_mock_probe):
+    """A 401 from the real client must fail the gate and diagnose as auth."""
+    client = _real_rest_client()
+
+    with (
+        patch.object(requests.Session, "request", return_value=_html_response(status_code=401)),
+        pytest.raises(CheckError) as failure,
+    ):
+        _rest_checks(client).check_access()
+
+    assert AIRFLOW_ERRORS.classify(failure.value.cause).title == "Authentication failed"
+
+
+@patch("metadata.core.connections.test_connection.network.tcp_probe")
+def test_rest_gate_surfaces_a_malformed_host_error(_mock_probe):
+    """Regression: get_raw returned None for an exception outside its transport tuple
+    (a mistyped host raises MissingSchema), so the gate hit AttributeError on None.
+    It now re-raises the real cause instead of swallowing it."""
+    client = _real_rest_client()
+
+    with (
+        patch.object(requests.Session, "request", side_effect=requests.exceptions.MissingSchema("bad url")),
+        pytest.raises(CheckError) as failure,
+    ):
+        _rest_checks(client).check_access()
+
+    assert isinstance(failure.value.cause, requests.exceptions.MissingSchema)
+    assert not isinstance(failure.value.cause, AttributeError)
+
+
+@patch("metadata.core.connections.test_connection.network.tcp_probe")
+def test_rest_gate_diagnoses_a_rate_limit_with_a_readable_error(_mock_probe):
+    """Regression: a 429 raised LimitsException with an empty message, so the gate's
+    errorLog was blank. The real HTTPError (status 429) is surfaced instead."""
+    client = _real_rest_client()
+    response = _html_response(status_code=429)
+
+    with (
+        patch.object(requests.Session, "request", return_value=response),
+        pytest.raises(CheckError) as failure,
+    ):
+        _rest_checks(client).check_access()
+
+    assert AIRFLOW_ERRORS.classify(failure.value.cause).title == "Rate limited"
+    assert "429" in str(failure.value.cause)
+
+
+# ── MWAA flavour ─────────────────────────────────────────────────────────────
+
+
+def _mwaa_client() -> AirflowApiClient:
+    """A real AirflowApiClient on the MWAA path, with only the boto3 client stubbed."""
+    config = AirflowConnectionConfig(
+        hostPort="https://airflow.example.com:8080",
+        connection=AirflowRestApiConnection(
+            authConfig=MwaaAuthentication(
+                mwaaConfig=MwaaConfig(
+                    awsConfig=AWSCredentials(awsRegion="us-east-1"),
+                    mwaaEnvironmentName="my-environment",
+                )
+            )
+        ),
+    )
+    with patch("metadata.ingestion.source.pipeline.airflow.api.mwaa.AWSClient"):
+        return AirflowApiClient(config)
+
+
+def test_mwaa_gate_fails_when_aws_rejects_the_call():
+    """Regression: MWAAClient.get_version is hardcoded and never calls AWS, so the
+    gate passed unconditionally - bad credentials, wrong environment, no route."""
+    client = _mwaa_client()
+    denied = ClientError(
+        {"Error": {"Code": "AccessDeniedException", "Message": "not authorized to perform mwaa:InvokeRestApi"}},
+        "InvokeRestApi",
+    )
+    client.mwaa_client._mwaa_client.invoke_rest_api.side_effect = denied
+
+    with pytest.raises(CheckError) as failure:
+        _rest_checks(client).check_access()
+
+    assert failure.value.evidence.command == "read the Airflow REST API version"
+    # The MWAA diagnostics hint wraps the AWS error, which stays in the chain.
+    assert any(isinstance(current, ClientError) for current in exception_chain(failure.value.cause))
+
+
+def test_mwaa_gate_passes_when_the_environment_answers():
+    client = _mwaa_client()
+    client.mwaa_client._mwaa_client.invoke_rest_api.return_value = {"RestApiResponse": {"dags": [], "total_entries": 0}}
+
+    evidence = _rest_checks(client).check_access()
+
+    assert evidence.summary == "authenticated"
+    client.mwaa_client._mwaa_client.invoke_rest_api.assert_called_once()
+
+
+def test_mwaa_gate_calls_aws_with_the_configured_environment():
+    """The call must name the configured environment - that is half of what the gate
+    is proving."""
+    client = _mwaa_client()
+    client.mwaa_client._mwaa_client.invoke_rest_api.return_value = {"RestApiResponse": {}}
+
+    _rest_checks(client).check_access()
+
+    kwargs = client.mwaa_client._mwaa_client.invoke_rest_api.call_args.kwargs
+    assert kwargs["Name"] == "my-environment"
+    assert kwargs["Path"] == "/dags"
+
+
+def test_ingestion_mwaa_get_version_stays_a_stub():
+    """get_version is on the ingestion path and stays hardcoded; only the
+    test-connection accessor makes a real call."""
+    client = _mwaa_client()
+
+    assert client.get_version() == {"version": "MWAA", "status": "connected"}
+    client.mwaa_client._mwaa_client.invoke_rest_api.assert_not_called()
+
+
+def test_ingestion_get_version_still_tolerates_a_non_json_reply():
+    """get_version is on the ingestion path and must keep its lenient behaviour;
+    only the test-connection accessor is strict. Guards against the fix being
+    applied to the wrong method."""
+    client = _real_rest_client()
+
+    with patch.object(requests.Session, "request", return_value=_html_response()):
+        assert client.get_version() == {}
 
 
 # ── Backend (metadata-DB) path ───────────────────────────────────────────────

--- a/ingestion/tests/unit/source/pipeline/dbtcloud/test_connection.py
+++ b/ingestion/tests/unit/source/pipeline/dbtcloud/test_connection.py
@@ -10,6 +10,7 @@
 #  limitations under the License.
 """Unit tests for dbt Cloud connection handling and its test-connection checks."""
 
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,6 +21,8 @@ from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection import collect_checks
 from metadata.core.connections.test_connection.check import CheckError
 from metadata.core.connections.test_connection.checks.pipeline import PipelineStep
+from metadata.core.connections.test_connection.classifier import exception_chain
+from metadata.core.connections.test_connection.network import NetworkUnreachableError
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.source.pipeline.dbtcloud.client import (
     TEST_RETRY_WAIT_SECONDS,
@@ -159,6 +162,37 @@ def test_error_pack_diagnoses_known_failures(error, title):
     assert diagnosis is not None
     assert diagnosis.title == title
     assert diagnosis.remediation
+
+
+def _dns_failure() -> RequestsConnectionError:
+    """A requests DNS failure, with the cause chain requests really builds.
+
+    Captured live from `requests.get("https://<unresolvable>/", timeout=5)`, whose
+    chain is ConnectionError <- MaxRetryError <- NameResolutionError <- gaierror.
+    Reproduced here rather than dialling a resolver, so the test cannot flake on
+    CI DNS - the shape is what matters, and the shape is the one observed.
+    """
+    error = RequestsConnectionError(
+        "HTTPSConnectionPool(host='nope.invalid', port=443): Max retries exceeded with url: "
+        "/api/v2/accounts/1/jobs/ (Caused by NameResolutionError(\"Failed to resolve 'nope.invalid'\"))"
+    )
+    error.__cause__ = socket.gaierror(8, "nodename nor servname provided, or not known")
+    return error
+
+
+def test_a_dns_failure_is_claimed_by_the_connectors_own_rule_not_the_network_pack():
+    """The gaierror IS in the chain - the fold was unreachable by precedence, not
+    absence: `including` appends lower, so the RequestsConnectionError rule wins."""
+    error = _dns_failure()
+
+    assert any(isinstance(current, socket.gaierror) for current in exception_chain(error))
+    assert DBTCLOUD_ERRORS.classify(error).title == "Cannot reach the host"
+
+
+def test_network_unreachable_is_impossible_without_a_preflight():
+    """The fold's fourth rule. Only tcp_probe raises NetworkUnreachableError, and
+    this connector runs no preflight, so the pack does not claim to diagnose one."""
+    assert DBTCLOUD_ERRORS.classify(NetworkUnreachableError("cloud.getdbt.com:443 is not reachable")) is None
 
 
 def test_error_pack_diagnoses_a_status_wrapped_by_a_check_error():

--- a/ingestion/tests/unit/topology/database/test_databricks.py
+++ b/ingestion/tests/unit/topology/database/test_databricks.py
@@ -38,6 +38,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.database.databricks.metadata import DatabricksSource
 
@@ -645,7 +646,7 @@ class DatabricksConnectionTest(TestCase):
             mock_connection.execute.assert_called_once()
 
     def test_databricks_engine_wrapper_get_tables_no_schemas(self):
-        """Test get_tables when no schemas are available"""
+        """get_tables raises rather than passing a mandatory step with nothing resolved."""
         mock_engine = Mock()
         mock_inspector = Mock()
         mock_inspector.get_schema_names.return_value = []
@@ -654,9 +655,8 @@ class DatabricksConnectionTest(TestCase):
             mock_inspect.return_value = mock_inspector
 
             wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
-            tables = wrapper.get_tables()
-
-            self.assertEqual(tables, [])
+            with self.assertRaises(SourceConnectionException):
+                wrapper.get_tables()
             mock_inspector.get_table_names.assert_not_called()
 
     def test_databricks_engine_wrapper_get_views_with_cached_schema(self):
@@ -728,7 +728,7 @@ class DatabricksConnectionTest(TestCase):
             mock_connection.execute.assert_called_once()
 
     def test_databricks_engine_wrapper_get_views_no_schemas(self):
-        """Test get_views when no schemas are available"""
+        """get_views raises rather than passing a mandatory step with nothing resolved."""
         mock_engine = Mock()
         mock_inspector = Mock()
         mock_inspector.get_schema_names.return_value = []
@@ -737,9 +737,8 @@ class DatabricksConnectionTest(TestCase):
             mock_inspect.return_value = mock_inspector
 
             wrapper = self.DatabricksEngineWrapper(Borrowed.of(mock_engine))
-            views = wrapper.get_views()
-
-            self.assertEqual(views, [])
+            with self.assertRaises(SourceConnectionException):
+                wrapper.get_views()
             mock_inspector.get_view_names.assert_not_called()
 
     def test_databricks_engine_wrapper_caching_behavior(self):

--- a/ingestion/tests/unit/topology/pipeline/test_airflow_connection.py
+++ b/ingestion/tests/unit/topology/pipeline/test_airflow_connection.py
@@ -1000,7 +1000,7 @@ class TestDiagnoseSwallowsExceptions:
 
 
 class TestDecoratedCheckAccess:
-    """Verify the post-failure decoration wrapping client.get_version in CheckAccess."""
+    """Verify the post-failure decoration wrapping client.test_get_version in CheckAccess."""
 
     def test_success_returns_result_unchanged(self):
         from metadata.ingestion.source.pipeline.airflow.connection import (
@@ -1008,7 +1008,7 @@ class TestDecoratedCheckAccess:
         )
 
         client = MagicMock()
-        client.get_version.return_value = {"version": "2.8.0"}
+        client.test_get_version.return_value = {"version": "2.8.0"}
         result = _decorated_check_access(client, "https://airflow.example.com", None, True)
         assert result == {"version": "2.8.0"}
 
@@ -1021,7 +1021,7 @@ class TestDecoratedCheckAccess:
         )
 
         client = MagicMock()
-        client.get_version.side_effect = ValueError("Expecting value: line 2 column 1 (char 1)")
+        client.test_get_version.side_effect = ValueError("Expecting value: line 2 column 1 (char 1)")
 
         with (
             patch(
@@ -1047,7 +1047,7 @@ class TestDecoratedCheckAccess:
         )
 
         client = MagicMock()
-        client.get_version.side_effect = RuntimeError("transport closed")
+        client.test_get_version.side_effect = RuntimeError("transport closed")
 
         with (
             patch(


### PR DESCRIPTION
Closes #30153

Stacked on #30150 — targets `connector-improvements-review` so the diff is only this branch's work. GitHub will retarget it to `main` when #30150 merges.

Every matcher kept or added here is traceable to a real driver observation: the exception class imported, or the driver source / official documentation cited in a comment. Where provenance could not be established, the matcher was deleted rather than guessed at.

### The connection reported the wrong outcome

| | |
|---|---|
| **airflow** | The gate went green against any web server. `ometa/client.py` returns the raw `Response` on a `JSONDecodeError`; `_parse_response` then catches `Exception` and returns `{}`, so `check_access` never raised. Added a strict `test_get_version()` (`get_raw` + `raise_for_status`, mirroring dbt Cloud's `_test_get`) and pointed the gate at it; `get_version` keeps its lenient behaviour for ingestion. |
| **mssql** | All six error codes were dead. `Matchers.errno` needs an `int` at `args[0]`; pytds (the default) puts the message there, pymssql a `(number, message)` tuple, pyodbc a SQLSTATE string. Added `_mssql_number`, reading `.number`/`.msg_no` and the pymssql tuple across the chain and `.orig`. The driver comment named pymssql and pyodbc while the default is pytds — corrected. |
| **databricks** | `get_tables`/`get_views` returned `[]` when no catalog or schema resolved, so a mandatory step passed. They now raise, as Unity Catalog already did. |
| **powerbi** | The real envelope nests `code` under `error`, so the shared client returned `None` and `DashboardsResponse(**None)` raised `TypeError`. Added `PowerBiApiError` + `_test_get`, and split the vague auth diagnosis into the three AADSTS causes — gated on `InvalidSourceException`, so a status-coded REST error echoing a code still classifies by status. |

### Rules deleted, with the evidence

- **redshift `28000`/`28P01`** — the module's own docstring already said connect-phase errors carry no SQLSTATE. Confirmed against PostgreSQL 15: wrong password → `pgcode=None`, missing database → `pgcode=None`, query-phase denial → `pgcode='42501'`. That validated the deletion *and* keeping 42501.
- **databricks `contains("forbidden")`** — `Error.__str__` returns only the message; the status lives in `context["http-code"]`, and "forbidden" appears nowhere in databricks-sql. Replaced with a regression test pinning that a table named `forbidden_items` is not misread as "Access denied".
- **snowflake `290404`** — a bad account returns 403, and `ForbiddenError.__init__` adds `ER_HTTP_GENERAL_ERROR + 250001`, so the code is 540001. Keyed on the message instead: 540001 is an artifact of that double-add, the message is the driver's deliberate signal.
- **looker's `NETWORK_ERRORS` fold** — driving the real transport shows a `ConnectionRefusedError` comes back as `Response(ok=False, value=b'[Errno 61] Connection refused')`. The type is destroyed, so the rules cannot fire; removal changes no diagnosis, because `_transport_text` already yields the same titles.
- **dbtcloud's `NETWORK_ERRORS` fold** — the rules were dead by *precedence*, not absence: a real DNS failure does carry `gaierror`, but the connector's own requests-typed rules always match first. Deleted rather than adding a TCP preflight: dbt Cloud is public SaaS, `requests` honours `HTTPS_PROXY` and a raw probe does not, so a preflight would fail a working proxied setup — the case `ping`'s own docstring warns about.

### Judgement calls worth a look

- **mssql 262 and 300 dropped, 297 kept.** 262 is statement permission (CREATE DATABASE) — test-connection only SELECTs. SQL Server emits 300+297 together on a VIEW SERVER STATE denial, which `GetQueries` provokes; pytds keeps only the last message's number (297), and 297's own text lacks "permission was denied", so the number is the only signal that catches it.
- **No databricks 403 rule.** The mechanism (`context["http-code"]`) exists, but whether a real 403 populates it could not be established without a live workspace, so no matcher.

### Tests

The fixtures are the point. mssql builds its errors through pytds's own `_create_exception_by_message` and the real `pyodbc` class, and proves the codes with **German** messages that no English `contains` rule can match. Several connectors now drive `TestConnectionRunner.run()` to a `TestConnectionResult` against a real `mssql+pytds` engine, so SQLAlchemy does the `.orig` wrapping itself.

Mutation-checked: neutering `_mssql_number` fails 9 tests — against the previous state, where neutering `Matchers.errno` entirely left all 20 mssql tests green.

**Not validated live** against real Airflow, Power BI, Databricks or Snowflake; provenance is driver source, official docs, or a local PostgreSQL container. Only the connectors named here were audited.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns ingestion test-connection diagnoses with errors produced by the supported clients and drivers. The main changes are:

- Adds strict, bounded connection probes for Airflow and Power BI.
- Handles Power BI REST envelopes and Microsoft Entra authentication codes.
- Detects unresolved Databricks catalog and schema targets.
- Extracts SQL Server error numbers across supported driver exception shapes.
- Removes unreachable or unsupported matchers from several connectors.
- Expands connector tests using realistic response and driver error shapes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Raw Airflow and Power BI requests now return a response or propagate the underlying error.
- Exhausted rate limits retain an HTTP status that the connector diagnoses can classify.
- No blocking issue remains in the updated connection-test paths.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/ometa/client.py | Raw GET requests now accept retry overrides and propagate unexpected failures instead of returning None. |
| ingestion/src/metadata/ingestion/source/pipeline/airflow/api/client.py | Airflow test connections now use a strict, bounded version probe with status and JSON validation. |
| ingestion/src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py | MWAA test connections now make a real API request instead of relying on a static version response. |
| ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py | Power BI test requests now preserve HTTP status, bound retries, and validate response payloads. |
| ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py | Power BI diagnoses now cover specific Entra failures and status-bearing REST errors. |
| ingestion/src/metadata/ingestion/source/database/databricks/connection.py | Mandatory listing checks now fail when no catalog and schema can be resolved. |
| ingestion/src/metadata/ingestion/source/database/mssql/connection.py | SQL Server diagnoses now read error numbers from pytds and pymssql exception shapes. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/testconn-p0..."](https://github.com/open-metadata/openmetadata/commit/922e2a463ca5b28a9becd330035371cc79caab31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45141145)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->