### PR TITLE
Fixes #30179: DataContract latestResult stuck stale after semantics-failing re-run

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java
@@ -6804,4 +6804,70 @@ public class DataContractResourceIT extends BaseEntityIT<DataContract, CreateDat
         result.getContractExecutionStatus(),
         "Empty rule should be treated as a failed semantics check");
   }
+
+  @Test
+  void testContractLatestResultTracksSemanticsFailureAfterEntityChange(TestNamespace ns) {
+    // Regression test for https://github.com/open-metadata/OpenMetadata/issues/30179
+    // When an entity change flips a semantic rule from passing to failing, the contract's
+    // aggregate latestResult (rendered by the entity header + Explore listing) must reflect
+    // the new Failed status — not stay stuck on the previous run's Success.
+    org.openmetadata.it.bootstrap.SharedEntities shared =
+        org.openmetadata.it.bootstrap.SharedEntities.get();
+
+    Table table = createTestTable(ns);
+    table.setOwners(List.of(shared.USER1_REF));
+    table = SdkClients.adminClient().tables().update(table.getId().toString(), table);
+
+    SemanticsRule ownerIsUser1 =
+        new SemanticsRule()
+            .withName("OwnerIsUser1")
+            .withDescription("Owner must be user1")
+            .withRule(
+                "{ \"some\": [ { \"var\": \"owners\" }, { \"==\": [ { \"var\": \"id\" }, \""
+                    + shared.USER1_REF.getId()
+                    + "\" ] } ] }")
+            .withEnabled(true);
+
+    CreateDataContract request =
+        new CreateDataContract()
+            .withName(ns.prefix("latest_result_regression"))
+            .withEntity(table.getEntityReference())
+            .withEntityStatus(EntityStatus.APPROVED)
+            .withSemantics(List.of(ownerIsUser1));
+    DataContract contract = createEntity(request);
+
+    DataContractResult firstResult =
+        SdkClients.adminClient().dataContracts().validate(contract.getId());
+    assertEquals(ContractExecutionStatus.Success, firstResult.getContractExecutionStatus());
+
+    DataContract afterFirstRun =
+        SdkClients.adminClient().dataContracts().get(contract.getId().toString());
+    assertNotNull(afterFirstRun.getLatestResult());
+    assertEquals(
+        ContractExecutionStatus.Success,
+        afterFirstRun.getLatestResult().getStatus(),
+        "latestResult should reflect the passing run");
+
+    Table refreshed = SdkClients.adminClient().tables().get(table.getId().toString(), "owners");
+    refreshed.setOwners(java.util.Collections.emptyList());
+    SdkClients.adminClient().tables().update(refreshed.getId().toString(), refreshed);
+
+    DataContractResult secondResult =
+        SdkClients.adminClient().dataContracts().validate(contract.getId());
+    assertEquals(ContractExecutionStatus.Failed, secondResult.getContractExecutionStatus());
+    assertEquals(1, secondResult.getSemanticsValidation().getFailed());
+
+    DataContract afterSecondRun =
+        SdkClients.adminClient().dataContracts().get(contract.getId().toString());
+    assertNotNull(afterSecondRun.getLatestResult());
+    assertEquals(
+        ContractExecutionStatus.Failed,
+        afterSecondRun.getLatestResult().getStatus(),
+        "Contract latestResult.status must be Failed after the semantics-failing re-run "
+            + "(regression: #30179 — stuck on prior Success while time-series row shows Failed)");
+    assertEquals(
+        secondResult.getId(),
+        afterSecondRun.getLatestResult().getResultId(),
+        "latestResult.resultId must point at the second run's result");
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -1471,22 +1471,47 @@ public class DataContractRepository extends EntityRepository<DataContract> {
     }
   }
 
