### PR TITLE
Fixes #30216: don't abort Postgres stored procedure ingestion on an unparseable row

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
@@ -275,7 +275,7 @@ class PostgresSource(CommonDbSourceService, MultiDBSource):
                     continue
                 yield stored_procedure
             except Exception as exc:
-                logger.error()
+                logger.debug(traceback.format_exc())
                 self.status.failed(
                     error=StackTraceError(
                         name=row._asdict().get("name", "UNKNOWN"),

--- a/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/metadata.py
@@ -275,12 +275,13 @@ class PostgresSource(CommonDbSourceService, MultiDBSource):
                     continue
                 yield stored_procedure
             except Exception as exc:
-                logger.debug(traceback.format_exc())
+                stack_trace = traceback.format_exc()
+                logger.debug(stack_trace)
                 self.status.failed(
                     error=StackTraceError(
-                        name=row._asdict().get("name", "UNKNOWN"),
+                        name=row._asdict().get("procedure_name", "UNKNOWN"),
                         error=f"Error parsing Stored Procedure payload: {exc}",
-                        stackTrace=traceback.format_exc(),
+                        stackTrace=stack_trace,
                     )
                 )
 

--- a/ingestion/tests/unit/topology/database/test_postgres.py
+++ b/ingestion/tests/unit/topology/database/test_postgres.py
@@ -848,6 +848,48 @@ class PostgresUnitTest(TestCase):
                 }
                 self.assertEqual(call_args[1]["entity_source_state"], expected_source_state)
 
+    def test_get_stored_procedures_skips_unparseable_row(self):
+        """
+        An unparseable row must be skipped and reported, not abort the whole schema
+        """
+        self.postgres_source.source_config.includeStoredProcedures = True
+        self.postgres_source.source_config.storedProcedureFilterPattern = None
+        self.postgres_source.status = MagicMock()
+
+        mock_engine = MagicMock()
+        self.postgres_source.engine = mock_engine
+
+        # definition is NULL: pg_proc.prosrc is nullable, the model requires a str
+        bad_row = MagicMock()
+        bad_row._mapping = {
+            "procedure_name": "null_prosrc_func",
+            "schema_name": "test_schema",
+            "definition": None,
+            "procedure_type": "Function",
+        }
+        bad_row._asdict.return_value = dict(bad_row._mapping)
+        good_row = MagicMock()
+        good_row._mapping = {
+            "procedure_name": "healthy_proc",
+            "schema_name": "test_schema",
+            "definition": "def1",
+            "procedure_type": "PROCEDURE",
+        }
+        good_row._asdict.return_value = dict(good_row._mapping)
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [bad_row, good_row]
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value = mock_result
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        results = list(self.postgres_source._get_stored_procedures_internal("query"))
+
+        self.assertEqual([result.name for result in results], ["healthy_proc"])
+        self.postgres_source.status.failed.assert_called_once()
+
 
 class TestPostgresCommonMappings(TestCase):
     """Verify extended type entries in the shared PostgreSQL ischema_names map."""

--- a/ingestion/tests/unit/topology/database/test_postgres.py
+++ b/ingestion/tests/unit/topology/database/test_postgres.py
@@ -873,7 +873,7 @@ class PostgresUnitTest(TestCase):
             "procedure_name": "healthy_proc",
             "schema_name": "test_schema",
             "definition": "def1",
-            "procedure_type": "PROCEDURE",
+            "procedure_type": "StoredProcedure",
         }
         good_row._asdict.return_value = dict(good_row._mapping)
 
@@ -889,6 +889,9 @@ class PostgresUnitTest(TestCase):
 
         self.assertEqual([result.name for result in results], ["healthy_proc"])
         self.postgres_source.status.failed.assert_called_once()
+        # the failure must name the offending procedure, not "UNKNOWN"
+        reported_error = self.postgres_source.status.failed.call_args.kwargs["error"]
+        self.assertEqual(reported_error.name, "null_prosrc_func")
 
 
 class TestPostgresCommonMappings(TestCase):


### PR DESCRIPTION
### Describe your changes:

Fixes #30216

I replaced the argument-less `logger.error()` in `PostgresSource._get_stored_procedures_internal` with `logger.debug(traceback.format_exc())`, because `logging.Logger.error()` requires a `msg` argument and was raising `TypeError` from inside the exception handler. That had three effects: the `TypeError` escaped the generator so every stored procedure and function after the offending row was silently dropped, the genuine `ValidationError` was destroyed, and the `self.status.failed(...)` call on the following line was unreachable so the failure never reached the pipeline summary.

A row reaches that handler whenever `pg_proc.prosrc` is NULL, since `POSTGRES_GET_STORED_PROCEDURES` / `POSTGRES_GET_FUNCTIONS` select `prosrc AS definition` while `PostgresStoredProcedure.definition` is a required `str`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line fix. `logger.debug(traceback.format_exc())` matches the idiom used elsewhere in this connector, and the existing `self.status.failed(...)` already carries the entity name, the real error message and the stack trace, so it remains the reporting path. Behaviour now matches the sibling method `yield_stored_procedure`, which already skips-and-reports rather than aborting.

#
### Tests:

#### Use cases covered
- A Postgres schema containing a stored procedure or function whose `prosrc` is NULL no longer aborts ingestion: the offending row is skipped and the remaining procedures/functions in that schema are still ingested.
- The genuine parse failure is surfaced through `status.failed(...)` and appears in the pipeline summary instead of being replaced by a logging `TypeError`.

#### Unit tests
- [x] Added `test_get_stored_procedures_skips_unparseable_row` in `ingestion/tests/unit/topology/database/test_postgres.py`, asserting the healthy procedure after the bad row is still yielded and that the failure is recorded.
- Verified the test is a genuine regression guard: it fails with `TypeError: Logger.error() missing 1 required positional argument: 'msg'` before the fix and passes after.
- Full file passes: 22 tests.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable — the failure is in per-row error handling and is covered by the unit test above.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Reproduced the original scenario against the real code path (bad row followed by a healthy one) before and after the change:

```
BEFORE
  procedures after the bad row : []              LOST
  status.failed() recorded     : 0               NOT RECORDED
  real parse error surfaced    : NO

AFTER
  procedures after the bad row : ['healthy_proc'] OK
  status.failed() recorded     : 1               OK
  real parse error surfaced    : YES
      -> Error parsing Stored Procedure payload: 1 validation error for PostgresStoredProcedure
```

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps PostgreSQL stored procedure ingestion running when one row cannot be parsed. The main changes are:

- Replaces the invalid argument-less error log with safe traceback logging.
- Reports the failed entity using the `procedure_name` query field.
- Adds a test for skipping a malformed row and ingesting the next valid row.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The exception handler no longer raises a secondary logging error.
- The failure name now matches the query's `procedure_name` alias.
- The test verifies that reporting occurs and later rows are still yielded.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/postgres/metadata.py | Updates per-row error handling so parsing failures are logged, attributed, and reported without stopping iteration. |
| ingestion/tests/unit/topology/database/test_postgres.py | Adds coverage for a malformed row followed by a valid stored procedure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Report the real procedure name and compu..."](https://github.com/open-metadata/openmetadata/commit/65b84efd4214efff34de2d852cc4b3dbffe0cee5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45568613)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->