### PR TITLE
fix(dq): stale incident status on the Test Case page after reopening a resolved incident (1.13)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -2795,7 +2795,6 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                   "bulk list derivation must agree with the single read");
             });
 
-    // A passing run does NOT close the incident: the pointer must survive it.
     client
         .testCaseResults()
         .create(
@@ -2805,7 +2804,7 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                 .withTestCaseStatus(org.openmetadata.schema.tests.type.TestCaseStatus.Success)
                 .withResult("Passing while incident open"));
 
-    Awaitility.await("open incident stays visible while the test passes")
+    Awaitility.await("a passing run hides the incident (rule A)")
         .atMost(90, TimeUnit.SECONDS)
         .pollInterval(Duration.ofSeconds(2))
         .untilAsserted(
@@ -2816,7 +2815,8 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
               assertEquals(
                   org.openmetadata.schema.tests.type.TestCaseStatus.Success,
                   fetched.getTestCaseResult().getTestCaseStatus());
-              assertNotNull(fetched.getIncidentId());
+              assertNull(fetched.getIncidentId());
+              assertNull(bulkListedIncidentId(client, table, testCase));
             });
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,6 +37,7 @@ import org.openmetadata.schema.api.classification.CreateTag;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.tests.CreateTestCase;
 import org.openmetadata.schema.api.tests.CreateTestCaseResolutionStatus;
+import org.openmetadata.schema.api.tests.CreateTestCaseResult;
 import org.openmetadata.schema.api.tests.CreateTestSuite;
 import org.openmetadata.schema.entity.classification.Classification;
 import org.openmetadata.schema.entity.classification.Tag;
@@ -2684,6 +2686,161 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
                   org.openmetadata.schema.tests.type.TestCaseStatus.Failed,
                   matching.getTestCaseStatus());
             });
