### PR TITLE
fix(search): restore table reindex fields dropped on 1.13 (ER diagram + schemaDefinition)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java
@@ -58,6 +58,17 @@ public record TableIndex(Table table) implements ColumnIndex, DataAssetIndex {
     // requested). Lineage nodes read (node as Table).testSuite to render the data-observability
     // summary, so without it getDataQualityLineage loses its test information after a reindex.
     fields.add("testSuite");
+    // "tableConstraints" is fields-gated as well (TableRepository.clearFields nulls it when not
+    // requested). buildSearchIndexDocInternal builds the "upstreamEntityRelationship" doc field —
+    // the only source the ER diagram's entity-relationship graph aggregates on — from
+    // table.getTableConstraints(). Without this, reindex-built docs carry an empty relationship
+    // list and foreign-key edges disappear from the ER diagram after a reindex.
+    fields.add("tableConstraints");
+    // "schemaDefinition" is fields-gated too (TableRepository.clearFields nulls it when not
+    // requested) and buildSearchIndexDocInternal indexes it (doc.put("schemaDefinition", ...)).
+    // Without this, reindex-built docs drop the view/DDL text and full-text search can no longer
+    // match tables by their schema definition.
+    fields.add("schemaDefinition");
     return java.util.Collections.unmodifiableSet(fields);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexReindexFieldsParityTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexReindexFieldsParityTest.java
@@ -26,6 +26,7 @@ import org.openmetadata.service.search.indexes.DashboardIndex;
 import org.openmetadata.service.search.indexes.DatabaseIndex;
 import org.openmetadata.service.search.indexes.DatabaseSchemaIndex;
 import org.openmetadata.service.search.indexes.SearchIndex;
+import org.openmetadata.service.search.indexes.TableIndex;
 import org.openmetadata.service.search.indexes.TeamIndex;
 import org.openmetadata.service.search.indexes.UserIndex;
 
@@ -172,6 +173,43 @@ class SearchIndexReindexFieldsParityTest {
             "certification",
             "dataProducts"),
         SearchIndex.COMMON_REINDEX_FIELDS);
+  }
+
+  // --- required-field contract guard (the positive side of the risk chain) --------
+
+  /**
+   * Regression guard for the "ER diagram loses foreign keys after a reindex" bug (customer: Assent,
+   * v1.13.1). {@code TableIndex.buildSearchIndexDocInternal} builds the {@code
+   * upstreamEntityRelationship} doc field — the sole source the entity-relationship graph aggregates
+   * on — from {@code table.getTableConstraints()}. {@code tableConstraints} is fields-gated ({@code
+   * TableRepository.clearFields} nulls it unless requested), so if reindex does not declare it the
+   * constraints read back null, the doc field is written empty, and FK edges silently vanish on the
+   * next reindex while the table's own schema tab still shows the constraints. Live indexing hides
+   * this because it serializes the full entity. Keep {@code tableConstraints} in the reindex set.
+   */
+  @Test
+  void tableIndexDeclaresTableConstraintsForErDiagram() {
+    assertTrue(
+        new TableIndex(null).getRequiredReindexFields().contains("tableConstraints"),
+        "TableIndex.getRequiredReindexFields() must include 'tableConstraints' — the ER diagram's "
+            + "upstreamEntityRelationship doc field is built from it; dropping it makes foreign-key "
+            + "edges disappear after a reindex");
+  }
+
+  /**
+   * Same fields-gated reindex-drop risk as {@link #tableIndexDeclaresTableConstraintsForErDiagram},
+   * for {@code schemaDefinition}: {@code buildSearchIndexDocInternal} indexes it ({@code
+   * doc.put("schemaDefinition", table.getSchemaDefinition())}) and {@code
+   * TableRepository.clearFields} nulls it unless requested, so dropping it from the reindex set
+   * removes the view/DDL text from the search doc after a reindex and breaks full-text search on it.
+   */
+  @Test
+  void tableIndexDeclaresSchemaDefinitionForSearch() {
+    assertTrue(
+        new TableIndex(null).getRequiredReindexFields().contains("schemaDefinition"),
+        "TableIndex.getRequiredReindexFields() must include 'schemaDefinition' — "
+            + "buildSearchIndexDocInternal indexes it; dropping it removes view/DDL text from the "
+            + "search doc after a reindex");
   }
 
   // --- helpers --------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Two symptoms after a **search reindex** on 1.13, both from the same root cause:

1. **ER diagram loses its foreign-key edges** — table constraints still show on the schema tab, but the ER diagram goes empty (reported by Assent on v1.13.1; exec-demo blocker).
2. **Schema-definition (view/DDL) text drops out of search** — full-text search can no longer match a table by its view/query SQL.

## Root cause

Selective-field reindexing (`getRequiredReindexFields()`) only hydrates the fields an index declares. `TableIndex`'s search-doc build reads two **field-gated** fields (`TableRepository.clearFields()` nulls them unless requested) that 1.13 never declared, so a reindex read them back `null` and wrote them empty into the doc:

| field | how the doc build uses it | effect when dropped on reindex |
|---|---|---|
| `tableConstraints` | `SearchIndex.populateUpstreamEntityRelationshipData` → `upstreamEntityRelationship` doc field, the only source the ER graph (`ES/OSEntityRelationshipGraphBuilder`) aggregates on | ER diagram FK edges vanish |
| `schemaDefinition` | `buildSearchIndexDocInternal` indexes it (`doc.put("schemaDefinition", …)`) | view/DDL text gone from search doc → search recall on it breaks |

The schema tab still shows constraints because that API call requests the field explicitly. Live indexing hides both bugs because it serializes the full entity.

> `main` already declares both (added incidentally by the AI-Context work), so this is a **1.13-only** gap. This PR backports the two missing fields + the regression guards.

## Fix

- Declare `tableConstraints` and `schemaDefinition` in `TableIndex.getRequiredReindexFields()`.
- Add two parity-test guards in `SearchIndexReindexFieldsParityTest` that fail if either is dropped again.

`joins` / `tablePartition` (also main-only on `TableIndex`) are intentionally **not** added — 1.13's table doc build doesn't read them; they exist on main only for the main-only `AIContextIndex` mixin. Confirmed by cross-comparing every `*Index.java` between the branches: `TableIndex` is the only shared index whose reindex-field contract diverges.

## Testing

`mvn -pl openmetadata-service test -Dtest=SearchIndexReindexFieldsParityTest` → **9/9 pass** on this branch. Verified each guard **fails** without its field and **passes** with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves table relationship and schema data during search reindexing. The main changes are:

- Adds `tableConstraints` to the required table reindex fields.
- Adds `schemaDefinition` to the required table reindex fields.
- Adds tests that guard both required-field declarations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The new field names match the table repository’s field gates.
- The search document builder consumes both hydrated fields.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/TableIndex.java | Adds table constraints and schema definitions to the fields loaded for table reindexing. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchIndexReindexFieldsParityTest.java | Adds tests that ensure both table fields remain in the required reindex set. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(search): restore table reindex field..."](https://github.com/open-metadata/openmetadata/commit/8e8898c4238522d43dd9f58e9c8cfd6cf104c388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45051430)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->