### PR TITLE
Cap external scale IT at 100k and fix external-cluster test flakiness

### DIFF
--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -396,8 +396,10 @@ jobs:
 
   scale-it-external:
     # Runs after search-it (shared instance, singleton reindex app). max-parallel: 1 so the matrix
-    # entries (e.g. 100k then 500k) seed + reindex one at a time — two concurrent reindexes on one
-    # cluster collide and the db/es counts would mix cohorts.
+    # entries seed + reindex one at a time — two concurrent reindexes on one cluster collide and the
+    # db/es counts would mix cohorts. Default cohort is 100k only; a 500k run took >5h and was
+    # cancelled every night without ever completing. Larger sizes can still be requested on demand
+    # via the scaleSeeds dispatch input (e.g. [100000, 500000]).
     needs: [search-it-external]
     if: ${{ always() && github.event.inputs.runScaleIt != 'false' }}
     runs-on: ubuntu-latest
@@ -406,7 +408,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        seed: ${{ fromJSON(github.event.inputs.scaleSeeds || '[100000, 500000]') }}
+        seed: ${{ fromJSON(github.event.inputs.scaleSeeds || '[100000]') }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchRelevancyPreviewIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchRelevancyPreviewIT.java
@@ -121,20 +121,27 @@ class SearchRelevancyPreviewIT {
 
     final SearchSettings base = currentSettings();
 
+    // Field selection is proven by which seeded table is IN vs OUT: name-only must match the
+    // name-carrier and exclude the description-carrier (and vice versa). Use
+    // contains/doesNotContain
+    // rather than containsExactly — on the shared cluster a foreign ngram-colliding table can add a
+    // hit without changing which of OUR two tables the searched field selects.
     SearchSettings nameOnly = SearchSettingsTestHelper.copyOf(base);
     SearchSettingsTestHelper.setOnlySearchField(nameOnly, TABLE_INDEX, NAME_FIELD, 5.0);
     nameOnly = SearchSettingsTestHelper.withRankingDisabled(nameOnly, TABLE_INDEX);
     assertThat(SearchSettingsTestHelper.previewIds(server, query, TABLE_INDEX, nameOnly, 10))
-        .as("searching only 'name' must return only the table whose name carries the token")
-        .containsExactly(tokenInName.getId().toString());
+        .as("searching only 'name' must match the name-carrier, not the description-carrier")
+        .contains(tokenInName.getId().toString())
+        .doesNotContain(tokenInDescription.getId().toString());
 
     SearchSettings descriptionOnly = SearchSettingsTestHelper.copyOf(base);
     SearchSettingsTestHelper.setOnlySearchField(
         descriptionOnly, TABLE_INDEX, DESCRIPTION_FIELD, 5.0);
     descriptionOnly = SearchSettingsTestHelper.withRankingDisabled(descriptionOnly, TABLE_INDEX);
     assertThat(SearchSettingsTestHelper.previewIds(server, query, TABLE_INDEX, descriptionOnly, 10))
-        .as("searching only 'description' must return only the table whose description carries it")
-        .containsExactly(tokenInDescription.getId().toString());
+        .as("searching only 'description' must match the description-carrier, not the name-carrier")
+        .contains(tokenInDescription.getId().toString())
+        .doesNotContain(tokenInName.getId().toString());
   }
 
   @Test
@@ -193,7 +200,8 @@ class SearchRelevancyPreviewIT {
     final DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns);
     final Table exactTable =
         RelevancyFixtures.createTable(schema, exactName, "plaindescription", null);
-    RelevancyFixtures.createTable(schema, exactName + "extra", "plaindescription", null);
+    final Table prefixedTable =
+        RelevancyFixtures.createTable(schema, exactName + "extra", "plaindescription", null);
     awaitIndexed(exactName, 2);
 
     final SearchSettings base = currentSettings();
@@ -210,9 +218,13 @@ class SearchRelevancyPreviewIT {
     SearchSettingsTestHelper.setOnlySearchField(
         standard, TABLE_INDEX, NAME_FIELD, 5.0, FieldBoost.MatchType.STANDARD);
     standard = SearchSettingsTestHelper.withRankingDisabled(standard, TABLE_INDEX);
+    // STANDARD is a fuzzy name.ngram match, so on the shared cluster a foreign ngram-colliding
+    // table can add hits beyond the two we seeded. Assert both seeded ids are present rather than
+    // an exact size (mirrors maxResultHitsClampsTheReturnedHits), which such a foreign hit
+    // inflates.
     assertThat(SearchSettingsTestHelper.previewIds(server, exactName, TABLE_INDEX, standard, 10))
         .as("matchType=standard must match both the exact and the prefixed name")
-        .hasSize(2);
+        .contains(exactTable.getId().toString(), prefixedTable.getId().toString());
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/ExternalTokenRefresher.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/ExternalTokenRefresher.java
@@ -29,9 +29,6 @@ import org.slf4j.LoggerFactory;
 public final class ExternalTokenRefresher implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExternalTokenRefresher.class);
-  // Renew this far ahead of expiry so a flaky login endpoint has room for several 60s retries
-  // before the token actually dies (login TTL is ~1h, so 10m early is safe).
-  private static final Duration EXPIRY_BUFFER = Duration.ofMinutes(10);
   // Bounds BOTH the connect and the read phase of each login. Without a read timeout a slow or
   // half-open gateway would block http.send() forever on the single-thread scheduler, and the
   // token would never renew for the rest of the run.
@@ -125,12 +122,18 @@ public final class ExternalTokenRefresher implements AutoCloseable {
     }
   }
 
