### PR TITLE
fix: scope glossary term duplicate-name check to parent, not whole glossary (#30144)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1103,6 +1103,82 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     }
   }
 
+  @Test
+  void test_createGlossaryTerm_sameNameUnderDifferentParents_succeeds(TestNamespace ns) {
+    // Regression test: two glossary terms sharing the same leaf name but living under different
+    // parents have distinct FQNs and must both be creatable. Previously the duplicate-name check
+    // run on create matched any term with the same name anywhere in the glossary, regardless of
+    // parent, causing the second term ("Loan.Balance") to be rejected as a duplicate of the
+    // already-persisted "Account.Balance".
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    CreateGlossary createGlossary = createMinimalRequest(ns);
+    Glossary glossary = createEntity(createGlossary);
+    String glossaryFqn = glossary.getFullyQualifiedName();
+
+    GlossaryTerm account =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("account"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Account parent term"));
+    GlossaryTerm loan =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("loan"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Loan parent term"));
+
+    GlossaryTerm accountBalance =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName("Balance")
+                    .withGlossary(glossaryFqn)
+                    .withParent(account.getFullyQualifiedName())
+                    .withDescription("Account balance definition"));
+    assertNotNull(accountBalance, "Account.Balance term should have been created");
+
+    GlossaryTerm loanBalance;
+    try {
+      loanBalance =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("Balance")
+                      .withGlossary(glossaryFqn)
+                      .withParent(loan.getFullyQualifiedName())
+                      .withDescription("Loan balance definition"));
+    } catch (Exception e) {
+      fail(
+          "Creating 'Balance' under a different parent ('"
+              + loan.getFullyQualifiedName()
+              + "') should not be rejected as a duplicate of the existing '"
+              + accountBalance.getFullyQualifiedName()
+              + "': "
+              + e.getMessage());
+      return;
+    }
+
+    assertNotNull(loanBalance, "Loan.Balance term should have been created");
+    assertEquals("Balance", accountBalance.getName());
+    assertEquals("Balance", loanBalance.getName());
+    assertEquals(
+        org.openmetadata.service.util.FullyQualifiedName.add(
+            account.getFullyQualifiedName(), "Balance"),
+        accountBalance.getFullyQualifiedName());
+    assertEquals(
+        org.openmetadata.service.util.FullyQualifiedName.add(
+            loan.getFullyQualifiedName(), "Balance"),
+        loanBalance.getFullyQualifiedName());
+  }
+
   /**
    * Helper method to create CSV content for glossary terms import.
    * Returns CSV with header and 3 glossary terms with all required columns.

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -1845,4 +1845,78 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
           "Glossary reviewer count should match");
     }
   }
+
+  @Test
+  void test_createGlossaryTerm_sameNameUnderDifferentParents_succeeds(TestNamespace ns) {
+    // Regression test: two glossary terms sharing the same leaf name but living under different
+    // parents have distinct FQNs and must both be creatable. Previously the duplicate-name check
+    // on create matched any term with the same name anywhere in the glossary, regardless of
+    // parent, causing the second term ("Loan.Balance") to be rejected as a duplicate of the
+    // already-persisted "Account.Balance".
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    CreateGlossary createGlossary = createMinimalRequest(ns);
+    Glossary glossary = createEntity(createGlossary);
+    String glossaryFqn = glossary.getFullyQualifiedName();
+
+    GlossaryTerm account =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("account"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Account parent term"));
+    GlossaryTerm loan =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName(ns.prefix("loan"))
+                    .withGlossary(glossaryFqn)
+                    .withDescription("Loan parent term"));
+
+    GlossaryTerm accountBalance =
+        client
+            .glossaryTerms()
+            .create(
+                new CreateGlossaryTerm()
+                    .withName("Balance")
+                    .withGlossary(glossaryFqn)
+                    .withParent(account.getFullyQualifiedName())
+                    .withDescription("Account balance definition"));
+    assertNotNull(accountBalance, "Account.Balance term should have been created");
+
+    GlossaryTerm loanBalance;
+    try {
+      loanBalance =
+          client
+              .glossaryTerms()
+              .create(
+                  new CreateGlossaryTerm()
+                      .withName("Balance")
+                      .withGlossary(glossaryFqn)
+                      .withParent(loan.getFullyQualifiedName())
+                      .withDescription("Loan balance definition"));
+    } catch (Exception e) {
+      fail(
+          "Creating 'Balance' under a different parent ('"
+              + loan.getFullyQualifiedName()
+              + "') should not be rejected as a duplicate of the existing '"
+              + accountBalance.getFullyQualifiedName()
+              + "': "
+              + e.getMessage());
+      return;
+    }
+
+    assertNotNull(loanBalance, "Loan.Balance term should have been created");
+    assertEquals("Balance", accountBalance.getName());
+    assertEquals("Balance", loanBalance.getName());
+    assertEquals(
+        account.getFullyQualifiedName() + ".Balance",
+        accountBalance.getFullyQualifiedName());
+    assertEquals(
+        loan.getFullyQualifiedName() + ".Balance",
+        loanBalance.getFullyQualifiedName());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -5940,6 +5940,26 @@ public interface CollectionDAO {
             String fqnhash,
         @Bind("termName") String termName);
 
+    // Duplicate-name check scoped to direct children of a single parent term (or glossary root),
+    // so that two terms with the same name under different parents are not flagged as duplicates.
+    // The NOT LIKE clause excludes grandchildren and deeper descendants, matching only the
+    // immediate next fqnHash segment.
+    @SqlQuery(
+        "SELECT COUNT(*) FROM glossary_term_entity WHERE fqnHash LIKE :parentHash "
+            + "AND fqnHash NOT LIKE :parentHashNested AND LOWER(name) = LOWER(:termName)")
+    int getGlossaryTermCountIgnoreCaseUnderParent(
+        @BindConcat(
+                value = "parentHash",
+                parts = {":fqnhash", ".%"},
+                hash = true)
+            String fqnhash,
+        @BindConcat(
+                value = "parentHashNested",
+                parts = {":fqnhash", ".%.%"},
+                hash = true)
+            String fqnhashRepeat,
+        @Bind("termName") String termName);
+
     @SqlQuery(
         "SELECT COUNT(*) FROM glossary_term_entity WHERE fqnHash LIKE :glossaryHash AND LOWER(name) = LOWER(:termName) AND id != :excludeId")
     int getGlossaryTermCountIgnoreCaseExcludingId(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -5943,7 +5943,9 @@ public interface CollectionDAO {
     // Duplicate-name check scoped to direct children of a single parent term (or glossary root),
     // so that two terms with the same name under different parents are not flagged as duplicates.
     // The NOT LIKE clause excludes grandchildren and deeper descendants, matching only the
-    // immediate next fqnHash segment.
+    // immediate next fqnHash segment. Both parameters below are @BindConcat over the SAME parent
+    // FQN, just concatenated with a different wildcard suffix (".%" vs ".%.%") for the two clauses
+    // — the caller intentionally passes the one parentFqn value twice, not two distinct FQNs.
     @SqlQuery(
         "SELECT COUNT(*) FROM glossary_term_entity WHERE fqnHash LIKE :parentHash "
             + "AND fqnHash NOT LIKE :parentHashNested AND LOWER(name) = LOWER(:termName)")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDataDAOs.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDataDAOs.java
@@ -378,6 +378,26 @@ public interface EntityDataDAOs {
         @Bind("termName") String termName,
         @Bind("excludeId") String excludeId);
 
+    // Duplicate-name check scoped to direct children of a single parent term (or glossary root),
+    // so that two terms with the same name under different parents are not flagged as duplicates.
+    // The NOT LIKE clause excludes grandchildren and deeper descendants, matching only the
+    // immediate next fqnHash segment.
+    @SqlQuery(
+        "SELECT COUNT(*) FROM glossary_term_entity WHERE fqnHash LIKE :parentHash "
+            + "AND fqnHash NOT LIKE :parentHashNested AND LOWER(name) = LOWER(:termName)")
+    int getGlossaryTermCountIgnoreCaseUnderParent(
+        @BindConcat(
+                value = "parentHash",
+                parts = {":fqnhash", ".%"},
+                hash = true)
+            String fqnhash,
+        @BindConcat(
+                value = "parentHashNested",
+                parts = {":fqnhash", ".%.%"},
+                hash = true)
+            String fqnhashRepeat,
+        @Bind("termName") String termName);
+
     @SqlQuery(
         "SELECT json FROM glossary_term_entity WHERE fqnHash LIKE :glossaryHash AND LOWER(name) = LOWER(:termName)")
     String getGlossaryTermByNameAndGlossaryIgnoreCase(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2027,6 +2027,9 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
         entity.getParent() != null
             ? entity.getParent().getFullyQualifiedName()
             : entity.getGlossary().getFullyQualifiedName();
+    // parentFqn is passed twice intentionally: the DAO method concatenates it with two different
+    // wildcard suffixes to build the LIKE/NOT LIKE bounds for "direct children only" (see its
+    // Javadoc) — this is not a mistaken duplicate argument.
     int count =
         daoCollection
             .glossaryTermDAO()

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2020,11 +2020,17 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   }
 
   private void checkDuplicateTerms(GlossaryTerm entity) {
+    // Term names only need to be unique among siblings sharing the same parent (or, for
+    // top-level terms, among the glossary's direct children) since the FQN already
+    // disambiguates terms with the same name under different parents.
+    String parentFqn =
+        entity.getParent() != null
+            ? entity.getParent().getFullyQualifiedName()
+            : entity.getGlossary().getFullyQualifiedName();
     int count =
         daoCollection
             .glossaryTermDAO()
-            .getGlossaryTermCountIgnoreCase(
-                entity.getGlossary().getFullyQualifiedName(), entity.getName());
+            .getGlossaryTermCountIgnoreCaseUnderParent(parentFqn, parentFqn, entity.getName());
     if (count > 0) {
       throw new IllegalArgumentException(
           CatalogExceptionMessage.duplicateGlossaryTerm(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java
@@ -2728,11 +2728,17 @@ public class GlossaryTermRepository extends EntityRepository<GlossaryTerm> {
   }
 
   private void checkDuplicateTerms(GlossaryTerm entity) {
+    // Term names only need to be unique among siblings sharing the same parent (or, for
+    // top-level terms, among the glossary's direct children) since the FQN already
+    // disambiguates terms with the same name under different parents.
+    String parentFqn =
+        entity.getParent() != null
+            ? entity.getParent().getFullyQualifiedName()
+            : entity.getGlossary().getFullyQualifiedName();
     int count =
         daoCollection
             .glossaryTermDAO()
-            .getGlossaryTermCountIgnoreCase(
-                entity.getGlossary().getFullyQualifiedName(), entity.getName());
+            .getGlossaryTermCountIgnoreCaseUnderParent(parentFqn, parentFqn, entity.getName());
     if (count > 0) {
       throw new IllegalArgumentException(
           CatalogExceptionMessage.duplicateGlossaryTerm(


### PR DESCRIPTION
Fixes #30144

## Root cause
`GlossaryTermRepository.checkDuplicateTerms()` rejects a new glossary term
if any term with the same name (case-insensitive) exists **anywhere in the
glossary**, via a SQL query that matches `fqnHash LIKE glossaryHash.%` —
i.e. the entire glossary subtree at any depth, not just the term's direct
siblings. Since glossary term uniqueness is actually defined by FQN
(`glossary.parent.term`), this over-broad check incorrectly rejects two
terms that legitimately share a leaf name under different parents, e.g.
`Banking.Account.Balance` and `Banking.Loan.Balance`.

## What changed
- Added `getGlossaryTermCountIgnoreCaseUnderParent` in `CollectionDAO`,
  scoped to direct children of a given parent FQN (using a `LIKE`/`NOT LIKE`
  pair to match one level deep and exclude grandchildren).
- Updated `checkDuplicateTerms` in `GlossaryTermRepository` to check against
  the term's actual parent (or the glossary root for top-level terms)
  instead of the whole glossary tree.

This is a minimal, targeted fix — the sibling `checkDuplicateTermsForUpdate`
method has the same scoping pattern but wasn't touched, since it isn't on
the path this issue reports and is out of scope for this change.

## Test evidence
Added `GlossaryResourceIT#test_createGlossaryTerm_sameNameUnderDifferentParents_succeeds`,
which creates two top-level terms ("Account", "Loan") and then a child term
named "Balance" under each. Verified fail → pass locally:
- **Before the fix**: fails with `AssertionFailedError: ... A term with the
  name 'Balance' already exists in '<glossary>' glossary.`
- **After the fix**: passes — both `Account.Balance` and `Loan.Balance` are
  created successfully with correct FQNs.

Also ran the full `GlossaryResourceIT` + `GlossaryTermResourceIT` suites
(524 tests) with the fix applied — all passed, no regressions (including
existing true-duplicate-name rejection behavior for same-parent terms).

`spotless:check` passes clean on the touched modules.

---
Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scopes the glossary term duplicate-name check from the entire glossary tree to direct siblings only, fixing a bug where two terms with the same leaf name under different parents (e.g. `Banking.Account.Balance` vs `Banking.Loan.Balance`) were incorrectly rejected as duplicates.

- **`CollectionDAO.java`**: Adds `getGlossaryTermCountIgnoreCaseUnderParent`, which uses a `LIKE parentHash.%` / `NOT LIKE parentHash.%.%` pair to match only direct children of a given parent, relying on the fact that FQN hash segments are hex strings containing no `.` characters.
- **`GlossaryTermRepository.java`**: Updates `checkDuplicateTerms` to derive `parentFqn` from the term's direct parent (or the glossary root for top-level terms) and calls the new scoped DAO method.
- **`GlossaryResourceIT.java`**: Adds an integration test that verifies `Balance` can be created under two different parents in the same glossary, confirming the regression is fixed.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is narrow and well-targeted, touching only the create-path duplicate check with no changes to update/delete paths or existing query behavior.

The SQL LIKE/NOT LIKE approach is sound given that FQN hash segments are hex strings with no dots, so `.` unambiguously acts as a segment separator. The `@BindConcat` annotation processes each parameter independently, so the two bindings produce correctly distinct suffixes. The `!update` guard in the repository ensures the new method is only invoked on create. The integration test directly reproduces the reported failure and verifies the fix, and the PR description confirms no regressions in the broader test suite.

No files require special attention.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds `getGlossaryTermCountIgnoreCaseUnderParent` with a LIKE/NOT LIKE pair scoped to direct children; the two `@BindConcat` parameters are intentionally distinct (different wildcard suffixes) and the design is well-documented. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java | Correctly gates on `entity.getParent() != null` to determine the effective parent FQN and calls the new scoped DAO method; only affects the create path (`!update` guard is unchanged). |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java | New integration test directly targets the reported regression; `try/catch`+`return` pattern correctly handles compiler reachability for the `loanBalance` variable and is a valid testing idiom. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant GlossaryTermRepository
    participant CollectionDAO
    participant DB as glossary_term_entity

    Client->>GlossaryTermRepository: create(GlossaryTerm entity)
    GlossaryTermRepository->>GlossaryTermRepository: checkDuplicateTerms(entity)
    Note over GlossaryTermRepository: parentFqn = entity.getParent()?.fqn<br/>OR entity.getGlossary().fqn
    GlossaryTermRepository->>CollectionDAO: getGlossaryTermCountIgnoreCaseUnderParent(parentFqn, parentFqn, name)
    Note over CollectionDAO: @BindConcat builds:<br/>parentHash = hash(parentFqn) + ".%"<br/>parentHashNested = hash(parentFqn) + ".%.%"
    CollectionDAO->>DB: "SELECT COUNT(*) WHERE fqnHash LIKE parentHash AND fqnHash NOT LIKE parentHashNested AND LOWER(name) = LOWER(:termName)"
    DB-->>CollectionDAO: count (siblings with same name only)
    CollectionDAO-->>GlossaryTermRepository: count
    alt "count > 0"
        GlossaryTermRepository-->>Client: 400 duplicateGlossaryTerm
    else "count == 0"
        GlossaryTermRepository-->>Client: 200 created
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant GlossaryTermRepository
    participant CollectionDAO
    participant DB as glossary_term_entity

    Client->>GlossaryTermRepository: create(GlossaryTerm entity)
    GlossaryTermRepository->>GlossaryTermRepository: checkDuplicateTerms(entity)
    Note over GlossaryTermRepository: parentFqn = entity.getParent()?.fqn<br/>OR entity.getGlossary().fqn
    GlossaryTermRepository->>CollectionDAO: getGlossaryTermCountIgnoreCaseUnderParent(parentFqn, parentFqn, name)
    Note over CollectionDAO: @BindConcat builds:<br/>parentHash = hash(parentFqn) + ".%"<br/>parentHashNested = hash(parentFqn) + ".%.%"
    CollectionDAO->>DB: "SELECT COUNT(*) WHERE fqnHash LIKE parentHash AND fqnHash NOT LIKE parentHashNested AND LOWER(name) = LOWER(:termName)"
    DB-->>CollectionDAO: count (siblings with same name only)
    CollectionDAO-->>GlossaryTermRepository: count
    alt "count > 0"
        GlossaryTermRepository-->>Client: 400 duplicateGlossaryTerm
    else "count == 0"
        GlossaryTermRepository-->>Client: 200 created
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java`, line 2041-2055 ([link](https://github.com/open-metadata/openmetadata/blob/6b31e57ae8ac142af5e25157164f869972f91f94/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/GlossaryTermRepository.java#L2041-L2055)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`checkDuplicateTermsForUpdate` has the same over-broad scoping bug**

   `checkDuplicateTermsForUpdate` still calls `getGlossaryTermCountIgnoreCaseExcludingId` with the glossary FQN, which matches any term anywhere in the glossary tree. Renaming `Banking.Loan.Balance` would be incorrectly rejected if `Banking.Account.Balance` already exists, even though they are distinct terms with different FQNs. The PR description calls this out as out-of-scope, but it's worth tracking as a follow-up since the user-visible failure mode (rename rejected with "a term with this name already exists") would be just as confusing as the create-path bug fixed here.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(glossary): clarify intentional dupl..."](https://github.com/open-metadata/openmetadata/commit/c2ced85169a0b917642c94426be1d3fe6fabdd9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45420531)</sub>

<!-- /greptile_comment -->