### PR TITLE
fix(contextCenter): prevent soft-deleted drive files from being silen…

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/drive/ContextFileExtractionService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/drive/ContextFileExtractionService.java
@@ -250,7 +250,26 @@ public class ContextFileExtractionService {
     if (updated == null) {
       return;
     }
+    // The file may have been soft-deleted between the getFile() read above and this
+    // write. repository.update(...) trusts the passed-in "current" snapshot as-is and
+    // never re-reads the row, so a stale non-deleted snapshot would silently flip the
+    // row's deleted flag back to false. Re-check right before writing and drop the
+    // async status update if a concurrent delete won the race.
+    if (isDeleted(fileId)) {
+      LOG.debug("Skipping async update for file {} because it was deleted concurrently", fileId);
+      return;
+    }
     repository.update(null, current, updated, ADMIN_USER_NAME);
+  }
+
+  private boolean isDeleted(UUID fileId) {
+    try {
+      ContextFile file =
+          repository.get(null, fileId, repository.getFields(""), Include.ALL, false);
+      return file == null || Boolean.TRUE.equals(file.getDeleted());
+    } catch (Exception e) {
+      return true;
+    }
   }
 
   private void updateContent(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java
@@ -675,7 +675,33 @@ public class ContextFileResource extends EntityResource<ContextFile, ContextFile
       @Context UriInfo uriInfo,
       @Context SecurityContext securityContext,
       @Valid RestoreEntity restore) {
-    return restoreEntity(uriInfo, securityContext, restore.getId());
+    Response response = restoreEntity(uriInfo, securityContext, restore.getId());
+    resubmitExtractionIfNotTerminal(uriInfo, securityContext, restore.getId());
+    return response;
+  }
+
+  private static final Set<ProcessingStatus> TERMINAL_PROCESSING_STATUSES =
+      Set.of(ProcessingStatus.Processed, ProcessingStatus.Failed, ProcessingStatus.Unsupported);
+
+  /**
+   * A file soft-deleted while extraction was still in flight (or before it even started)
+   * can be restored with processingStatus permanently stuck at Uploaded or Analyzing: the
+   * async extraction thread's status write is dropped (see
+   * ContextFileExtractionService.updateFile) once it detects the file was deleted, and
+   * nothing else ever re-submits the job. Re-kick extraction here so the pipeline picks up
+   * where it left off instead of leaving the restored file stuck.
+   */
+  private void resubmitExtractionIfNotTerminal(
+      UriInfo uriInfo, SecurityContext securityContext, UUID id) {
+    ContextFile file = getInternal(uriInfo, securityContext, id, "", Include.NON_DELETED);
+    if (shouldResubmitExtraction(file)) {
+      extractionService.submit(file.getId(), UUID.fromString(file.getHeadContentId()));
+    }
+  }
+
+  static boolean shouldResubmitExtraction(ContextFile file) {
+    return !TERMINAL_PROCESSING_STATUSES.contains(file.getProcessingStatus())
+        && file.getHeadContentId() != null;
   }
 
   @PUT

--- a/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
@@ -87,6 +87,12 @@ class ContextFileExtractionServiceTest {
     lenient().when(repository.getAssetRepository()).thenReturn(assetRepository);
     when(repository.get(isNull(), eq(fileId), any(), eq(Include.NON_DELETED), eq(false)))
         .thenReturn(file);
+    // updateFile() re-checks deleted state via Include.ALL right before writing; the file
+    // is not deleted for the vast majority of tests, so default this to the live (non-deleted)
+    // file everywhere, and let individual tests override with a soft-deleted snapshot.
+    lenient()
+        .when(repository.get(isNull(), eq(fileId), any(), eq(Include.ALL), eq(false)))
+        .thenReturn(file);
     lenient().when(contentRepository.getById(contentId)).thenReturn(content);
     lenient().when(assetRepository.getById("asset-1")).thenReturn(asset);
   }
