### PR TITLE
Fixes #30192: bind BoundedListFilter params in TestSuite keyset reads

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -7236,7 +7236,14 @@ public interface CollectionDAO {
             String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
       }
       return listBefore(
-          getTableName(), mySqlCondition, postgresCondition, limit, beforeName, beforeId, groupBy);
+          getTableName(),
+          filter.getQueryParams(),
+          mySqlCondition,
+          postgresCondition,
+          limit,
+          beforeName,
+          beforeId,
+          groupBy);
     }
 
     @Override
@@ -7263,7 +7270,14 @@ public interface CollectionDAO {
             String.format("%s %s", postgresCondition, filter.getCondition(getTableName()));
       }
       return listAfter(
-          getTableName(), mySqlCondition, postgresCondition, limit, afterName, afterId, groupBy);
+          getTableName(),
+          filter.getQueryParams(),
+          mySqlCondition,
+          postgresCondition,
+          limit,
+          afterName,
+          afterId,
+          groupBy);
     }
 
     @SqlQuery(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -509,6 +509,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listBefore(
       @Define("table") String table,
+      @BindMap Map<String, ?> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,
@@ -534,6 +535,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listAfter(
       @Define("table") String table,
+      @BindMap Map<String, ?> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java
@@ -509,7 +509,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listBefore(
       @Define("table") String table,
-      @BindMap Map<String, ?> params,
+      @BindMap Map<String, String> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,
@@ -535,7 +535,7 @@ public interface EntityDAO<T extends EntityInterface> {
       connectionType = POSTGRES)
   List<String> listAfter(
       @Define("table") String table,
-      @BindMap Map<String, ?> params,
+      @BindMap Map<String, String> params,
       @Define("mysqlCond") String mysqlCond,
       @Define("postgresCond") String postgresCond,
       @Bind("limit") int limit,

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestSuiteReindexKeysetTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestSuiteReindexKeysetTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.jdbi3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.type.Include;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.OpenMetadataApplicationTest;
+
+/**
+ * Regression for issue #30192: multi-reader reindexing reads each entity type through an
+ * upper-bounded keyset filter ({@link BoundedListFilter}), whose condition references {@code
+ * :reindexEndName} / {@code :reindexEndId}. {@link CollectionDAO.TestSuiteDAO} overrides {@code
+ * listAfter}/{@code listBefore} to splice the filter condition in via {@code @Define}, so those
+ * queries must also bind the filter's query params. Before the fix they did not, and JDBI threw
+ * {@code Missing named parameter 'reindexEndName'} — the reindex failed at the {@code testSuite}
+ * entity type with {@code successCount: 0}.
+ */
+class TestSuiteReindexKeysetTest extends OpenMetadataApplicationTest {
+
+  private static final String MAX_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+  private static final String MAX_NAME = new String(Character.toChars(0xFFFF));
+
+  @Test
+  void boundedKeysetReadOfTestSuitesBindsUpperBoundParams() {
+    CollectionDAO.TestSuiteDAO dao = Entity.getCollectionDAO().testSuiteDAO();
+    BoundedListFilter filter = new BoundedListFilter(Include.ALL, MAX_NAME, MAX_ID);
+
+    // The forward page is exactly what SearchIndexExecutor issues during reindex; both overrides
+    // splice the bounded condition via @Define and so must bind reindexEndName/reindexEndId.
+    List<String> afterPage = dao.listAfter(filter, 100, "", "");
+    List<String> beforePage = dao.listBefore(filter, 100, MAX_NAME, MAX_ID);
+
+    assertThat(afterPage)
+        .as("bounded keyset listAfter must bind :reindexEndName/:reindexEndId")
+        .isNotNull();
+    assertThat(beforePage)
+        .as("bounded keyset listBefore must bind :reindexEndName/:reindexEndId")
+        .isNotNull();
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #30192

Reindexing failed at the `testSuite` entity type with `Missing named parameter 'reindexEndName'` because `TestSuiteDAO.listAfter`/`listBefore` splice `filter.getCondition()` into the group-by SQL via `@Define` but call the only `listAfter`/`listBefore` variants lacking `@BindMap`, so the `BoundedListFilter` upper-bound params (`:reindexEndName`/`:reindexEndId`) were never bound. I added `@BindMap Map<String, ?> params` to those two `EntityDAO` group-by SQL methods and pass `filter.getQueryParams()` from `TestSuiteDAO`, mirroring the generic keyset path. Verified with `mvn spotless:apply` and a new `OpenMetadataApplicationTest`-backed regression test (`TestSuiteReindexKeysetTest`) that issues the exact `BoundedListFilter` keyset read the reindex makes and fails without the fix. (Backport of the same fix to the 1.12.x line.)

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.

- [x] I have added a test that covers the exact scenario we are fixing (`TestSuiteReindexKeysetTest`, issue #30192).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes bounded TestSuite keyset reads used during reindexing. The main changes are:

- Bind `BoundedListFilter` query parameters in grouped `listAfter` and `listBefore` queries.
- Pass the filter parameter map from `TestSuiteDAO` to both query methods.
- Add an application-backed test for forward and backward bounded reads.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Both affected query directions now receive the required named parameters.
- The test executes the changed DAO paths against the application database layer.
- No blocking issues were found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Passes bounded filter parameters into both TestSuite keyset query directions. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityDAO.java | Adds map-based parameter binding to the grouped keyset SQL methods. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestSuiteReindexKeysetTest.java | Exercises forward and backward bounded TestSuite reads through the application database layer. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Use concrete Map&lt;String, String&gt; for @Bi..."](https://github.com/open-metadata/openmetadata/commit/998d9eb7a694819d90f0d5da065a8fe57866dad6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45575115)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->