### PR TITLE
fix(ingestion): pin sklearn serialization format in mlflow integration test

### DIFF
--- a/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
@@ -21,6 +21,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from mlflow.models import infer_signature
+from mlflow.sklearn import SERIALIZATION_FORMAT_CLOUDPICKLE
 from sklearn.linear_model import ElasticNet
 from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
 from sklearn.model_selection import train_test_split
@@ -136,13 +137,16 @@ def create_data(mlflow_environment):
                         "model",
                         registered_model_name=MODEL_NAME,
                         signature=signature,
+                        serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,
                     )
                 else:
-                    mlflow.sklearn.log_model(lr, "model")
+                    mlflow.sklearn.log_model(lr, "model", serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE)
                 break
-            except Exception:
+            except Exception as exc:
                 if attempt < 4:
-                    logging.getLogger(__name__).warning("Retry %d/5: S3 upload failed, retrying...", attempt + 1)
+                    logging.getLogger(__name__).warning(
+                        "Retry %d/5: log_model failed (%s), retrying...", attempt + 1, exc
+                    )
                     time.sleep(5 * (attempt + 1))
                 else:
                     raise


### PR DESCRIPTION
The `test_mlflow` integration test fails at fixture setup on every PR whose base includes #30046:

```
E   ModuleNotFoundError: No module named 'skops'
../env/lib/python3.10/site-packages/mlflow/sklearn/__init__.py:678: ModuleNotFoundError
```

## Cause

#30046 widened the pin to `mlflow-skinny>=3.13.0,<3.15`, so the resolver now picks mlflow 3.14.0 for the first time. mlflow 3.14 changed the default `serialization_format` of `mlflow.sklearn.log_model` from `SERIALIZATION_FORMAT_CLOUDPICKLE` to `SERIALIZATION_FORMAT_SKOPS` (`mlflow/sklearn/__init__.py:182` and `:385`). `skops` is an optional dependency that mlflow never installs, so the `create_data` fixture dies on the first `log_model` call.

This is deterministic, not flaky. It only looked flaky because the retry loop caught bare `Exception` and logged a hardcoded `"S3 upload failed"` for any error, burying the real traceback under five retries. MinIO and S3 were never involved — the failure is in local serialization, before any upload.

## Fix

Request cloudpickle explicitly rather than inheriting whatever mlflow defaults to, and log the exception the retry loop actually caught.

## Scope

Test-only; the connector has no exposure. `ingestion/src/metadata/ingestion/source/mlmodel/mlflow/` uses `MlflowClient` to read run metadata, takes the artifact location as a string (`run.info.artifact_uri` → `MlStore`), and reads features from the `mlflow.log-model.history` tag. It never calls `log_model`/`save_model`/`load_model` and never deserializes an artifact, so the serialization format is invisible to it. Users on mlflow >=3.14 producing skops artifacts ingest identically.

## Verification

Reproduced and fixed locally against real MySQL/MinIO/mlflow containers and a live OM server, with `mlflow-skinny==3.14.0` installed (the version CI resolves):

- before: `1 error in 154.95s`, four `Retry N/5: S3 upload failed` warnings, `ModuleNotFoundError: No module named 'skops'`
- after: `1 passed in 26.69s`, exit code 0, zero retries

Also confirmed directly that `log_model` with the explicit format succeeds on both mlflow-skinny 3.13.0 and 3.14.0, while the default succeeds only on 3.13.0.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the MLflow integration test against serialization-default changes. The main changes are:

- Pins both model logging branches to cloudpickle serialization.
- Includes the caught exception in retry warnings.
- Replaces the misleading S3-specific warning.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Both model logging branches use the explicit serialization format.
- The final failed retry still raises the original exception.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py | Pins MLflow model serialization to cloudpickle in both branches and improves retry diagnostics. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/mlflow-skle..."](https://github.com/open-metadata/openmetadata/commit/db40cd7bb3388b192a334d91cc2d734126cc5f22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45036674)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->