### PR TITLE
Fixes #30189: Repair Mlflow version selection and unbreak AutoPilot E2E

### DIFF
--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
@@ -82,10 +82,10 @@ class MlflowSource(MlModelServiceSource):
                 )
                 continue
 
-            # Get the latest version
-            latest_version: Optional[ModelVersion] = next(  # noqa: UP045
-                (ver for ver in model.latest_versions if ver.last_updated_timestamp == model.last_updated_timestamp),
-                None,
+            latest_version: Optional[ModelVersion] = max(  # noqa: UP045
+                model.latest_versions,
+                key=lambda ver: int(ver.version),
+                default=None,
             )
             if not latest_version:
                 self.status.failed(

--- a/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py
@@ -13,7 +13,7 @@
 import ast  # noqa: I001
 import json
 import traceback
-from typing import Iterable, List, Optional, Tuple, cast  # noqa: UP035
+from collections.abc import Iterable
 
 from mlflow.entities import RunData
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
@@ -61,7 +61,7 @@ class MlflowSource(MlModelServiceSource):
     """
 
     @classmethod
-    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045
+    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: str | None = None):
         config: WorkflowSource = WorkflowSource.model_validate(config_dict)
         connection: MlflowConnection = config.serviceConnection.root.config
         if not isinstance(connection, MlflowConnection):
@@ -70,11 +70,11 @@ class MlflowSource(MlModelServiceSource):
 
     def get_mlmodels(  # pylint: disable=arguments-differ
         self,
-    ) -> Iterable[Tuple[RegisteredModel, ModelVersion]]:  # noqa: UP006
+    ) -> Iterable[tuple[RegisteredModel, ModelVersion]]:
         """
         List and filters models from the registry
         """
-        for model in cast(RegisteredModel, self.client.search_registered_models()):  # noqa: TC006
+        for model in self.client.search_registered_models():
             if filter_by_mlmodel(self.source_config.mlModelFilterPattern, mlmodel_name=model.name):
                 self.status.filter(
                     model.name,
@@ -82,7 +82,7 @@ class MlflowSource(MlModelServiceSource):
                 )
                 continue
 
-            latest_version: Optional[ModelVersion] = max(  # noqa: UP045
+            latest_version: ModelVersion | None = max(
                 model.latest_versions,
                 key=lambda ver: int(ver.version),
                 default=None,
@@ -105,7 +105,7 @@ class MlflowSource(MlModelServiceSource):
 
     def yield_mlmodel(  # pylint: disable=arguments-differ
         self,
-        model_and_version: Tuple[RegisteredModel, ModelVersion],  # noqa: UP006
+        model_and_version: tuple[RegisteredModel, ModelVersion],
     ) -> Iterable[Either[CreateMlModelRequest]]:
         """Prepare the Request model"""
         model, latest_version = model_and_version
@@ -129,7 +129,7 @@ class MlflowSource(MlModelServiceSource):
     def _get_hyper_params(  # pylint: disable=arguments-differ
         self,
         data: RunData,
-    ) -> Optional[List[MlHyperParameter]]:  # noqa: UP006, UP045
+    ) -> list[MlHyperParameter] | None:
         """
         Get the hyper parameters from the parameters
         logged in the run data object.
@@ -150,7 +150,7 @@ class MlflowSource(MlModelServiceSource):
         self,
         version: ModelVersion,
         run,
-    ) -> Optional[MlStore]:  # noqa: UP045
+    ) -> MlStore | None:
         """
         Get the Ml Store from the model version object.
         Uses the artifact URI from the run for actual storage location.
@@ -169,7 +169,7 @@ class MlflowSource(MlModelServiceSource):
 
     def _get_ml_features(  # pylint: disable=arguments-differ
         self, data: RunData, run_id: str, model_name: str
-    ) -> Optional[List[MlFeature]]:  # noqa: UP006, UP045
+    ) -> list[MlFeature] | None:
         """
         The RunData object comes with stringified `tags`.
         Let's transform those and try to extract the `signature`

--- a/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
+++ b/ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py
@@ -57,6 +57,7 @@ MODEL_HYPERPARAMS = {
 }
 
 MODEL_NAME = "ElasticnetWineModel"
+MODEL_DESCRIPTION = "ElasticNet model predicting wine quality"
 
 
 def eval_metrics(actual, pred):
@@ -149,6 +150,10 @@ def create_data(mlflow_environment):
                 else:
                     raise
 
+    # Describing the model bumps RegisteredModel.last_updated_timestamp past the
+    # version's, which must not hide the version from the registry listing.
+    mlflow.MlflowClient().update_registered_model(MODEL_NAME, description=MODEL_DESCRIPTION)
+
 
 @pytest.fixture(scope="module")
 def service(metadata, mlflow_environment):
