### PR TITLE
fix(test): persona related flaky tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts
@@ -155,7 +155,9 @@ test.describe(
     });
 
     test('should show all the customize options', async ({ adminPage }) => {
-      await expect(adminPage.getByText('Navigation')).toBeVisible();
+      await expect(
+        adminPage.getByText('Navigation', { exact: true })
+      ).toBeVisible();
       await expect(adminPage.getByText('Home Page')).toBeVisible();
       await expect(adminPage.getByText('Governance')).toBeVisible();
       await expect(adminPage.getByText('Data Assets')).toBeVisible();
@@ -182,7 +184,7 @@ test.describe(
     });
 
     test('Navigation check default state', async ({ adminPage }) => {
-      await adminPage.getByText('Navigation').click();
+      await adminPage.getByText('Navigation', { exact: true }).click();
       await checkDefaultStateForNavigationTree(adminPage);
     });
 
@@ -201,7 +203,7 @@ test.describe(
         navigationPersona.data.name,
         true
       );
-      await adminPage.getByText('Navigation').click();
+      await adminPage.getByText('Navigation', { exact: true }).click();
 
       await test.step('hide navigation items and validate with persona', async () => {
         // Hide Explore

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
@@ -152,6 +152,9 @@ test.describe.serial('User profile works after persona deletion', () => {
 
     // Step 4: Go back to user profile and verify it still loads
     await test.step('Verify user profile still loads after persona deletion', async () => {
+      // Reload the page to ensure that the user profile is still accessible and loads correctly after the persona has been deleted
+      await page.reload();
+      await waitForAllLoadersToDisappear(page);
       await visitUserProfilePage(page, user.responseData.name);
       await waitForAllLoadersToDisappear(page);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -21,7 +21,6 @@ import { selectOption } from '../../utils/advancedSearch';
 import {
   createNewPage,
   descriptionBox,
-  getDefaultAdminAPIContext,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -48,7 +47,6 @@ const PERSONA_DETAILS = {
   description: `Persona description ${uuid()}.`,
 };
 
-const user = new UserClass();
 const persona1 = new PersonaClass();
 const persona2 = new PersonaClass();
 
@@ -347,16 +345,16 @@ test.describe.serial('Default persona setting and removal flow', () => {
 
         const searchUser = adminPage.waitForResponse(
           `/api/v1/search/query?q=*${encodeURIComponent(
-            user.responseData.displayName
+            user1.responseData.displayName
           )}*`
         );
         await adminPage
           .getByTestId('searchbar')
-          .fill(user.responseData.displayName);
+          .fill(user1.responseData.displayName);
         await searchUser;
 
         await adminPage
-          .getByRole('listitem', { name: user.responseData.displayName })
+          .getByRole('listitem', { name: user1.responseData.displayName })
           .click();
         await adminPage.getByTestId('selectable-list-update-btn').click();
 
@@ -393,8 +391,8 @@ test.describe.serial('Default persona setting and removal flow', () => {
         ).toContainText(PERSONA_DETAILS.description);
 
         await expect(
-          adminPage.getByTestId(user.responseData.name)
-        ).toContainText(user.responseData.name);
+          adminPage.getByTestId(user1.responseData.name)
+        ).toContainText(user1.responseData.name);
 
         await setPersonaAsDefault(adminPage);
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -21,6 +21,7 @@ import { selectOption } from '../../utils/advancedSearch';
 import {
   createNewPage,
   descriptionBox,
+  getDefaultAdminAPIContext,
   redirectToHomePage,
   uuid,
 } from '../../utils/common';
@@ -278,14 +279,16 @@ test.describe.serial('Persona operations', () => {
 });
 
 test.describe.serial('Default persona setting and removal flow', () => {
+  const user1 = new UserClass();
+
   test.beforeAll('Setup user for default persona flow', async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
-    await user.create(apiContext);
+    await user1.create(apiContext);
     const adminResponse = await apiContext.get('/api/v1/users/name/admin');
     const adminData = await adminResponse.json();
 
-    await persona1.create(apiContext, [user.responseData.id, adminData.id]);
-    await persona2.create(apiContext, [user.responseData.id]);
+    await persona1.create(apiContext, [user1.responseData.id, adminData.id]);
+    await persona2.create(apiContext, [user1.responseData.id]);
     await afterAction();
   });
 
@@ -294,7 +297,7 @@ test.describe.serial('Default persona setting and removal flow', () => {
     async ({ browser }) => {
       const { apiContext, afterAction } = await createNewPage(browser);
       await Promise.all([
-        user.delete(apiContext),
+        user1.delete(apiContext),
         persona1.delete(apiContext),
         persona2.delete(apiContext),
       ]);
@@ -308,7 +311,8 @@ test.describe.serial('Default persona setting and removal flow', () => {
   }) => {
     const userContext = await browser.newContext({ storageState: undefined });
     const userPage = await userContext.newPage();
-    await user.login(userPage);
+
+    await user1.login(userPage);
 
     test.slow(true);
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test stability improvements:**
    - Replaced shared `user` object with `user1` in `PersonaFlow.spec.ts` to prevent test interference.
    - Added explicit `exact: true` matchers for 'Navigation' text in `CustomizeDetailPage.spec.ts` to avoid selector ambiguity.
    - Included `page.reload()` and `waitForAllLoadersToDisappear` in `PersonaDeletionUserProfile.spec.ts` to ensure consistent state after persona deletion.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes persona-related Playwright tests. The main changes are:

- Uses one describe-scoped user throughout the default persona flow.
- Removes the stale shared user and unused import.
- Uses exact matching for Navigation locators.
- Reloads the profile flow after persona deletion.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The persona flow now uses the same initialized user for setup, login, search, assertions, and cleanup.
- The unused import that broke the TypeScript check is removed.
- No blocking issues remain in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts | Uses the describe-scoped user consistently and removes stale shared state. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomizeDetailPage.spec.ts | Makes Navigation locators exact to avoid ambiguous matches. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts | Reloads the page before validating the user profile after persona deletion. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix checkstyle + test"](https://github.com/open-metadata/openmetadata/commit/c5942f2a109a762edd75c043583491c27b1f5a93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45073246)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->