### PR TITLE
fix(test): use explicit node ID in OntologyExplorer entity panel close test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorer.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorer.spec.ts
@@ -620,7 +620,14 @@ test.describe('Ontology Explorer', () => {
       await waitForGraphLoaded(page);
       await page.getByTestId('fit-view').click();
 
-      await clickFirstGraphNode(page);
+      const positions = await readNodePositions(page);
+      const term1Pos = positions[term1.responseData.id];
+
+      expect(
+        term1Pos,
+        'term1 node must be present in graph positions after glossary filter'
+      ).toBeDefined();
+      await page.mouse.click(term1Pos.x, term1Pos.y);
 
       await expect(
         page.getByTestId('entity-summary-panel-container')


### PR DESCRIPTION
## Summary

- `clickFirstGraphNode(page)` uses `Object.values(positions)[0]` whose ordering is non-deterministic after the graph repositions following a glossary filter + fit-view. The click could miss the intended node, G6 never fires `NodeEvent.CLICK`, `setSelectedNode` is never called, the `EntitySummaryPanel` is never rendered, and the `entity-summary-panel-container` locator times out.
- Fix: replace the generic `clickFirstGraphNode` call with an explicit lookup by `term1.responseData.id` — the same pattern already used at line 459 (passing) and throughout `OntologyExplorerE2E.spec.ts` (passing).
- 1 file changed, 8 insertions(+), 1 deletion(-).

## Test plan

- [ ] Verify `OntologyExplorer.spec.ts` "should close entity summary panel when close button is clicked" passes consistently in CI.
- [ ] Confirm no other tests in the file are affected.

Fixes nightly failure: https://github.com/open-metadata/openmetadata-nightly/actions/runs/29531350950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Ontology Explorer close-panel test select a deterministic graph node. The main changes are:

- Looks up the first glossary term by its explicit node ID.
- Asserts that the expected node position is available.
- Clicks the node using its stored viewport coordinates.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The node ID and coordinate formats match the graph test helpers.
- The same explicit-node pattern is already used by a nearby test.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorer.spec.ts | Replaces non-deterministic first-node selection with an explicit term ID lookup and a clear position assertion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): use explicit term1 node ID in..."](https://github.com/open-metadata/openmetadata/commit/9d6bb9c79984e94ede64ec9ea22b152388a5692f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45304040)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->