### PR TITLE
Fixes 30167: Add skops to test deps for mlflow 3.14 sklearn default

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -507,6 +507,7 @@ test = {
     "testcontainers~=4.8.0",
     "minio==7.2.5",
     *plugins["mlflow"],
+    "skops",  # mlflow 3.14 switched the mlflow.sklearn serialization default to skops, which mlflow-skinny does not pull in
     *plugins["datalake-s3"],
     *plugins["kafka"],
     "kafka-python==2.0.2",

--- a/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
@@ -140,9 +140,11 @@ def create_data(mlflow_environment):
                 else:
                     mlflow.sklearn.log_model(lr, "model")
                 break
-            except Exception:
+            except Exception as exc:
                 if attempt < 4:
-                    logging.getLogger(__name__).warning("Retry %d/5: S3 upload failed, retrying...", attempt + 1)
+                    logging.getLogger(__name__).warning(
+                        "Retry %d/5: log_model failed (%s: %s), retrying...", attempt + 1, type(exc).__name__, exc
+                    )
                     time.sleep(5 * (attempt + 1))
                 else:
                     raise


### PR DESCRIPTION
### Describe your changes:

Fixes #30167

mlflow 3.14 switched the `mlflow.sklearn` `save_model` / `log_model` default `serialization_format` from cloudpickle to `skops`. `skops` is not an `mlflow-skinny` dependency and is not declared anywhere in `setup.py`, so `test_mlflow` errors at fixture setup:

```
ERROR at setup of test_mlflow
E   ModuleNotFoundError: No module named 'skops'
    mlflow/sklearn/__init__.py:678
```

Only the default changed. `mlflow/sklearn/__init__.py` is otherwise identical between 3.13.0 and 3.14.0 (2099 lines, 41 `skops` references in both), and the `import skops.io` at line 678 was already there behind the `serialization_format` check:

```diff
182c182
<     serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,   # save_model default
---
>     serialization_format=SERIALIZATION_FORMAT_SKOPS,
385c385
<     serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE,   # log_model default
---
>     serialization_format=SERIALIZATION_FORMAT_SKOPS,
```

Adding `skops` to the `test` extra rather than capping `mlflow-skinny<3.14`, so the test keeps covering the default path users on 3.14 actually hit, and the CVE-2026-13484 fix in 3.14.0 is retained.

Also surfaces the real exception in the `log_model` retry loop. It logged every failure as `S3 upload failed`, which sent this one to the wrong place.

**Test-only.** The mlflow connector uses `MlflowClient` / `RunData` / `ModelVersion` / `RegisteredModel` and never touches `mlflow.sklearn`. ML Model ingestion is unaffected.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `test_mlflow` seeds its fixture via `mlflow.sklearn.log_model(...)` and now runs against the mlflow 3.14 skops default

#### Unit tests
Not applicable — dependency declaration + test-only logging change.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
No new test. Restores the existing `ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py`, which is what caught this.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
Reproduced and confirmed the fix in a clean venv (`mlflow-skinny>=3.13.0,<3.15` → 3.14.0, `scikit-learn>=1.3,<2`, `numpy<2`), calling `mlflow.sklearn.log_model` on an `ElasticNet` with an inferred signature:

```
without skops  ->  ModuleNotFoundError: No module named 'skops'
with skops 0.14.0  ->  log_model OK
```

Resolution check under the `test` extra's existing constraints (py3.10, exit 0):

```
skops==0.14.0  mlflow-skinny==3.14.0  numpy==1.26.4  scikit-learn==1.7.2  scipy==1.15.3
```

`numpy<2` and `scikit-learn>=1.3,<2` both respected. Only new transitive is `prettytable`.

`ruff check` and `ruff format --check` pass on both changed files.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the MLflow sklearn integration fixture for MLflow 3.14. The main changes are:

- Adds `skops` to the ingestion test dependencies.
- Reports the actual `log_model` exception during retries.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The changed flow looks mergeable after bounding the new test dependency.

- The retry behavior remains unchanged.
- Current `skops` releases support the repository's Python versions.
- An unconstrained future `skops` release can destabilize test environment installation.

ingestion/setup.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/setup.py | Adds skops to the test extra without constraining it to the versions compatible with the fixed MLflow range. |
| ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py | Improves retry diagnostics while preserving the existing retry and final re-raise behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add skops to test deps for mlflow 3.14 s..."](https://github.com/open-metadata/openmetadata/commit/60b7e0c0c80a3bf468fe62cae0bded045a8f9a97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45038539)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->