### PR TITLE
fix(ui): prevent schedule column text from wrapping mid-word in pipeline table

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx
@@ -500,7 +500,7 @@ const TestSuitePipelineTab = ({
                       />
                     </Table.Cell>
 
-                    <Table.Cell className="tw:align-middle tw:w-44">
+                    <Table.Cell className="tw:align-middle tw:w-44 tw:max-w-44">
                       {renderScheduleField(record.name, record)}
                     </Table.Cell>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -327,6 +327,7 @@ function IngestionListTable({
         dataIndex: 'schedule',
         key: 'schedule',
         width: 150,
+        onCell: () => ({ style: { maxWidth: 150 } }),
         render: renderScheduleField,
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -327,7 +327,6 @@ function IngestionListTable({
         dataIndex: 'schedule',
         key: 'schedule',
         width: 150,
-        onCell: () => ({ style: { maxWidth: 150 } }),
         render: renderScheduleField,
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
@@ -88,14 +88,14 @@ const ScheduleFieldCell = ({
         <Row className="line-height-16">
           <Col span={24}>
             <Typography.Text
-              className="font-medium"
+              className="font-medium whitespace-nowrap"
               data-testid="schedule-primary-details">
               {descriptionFirstPart}
             </Typography.Text>
           </Col>
           <Col span={24}>
             <Typography.Text
-              className="text-xs text-grey-muted"
+              className="text-xs text-grey-muted whitespace-nowrap"
               data-testid="schedule-secondary-details">
               {descriptionSecondPart}
             </Typography.Text>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx
@@ -81,22 +81,24 @@ const ScheduleFieldCell = ({
 
   return (
     <Row gutter={[8, 8]} wrap={false}>
-      <Col>
+      <Col flex="none">
         <TimeDateIcon className="m-t-xss" height={20} width={20} />
       </Col>
-      <Col>
+      <Col className="tw:min-w-0" flex="auto">
         <Row className="line-height-16">
           <Col span={24}>
             <Typography.Text
-              className="font-medium whitespace-nowrap"
-              data-testid="schedule-primary-details">
+              className="font-medium"
+              data-testid="schedule-primary-details"
+              ellipsis={{ tooltip: descriptionFirstPart }}>
               {descriptionFirstPart}
             </Typography.Text>
           </Col>
           <Col span={24}>
             <Typography.Text
-              className="text-xs text-grey-muted whitespace-nowrap"
-              data-testid="schedule-secondary-details">
+              className="text-xs text-grey-muted"
+              data-testid="schedule-secondary-details"
+              ellipsis={{ tooltip: descriptionSecondPart }}>
               {descriptionSecondPart}
             </Typography.Text>
           </Col>


### PR DESCRIPTION
## issue
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/5755288c-8ff8-44c7-808f-39bb26f8f6db" />


## fix
<img width="1511" height="852" alt="image" src="https://github.com/user-attachments/assets/43e34e00-b2ff-47dd-bea6-7c8f55512580" />


## Problem

In the pipeline table (test-suite Data Observability tab and the ingestion list table), the **Schedule** column text broke character-by-character — e.g. "At 12:00 AM" rendered as "At 12:", "00", "AM" stacked vertically.

The schedule cell renders its two text lines inside a `wrap={false}` Ant Design flex row. With `wrap={false}`, the flex items don't wrap but the text column still shrinks below its content width, so the text itself wrapped mid-word.

## Fix

Add `whitespace-nowrap` to both schedule detail lines (`schedule-primary-details` and `schedule-secondary-details`) in `ScheduleFieldCell` so each stays on a single line within the fixed-width column.

## Verification

- **UI checkstyle** — organize-imports + eslint + prettier pass clean; diff is only the two className additions.
- **DOM measurement** — both lines now compute `whiteSpace: nowrap` and render on a single line (85px and 56px wide, inside the 176px column).
- **Visual** — confirmed in the running UI at laptop width: "At 12:00 AM" / "Every day" display on two tidy lines.

### Before
"At 12:" / "00" / "AM" wrapping vertically in the Schedule column.

### After
"At 12:00 AM" / "Every day" — clean two-line layout, no mid-word breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Layout improvements:**
    - Constrained column width in `TestSuitePipelineTab` and `IngestionListTable` to prevent layout breaking.
    - Applied `flex="auto"` and `tw:min-w-0` to schedule column containers to ensure proper truncation behavior.
- **UI behavior:**
    - Replaced `whitespace-nowrap` with `ellipsis` on schedule details to safely handle long descriptions.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves Schedule column rendering in pipeline tables. The main changes are:

- Adds fixed-width constraints to the Test Suite pipeline Schedule cell.
- Makes the schedule icon and text use explicit flex sizing.
- Truncates long schedule details with hover tooltips.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No new blocking issue distinct from the previously reported schedule overflow case was found.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.component.tsx | Caps the Test Suite pipeline Schedule cell at its configured width. |
| openmetadata-ui/src/main/resources/ui/src/utils/IngestionListTableUtils.tsx | Updates schedule content sizing and adds ellipsis tooltips to both detail lines. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): drop redundant maxWidth onCell ..."](https://github.com/open-metadata/openmetadata/commit/be088625ce3f58defec7c5d1bf3a43f3f7ba840d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45339597)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->