### PR TITLE
Fix: preserve task comments, reply reactions, and resolution author in v200 task migration

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -746,26 +746,36 @@ public class MigrationUtil {
         if (createdByUserId != null) {
           taskJson.put("createdById", createdByUserId);
         }
+        ObjectNode createdByRef = lookupUserRef(handle, createdByName);
 
         taskJson.put("createdAt", createdAt);
         taskJson.put("updatedAt", updatedAt);
         taskJson.put("updatedBy", updatedBy);
         taskJson.put("deleted", false);
         taskJson.put("version", 0.1);
-        taskJson.set("comments", JsonUtils.getObjectNode().arrayNode());
-        taskJson.put("commentCount", 0);
+        ArrayNode migratedComments = buildCommentsFromPosts(handle, threadJson, createdByRef);
+        taskJson.set("comments", migratedComments);
+        taskJson.put("commentCount", migratedComments.size());
         taskJson.set("tags", JsonUtils.getObjectNode().arrayNode());
 
         // Set resolution details for closed tasks
         if ("Closed".equals(oldStatus)) {
           ObjectNode resolution = JsonUtils.getObjectNode();
-          resolution.put("type", newStatus.equals("Approved") ? "Approved" : "Completed");
-          if (taskDetails.has("closedBy")) {
-            resolution.put("comment", "Migrated from thread-based task system");
+          resolution.put("type", resolveMigratedResolutionType(oldType, taskDetails));
+          ObjectNode resolvedByRef = null;
+          if (taskDetails.has("closedBy") && !taskDetails.get("closedBy").isNull()) {
+            resolvedByRef = lookupUserRef(handle, taskDetails.get("closedBy").asText());
           }
-          if (taskDetails.has("closedAt")) {
-            resolution.put("resolvedAt", taskDetails.get("closedAt").asLong());
+          if (resolvedByRef == null) {
+            resolvedByRef = createdByRef;
           }
+          if (resolvedByRef != null) {
+            resolution.set("resolvedBy", resolvedByRef.deepCopy());
+          }
+          resolution.put(
+              "resolvedAt",
+              taskDetails.has("closedAt") ? taskDetails.get("closedAt").asLong() : updatedAt);
+          resolution.put("comment", "Migrated from legacy thread task");
           if (taskDetails.has("newValue")) {
             resolution.put("newValue", taskDetails.get("newValue").asText());
           }
@@ -1469,6 +1479,88 @@ public class MigrationUtil {
       LOG.debug("Could not look up user '{}': {}", userName, e.getMessage());
       return null;
     }
+  }
+
+  private static ObjectNode lookupUserRef(Handle handle, String userName) {
+    if (userName == null || "system".equals(userName)) {
+      return null;
+    }
+    try {
+      String nameHash = FullyQualifiedName.buildHash(userName);
+      return handle
+          .createQuery("SELECT id, name FROM user_entity WHERE nameHash = :nameHash")
+          .bind("nameHash", nameHash)
+          .map(
+              (rs, ctx) -> {
+                ObjectNode ref = JsonUtils.getObjectNode();
+                ref.put("id", rs.getString("id"));
+                ref.put("type", Entity.USER);
+                ref.put("name", rs.getString("name"));
+                ref.put("fullyQualifiedName", rs.getString("name"));
+                return ref;
+              })
+          .findOne()
+          .orElse(null);
+    } catch (Exception e) {
+      LOG.debug("Could not look up user ref '{}': {}", userName, e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Convert a legacy thread's {@code posts} (replies) into {@code task_entity.comments}, preserving
+   * each reply's author, timestamp and reactions. Mirrors {@code TaskWorkflow.convertPostsToComments}
+   * so the reliable bulk-insert path retains the conversation the workflow cutover path would build.
+   */
+  private static ArrayNode buildCommentsFromPosts(
+      Handle handle, JsonNode threadJson, JsonNode fallbackAuthorRef) {
+    ArrayNode comments = JsonUtils.getObjectNode().arrayNode();
+    JsonNode posts = threadJson.get("posts");
+    if (posts == null || !posts.isArray()) {
+      return comments;
+    }
+    long fallbackTs = threadJson.has("updatedAt") ? threadJson.get("updatedAt").asLong() : 0;
+    for (JsonNode post : posts) {
+      String message = post.has("message") ? post.get("message").asText() : null;
+      if (message == null || message.isEmpty()) {
+        continue;
+      }
+      JsonNode authorRef = null;
+      if (post.has("from") && !post.get("from").isNull()) {
+        authorRef = lookupUserRef(handle, post.get("from").asText());
+      }
+      if (authorRef == null) {
+        authorRef = fallbackAuthorRef;
+      }
+      if (authorRef == null) {
+        continue;
+      }
+      ObjectNode comment = JsonUtils.getObjectNode();
+      comment.put(
+          "id",
+          post.has("id") && !post.get("id").isNull()
+              ? post.get("id").asText()
+              : UUID.randomUUID().toString());
+      comment.put("message", message);
+      comment.set("author", authorRef.deepCopy());
+      comment.put("createdAt", post.has("postTs") ? post.get("postTs").asLong() : fallbackTs);
+      if (post.has("reactions") && post.get("reactions").isArray()) {
+        comment.set("reactions", post.get("reactions"));
+      }
+      comments.add(comment);
+    }
+    return comments;
+  }
+
+  private static String resolveMigratedResolutionType(String oldType, JsonNode taskDetails) {
+    if ("RequestApproval".equals(oldType) || "RecognizerFeedbackApproval".equals(oldType)) {
+      boolean hasNewValue =
+          taskDetails.has("newValue")
+              && !taskDetails.get("newValue").isNull()
+              && !taskDetails.get("newValue").asText().isEmpty();
+      return hasNewValue ? "Approved" : "Rejected";
+    }
+    return "Completed";
   }
 
   /**


### PR DESCRIPTION
## Problem

When upgrading to 2.0, thread-based tasks are migrated into `task_entity` by the v200
data migration. Tasks that carried a reply thread or were closed lose data:

- **Comments/replies are dropped** — every migrated task lands with `comments: []` and
  `commentCount: 0`, regardless of how many replies the original task had.
- **Reply reactions are dropped** — reactions on those replies disappear with the replies.
- **Resolution attribution is lost** — closed tasks get a generic
  `"Migrated from thread-based task system"` comment with **no `resolvedBy`**, so the UI
  cannot show who completed/approved/rejected the task, and approvals vs. rejections are
  not distinguished.

## Root cause

The v200 runner has two task-migration passes (`postgres/v200/Migration.java`,
`mysql/v200/Migration.java`):

1. `MigrationUtil.migrateThreadTasksToTaskEntity(...)` — a raw-SQL bulk insert that reliably
   creates the `task_entity` rows.
2. `MigrationUtil.TaskWorkflow.runTaskWorkflowCutoverMigration()` — a richer pass whose
   `buildTaskFromLegacyThread` *does* populate comments (`convertPostsToComments`, which also
   carries `post.getReactions()`) and a proper resolution (`buildLegacyResolution`, with
   `resolvedBy`).

Pass (2) never populates task content in practice:

- `migrateLegacyThreadTask` guards on `isAlreadyMigrated()` → `taskRepository.find(id) != null`.
  Pass (1) has already inserted a row with that id, so pass (2) treats **every** task as
  already migrated and skips the rich build.
- Pass (2) is additionally wrapped behind `initializeWorkflowHandler()`; if that throws, the
  whole block is caught-and-continued and never runs at all (observed:
  `task_migration_mapping` left empty after migration).

So pass (1) is the path that actually persists task content — and it hardcoded empty
comments and a generic resolution.

## Fix

Populate the missing fields in the reliable bulk-insert path
(`migrateThreadTasksToTaskEntity`), mirroring the semantics of the intended
`TaskWorkflow` path so both agree:

- `buildCommentsFromPosts(...)` converts the thread's `posts` into `task_entity.comments`
  (`id`, `message`, `author`, `createdAt`, and each reply's `reactions`), and sets
  `commentCount`. Falls back to the task creator when a reply's author cannot be resolved.
- The resolution block now sets `resolvedBy` (from `task.closedBy`, falling back to the
  creator) and uses `resolveMigratedResolutionType(...)` to distinguish
  `Approved`/`Rejected`/`Completed`, matching `TaskWorkflow.buildLegacyResolution` /
  `mapLegacyResolutionType`.

The suggestion→task path (`migrateSuggestionsToTaskEntity`) is intentionally left with empty
comments: a legacy Suggestion has no reply thread.

## Scope / not included

- **Task-level reactions** (reactions on the task itself, not on a reply) are not restored —
  the 2.0 `task.json` schema has no top-level `reactions` field, and the intended
  `TaskWorkflow` path does not preserve them either. Restoring them would require a schema
  change and is out of scope here. Reply-level reactions **are** preserved.
- The migrated **test-case incident resolve 500** is a Flowable workflow-transition issue,
  independent of this migration code, and is not addressed here.

This PR is independent of #29978 (which touches `entity_relationship` ON CONFLICT and dotted
usernames) — the diffs do not overlap.

## Testing

- `mvn -pl openmetadata-service -am spotless:apply install -DskipTests` — BUILD SUCCESS.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes data loss in the v200 bulk-insert migration path (`migrateThreadTasksToTaskEntity`) where thread replies, their reactions, and resolution attribution were all dropped. The fix adds `buildCommentsFromPosts`, `lookupUserRef`, and `resolveMigratedResolutionType` to the reliable SQL path, mirroring the semantics of the `TaskWorkflow` path that was being bypassed by the pre-existing `isAlreadyMigrated` guard.

- **Comments/reactions preserved**: `buildCommentsFromPosts` iterates the thread's `posts`, resolves each author, and carries `reactions` — matching `TaskWorkflow.convertPostsToComments`.
- **Resolution attribution fixed**: `resolvedBy` is now populated from `closedBy` (with creator fallback), and `resolveMigratedResolutionType` correctly distinguishes `Approved`/`Rejected`/`Completed` instead of the previous `newStatus`-based heuristic.
- **Minor divergences from the `TaskWorkflow` path**: `lookupUserRef` does not populate `displayName` in stored refs, and comments are silently dropped when both the post author and the task creator are unresolvable — whereas `convertPostsToComments` always falls back to the admin user.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge for most deployments; the fix is strictly additive to a one-shot migration path and the risk is bounded to edge cases at migration time.

The fix is additive and targets a one-shot migration path. The main risk is permanent data loss for edge-case tasks (system-created threads with deleted-user replies) and missing displayName in stored refs, both of which are narrow in scope.

The new helper methods in MigrationUtil.java — particularly lookupUserRef and buildCommentsFromPosts — deserve a second look for the two divergences from convertPostsToComments noted above.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java | Adds `buildCommentsFromPosts`, `lookupUserRef`, and `resolveMigratedResolutionType` to the bulk-insert migration path so replies, their reactions, and resolution attribution are preserved. Logic closely mirrors the `TaskWorkflow` path but has a few minor divergences: `displayName` is not fetched in user refs, a silent comment-drop can occur when both the post author and task creator are unresolvable, and the task creator is looked up twice per row. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java`, line 745-749 ([link](https://github.com/open-metadata/openmetadata/blob/d0ef37ccf2e266b291f86034997751e690f660c3/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java#L745-L749)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Two DB round-trips for the same user per task**

   `lookupUserId` and `lookupUserRef` both issue a `SELECT … FROM user_entity WHERE nameHash = :nameHash` query for the same `createdByName`. For large migrations this doubles the per-row query count just for the creator lookup. Since `lookupUserRef` already retrieves `id`, the `createdByUserId` can be extracted directly from the returned `ObjectNode` instead of calling `lookupUserId` separately.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Fix: preserve task comments, reply react..."](https://github.com/open-metadata/openmetadata/commit/d0ef37ccf2e266b291f86034997751e690f660c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45435464)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->