### PR TITLE
fix(test): persona spec for AUTs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
@@ -168,9 +168,27 @@ test.describe.serial('User profile works after persona deletion', () => {
       await expect(personaCard).toBeVisible();
 
       // Check if deleted persona still appears (this would be the bug)
-      await expect(personaCard).not.toContainText(PERSONA_DETAILS.displayName);
-
+      // Retry up to 3 times with page reload to handle eventual consistency
+      const deletedPersonaLink = page.getByTestId(
+        `${PERSONA_DETAILS.name}-link`
+      );
       const noPersonaText = personaCard.getByText('No persona assigned');
+
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        if (
+          !(await deletedPersonaLink.isVisible()) &&
+          (await noPersonaText.isVisible())
+        ) {
+          break;
+        }
+
+        if (attempt < 3) {
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+        }
+      }
+
+      await expect(deletedPersonaLink).not.toBeVisible();
       await expect(noPersonaText).toBeVisible();
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -401,6 +401,7 @@ test.describe.serial('Default persona setting and removal flow', () => {
         await userPage.reload();
         await waitForAllLoadersToDisappear(userPage);
         await checkPersonaInProfile(userPage, PERSONA_DETAILS.displayName);
+        await redirectToHomePage(userPage);
       });
 
       await test.step('Changing default persona', async () => {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test improvements:**
    - Added retry logic to `PersonaDeletionUserProfile.spec.ts` to handle eventual consistency when checking for deleted persona visibility.
    - Included a page reload mechanism in the retry loop for `PersonaDeletionUserProfile.spec.ts` to ensure data synchronization.
    - Added a `redirectToHomePage` call in `PersonaFlow.spec.ts` to correctly navigate after default persona verification.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts the Playwright persona flows to handle refreshed application state. The main changes are:

- Retry persona-deletion checks across page reloads.
- Assert both the removed persona link and the empty persona state.
- Return the user page home after checking its default persona.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after a small test-stability cleanup.

- The new retry can exhaust its attempts before profile data appears after a reload.
- The added home redirect does not break later route assumptions.

openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaDeletionUserProfile.spec.ts | Adds bounded reload retries for deleted-persona state, but the retry probes can run before profile data has rendered. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts | Returns the secondary user page to the home route after verifying the applied default persona. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): persona spec for AUTs"](https://github.com/open-metadata/openmetadata/commit/6c9a9045909bab254d54f25809ca1f2fa2249965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45303227)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->