### PR TITLE
feat(ui): send X-OpenMetadata-Language header from active UI locale

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -545,7 +545,9 @@ export const AuthProvider = ({
         config.headers['Content-type'] = 'application/json-patch+json';
       }
 
-      return withLanguageHeader(withActivePersonaHeader(withDomainFilter(config)));
+      return withLanguageHeader(
+        withActivePersonaHeader(withDomainFilter(config))
+      );
     });
 
     // Axios response interceptor for statusCode 401,403

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -52,6 +52,7 @@ import { User } from '../../../generated/entity/teams/user';
 import { AuthProvider as AuthProviderEnum } from '../../../generated/settings/settings';
 import { withActivePersonaHeader } from '../../../hoc/withActivePersonaHeader';
 import { withDomainFilter } from '../../../hoc/withDomainFilter';
+import { withLanguageHeader } from '../../../hoc/withLanguageHeader';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
 import { useExploreCache } from '../../../hooks/useExploreCache';
@@ -544,7 +545,7 @@ export const AuthProvider = ({
         config.headers['Content-type'] = 'application/json-patch+json';
       }
 
-      return withActivePersonaHeader(withDomainFilter(config));
+      return withLanguageHeader(withActivePersonaHeader(withDomainFilter(config)));
     });
 
     // Axios response interceptor for statusCode 401,403

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { InternalAxiosRequestConfig } from 'axios';
+import i18next from 'i18next';
+import { LANGUAGE_HEADER, withLanguageHeader } from './withLanguageHeader';
+
+jest.mock('i18next', () => ({
+  __esModule: true,
+  default: { language: '', resolvedLanguage: '' },
+}));
+
+describe('withLanguageHeader', () => {
+  const mockI18next = i18next as unknown as {
+    language: string;
+    resolvedLanguage: string;
+  };
+
+  beforeEach(() => {
+    mockI18next.language = '';
+    mockI18next.resolvedLanguage = '';
+  });
+
+  const createMockConfig = (): InternalAxiosRequestConfig =>
+    ({ headers: {} } as InternalAxiosRequestConfig);
+
+  it('sets the language header to the active UI language', () => {
+    mockI18next.resolvedLanguage = 'fr-FR';
+    mockI18next.language = 'fr-FR';
+    const config = createMockConfig();
+
+    const result = withLanguageHeader(config);
+
+    expect(result).toBe(config);
+    expect(result.headers[LANGUAGE_HEADER]).toBe('fr-FR');
+  });
+
+  it('leaves the config unchanged when no language is set', () => {
+    const config = createMockConfig();
+
+    const result = withLanguageHeader(config);
+
+    expect(result).toBe(config);
+    expect(result.headers[LANGUAGE_HEADER]).toBeUndefined();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { InternalAxiosRequestConfig } from 'axios';
+import i18next from 'i18next';
+
+export const LANGUAGE_HEADER = 'X-OpenMetadata-Language';
+
+/**
+ * Stamps the user's currently selected UI language (BCP-47, e.g. `fr-FR`) onto every outgoing
+ * request as the `X-OpenMetadata-Language` header. Downstream (Collate server -> AI Platform) this
+ * pins the agent's response language deterministically instead of letting it infer one.
+ */
+export const withLanguageHeader = (
+  config: InternalAxiosRequestConfig
+): InternalAxiosRequestConfig => {
+  const language = i18next.resolvedLanguage || i18next.language;
+
+  if (language) {
+    config.headers[LANGUAGE_HEADER] = language;
+  }
+
+  return config;
+};


### PR DESCRIPTION
Fixes #30170

## What
Adds a `withLanguageHeader` axios request-interceptor HOC (mirrors `withActivePersonaHeader`) that stamps the active i18next language (e.g. `fr-FR`) as the `X-OpenMetadata-Language` header on outgoing requests, composed in `AuthProvider`.

## Why
Lets the AskCollate AI agent respond in the user's selected UI language instead of inferring it. The downstream side (collate server → AI platform) consumes this header.

## Part of a coordinated 3-PR set
- ai-platform: open-metadata/ai-platform#904 (read header + inject directive)
- openmetadata-collate: open-metadata/openmetadata-collate#5107 (forward the header)
- **OpenMetadata (this)**: send the header from the active UI locale

## Testing
`withLanguageHeader.test.ts` added (mirrors the persona HOC test): stamps the header when a language is active, no-op otherwise. Note: run via CI — validated by inspection locally (workspace has no installed `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR sends the active UI locale with API requests. The main changes are:

- Adds an `X-OpenMetadata-Language` request-header helper.
- Composes the helper into the shared Axios interceptor.
- Adds tests for active and unavailable language states.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Composes the language-header helper into the shared Axios request interceptor. |
| openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts | Adds a helper that sends the resolved or active i18next language. |
| openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts | Tests requests with an active language and with no available language. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(ui): wrap AuthProvider return to s..."](https://github.com/open-metadata/openmetadata/commit/78b5ab0f96ba6776a394f44ed28255967788b123) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45028981)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->