### PR TITLE
fix(ui): use i18next.language (not resolvedLanguage) for X-OpenMetadata-Language

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts
@@ -34,7 +34,9 @@ describe('withLanguageHeader', () => {
     ({ headers: {} } as InternalAxiosRequestConfig);
 
   it('sets the language header to the active UI language', () => {
-    mockI18next.resolvedLanguage = 'fr-FR';
+    // resolvedLanguage may sit at the fallback while language holds the real selection — the header
+    // must use language.
+    mockI18next.resolvedLanguage = 'en-US';
     mockI18next.language = 'fr-FR';
     const config = createMockConfig();
 

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts
@@ -23,7 +23,10 @@ export const LANGUAGE_HEADER = 'X-OpenMetadata-Language';
 export const withLanguageHeader = (
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig => {
-  const language = i18next.resolvedLanguage || i18next.language;
+  // Use i18next.language (the selected UI language, e.g. 'fr-FR'), NOT resolvedLanguage — the latter
+  // can sit at the fallback ('en-US') even when a non-fallback language is active. This matches the
+  // NavBar language switcher, which reads i18next.language as the source of truth.
+  const language = i18next.language;
 
   if (language) {
     config.headers[LANGUAGE_HEADER] = language;


### PR DESCRIPTION
## What
The `withLanguageHeader` interceptor read `i18next.resolvedLanguage || i18next.language`. `resolvedLanguage` can stay pinned at the fallback (`en-US`) even when a non-fallback language is selected, so the `X-OpenMetadata-Language` header was sent as `en-US` on, e.g., a French UI. Read `i18next.language` instead — the same source the NavBar language switcher uses (`NavBar.tsx`).

## Why
Follow-up to the merged X-OpenMetadata-Language header PR (#30169): with the bug, the AI agent always received `en-US` regardless of the selected UI language.

## Testing
Updated `withLanguageHeader.test.ts`: with `resolvedLanguage='en-US'` and `language='fr-FR'`, the header is `fr-FR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes how the UI sets the language request header. The main changes are:

- Read `X-OpenMetadata-Language` from `i18next.language`.
- Add coverage for a French selection with an English resolved fallback.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The browser-detected locale path needs normalization before merging.

- The intended French selection now reaches the request header.
- A generic browser locale can still be sent even when the UI falls back to a different supported locale.

openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.ts | Uses the selected or detected i18next language directly, which fixes the reported fallback issue but can send an unsupported detected locale. |
| openmetadata-ui/src/main/resources/ui/src/hoc/withLanguageHeader.test.ts | Updates the test to cover a French selection while the resolved language remains English. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): use i18next.language (not resol..."](https://github.com/open-metadata/openmetadata/commit/def636a698942feba353c3b2e9c5bd4dd95a66c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45058431)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->