@@ -158,6 +164,56 @@ class ContextFileExtractionServiceTest {
     verify(repository, never()).update(any(), any(), any(), anyString());
     verify(contentRepository, never()).update(any(), any(), any(), anyString());
     verify(assetService, never()).read(any());
+  }
+
+  @Test
+  void processSkipsWritingTerminalStatusWhenFileWasDeletedConcurrently() throws Exception {
+    when(assetService.read(asset))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ByteArrayInputStream("Quarterly results".getBytes())));
+    when(textExtractor.extract(any(InputStream.class), same(file)))
+        .thenReturn(ContextFileTextExtractor.ExtractionResult.processed("Quarterly results", 3));
+
+    ContextFile deletedFile = new ContextFile().withId(fileId).withDeleted(true);
+    when(repository.get(isNull(), eq(fileId), any(), eq(Include.ALL), eq(false)))
+        .thenReturn(file) // first updateFile() call (Analyzing) - not yet deleted
+        .thenReturn(deletedFile); // second updateFile() call (Processed) - deleted concurrently
+
+    service(Runnable::run, () -> assetService).process(fileId, contentId);
+
+    // Only the first (Analyzing) write should have gone through; the terminal write is dropped.
+    verify(repository, times(1))
+        .update(isNull(), same(file), updatedFileCaptor.capture(), anyString());
+    assertEquals(ProcessingStatus.Analyzing, updatedFileCaptor.getValue().getProcessingStatus());
+
+    // updateContent() has no deleted-guard (content has no independent deleted field), so
+    // both content writes still land even though the file's terminal write was dropped.
+    verify(contentRepository, times(2))
+        .update(isNull(), same(content), updatedContentCaptor.capture(), anyString());
+    assertEquals(
+        ProcessingStatus.Processed,
+        updatedContentCaptor.getAllValues().get(1).getProcessingStatus());
+  }
+
+  @Test
+  void processSkipsWritingWhenFileNoLongerExists() throws Exception {
+    when(assetService.read(asset))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ByteArrayInputStream("Quarterly results".getBytes())));
+    when(textExtractor.extract(any(InputStream.class), same(file)))
+        .thenReturn(ContextFileTextExtractor.ExtractionResult.processed("Quarterly results", 3));
+
+    when(repository.get(isNull(), eq(fileId), any(), eq(Include.ALL), eq(false)))
+        .thenReturn(file)
+        .thenReturn(null);
+
+    service(Runnable::run, () -> assetService).process(fileId, contentId);
+
+    verify(repository, times(1))
+        .update(isNull(), same(file), updatedFileCaptor.capture(), anyString());
+    assertEquals(ProcessingStatus.Analyzing, updatedFileCaptor.getValue().getProcessingStatus());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/drive/ContextFileResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/drive/ContextFileResourceTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.sql.SQLException;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.data.ContextFile;
+import org.openmetadata.schema.entity.data.ProcessingStatus;
 
 class ContextFileResourceTest {
 
@@ -146,5 +149,68 @@ class ContextFileResourceTest {
   @Test
   void testClampExpiry_intMaxClampedToMax() {
     assertEquals(3600, ContextFileResource.clampExpiry(Integer.MAX_VALUE));
+  }
+
+  // ------------------------------------------------------------------
+  // shouldResubmitExtraction
+  //
+  // A file soft-deleted while extraction was in flight (or before it even started) can be
+  // restored with processingStatus stuck at a non-terminal value, because the async
+  // extraction thread's write is silently dropped once it detects the concurrent delete
+  // (see ContextFileExtractionService.updateFile). Restore must re-submit extraction in
+  // that case so the file doesn't get permanently stuck.
+  // ------------------------------------------------------------------
+
+  @Test
+  void testShouldResubmitExtraction_stuckAtUploaded() {
+    ContextFile file = restoredFileWith(ProcessingStatus.Uploaded);
+
+    assertTrue(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  @Test
+  void testShouldResubmitExtraction_stuckAtAnalyzing() {
+    ContextFile file = restoredFileWith(ProcessingStatus.Analyzing);
+
+    assertTrue(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  @Test
+  void testShouldResubmitExtraction_terminalProcessed() {
+    ContextFile file = restoredFileWith(ProcessingStatus.Processed);
+
+    assertFalse(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  @Test
+  void testShouldResubmitExtraction_terminalFailed() {
+    ContextFile file = restoredFileWith(ProcessingStatus.Failed);
+
+    assertFalse(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  @Test
+  void testShouldResubmitExtraction_terminalUnsupported() {
+    ContextFile file = restoredFileWith(ProcessingStatus.Unsupported);
+
+    assertFalse(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  @Test
+  void testShouldResubmitExtraction_noHeadContentIdNeverResubmits() {
+    ContextFile file =
+        new ContextFile()
+            .withId(UUID.randomUUID())
+            .withProcessingStatus(ProcessingStatus.Analyzing);
+    file.setHeadContentId(null);
+
+    assertFalse(ContextFileResource.shouldResubmitExtraction(file));
+  }
+
+  private static ContextFile restoredFileWith(ProcessingStatus processingStatus) {
+    return new ContextFile()
+        .withId(UUID.randomUUID())
+        .withProcessingStatus(processingStatus)
+        .withHeadContentId(UUID.randomUUID().toString());
   }
 }


### PR DESCRIPTION
…tly un-deleted by async extraction

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

## Summary

Fixes a race condition where a `ContextFile` (Context Center drive document) soft-deleted while its async text-extraction job is still in flight can have the deletion silently undone, causing the document to disappear from the Archive page and reappear as active.

- The background extraction thread (`ContextFileExtractionService`) reads a file snapshot, does its work, then writes back a `processingStatus` update using that stale snapshot. If a soft-delete lands in between, `EntityRepository.update(...)` trusts the caller-supplied `original` object as-is and never re-checks the DB — so the extraction thread's write silently flips `deleted` back to `false`.
- `ContextFileExtractionService.updateFile` now re-checks the file's live `deleted` state immediately before writing, and drops the write if the file was deleted concurrently.
- That guard introduces a side effect: a file soft-deleted mid-extraction and later restored could be left permanently stuck at a non-terminal `processingStatus` (`Uploaded` or `Analyzing`), since nothing previously re-triggered extraction on restore. `ContextFileResource.restore` now re-submits the extraction job if the restored file isn't in a terminal state (`Processed` / `Failed` / `Unsupported`).

This was surfacing as intermittent failures in three Playwright E2E tests (`ContextCenterPermission.spec.ts`) that upload and immediately soft-delete a document, then expect it in the Archive listing — the tests were correctly catching a real backend bug, not exhibiting flakiness of their own, so they were left unmodified.

## Changes

- `ContextFileExtractionService.java`: `updateFile` re-verifies the file isn't deleted right before persisting an async status update.
- `ContextFileResource.java`: `restore` re-submits extraction when the restored file's `processingStatus` isn't terminal; extracted the decision into a testable `shouldResubmitExtraction` helper.
- Added unit tests covering both the dropped-write guard and the restore resubmission logic.

## Test plan

- [x] Added unit tests: `ContextFileExtractionServiceTest` (guard drops the terminal-status write on concurrent delete / missing file, content-side write still lands) and `ContextFileResourceTest` (`shouldResubmitExtraction` for `Uploaded`/`Analyzing`/terminal statuses/missing `headContentId`)
- [ ] Run `mvn test -pl openmetadata-service` to confirm new and existing tests pass
- [ ] Run the previously-flaky Playwright tests repeatedly (`ContextCenterPermission.spec.ts`, e.g. `--repeat-each=10`) to confirm they no longer fail
- [ ] `mvn spotless:apply -pl openmetadata-service` before merge


Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `ContextFileExtractionService` where a file soft-deleted while its async text-extraction job was in flight could have its `deleted` flag silently reset to `false` by the extraction thread's status write-back. It also handles the symmetric restore path: a file deleted mid-extraction and later restored could be permanently stuck at a non-terminal `processingStatus`, so `ContextFileResource.restore` now re-submits the extraction job when needed.

- `ContextFileExtractionService.updateFile` now calls `isDeleted(fileId)` immediately before writing and drops the update if the file was concurrently deleted, preventing the silent un-delete.
- `ContextFileResource.restore` calls `resubmitExtractionIfNotTerminal` after restoring, restarting extraction for files stuck at `Uploaded` or `Analyzing`; the helper `shouldResubmitExtraction` is extracted as a package-visible static for unit testing.
- Unit tests are added for both the dropped-write guard in `ContextFileExtractionServiceTest` and the resubmission logic in `ContextFileResourceTest`.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The core extraction-thread guard is correct, but the restore path has two defects that can turn a successful restore into a 500 for the client under edge cases.

The extraction-thread guard in ContextFileExtractionService is correct and well-tested, but shouldResubmitExtraction calls Set.of().contains(null) without a null guard, throwing NPE if processingStatus is null. Any uncaught exception from resubmitExtractionIfNotTerminal also propagates through the restore handler even though the entity is already restored, causing the client to see an error and potentially retry a completed operation.

ContextFileResource.java — the restore method and shouldResubmitExtraction helper need a null-status guard and exception isolation before the resubmission side-effect can be considered safe.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/drive/ContextFileExtractionService.java | Adds a deleted-state re-check (`isDeleted`) in `updateFile` before writing back async status, preventing the extraction thread from silently un-deleting a soft-deleted file; a tiny TOCTOU window remains between the check and the write. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/drive/ContextFileResource.java | Adds extraction resubmission on restore for non-terminal files; two issues — `shouldResubmitExtraction` can NPE on a null `processingStatus` (via `Set.of().contains(null)`), and any exception from `resubmitExtractionIfNotTerminal` propagates through the restore response, turning a successful restore into a 500 for the client. |
| openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java | Adds tests covering the concurrent-delete guard (terminal write dropped, Analyzing write and content writes still land) and the missing-file path; well-structured and uses the existing mock scaffolding correctly. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/drive/ContextFileResourceTest.java | Adds unit tests for `shouldResubmitExtraction` covering Uploaded, Analyzing, and all three terminal statuses, plus null `headContentId`; missing a test case for null `processingStatus`, which is the gap that corresponds to the NPE bug. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant ContextFileResource
    participant ContextFileExtractionService
    participant Repository

    Note over Client,Repository: Upload then immediate soft-delete race condition (fixed)
    Client->>ContextFileResource: POST /files (upload)
    ContextFileResource->>Repository: "create ContextFile (processingStatus=Uploaded)"
    ContextFileResource->>ContextFileExtractionService: submit(fileId, contentId)
    Client->>ContextFileResource: "DELETE /files/{id} (soft-delete)"
    Repository-->>Repository: "deleted=true"

    Note over ContextFileExtractionService,Repository: Async extraction thread in flight
    ContextFileExtractionService->>Repository: updateFile(Analyzing) isDeleted() check passes
    Repository-->>Repository: write OK
    ContextFileExtractionService->>Repository: isDeleted(fileId) re-check before terminal write
    Repository-->>ContextFileExtractionService: "deleted=true"
    ContextFileExtractionService-->>ContextFileExtractionService: drop write skip un-delete

    Note over Client,Repository: Restore path resubmit extraction if stuck
    Client->>ContextFileResource: PUT /files/restore
    ContextFileResource->>Repository: "restoreEntity deleted=false"
    ContextFileResource->>Repository: getInternal NON_DELETED
    Repository-->>ContextFileResource: "ContextFile processingStatus=Analyzing"
    ContextFileResource->>ContextFileExtractionService: shouldResubmitExtraction true
    ContextFileResource->>ContextFileExtractionService: submit(fileId, headContentId)
    ContextFileResource-->>Client: 200 OK restored
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant ContextFileResource
    participant ContextFileExtractionService
    participant Repository

    Note over Client,Repository: Upload then immediate soft-delete race condition (fixed)
    Client->>ContextFileResource: POST /files (upload)
    ContextFileResource->>Repository: "create ContextFile (processingStatus=Uploaded)"
    ContextFileResource->>ContextFileExtractionService: submit(fileId, contentId)
    Client->>ContextFileResource: "DELETE /files/{id} (soft-delete)"
    Repository-->>Repository: "deleted=true"

    Note over ContextFileExtractionService,Repository: Async extraction thread in flight
    ContextFileExtractionService->>Repository: updateFile(Analyzing) isDeleted() check passes
    Repository-->>Repository: write OK
    ContextFileExtractionService->>Repository: isDeleted(fileId) re-check before terminal write
    Repository-->>ContextFileExtractionService: "deleted=true"
    ContextFileExtractionService-->>ContextFileExtractionService: drop write skip un-delete

    Note over Client,Repository: Restore path resubmit extraction if stuck
    Client->>ContextFileResource: PUT /files/restore
    ContextFileResource->>Repository: "restoreEntity deleted=false"
    ContextFileResource->>Repository: getInternal NON_DELETED
    Repository-->>ContextFileResource: "ContextFile processingStatus=Analyzing"
    ContextFileResource->>ContextFileExtractionService: shouldResubmitExtraction true
    ContextFileResource->>ContextFileExtractionService: submit(fileId, headContentId)
    ContextFileResource-->>Client: 200 OK restored
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(contextCenter): prevent soft-deleted..."](https://github.com/open-metadata/openmetadata/commit/3c584fe21c7289f2c1df3e37b855bb8b62777214) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45439349)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->