### PR TITLE
Fixes #30192: bind BoundedListFilter params in TestSuite keyset reads

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/repositories/TestSuiteKeysetReindexIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/repositories/TestSuiteKeysetReindexIT.java
@@ -1,0 +1,61 @@
+package org.openmetadata.it.tests.repositories;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.it.util.OssTestServer;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.BoundedListFilter;
+import org.openmetadata.service.jdbi3.CollectionDAO;
+
+/**
+ * Regression for issue #30192: multi-reader reindexing reads each entity type through an
+ * upper-bounded keyset filter ({@link BoundedListFilter}), whose condition references
+ * {@code :reindexEndName} / {@code :reindexEndId}. {@link CollectionDAO.TestSuiteDAO} overrides
+ * {@code listAfter}/{@code listBefore} to splice the filter condition in via {@code @Define}, so
+ * those queries must also bind the filter's query params. Before the fix they did not, and JDBI
+ * threw {@code Missing named parameter 'reindexEndName'} — the reindex failed at the {@code
+ * testSuite} entity type with {@code successCount: 0}.
+ *
+ * <p>Exercises the exact DAO call {@code EntityRepository.listAfterKeyset} makes during reindex.
+ * Embedded-only: it needs the in-JVM DAO.
+ */
+class TestSuiteKeysetReindexIT {
+
+  private static final String MAX_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+  private static final String MAX_NAME = "\uffff";
+
+  @BeforeAll
+  static void setup() {
+    OssTestServer.defaultHandle();
+    SdkClients.adminClient();
+  }
+
+  @Test
+  void boundedKeysetReadOfTestSuitesBindsUpperBoundParams() {
+    assumeTrue(
+        !OssTestServer.isExternalMode(),
+        "reindex reads test suites through the in-JVM DAO with a BoundedListFilter; external mode "
+            + "has no in-process DAO");
+
+    CollectionDAO.TestSuiteDAO dao = Entity.getCollectionDAO().testSuiteDAO();
+    BoundedListFilter filter = new BoundedListFilter(Include.ALL, MAX_NAME, MAX_ID);
+
+    // The forward page is exactly what EntityRepository.listAfterKeyset issues during reindex; both
+    // overrides splice the bounded condition via @Define and so must bind reindexEndName/EndId.
+    List<String> afterPage = dao.listAfter(filter, 100, "", "");
+    List<String> beforePage = dao.listBefore(filter, 100, MAX_NAME, MAX_ID);
+
+    assertThat(afterPage)
+        .as("bounded keyset listAfter must bind :reindexEndName/:reindexEndId")
+        .isNotNull();
+    assertThat(beforePage)
+        .as("bounded keyset listBefore must bind :reindexEndName/:reindexEndId")
+        .isNotNull();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -7783,7 +7783,14 @@ public interface CollectionDAO {
             String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
       }
       return listBefore(
-          getTableName(), mySqlCondition, postgresCondition, limit, beforeName, beforeId, groupBy);
+          getTableName(),
+          filter.getQueryParams(),
+          mySqlCondition,
+          postgresCondition,
+          limit,
+          beforeName,
+          beforeId,
+          groupBy);
     }
 
     @Override
@@ -7808,7 +7815,14 @@ public interface CollectionDAO {
             String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
       }
       return listAfter(
-          getTableName(), mySqlCondition, postgresCondition, limit, afterName, afterId, groupBy);
+          getTableName(),
+          filter.getQueryParams(),
+          mySqlCondition,
+          postgresCondition,
+          limit,
+          afterName,
+          afterId,
+          groupBy);
     }
 
     @SqlQuery(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -585,7 +585,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listBefore(
       @Define("table") String table,
-      @BindMap Map<String, ?> params,
+      @BindMap Map<String, String> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,
@@ -619,7 +619,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listAfter(
       @Define("table") String table,
-      @BindMap Map<String, ?> params,
+      @BindMap Map<String, String> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -585,6 +585,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listBefore(
       @Define("table") String table,
+      @BindMap Map<String, ?> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,
@@ -618,6 +619,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listAfter(
       @Define("table") String table,
+      @BindMap Map<String, ?> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,


### PR DESCRIPTION
### Describe your changes:

Fixes #30192

Reindexing failed at the `testSuite` entity type with `Missing named parameter 'reindexEndName'` because `TestSuiteDAO.listAfter`/`listBefore` splice `filter.getCondition()` into the group-by SQL via `@Define` but call the only `listAfter`/`listBefore` variants lacking `@BindMap`, so the `BoundedListFilter` upper-bound params (`:reindexEndName`/`:reindexEndId`) were never bound. I added `@BindMap Map<String, ?> params` to those two `EntityDAO` group-by SQL methods and pass `filter.getQueryParams()` from `TestSuiteDAO`, mirroring the generic keyset path. Verified with `mvn spotless:apply` and a new embedded regression IT (`TestSuiteKeysetReindexIT`) that issues the exact `BoundedListFilter` keyset read the reindex makes and fails without the fix.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.

- [x] I have added a test that covers the exact scenario we are fixing (`TestSuiteKeysetReindexIT`, issue #30192).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes bounded keyset reads for test suites during reindexing. The main changes are:

- Pass filter query parameters to grouped `listBefore` and `listAfter` calls.
- Bind those parameters in the corresponding `EntityDAO` queries.
- Add an embedded integration test for forward and reverse bounded reads.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated calls supply the named parameters used by the bounded SQL condition.
- The parameter map type matches the filter API.
- No blocking issue remains in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Passes bounded filter parameters through both grouped TestSuite keyset read paths. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java | Adds parameter-map binding to the grouped forward and reverse keyset queries. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/repositories/TestSuiteKeysetReindexIT.java | Adds embedded coverage for bounded TestSuite reads in both pagination directions. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Use concrete Map&lt;String, String&gt; for @Bi..."](https://github.com/open-metadata/openmetadata/commit/23ad4c16154dbf319af7534fcd08ca0b8f45a3a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45574401)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->