@@ -203,6 +208,8 @@ def test_mlflow(ingest_mlflow, metadata, service):
 
     # Assert name is as expected
     assert model.name.root == MODEL_NAME
+
+    assert model.description.root == MODEL_DESCRIPTION
 
     # Assert HyperParameters are as expected
     assert len(model.mlHyperParameters) == 2

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts
@@ -55,9 +55,12 @@ class MlFlowIngestionClass extends ServiceBaseClass {
   }
 
   async fillConnectionDetails(page: Page) {
-    await page.fill('#root\\/trackingUri', 'mlModelTrackingUri');
+    // MLflow 3.13+ rejects the filesystem backend, which is what a non-URI
+    // string resolves to. SQLite is a supported backend and bootstraps itself,
+    // yielding an empty registry the agent can walk without a live MLflow.
+    await page.fill('#root\\/trackingUri', 'sqlite:////tmp/mlflow_tracking.db');
     await checkServiceFieldSectionHighlighting(page, 'trackingUri');
-    await page.fill('#root\\/registryUri', 'mlModelRegistryUri');
+    await page.fill('#root\\/registryUri', 'sqlite:////tmp/mlflow_registry.db');
     await checkServiceFieldSectionHighlighting(page, 'registryUri');
   }
 


### PR DESCRIPTION
Fixes #30189

Two defects surfaced by the `mlflow-skinny` bump to `>=3.13.0,<3.15` (#30046, resolves to 3.14.0).

## Models are dropped once their registry metadata is edited

`get_mlmodels` picked a version by exact timestamp equality with its parent, which only holds while the version creation was the last write to the registered model. Editing the description, adding tags or assigning an alias bumps `RegisteredModel.last_updated_timestamp` without touching the version, so every version fails the check and the model is skipped as "Version not found" — while the error prints a list that visibly contains the version.

Now selects the newest version by version number. Version number is monotonic and is the actual definition of "latest", whereas re-tagging an older version could give it the newest timestamp. An empty `latest_versions` still yields `None`, so the existing failure path is unchanged.

The integration test now describes the model after registering it, which desyncs the timestamps and fails without this change.

## AutoPilot E2E fails on every PR

`Mlflow › Create Service and check the AutoPilot status` fails deterministically on `main`, blocking the `playwright-ci-postgresql (7, 7)` shard.

`MlFlowIngestionClass` fills placeholder connection strings. MLflow resolved a non-URI string to a local file store, so the agent walked an empty registry and succeeded — an accident that expired when 3.13 put the file store into maintenance mode and made it raise:

| mlflow-skinny | `search_registered_models()` with a placeholder URI |
| --- | --- |
| 3.11.1 (old ceiling) | OK — file store accepted |
| 3.13.0 (new floor) | raises `MlflowException` |

The fields now hold sqlite DSNs. SQLite is a supported backend that bootstraps its own schema, so it keeps the "empty registry, agent succeeds" semantics the test already relied on — as a deliberate choice rather than a side effect of MLflow's string parsing. Both fields are plain `type: string` in the schema, so no schema or UI change is needed. `MLFLOW_ALLOW_FILE_STORE=true` was rejected as an alternative: it puts a prod-image env var behind a test's placeholder data and re-enables a backend MLflow is sunsetting.

## Key finding

Neither defect was catchable by CI. The AutoPilot test never touches a real MLflow, and `test_mlflow.py` registered a model and never mutated it, so the timestamps stayed coincidentally equal. The Snyk bump crossed two MLflow minors with real behavioural changes and no connector-side validation.

Out of scope, tracked in #30189: `_get_ml_features` reads the `mlflow.log-model.history` run tag, which MLflow 3.x no longer writes (the signature moved to the logged-model API), so `mlFeatures` ingests as `null`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR repairs MLflow model selection and restores the AutoPilot end-to-end workflow. The main changes are:

- Select the newest model by its numeric version instead of timestamp equality.
- Update the integration fixture to reproduce registered-model timestamp changes.
- Use SQLite MLflow backends in the AutoPilot test setup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The numeric version selection matches MLflow's version ordering.
- The updated fixture covers metadata changes that previously hid registered versions.
- No blocking issue distinct from the existing test-coverage feedback was found.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/mlmodel/mlflow/metadata.py | Selects the highest numeric MLflow model version and modernizes Python type annotations. |
| ingestion/tests/integration/sources/mlmodels/mlflow/test_mlflow.py | Updates registered-model metadata after registration and verifies the description is ingested. |
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts | Replaces invalid placeholder URIs with supported SQLite MLflow backends. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ingestion): drop the bogus Registere..."](https://github.com/open-metadata/openmetadata/commit/0aaa3d6d3c515a702d7991272a021f80de134fdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45098374)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->