### PR TITLE
feat(aicontext): expose id/owners/serviceType + knowledge-item links

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -172,6 +172,7 @@ public class AIContextBuilder {
     List<LineageEdgeContext> downstreamEdges = edgeContexts(lineage, false);
     AIContext context =
         new AIContext()
+            .withId(entity.getId())
             .withFullyQualifiedName(entity.getFullyQualifiedName())
             .withEntityType(entityType)
             .withDisplayName(entity.getDisplayName())
@@ -605,6 +606,7 @@ public class AIContextBuilder {
       if (isApproved(term) && canViewKnowledge(Entity.GLOSSARY_TERM, termFqn)) {
         item =
             new KnowledgeItem()
+                .withId(term.getId())
                 .withType(KnowledgeItem.Type.GLOSSARY_TERM)
                 .withName(term.getName())
                 .withDisplayName(term.getDisplayName())
@@ -668,6 +670,7 @@ public class AIContextBuilder {
       if (canViewPill(pill)) {
         item =
             new KnowledgeItem()
+                .withId(pill.getId())
                 .withType(KnowledgeItem.Type.CONTEXT_MEMORY)
                 .withName(pill.getName())
                 .withDisplayName(pill.getDisplayName())
@@ -718,6 +721,7 @@ public class AIContextBuilder {
       if (canViewKnowledge(Entity.METRIC, metric.getFullyQualifiedName())) {
         item =
             new KnowledgeItem()
+                .withId(metric.getId())
                 .withType(KnowledgeItem.Type.METRIC)
                 .withName(metric.getName())
                 .withDisplayName(metric.getDisplayName())
@@ -781,6 +785,7 @@ public class AIContextBuilder {
       if (canViewKnowledge(Entity.PAGE, page.getFullyQualifiedName())) {
         item =
             new KnowledgeItem()
+                .withId(page.getId())
                 .withType(KnowledgeItem.Type.PAGE)
                 .withName(page.getName())
                 .withDisplayName(page.getDisplayName())

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AttachedKnowledgeBatch.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AttachedKnowledgeBatch.java
@@ -174,6 +174,7 @@ public final class AttachedKnowledgeBatch {
     if (content != null && content.length() > MAX_CONTENT_CHARS) {
       result =
           new KnowledgeItem()
+              .withId(item.getId())
               .withType(item.getType())
               .withName(item.getName())
               .withDisplayName(item.getDisplayName())

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextBuilder.java
@@ -319,9 +319,18 @@ public class PersonaContextBuilder {
       ContextRule rule, Map<String, Object> document, boolean loadHeavySections) {
     String fqn = stringValue(document.get("fullyQualifiedName"));
     String id = stringValue(document.get("id"));
+    UUID assetId = null;
+    if (!nullOrEmpty(id)) {
+      try {
+        assetId = UUID.fromString(id);
+      } catch (IllegalArgumentException ignored) {
+        // Degrade like the sibling owner/href parses rather than aborting the whole build.
+        LOG.debug("Ignoring invalid indexed id for {}: {}", fqn, id);
+      }
+    }
     AIContext context =
         new AIContext()
-            .withId(nullOrEmpty(id) ? null : UUID.fromString(id))
+            .withId(assetId)
             .withFullyQualifiedName(fqn)
             .withEntityType(rule.getEntityType())
             .withDisplayName(stringValue(document.get("displayName")))

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextBuilder.java
@@ -124,6 +124,8 @@ public class PersonaContextBuilder {
     "entityType",
     "entityStatus",
     "href",
+    "owners",
+    "serviceType",
     "tags",
     "tier",
     "classificationTags",
@@ -319,11 +321,14 @@ public class PersonaContextBuilder {
     String id = stringValue(document.get("id"));
     AIContext context =
         new AIContext()
+            .withId(nullOrEmpty(id) ? null : UUID.fromString(id))
             .withFullyQualifiedName(fqn)
             .withEntityType(rule.getEntityType())
             .withDisplayName(stringValue(document.get("displayName")))
             .withDescription(stringValue(document.get("description")))
+            .withServiceType(stringValue(document.get("serviceType")))
             .withTags(classificationTags(document))
+            .withOwners(ownerReferences(document))
             .withAssetContext(assetContext(document))
             .withGeneratedAt(System.currentTimeMillis());
     String href = stringValue(document.get("href"));
@@ -438,6 +443,7 @@ public class PersonaContextBuilder {
       }
       AIContext context =
           new AIContext()
+              .withId(entity.getId())
               .withFullyQualifiedName(entity.getFullyQualifiedName())
               .withEntityType(entityType)
               .withDisplayName(entity.getDisplayName())
@@ -681,6 +687,7 @@ public class PersonaContextBuilder {
               "Unsupported knowledge type: " + entityType);
         };
     return new KnowledgeItem()
+        .withId(entity.getId())
         .withType(type)
         .withName(entity.getName())
         .withDisplayName(entity.getDisplayName())
@@ -690,6 +697,7 @@ public class PersonaContextBuilder {
 
   private static KnowledgeItem referenceOf(KnowledgeItem item) {
     return new KnowledgeItem()
+        .withId(item.getId())
         .withType(item.getType())
         .withName(item.getName())
         .withDisplayName(item.getDisplayName())
@@ -774,6 +782,33 @@ public class PersonaContextBuilder {
       }
     }
     return new ArrayList<>(terms);
+  }
+
+  private static List<EntityReference> ownerReferences(Map<String, Object> document) {
+    List<EntityReference> owners = new ArrayList<>();
+    for (Map<String, Object> owner : tagMaps(document.get("owners"))) {
+      String name = stringValue(owner.get("name"));
+      String fqn = stringValue(owner.get("fullyQualifiedName"));
+      if (nullOrEmpty(name) && nullOrEmpty(fqn)) {
+        continue;
+      }
+      EntityReference reference =
+          new EntityReference()
+              .withName(name)
+              .withType(stringValue(owner.get("type")))
+              .withFullyQualifiedName(fqn)
+              .withDisplayName(stringValue(owner.get("displayName")));
+      String ownerId = stringValue(owner.get("id"));
+      if (!nullOrEmpty(ownerId)) {
+        try {
+          reference.withId(UUID.fromString(ownerId));
+        } catch (IllegalArgumentException ignored) {
+          // Non-UUID id in the indexed document; keep name/type, skip the id.
+        }
+      }
+      owners.add(reference);
+    }
+    return owners;
   }
 
   private static void addStrings(Set<String> destination, Object value) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
@@ -497,13 +497,10 @@ final class PersonaContextMarkdown {
             .append(": ")
             .append(labelOf(item))
             .append('\n');
-    // Emit a ready-to-cite chat entity link so the agent renders this metric / glossary term /
-    // article as a clickable link (like it does for tables), instead of leaving it as plain text.
-    // Fall back to the bare backticked FQN for types with no chat-linkable form (e.g. knowledge
-    // pills). See the entity-link format in SharedChatGuardrails (FORMATTING_RULES).
-    String chatLink = chatEntityLink(item);
-    if (chatLink != null) {
-      markdown.append(chatLink).append('\n');
+    // Prefer an entity link for linkable types; otherwise a bare FQN.
+    String link = entityLink(item);
+    if (link != null) {
+      markdown.append(link).append('\n');
     } else if (!nullOrEmpty(item.getFullyQualifiedName())) {
       markdown.append('`').append(item.getFullyQualifiedName()).append("`\n");
     }
@@ -514,13 +511,11 @@ final class PersonaContextMarkdown {
   }
 
   /**
-   * Builds a chat entity link ({@code [label](#entityType/fqn)}) for a knowledge item so the agent
-   * can cite it directly. Returns null when the item has no fqn or its type has no chat-linkable
-   * form (a context-memory knowledge pill is not a browsable entity). The fqn path segment is
-   * percent-encoded for the characters the chat UI expects (space, parentheses), matching the entity
-   * link format the agent's formatting rules use.
+   * Builds an entity link ({@code [label](#entityType/fqn)}) for a linkable knowledge item, or null
+   * for items with no FQN or a non-linkable type (context memory). The FQN is percent-encoded for
+   * spaces and parentheses.
    */
-  private static String chatEntityLink(KnowledgeItem item) {
+  private static String entityLink(KnowledgeItem item) {
     if (item.getType() == null || nullOrEmpty(item.getFullyQualifiedName())) {
       return null;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
@@ -497,13 +497,46 @@ final class PersonaContextMarkdown {
             .append(": ")
             .append(labelOf(item))
             .append('\n');
-    if (!nullOrEmpty(item.getFullyQualifiedName())) {
+    // Emit a ready-to-cite chat entity link so the agent renders this metric / glossary term /
+    // article as a clickable link (like it does for tables), instead of leaving it as plain text.
+    // Fall back to the bare backticked FQN for types with no chat-linkable form (e.g. knowledge
+    // pills). See the entity-link format in SharedChatGuardrails (FORMATTING_RULES).
+    String chatLink = chatEntityLink(item);
+    if (chatLink != null) {
+      markdown.append(chatLink).append('\n');
+    } else if (!nullOrEmpty(item.getFullyQualifiedName())) {
       markdown.append('`').append(item.getFullyQualifiedName()).append("`\n");
     }
     if (!nullOrEmpty(item.getContent())) {
       markdown.append('\n').append(item.getContent().strip()).append('\n');
     }
     return markdown.toString();
+  }
+
+  /**
+   * Builds a chat entity link ({@code [label](#entityType/fqn)}) for a knowledge item so the agent
+   * can cite it directly. Returns null when the item has no fqn or its type has no chat-linkable
+   * form (a context-memory knowledge pill is not a browsable entity). The fqn path segment is
+   * percent-encoded for the characters the chat UI expects (space, parentheses), matching the entity
+   * link format the agent's formatting rules use.
+   */
+  private static String chatEntityLink(KnowledgeItem item) {
+    if (item.getType() == null || nullOrEmpty(item.getFullyQualifiedName())) {
+      return null;
+    }
+    String entityType =
+        switch (item.getType()) {
+          case METRIC -> "metric";
+          case GLOSSARY_TERM -> "glossaryTerm";
+          case PAGE -> "page";
+          default -> null;
+        };
+    if (entityType == null) {
+      return null;
+    }
+    String encodedFqn =
+        item.getFullyQualifiedName().replace(" ", "%20").replace("(", "%28").replace(")", "%29");
+    return "[" + labelOf(item) + "](#" + entityType + "/" + encodedFqn + ")";
   }
 
   private static void appendManifest(StringBuilder markdown, List<ManifestEntry> manifest) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java
@@ -536,7 +536,10 @@ final class PersonaContextMarkdown {
     }
     String encodedFqn =
         item.getFullyQualifiedName().replace(" ", "%20").replace("(", "%28").replace(")", "%29");
-    return "[" + labelOf(item) + "](#" + entityType + "/" + encodedFqn + ")";
+    // Escape Markdown link-text delimiters so a display name like "Revenue [YTD]" does not
+    // terminate the link text early and produce a broken link.
+    String label = labelOf(item).replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]");
+    return "[" + label + "](#" + entityType + "/" + encodedFqn + ")";
   }
 
   private static void appendManifest(StringBuilder markdown, List<ManifestEntry> manifest) {

--- a/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
@@ -391,7 +391,7 @@
     },
     "properties": {
         "id": {
-            "description": "Unique identifier of the asset this context describes. Stable, non-null primary key, unlike the presentation-layer `resource` href.",
+            "description": "Unique identifier of the asset this context describes.",
             "$ref": "basic.json#/definitions/uuid"
         },
         "fullyQualifiedName": {
@@ -403,7 +403,7 @@
             "type": "string"
         },
         "serviceType": {
-            "description": "Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick the service icon.",
+            "description": "Service type of the asset's service (e.g. Snowflake, BigQuery).",
             "type": "string"
         },
         "displayName": {

--- a/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/aiContext.json
@@ -11,6 +11,10 @@
             "javaType": "org.openmetadata.schema.type.aicontext.KnowledgeItem",
             "description": "A single piece of business knowledge attached to the asset (glossary term definition, metric definition, or Context Center article/pill).",
             "properties": {
+                "id": {
+                    "description": "Unique identifier of the knowledge entity.",
+                    "$ref": "basic.json#/definitions/uuid"
+                },
                 "type": {
                     "description": "The entity type of the knowledge item.",
                     "type": "string",
@@ -386,6 +390,10 @@
         }
     },
     "properties": {
+        "id": {
+            "description": "Unique identifier of the asset this context describes. Stable, non-null primary key, unlike the presentation-layer `resource` href.",
+            "$ref": "basic.json#/definitions/uuid"
+        },
         "fullyQualifiedName": {
             "description": "Fully qualified name of the asset this context describes.",
             "$ref": "basic.json#/definitions/fullyQualifiedEntityName"
@@ -394,11 +402,23 @@
             "description": "Entity type of the asset (table, dashboard, pipeline, topic, ...).",
             "type": "string"
         },
+        "serviceType": {
+            "description": "Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick the service icon.",
+            "type": "string"
+        },
         "displayName": {
             "type": "string"
         },
         "description": {
             "type": "string"
+        },
+        "owners": {
+            "description": "Owners (users/teams) of the asset.",
+            "type": "array",
+            "items": {
+                "$ref": "entityReference.json"
+            },
+            "default": null
         },
         "resource": {
             "description": "Canonical URI of the asset this context describes (the OKF `resource` frontmatter key).",

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
@@ -61,6 +61,11 @@ export interface AIContext {
      */
     glossaryTerms?: KnowledgeItem[];
     /**
+     * Unique identifier of the asset this context describes. Stable, non-null primary key,
+     * unlike the presentation-layer `resource` href.
+     */
+    id?: string;
+    /**
      * Metrics associated with the asset.
      */
     metrics?: KnowledgeItem[];
@@ -70,9 +75,18 @@ export interface AIContext {
      */
     observability?: Observability;
     /**
+     * Owners (users/teams) of the asset.
+     */
+    owners?: EntityReference[];
+    /**
      * Canonical URI of the asset this context describes (the OKF `resource` frontmatter key).
      */
     resource?: string;
+    /**
+     * Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick
+     * the service icon.
+     */
+    serviceType?: string;
     /**
      * Classification tags and tier applied to the asset (tag fully qualified names).
      */
@@ -106,7 +120,11 @@ export interface KnowledgeItem {
     contentTruncated?:   boolean;
     displayName?:        string;
     fullyQualifiedName?: string;
-    name?:               string;
+    /**
+     * Unique identifier of the knowledge entity.
+     */
+    id?:   string;
+    name?: string;
     /**
      * The entity type of the knowledge item.
      */
@@ -375,4 +393,53 @@ export interface DataQuality {
     openIncidents?: number;
     passed?:        number;
     total?:         number;
+}
+
+/**
+ * This schema defines the EntityReference type used for referencing an entity.
+ * EntityReference is used for capturing relationships from one entity to another. For
+ * example, a table has an attribute called database of type EntityReference that captures
+ * the relationship of a table `belongs to a` database.
+ */
+export interface EntityReference {
+    /**
+     * If true the entity referred to has been soft-deleted.
+     */
+    deleted?: boolean;
+    /**
+     * Optional description of entity.
+     */
+    description?: string;
+    /**
+     * Display Name that identifies this entity.
+     */
+    displayName?: string;
+    /**
+     * Fully qualified name of the entity instance. For entities such as tables, databases
+     * fullyQualifiedName is returned in this field. For entities that don't have name hierarchy
+     * such as `user` and `team` this will be same as the `name` field.
+     */
+    fullyQualifiedName?: string;
+    /**
+     * Link to the entity resource.
+     */
+    href?: string;
+    /**
+     * Unique identifier that identifies an entity instance.
+     */
+    id: string;
+    /**
+     * If true the relationship indicated by this entity reference is inherited from the parent
+     * entity.
+     */
+    inherited?: boolean;
+    /**
+     * Name of the entity instance.
+     */
+    name?: string;
+    /**
+     * Entity type/class name - Examples: `database`, `table`, `metrics`, `databaseService`,
+     * `dashboardService`...
+     */
+    type: string;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts
@@ -61,8 +61,7 @@ export interface AIContext {
      */
     glossaryTerms?: KnowledgeItem[];
     /**
-     * Unique identifier of the asset this context describes. Stable, non-null primary key,
-     * unlike the presentation-layer `resource` href.
+     * Unique identifier of the asset this context describes.
      */
     id?: string;
     /**
@@ -83,8 +82,7 @@ export interface AIContext {
      */
     resource?: string;
     /**
-     * Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick
-     * the service icon.
+     * Service type of the asset's service (e.g. Snowflake, BigQuery).
      */
     serviceType?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
@@ -157,8 +157,7 @@ export interface AIContext {
      */
     glossaryTerms?: KnowledgeItem[];
     /**
-     * Unique identifier of the asset this context describes. Stable, non-null primary key,
-     * unlike the presentation-layer `resource` href.
+     * Unique identifier of the asset this context describes.
      */
     id?: string;
     /**
@@ -179,8 +178,7 @@ export interface AIContext {
      */
     resource?: string;
     /**
-     * Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick
-     * the service icon.
+     * Service type of the asset's service (e.g. Snowflake, BigQuery).
      */
     serviceType?: string;
     /**

--- a/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts
@@ -157,6 +157,11 @@ export interface AIContext {
      */
     glossaryTerms?: KnowledgeItem[];
     /**
+     * Unique identifier of the asset this context describes. Stable, non-null primary key,
+     * unlike the presentation-layer `resource` href.
+     */
+    id?: string;
+    /**
      * Metrics associated with the asset.
      */
     metrics?: KnowledgeItem[];
@@ -166,9 +171,18 @@ export interface AIContext {
      */
     observability?: Observability;
     /**
+     * Owners (users/teams) of the asset.
+     */
+    owners?: EntityReference[];
+    /**
      * Canonical URI of the asset this context describes (the OKF `resource` frontmatter key).
      */
     resource?: string;
+    /**
+     * Service type of the asset's service (e.g. Snowflake, BigQuery), used by clients to pick
+     * the service icon.
+     */
+    serviceType?: string;
     /**
      * Classification tags and tier applied to the asset (tag fully qualified names).
      */
@@ -202,7 +216,11 @@ export interface KnowledgeItem {
     contentTruncated?:   boolean;
     displayName?:        string;
     fullyQualifiedName?: string;
-    name?:               string;
+    /**
+     * Unique identifier of the knowledge entity.
+     */
+    id?:   string;
+    name?: string;
     /**
      * The entity type of the knowledge item.
      */


### PR DESCRIPTION
### Describe your changes:

Fixes #30185 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on 
- aiContext.json: add id/owners/serviceType on the asset and id on knowledgeItem
- PersonaContextBuilder: fetch owners/serviceType, set id/owners/serviceType, thread id onto knowledge items
- AIContextBuilder / AttachedKnowledgeBatch: set id on the asset and every knowledge item
- PersonaContextMarkdown: render attached metrics/glossary/articles as chat entity links
#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands AI context metadata and adds links for attached knowledge items. The main changes are:

- Adds asset IDs, owners, and service types to AI context data.
- Propagates knowledge-item IDs through builder, reference, and truncation paths.
- Updates the schema and generated TypeScript definitions.
- Renders metrics, glossary terms, and articles as escaped entity links.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated link builder escapes the user-defined delimiters that previously produced malformed links.
- No blocking issue remains in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextMarkdown.java | Adds entity links for attached knowledge and escapes link-text brackets and backslashes. |
| openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextBuilder.java | Populates asset IDs, owners, service types, and knowledge-item IDs. |
| openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java | Adds persisted entity IDs to asset and knowledge context objects. |
| openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AttachedKnowledgeBatch.java | Preserves knowledge-item IDs when long content is truncated. |
| openmetadata-spec/src/main/resources/json/schema/type/aiContext.json | Defines the new asset and knowledge-item metadata fields. |
| openmetadata-ui/src/main/resources/ui/src/generated/type/aiContext.ts | Updates generated AI context types for the expanded schema. |
| openmetadata-ui/src/main/resources/ui/src/generated/type/personaContext.ts | Updates generated persona context types for the expanded AI context shape. |

</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into aicontext-perso..."](https://github.com/open-metadata/openmetadata/commit/3f98c21c42c6233f41d2a4c57f786e8918ae9305) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45089761)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->