### PR TITLE
fix(ingestion): gate trino IT on catalog scheduling, not node liveness

### DIFF
--- a/ingestion/tests/integration/trino/conftest.py
+++ b/ingestion/tests/integration/trino/conftest.py
@@ -59,8 +59,12 @@ class TrinoContainer(DbContainer):
                 with engine.connect() as conn:
                     return conn.execute(text(sql))
 
+            # Scan a real catalog, not system.runtime.nodes: for the first seconds after startup
+            # trino accepts queries but cannot yet schedule one against a catalog
+            # (NO_NODES_AVAILABLE), while the system connector, registered on every active node,
+            # already answers. Any catalog proves the rest -- one announcement lists them all.
             retry(wait=wait_fixed(1), stop=stop_after_delay(120))(_exec)(
-                "select system.runtime.nodes.node_id from system.runtime.nodes"
+                "SELECT count(*) FROM tpch.tiny.nation"
             ).fetchall()
         finally:
             engine.dispose()


### PR DESCRIPTION
## Problem

The trino integration tests fail intermittently in CI with `NO_NODES_AVAILABLE` — all 38 tests erroring at `create_test_data` setup, hitting one random python leg per run.

## Root cause

For the first ~1–3s after `======== SERVER STARTED ========`, the trino coordinator accepts queries but cannot yet schedule one against a *catalog*. `DiscoveryNodeManager` rebuilds its per-catalog node map (`activeNodesByCatalogHandle`) only on a 5s timer, and its `@PostConstruct` poll runs during `app.initialize()` — before `loadInitialCatalogs()` / `updateConnectorIds()`. So the last rebuild before startup completes carries no catalogs, and until the next tick a catalog scan fails with `NO_NODES_AVAILABLE`.

Meanwhile the **system** connector is registered on every active node unconditionally:

```java
// DiscoveryNodeManager.refreshNodesInternal()
byCatalogHandleBuilder.put(CATALOG_HANDLE, node);   // always
```

The old readiness gate queried `system.runtime.nodes`, served by that system connector — so it passed the instant the node was active and could never witness the unscheduled catalog. That is why the `information_schema` probe sailed through while the first real scan died.

## Fix

Gate on a real catalog scan instead:

```python
"SELECT count(*) FROM tpch.tiny.nation"
```

`tpch` ships in the base image and `COPY etc /etc/trino` merges, so the test image already has both `minio` and `tpch`. One catalog proves the rest — a single announcement lists them all, so one refresh admits them together. This mirrors testcontainers' own `TrinoContainer.getTestQueryString()`, which uses exactly this query for exactly this reason.

Metadata-only probes (`information_schema`, `SHOW SCHEMAS`) are **not** valid: those use separate catalog sub-handles and pass during the window.

## Validation

Reproduced the startup window deterministically against the repo's own trino image (6/6 cycles, `SELECT count(*) FROM tpch.tiny.nation` returning `NO_NODES_AVAILABLE` for ~0.8–1.5s after the old gate already passed). A/B at catalog level: baseline 6/6 fail, gated 0/6. Full fixture stack passes with the change.