+  }
+
+  @Test
+  void test_incidentIdDerivation_followsLatestUnresolvedTcrs(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("incident_derivation"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    TestCase beforeIncident = client.testCases().get(testCase.getId().toString(), "incidentId");
+    assertNull(beforeIncident.getIncidentId(), "no incident yet -> incidentId must be null");
+
+    client
+        .testCaseResults()
+        .create(
+            testCase.getFullyQualifiedName(),
+            new CreateTestCaseResult()
+                .withTimestamp(System.currentTimeMillis())
+                .withTestCaseStatus(org.openmetadata.schema.tests.type.TestCaseStatus.Failed)
+                .withResult("Initial failure"));
+
+    final UUID stateId =
+        Awaitility.await()
+            .atMost(90, TimeUnit.SECONDS)
+            .pollInterval(Duration.ofSeconds(2))
+            .until(
+                () ->
+                    client
+                        .testCases()
+                        .get(testCase.getId().toString(), "incidentId")
+                        .getIncidentId(),
+                java.util.Objects::nonNull);
+
+    client
+        .testCaseResolutionStatuses()
+        .create(
+            new CreateTestCaseResolutionStatus()
+                .withTestCaseReference(testCase.getFullyQualifiedName())
+                .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.Ack));
+
+    Awaitility.await("Ack keeps the ongoing incident pointer")
+        .atMost(90, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              org.openmetadata.schema.tests.type.TestCaseResolutionStatus latestStatus =
+                  latestIncidentStatus(client, testCase.getFullyQualifiedName());
+              assertEquals(
+                  TestCaseResolutionStatusTypes.Ack,
+                  latestStatus.getTestCaseResolutionStatusType());
+              TestCase fetched = client.testCases().get(testCase.getId().toString(), "incidentId");
+              assertEquals(stateId, fetched.getIncidentId());
+            });
+
+    client
+        .testCaseResolutionStatuses()
+        .create(
+            new CreateTestCaseResolutionStatus()
+                .withTestCaseReference(testCase.getFullyQualifiedName())
+                .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.Resolved)
+                .withTestCaseResolutionStatusDetails(
+                    new org.openmetadata.schema.tests.type.Resolved()));
+
+    Awaitility.await("Resolved clears the ongoing incident pointer")
+        .atMost(90, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              TestCase fetched = client.testCases().get(testCase.getId().toString(), "incidentId");
+              assertNull(fetched.getIncidentId());
+              assertNull(
+                  bulkListedIncidentId(client, table, testCase),
+                  "bulk list derivation must also clear the pointer after resolve");
+            });
+
+    // On this branch a manual Ack after Resolved starts a NEW incident (new stateId); the
+    // pointer must follow it so the test case page shows the current status.
+    client
+        .testCaseResolutionStatuses()
+        .create(
+            new CreateTestCaseResolutionStatus()
+                .withTestCaseReference(testCase.getFullyQualifiedName())
+                .withTestCaseResolutionStatusType(TestCaseResolutionStatusTypes.Ack));
+
+    Awaitility.await("reopen points at the new ongoing incident")
+        .atMost(90, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              org.openmetadata.schema.tests.type.TestCaseResolutionStatus latestStatus =
+                  latestIncidentStatus(client, testCase.getFullyQualifiedName());
+              assertEquals(
+                  TestCaseResolutionStatusTypes.Ack,
+                  latestStatus.getTestCaseResolutionStatusType());
+              assertNotEquals(stateId, latestStatus.getStateId());
+              TestCase fetched = client.testCases().get(testCase.getId().toString(), "incidentId");
+              assertEquals(latestStatus.getStateId(), fetched.getIncidentId());
+              assertEquals(
+                  latestStatus.getStateId(),
+                  bulkListedIncidentId(client, table, testCase),
+                  "bulk list derivation must agree with the single read");
+            });
+
+    // A passing run does NOT close the incident: the pointer must survive it.
+    client
+        .testCaseResults()
+        .create(
+            testCase.getFullyQualifiedName(),
+            new CreateTestCaseResult()
+                .withTimestamp(System.currentTimeMillis() + 1)
+                .withTestCaseStatus(org.openmetadata.schema.tests.type.TestCaseStatus.Success)
+                .withResult("Passing while incident open"));
+
+    Awaitility.await("open incident stays visible while the test passes")
+        .atMost(90, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              TestCase fetched =
+                  client.testCases().get(testCase.getId().toString(), "incidentId,testCaseResult");
+              assertNotNull(fetched.getTestCaseResult());
+              assertEquals(
+                  org.openmetadata.schema.tests.type.TestCaseStatus.Success,
+                  fetched.getTestCaseResult().getTestCaseStatus());
+              assertNotNull(fetched.getIncidentId());
+            });
+  }
+
+  private UUID bulkListedIncidentId(OpenMetadataClient client, Table table, TestCase testCase) {
+    RequestOptions options =
+        RequestOptions.builder()
+            .queryParam("fields", "incidentId")
+            .queryParam("entityLink", "<#E::table::" + table.getFullyQualifiedName() + ">")
+            .queryParam("includeAllTests", "true")
+            .queryParam("limit", "100")
+            .build();
+
+    String responseJson =
+        client
+            .getHttpClient()
+            .executeForString(HttpMethod.GET, "/v1/dataQuality/testCases", null, options);
+    TestCaseResource.TestCaseList result =
+        JsonUtils.readValue(responseJson, TestCaseResource.TestCaseList.class);
+
+    return result.getData().stream()
+        .filter(tc -> testCase.getId().equals(tc.getId()))
+        .findFirst()
+        .map(TestCase::getIncidentId)
+        .orElse(null);
   }
 
   private org.openmetadata.schema.tests.type.TestCaseResolutionStatus latestIncidentStatus(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8865,6 +8865,20 @@ public interface CollectionDAO {
                 + "WHERE stateId = :stateId ORDER BY timestamp ASC LIMIT 1")
     String listFirstTestCaseResolutionStatusesForStateId(@Bind("stateId") String stateId);
 
+    @RegisterRowMapper(LatestRecordWithFQNHashMapper.class)
+    @SqlQuery(
+        "SELECT t1.entityFQNHash, t1.json FROM test_case_resolution_status_time_series t1 "
+            + "INNER JOIN (SELECT entityFQNHash, MAX(timestamp) as maxTs "
+            + "FROM test_case_resolution_status_time_series WHERE entityFQNHash IN (<entityFQNHashes>) "
+            + "GROUP BY entityFQNHash) t2 "
+            + "ON t1.entityFQNHash = t2.entityFQNHash AND t1.timestamp = t2.maxTs")
+    List<LatestRecordWithFQNHash> getLatestRecordBatchInternal(
+        @BindListFQN("entityFQNHashes") List<String> entityFQNs);
+
+    default List<LatestRecordWithFQNHash> getLatestRecordBatch(List<String> entityFQNs) {
+      return EntityDAO.queryInChunks(entityFQNs, this::getLatestRecordBatchInternal);
+    }
+
     @SqlUpdate(
         "DELETE FROM test_case_resolution_status_time_series WHERE entityFQNHash = :entityFQNHash")
     void delete(@BindFQN("entityFQNHash") String entityFQNHash);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -8867,11 +8867,12 @@ public interface CollectionDAO {
 
     @RegisterRowMapper(LatestRecordWithFQNHashMapper.class)
     @SqlQuery(
-        "SELECT t1.entityFQNHash, t1.json FROM test_case_resolution_status_time_series t1 "
-            + "INNER JOIN (SELECT entityFQNHash, MAX(timestamp) as maxTs "
-            + "FROM test_case_resolution_status_time_series WHERE entityFQNHash IN (<entityFQNHashes>) "
-            + "GROUP BY entityFQNHash) t2 "
-            + "ON t1.entityFQNHash = t2.entityFQNHash AND t1.timestamp = t2.maxTs")
+        "SELECT entityFQNHash, json FROM ("
+            + "SELECT entityFQNHash, json, "
+            + "ROW_NUMBER() OVER (PARTITION BY entityFQNHash ORDER BY timestamp DESC, id DESC) AS rn "
+            + "FROM test_case_resolution_status_time_series "
+            + "WHERE entityFQNHash IN (<entityFQNHashes>)) ranked "
+            + "WHERE rn = 1")
     List<LatestRecordWithFQNHash> getLatestRecordBatchInternal(
         @BindListFQN("entityFQNHashes") List<String> entityFQNs);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -426,8 +426,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       }
     }
 
