### PR TITLE
Fixes: latestKpiResult returns most recent bucket, not the partial leading one

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
@@ -1,5 +1,6 @@
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.Entity.DATA_INSIGHT_CHART;
 import static org.openmetadata.service.Entity.DATA_INSIGHT_CUSTOM_CHART;
 import static org.openmetadata.service.Entity.KPI;
@@ -128,9 +129,8 @@ public class KpiRepository extends EntityRepository<Kpi> {
         DataInsightCustomChartResultList resultList =
             searchRepository.getSearchClient().buildDIChart(chart, start, end);
 
-        if (resultList != null && !resultList.getResults().isEmpty()) {
-          DataInsightCustomChartResult result = resultList.getResults().get(0);
-
+        DataInsightCustomChartResult result = getMostRecentResult(resultList);
+        if (result != null) {
           // Apply the result to all KPIs using this chart
           for (Kpi kpi : entry.getValue()) {
             KpiTarget target =
@@ -205,6 +205,15 @@ public class KpiRepository extends EntityRepository<Kpi> {
     return getToEntityRef(kpi.getId(), Relationship.USES, DATA_INSIGHT_CUSTOM_CHART, true);
   }
 
+  static DataInsightCustomChartResult getMostRecentResult(
+      DataInsightCustomChartResultList resultList) {
+    DataInsightCustomChartResult result = null;
+    if (resultList != null && !nullOrEmpty(resultList.getResults())) {
+      result = resultList.getResults().getLast();
+    }
+    return result;
+  }
+
   public KpiResult getKpiResult(String fqn) {
 
     long end = System.currentTimeMillis();
@@ -220,8 +229,8 @@ public class KpiRepository extends EntityRepository<Kpi> {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    if (resultList != null && !resultList.getResults().isEmpty()) {
-      DataInsightCustomChartResult result = resultList.getResults().get(0);
+    DataInsightCustomChartResult result = getMostRecentResult(resultList);
+    if (result != null) {
       KpiTarget target =
           new KpiTarget()
               .withValue(result.getCount().toString())

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KpiRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KpiRepositoryTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResult;
+import org.openmetadata.schema.dataInsight.custom.DataInsightCustomChartResultList;
+
+class KpiRepositoryTest {
+
+  @Test
+  void latestResultUsesMostRecentBucketNotFirst() {
+    DataInsightCustomChartResult partialLeadingBucket =
+        new DataInsightCustomChartResult().withCount(0.0).withDay(1784160000000.0);
+    DataInsightCustomChartResult mostRecentFullDay =
+        new DataInsightCustomChartResult().withCount(0.6804130832728905).withDay(1784246400000.0);
+    DataInsightCustomChartResultList resultList =
+        new DataInsightCustomChartResultList()
+            .withResults(List.of(partialLeadingBucket, mostRecentFullDay));
+
+    DataInsightCustomChartResult latest = KpiRepository.getMostRecentResult(resultList);
+
+    assertEquals(0.6804130832728905, latest.getCount(), 0.0);
+    assertEquals(1784246400000.0, latest.getDay(), 0.0);
+  }
+
+  @Test
+  void latestResultReturnsNullWhenNoBuckets() {
+    assertNull(
+        KpiRepository.getMostRecentResult(
+            new DataInsightCustomChartResultList().withResults(List.of())));
+    assertNull(KpiRepository.getMostRecentResult(null));
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #<!-- ISSUE NUMBER REQUIRED — please add the GitHub issue number here -->

I fixed `/api/v1/kpi/{fqn}/latestKpiResult` returning `0.0` while the day-aligned `/kpiResult` time series correctly showed the real value (e.g. `0.68`). `KpiRepository.getKpiResult()` (and the bulk `fetchAndSetKpiResults()` path) aggregated a trailing 24h window and took `results.get(0)` — but that window straddles two day buckets and the first/oldest one is a partial fragment that aggregates to `0.0`. I introduced a shared `getMostRecentResult()` helper that selects the most recent bucket via `getLast()` and routed both call sites through it.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `latestKpiResult` for a KPI now returns the most recent day's value instead of the partial leading bucket's `0.0`.

#### Unit tests
- [x] Added `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KpiRepositoryTest.java`
  - `latestResultUsesMostRecentBucketNotFirst` — asserts the newest bucket (`0.68`) is chosen over the leading `0.0` bucket (fails against the old `get(0)` logic).
  - `latestResultReturnsNullWhenNoBuckets` — null/empty guard.

#### Backend integration tests
- [x] Not applicable (no API contract change; existing `KpiResourceIT` still covers the endpoint).

#### Manual testing performed
Reproduced via curl against a live instance: `latestKpiResult` returned `0.0` and equalled `kpiResult(now-24h, now).results[0]`, while `results[-1]` held the correct `0.68`; polling confirmed it was structural, not a transient reindex.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes KPI lookup to select the final result bucket. The main changes are:

- Adds a shared helper for selecting the final chart result.
- Uses the helper in single and bulk KPI result paths.
- Adds tests for ascending buckets and empty results.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The changed result-selection path can return an unrelated term bucket or an incomplete current-day bucket.

- The helper works for the ascending two-bucket fixture.
- Non-timestamp charts do not give list position a recency meaning.
- A trailing partial day can still replace the latest completed value with zero or null.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KpiRepository.java | Centralizes final-bucket selection, but applies positional ordering to non-temporal and incomplete temporal results. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/KpiRepositoryTest.java | Covers ascending temporal buckets and empty inputs, but not non-temporal charts or an incomplete trailing bucket. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(kpi): latestKpiResult returns most r..."](https://github.com/open-metadata/openmetadata/commit/4b8ad97c920c96c6c08df1a914d82f874d015636) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45027878)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->