+  /**
+   * Persist the aggregate {@code latestResult} on the DataContract row.
+   *
+   * <p>Called twice per validation run (once with {@code Running}, once with the final
+   * {@code Success}/{@code Failed}). The caller's {@code dataContract} reference is <b>not</b>
+   * refreshed between the two calls, so its in-memory state (version, {@code changeDescription},
+   * {@code latestResult}) becomes stale immediately after the first write. Going through
+   * {@link EntityRepository.EntityUpdater} on the second call replayed a stale baseline through
+   * session-consolidation and could silently drop the terminal-status write — leaving
+   * {@code latestResult} stuck on {@code Running} (or on the previous run's status) while the
+   * per-run time-series row was written correctly (see #30179).
+   *
+   * <p>{@code latestResult} is a read-only status stamp; it doesn't participate in entity
+   * versioning or approval workflows (see ETagResponseFilter which documents that
+   * {@code updateLatestResult} intentionally does not bump entity {@code version} or
+   * {@code updatedAt}). We write it via a targeted DAO update instead of the full
+   * {@link EntityRepository.EntityUpdater} path: read the current stored contract, set the
+   * new {@code latestResult}, and rewrite the row. This bypasses consolidation entirely and
+   * cannot silently drop the write; the caller's reference is updated so the follow-up
+   * comparison in {@link #addContractResult} sees fresh state.
+   */
   private void updateLatestResult(DataContract dataContract, DataContractResult result) {
+    LatestResult newLatestResult =
+        new LatestResult()
+            .withTimestamp(result.getTimestamp())
+            .withStatus(result.getContractExecutionStatus())
+            .withMessage(result.getResult())
+            .withResultId(result.getId());
     try {
-      DataContract updated = JsonUtils.deepCopy(dataContract, DataContract.class);
-      updated.setLatestResult(
-          new LatestResult()
-              .withTimestamp(result.getTimestamp())
-              .withStatus(result.getContractExecutionStatus())
-              .withMessage(result.getResult())
-              .withResultId(result.getId()));
-      EntityRepository.EntityUpdater entityUpdater =
-          getUpdater(dataContract, updated, EntityRepository.Operation.PATCH, null);
-      entityUpdater.update();
+      DataContract current = dao.findEntityById(dataContract.getId(), Include.NON_DELETED);
+      current.setLatestResult(newLatestResult);
+      dao.update(current);
+      // Direct dao.update skips invalidateCachesAfterStore, so drop cached variants explicitly.
+      invalidateCacheForEntity(
+          Entity.DATA_CONTRACT, current.getId(), current.getFullyQualifiedName());
+      dataContract.setLatestResult(newLatestResult);
     } catch (Exception e) {
       LOG.error(
-          "Failed to update latest result for data contract {}",
+          "Failed to update latest result for data contract {}: {}",
           dataContract.getFullyQualifiedName(),
+          e.getMessage(),
           e);
     }
   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/open-metadata/OpenMetadata/issues/30179.

After an entity change flips a semantic rule from passing to failing, re-running the contract shows the individual semantics check as `Failed` (per-run time-series row is correct), but the contract's aggregate `latestResult.status` — the value driving the entity-header `data-contract-latest-result-btn` and the Explore listing indicator — stays stuck on the previous run's `Success`.

## Root cause

`DataContractRepository.updateLatestResult` routed the aggregate status write through `EntityRepository.EntityUpdater` — full versioning + session consolidation + snapshot/retry. That path has two failure modes for this call site:

1. `updateLatestResult` runs **twice per validate** (`Running` first, then the terminal `Success`/`Failed`), and both calls reuse the same caller-supplied `dataContract` reference — its version, `changeDescription`, and `latestResult` stay stale after the first write.
2. On the second call, consolidation reverts to `previous` (the pre-session baseline where `latestResult=null`), the perf-refactor snapshot/retry replays the diff against that stale baseline, and any thrown exception (concurrent update, cache invalidation, index conflict) is swallowed by the catch-all in `updateLatestResult`.

The per-run time-series row is written via a direct SQL upsert (`entityExtensionTimeSeriesDao`) and always succeeds — hence the asymmetry the bug report describes: per-check status correct, aggregate `latestResult` stale.

`ETagResponseFilter` already documents the **design intent** at lines 42–44: `updateLatestResult` should not bump entity `version`/`updatedAt`. The implementation went through the heavy EntityUpdater path anyway — intent/implementation mismatch is the smell.

## Fix

Write `latestResult` directly via `dao.findEntityById` + `dao.update`, bypassing `EntityUpdater`/consolidation/snapshot machinery entirely:
- Read the current stored contract fresh (no stale in-memory baseline).
- Set the new `latestResult`.
- Rewrite the row via the DAO.
- Invalidate the entity cache explicitly (the direct DAO path skips `invalidateCachesAfterStore` — this mirrors the pattern at `EntityRepository.java:4419-4422`).
- Update the caller's `dataContract.latestResult` so the follow-up comparison in `addContractResult` sees fresh state.

The catch-all remains but logs `e.getMessage()` explicitly so a swallowed failure is grep-able.

## Regression test

`DataContractResourceIT.testContractLatestResultTracksSemanticsFailureAfterEntityChange` — table + owner-based semantic rule → validate (pass) → **GET the contract, assert `latestResult.status == Success`** → strip owner → validate → **GET the contract, assert `latestResult.status == Failed` and `resultId` matches the second run**. The existing `testValidateContractWithEmptySemanticsRuleDoesNotThrowNPE` asserted on the returned `DataContractResult` only, not on the fetched contract's `latestResult` — that gap is why this shipped.

## Test plan

- [ ] `mvn -pl openmetadata-integration-tests -Dtest=DataContractResourceIT#testContractLatestResultTracksSemanticsFailureAfterEntityChange test` — red without the fix, green with it.
- [ ] Existing `DataContractResourceIT` suite green.
- [ ] Playwright `DataContractsSemanticRules.spec.ts` "Owner with is not condition should failed with same owner" scenario (the shape flagged in the nightly linked from #30179) passes without the fallback.
- [ ] Manual: create table with owner + contract with owner-based semantic rule, validate (pass), remove owner, validate (fail), confirm entity-header `Contract Failed` badge appears and the `GET /api/v1/dataContracts/{id}` response shows `latestResult.status = Failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps a data contract’s aggregate result in sync after semantic re-validation. The main changes are:

- Replaces the versioned updater with a fresh DAO read and direct write.
- Invalidates cached contract data after storing the latest result.
- Synchronizes the caller’s in-memory contract with the stored result.
- Adds an integration test for a Success-to-Failed re-run.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The targeted stale-result path is fixed, but the updated persistence path still has unresolved merge risks.

- The new test covers the reported Success-to-Failed workflow.
- Direct full-row writes can still conflict with concurrent contract updates.
- Overlapping validations and cache-invalidation failures can still leave the aggregate result stale.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java | Stores latestResult through a fresh DAO read and direct update, then invalidates caches and synchronizes caller state. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataContractResourceIT.java | Adds coverage proving that a failed semantic re-run replaces the previous successful aggregate result. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into rca-issue-30179"](https://github.com/open-metadata/openmetadata/commit/f31aefb8cf815c60ea953fc941ad04c1c9b0c4ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45564383)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->