-    // Ongoing incidents come from the resolution-status timeseries (latest unresolved record),
-    // not from the incidentId frozen on the latest test case result at ingestion time.
+    // Ongoing incident = latest unresolved resolution-status record, not the result's stamped id.
     Map<String, UUID> fqnToOngoingIncident = new HashMap<>();
     if (setIncidents) {
       List<CollectionDAO.LatestRecordWithFQNHash> incidentRecords =
@@ -1074,10 +1073,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     return testCaseResult;
   }
 
-  /**
-   * Return the stateId of the test case's ongoing incident: the latest unresolved
-   * TestCaseResolutionStatus record. Resolved incidents are terminal and no longer ongoing.
-   */
+  /** StateId of the test case's ongoing incident: latest unresolved record, or null if resolved. */
   private UUID getIncidentId(TestCase test) {
     TestCaseResolutionStatusRepository tcrsRepo =
         (TestCaseResolutionStatusRepository)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -75,6 +75,7 @@ import org.openmetadata.schema.tests.type.TestCaseFailureReasonType;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
 import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
 import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
 import org.openmetadata.schema.type.EntityReference;
@@ -412,7 +413,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     }
 
     Map<String, TestCaseResult> fqnToResult = new HashMap<>();
-    if (setResults) {
+    if (setResults || setIncidents) {
       List<CollectionDAO.LatestRecordWithFQNHash> records =
           daoCollection.dataQualityDataTimeSeriesDao().getLatestRecordBatch(fqns);
       for (CollectionDAO.LatestRecordWithFQNHash record : records) {
@@ -426,7 +427,6 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       }
     }
 
-    // Ongoing incident = latest unresolved resolution-status record, not the result's stamped id.
     Map<String, UUID> fqnToOngoingIncident = new HashMap<>();
     if (setIncidents) {
       List<CollectionDAO.LatestRecordWithFQNHash> incidentRecords =
@@ -439,7 +439,8 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
           if (latest != null
               && latest.getStateId() != null
               && !TestCaseResolutionStatusTypes.Resolved.equals(
-                  latest.getTestCaseResolutionStatusType())) {
+                  latest.getTestCaseResolutionStatusType())
+              && isFailedResult(fqnToResult.get(fqn))) {
             fqnToOngoingIncident.put(fqn, latest.getStateId());
           }
         }