+  // Renew at half the token's remaining lifetime (~30m on the external cluster's ~1h token) rather
+  // than a fixed buffer before expiry. That leaves ~half the TTL as retry runway if the login
+  // endpoint is unreachable at renewal time: a ~10m login-endpoint outage that lands on the renewal
+  // window (observed 2026-07-17) burned through a fixed 10m buffer and let the token expire
+  // mid-seed; half-life gives the 60s retries far more room to catch the endpoint before the token
+  // actually dies.
   private long refreshDelaySeconds(final String token) {
     long delaySeconds = FALLBACK_REFRESH_SECONDS;
     final Long exp = expiryEpochSeconds(token);
     if (exp != null) {
       final long now = System.currentTimeMillis() / 1000;
-      delaySeconds = Math.max(60, exp - now - EXPIRY_BUFFER.toSeconds());
+      delaySeconds = Math.max(60, (exp - now) / 2);
     }
     return delaySeconds;
   }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java
@@ -187,8 +187,17 @@ public final class DataQualityListPage extends PageObject {
 
   /** Open the page-size dropdown and assert the standard 3 options render. */
   public DataQualityListPage assertPageSizeOptionsCount(final int expected) {
-    openMenu(byTestId("page-size-selection-dropdown"), page.locator(".ant-dropdown-menu"));
-    PlaywrightAssertions.assertThat(page.locator(".ant-dropdown-menu-item")).hasCount(expected);
+    // Scope to the OPEN overlay: every Ant <Dropdown> on the page (nav bar, help, etc.) portals a
+    // .ant-dropdown-menu to <body> and keeps it in the DOM while hidden, so a bare
+    // .ant-dropdown-menu first-matches a foreign hidden menu and the visibility wait times out.
+    // :not(.ant-dropdown-hidden) pins it to the just-opened page-size menu (mirrors the
+    // .ant-select-dropdown idiom above).
+    final Locator pageSizeMenu =
+        page.locator(".ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu");
+    openMenu(byTestId("page-size-selection-dropdown"), pageSizeMenu);
+    PlaywrightAssertions.assertThat(
+            page.locator(".ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu-item"))
+        .hasCount(expected);
     return this;
   }
 


### PR DESCRIPTION
### Describe your changes:

<!-- No tracking issue yet — this is CI / test-infra stabilization for the
     "Java Integration Tests (External Cluster)" nightly workflow, which was
     failing on every run. Happy to open an issue if the team wants one linked. -->

The nightly **External Cluster** workflow failed every run, for four unrelated reasons. This fixes each:

- **500k scale job cancelled nightly** — it runs after 100k (`max-parallel: 1`), took >5h, and never completed. The scale matrix fallback now defaults to `[100000]`; larger cohorts stay available on demand via the `scaleSeeds` dispatch input.
- **scale-100k `401 Expired token` mid-seed** — `ExternalTokenRefresher` renewed only 10m before expiry, so a ~10m login-endpoint outage on the renewal window let the ~1h token die. It now renews at **half the token's remaining life** (~30m runway). Validated live against the cluster (`refresh scheduled in 1795s`).
- **`SearchRelevancyPreviewIT` flaky (`matchType`/`searchFields`)** — exact-set assertions (`hasSize`/`containsExactly`) on fuzzy `name.ngram` queries were inflated by foreign ngram-colliding tables on the shared cluster. Switched to `contains`/`doesNotContain` (matching the existing `maxResultHits` fix). **Verified 7/7 green against `mohitcorp2.getcollate.io`.**
- **`DataQualityPaginationReindexUIIT` dropdown timeout** — the unscoped `.ant-dropdown-menu` first-matched a hidden nav-bar menu portaled to `<body>` (`NextPrevious` is a shared component). Scoped to `.ant-dropdown:not(.ant-dropdown-hidden)`, mirroring the existing `.ant-select-dropdown` idiom.

**Not changed — `NoDuplicatesDuringReindexIT`:** current `DefaultRecreateHandler` is zero-downtime (staged index + atomic `swapAliases`), so the read alias is never empty. The `count=0` is the test correctly catching a read-gap in the **older build deployed on the cluster** (rev `f1f786a8`, not in this repo). Silencing it would remove a valid regression guard — the cluster needs redeploying instead.

#
### Type of change:
- [x] Bug fix

#
### High-level design:
N/A — CI config + test/selector robustness only; no production code changed.

#
### Tests:

#### Manual testing performed
1. Acquired a token and ran `SearchRelevancyPreviewIT` (`-P search-it -Dit.test=...`) against `https://mohitcorp2.getcollate.io` — reproduced the flake, applied the fix, re-ran **7/7 green**.
2. Confirmed the token-renewal change live: the refresher now schedules the next re-login at ~30m (half-life) instead of ~50m.
3. Verified the page-size dropdown fix against the actual `NextPrevious.tsx` Ant `<Dropdown>` markup (Playwright not runnable in this environment).

#### Backend integration tests
- [x] Not applicable — these ARE the integration tests; changes make them reliable on the shared external cluster.

#### Playwright (UI) tests
- [x] Not applicable — page-object selector robustness only; no UI/product change.

#
### UI screen recording / screenshots:
Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the nightly external-cluster integration tests. The main changes are:

- Limits the default scale test to the 100k cohort.
- Tolerates unrelated ngram hits in search preview assertions.
- Schedules token renewal at half of the remaining lifetime.
- Scopes the page-size locator to visible Ant dropdowns.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The aged-token refresh path needs a fix before merging.

- Fresh one-hour tokens gain more retry time.
- Tokens already near expiry can now wait longer before renewal and expire during a shorter login outage.
- The workflow, search assertions, and dropdown selector preserve their intended behavior.

openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/ExternalTokenRefresher.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-playwright-external.yml | Changes the scheduled and default scale matrix to 100k while preserving manually supplied cohorts. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchRelevancyPreviewIT.java | Allows unrelated fuzzy-search hits while retaining the expected seeded inclusions and field-specific exclusions. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/ExternalTokenRefresher.java | Gives fresh one-hour tokens more retry runway, but can refresh an aged initial token later than the previous policy. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java | Scopes page-size menu checks to non-hidden Ant dropdown overlays. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Cap external scale IT at 100k and fix ex..."](https://github.com/open-metadata/openmetadata/commit/4b8a2cd9d53bb6ceceb0e6dc7b000125a76ff636) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45299887)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->