@@ -1075,11 +1076,27 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
 
   /** StateId of the test case's ongoing incident: latest unresolved record, or null if resolved. */
   private UUID getIncidentId(TestCase test) {
+    if (!latestResultIsFailed(test.getFullyQualifiedName())) {
+      return null;
+    }
     TestCaseResolutionStatusRepository tcrsRepo =
         (TestCaseResolutionStatusRepository)
             Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
     TestCaseResolutionStatus latest = tcrsRepo.getLatestRecord(test.getFullyQualifiedName());
     return Boolean.TRUE.equals(tcrsRepo.unresolvedIncident(latest)) ? latest.getStateId() : null;
+  }
+
+  private boolean latestResultIsFailed(String testCaseFqn) {
+    List<CollectionDAO.LatestRecordWithFQNHash> records =
+        daoCollection.dataQualityDataTimeSeriesDao().getLatestRecordBatch(List.of(testCaseFqn));
+    if (records.isEmpty() || records.get(0).getJson() == null) {
+      return false;
+    }
+    return isFailedResult(JsonUtils.readValue(records.get(0).getJson(), TestCaseResult.class));
+  }
+
+  private static boolean isFailedResult(TestCaseResult result) {
+    return result != null && result.getTestCaseStatus() == TestCaseStatus.Failed;
   }
 
   public int getTestCaseCount(List<UUID> testCaseIds) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -411,27 +411,48 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       fqnHashToFqn.put(FullyQualifiedName.buildHash(fqn), fqn);
     }
 
-    List<CollectionDAO.LatestRecordWithFQNHash> records =
-        daoCollection.dataQualityDataTimeSeriesDao().getLatestRecordBatch(fqns);
-
     Map<String, TestCaseResult> fqnToResult = new HashMap<>();
-    for (CollectionDAO.LatestRecordWithFQNHash record : records) {
-      String fqn = fqnHashToFqn.get(record.getEntityFQNHash());
-      if (fqn != null && record.getJson() != null) {
-        TestCaseResult result = JsonUtils.readValue(record.getJson(), TestCaseResult.class);
-        if (result != null) {
-          fqnToResult.put(fqn, result);
+    if (setResults) {
+      List<CollectionDAO.LatestRecordWithFQNHash> records =
+          daoCollection.dataQualityDataTimeSeriesDao().getLatestRecordBatch(fqns);
+      for (CollectionDAO.LatestRecordWithFQNHash record : records) {
+        String fqn = fqnHashToFqn.get(record.getEntityFQNHash());
+        if (fqn != null && record.getJson() != null) {
+          TestCaseResult result = JsonUtils.readValue(record.getJson(), TestCaseResult.class);
+          if (result != null) {
+            fqnToResult.put(fqn, result);
+          }
+        }
+      }
+    }
+
+    // Ongoing incidents come from the resolution-status timeseries (latest unresolved record),
+    // not from the incidentId frozen on the latest test case result at ingestion time.
+    Map<String, UUID> fqnToOngoingIncident = new HashMap<>();
+    if (setIncidents) {
+      List<CollectionDAO.LatestRecordWithFQNHash> incidentRecords =
+          daoCollection.testCaseResolutionStatusTimeSeriesDao().getLatestRecordBatch(fqns);
+      for (CollectionDAO.LatestRecordWithFQNHash record : incidentRecords) {
+        String fqn = fqnHashToFqn.get(record.getEntityFQNHash());
+        if (fqn != null && record.getJson() != null) {
+          TestCaseResolutionStatus latest =
+              JsonUtils.readValue(record.getJson(), TestCaseResolutionStatus.class);
+          if (latest != null
+              && latest.getStateId() != null
+              && !TestCaseResolutionStatusTypes.Resolved.equals(
+                  latest.getTestCaseResolutionStatusType())) {
+            fqnToOngoingIncident.put(fqn, latest.getStateId());
+          }
         }
       }
     }
 
     for (TestCase testCase : testCases) {
-      TestCaseResult result = fqnToResult.get(testCase.getFullyQualifiedName());
       if (setResults) {
-        testCase.setTestCaseResult(result);
+        testCase.setTestCaseResult(fqnToResult.get(testCase.getFullyQualifiedName()));
       }
       if (setIncidents) {
-        testCase.setIncidentId(result != null ? result.getIncidentId() : null);
+        testCase.setIncidentId(fqnToOngoingIncident.get(testCase.getFullyQualifiedName()));
       }
     }
   }
@@ -1054,21 +1075,15 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   }
 
   /**
-   * Check all the test case results that have an ongoing incident and get the stateId of the
-   * incident
+   * Return the stateId of the test case's ongoing incident: the latest unresolved
+   * TestCaseResolutionStatus record. Resolved incidents are terminal and no longer ongoing.
    */
   private UUID getIncidentId(TestCase test) {
-    UUID ongoingIncident = null;
-
-    String json =
-        daoCollection.dataQualityDataTimeSeriesDao().getLatestRecord(test.getFullyQualifiedName());
-    TestCaseResult latestTestCaseResult = JsonUtils.readValue(json, TestCaseResult.class);
-
-    if (!nullOrEmpty(latestTestCaseResult)) {
-      ongoingIncident = latestTestCaseResult.getIncidentId();
-    }
-
-    return ongoingIncident;
+    TestCaseResolutionStatusRepository tcrsRepo =
+        (TestCaseResolutionStatusRepository)
+            Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+    TestCaseResolutionStatus latest = tcrsRepo.getLatestRecord(test.getFullyQualifiedName());
+    return Boolean.TRUE.equals(tcrsRepo.unresolvedIncident(latest)) ? latest.getStateId() : null;
   }
 
   public int getTestCaseCount(List<UUID> testCaseIds) {


### PR DESCRIPTION
Fixes #30168

1.13 backport. The main PR is #30182; this branch carries the read-derivation fix only (the task-first reopen behavior is main-only).

## The mental model you need first

When a Data Quality test fails, the system opens an incident: a tracked problem someone has to work. An incident has a lifecycle (New -> Acknowledged -> Assigned -> Resolved) and is identified by a `stateId`; every status change appends a row to the incident timeline.

Two separate things get written as a test lives its life:

1. **Test results**: every run writes a row (pass/fail). When a run fails, that row is stamped with the id of the incident it belongs to (`result.incidentId`). This stamp is written once, at the moment the result is ingested, and never touched again.
2. **Incident status records**: every status change (New/Ack/Assigned/Resolved) writes a row to a separate timeline, all sharing the incident's `stateId`.

The Test Case page needs to answer one question: "Does this test case have an open incident right now, and what's its status?" It reads a field called `TestCase.incidentId` to do that. That field is the whole story.

## The problem (what the customer saw)

Someone resolved an incident by mistake, then set it back to Acknowledged. The incident itself showed Acknowledged correctly, but the Test Case page kept showing Resolved, until the test failed again.

## Why it happened (how it worked before)

`TestCase.incidentId` was computed from the wrong source: the read paths derived it from the latest **test result's** stamp (`result.incidentId`), which is frozen at ingestion time. That answers "which incident did the last run belong to," which is not the same question as "what is the current incident."

Walk the reopen scenario:

1. Test fails -> incident S1 opens, the failed result is stamped `incidentId = S1`.
2. Ack, then Resolved -> all still on S1.
3. User reopens with Ack. Resolved is a terminal state, so a brand-new incident S2 is created. But no test result points at S2: the last result is still stamped S1.

Now `TestCase.incidentId` (from the frozen stamp) still says S1, whose latest status is Resolved. So the page shows Resolved even though the live incident is S2/Ack. It only self-corrects on the next failed run, because that writes a new result stamped with the current incident.

## What the PR changes

This is a **read-derivation fix only** (the task-first reopen behavior lands on main in #30182). The bug was that the page identified the current incident from the frozen result stamp. This PR fixes *which* incident the page points at, while deliberately keeping 1.13's existing rule for *when* an incident is shown.

`TestCase.incidentId` is now, on both read paths:

> **the `stateId` of the latest unresolved incident record when the test's latest result is a failure; null otherwise** (no open incident, or the test's latest run passed).

- `getIncidentId` (single read): if the latest result is a failure, return the `stateId` of the latest unresolved record from the incident timeline; otherwise null.
- `fetchAndSetTestCaseResultsAndIncidents` (bulk/list read): the same, via a new batch query over the incident timeline, gated on the latest result.

The frozen `result.incidentId` stamp is no longer used to identify the current incident: that was the bug. The "only surface an incident while the test is currently failing" gate is unchanged from before, so a passing test still shows nothing on the Test Case page.

## How it works now

Reopen scenario (the reported bug), test failing throughout:

1. Test fails -> incident S1, page shows the open incident.
2. Ack -> S1, page shows Ack.
3. Resolved -> `TestCase.incidentId` becomes null -> page shows No Incident (correct: nothing is open).
4. Reopen with Ack -> a new incident S2 opens; the pointer now follows it -> `TestCase.incidentId` = S2 -> page shows Ack. **This is the fix** (before, it stayed stuck on the stale S1/Resolved).

Passing test with an open incident (unchanged behavior):

5. A test that had an open incident then passes -> the page shows No Incident, exactly as before. The incident record stays open in the incident timeline and is still visible and resolvable from the Incident Manager; it just does not surface on the Test Case page of a currently-green test.

## Why this is the right way

- **The pointer follows the live incident, not a frozen stamp.** "Which incident is current" is a fact about the incident's own lifecycle, so the `stateId` is read from the incident timeline. The single-read and list paths now agree, and the "self-heals only on the next failed run" staleness class is gone. This is the entire fix for the reported bug.
- **Existing display behavior is preserved on purpose.** The old behavior surfaced an incident only while the test was currently failing; a passing run showed nothing. That gate is kept intact. We changed *which* incident the page points at, not *when* it shows one, so this backport stays tight: the only behavior a user perceives is the reported bug being fixed. (main, which has an opt-in auto-close for recovered incidents, deliberately takes the fuller incident-centric behavior in #30182; 1.13 has no such mechanism, so it keeps the historical gate.)

One intended change falls out of the fix: after a resolve, the page shows "No Incident" instead of a stale Resolved chip. This matches what the page already showed within the same session before a refresh.

## Testing

- New `TestCaseResourceIT#test_incidentIdDerivation_followsLatestUnresolvedTcrs`: derivation matrix over the single GET and the bulk list, with the 1.13 expectations (no incident -> null; New/Ack while failing -> stateId; Resolved -> null; reopen with Ack -> the new stateId the pointer follows; a passing run while an incident is open -> null on both read paths).
- Existing incident tests in `TestCaseResourceIT` pass.
- Reproduced the customer scenario end to end on a live 1.13.1 deployment before and after the fix: after `Resolved -> Ack` the test case entity returns the new incident and the page shows Ack; after `Resolved` it returns null; a passing run leaves the page showing No Incident.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects how the Test Case page identifies the current incident. The main changes are:

- Derive `incidentId` from the latest unresolved incident record.
- Keep incident visibility gated by the latest failed test result.
- Apply the derivation to detail and bulk read paths.
- Add integration coverage for resolve, reopen, and passing-result flows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issue qualifies for this follow-up review.

- The changed read paths implement the intended incident derivation.
- The tests cover the reported resolve-and-reopen workflow.
- No separate production failure remains within the allowed review scope.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds a batch query that selects one latest incident record per test case. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Derives incident IDs from unresolved incident records while preserving the failed-result gate. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java | Covers incident creation, resolution, reopening, and passing-result behavior across both read paths. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(dq): surface the derived incident on..."](https://github.com/open-metadata/openmetadata/commit/62078c47c7de1e994f50985ecb89ec7d891ffea4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45078032)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->