### PR TITLE
Backport Mlflow AutoPilot E2E fix to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts
@@ -55,9 +55,12 @@ class MlFlowIngestionClass extends ServiceBaseClass {
   }
 
   async fillConnectionDetails(page: Page) {
-    await page.fill('#root\\/trackingUri', 'mlModelTrackingUri');
+    // MLflow 3.13+ rejects the filesystem backend, which is what a non-URI
+    // string resolves to. SQLite is a supported backend and bootstraps itself,
+    // yielding an empty registry the agent can walk without a live MLflow.
+    await page.fill('#root\\/trackingUri', 'sqlite:////tmp/mlflow_tracking.db');
     await checkServiceFieldSectionHighlighting(page, 'trackingUri');
-    await page.fill('#root\\/registryUri', 'mlModelRegistryUri');
+    await page.fill('#root\\/registryUri', 'sqlite:////tmp/mlflow_registry.db');
     await checkServiceFieldSectionHighlighting(page, 'registryUri');
   }
 


### PR DESCRIPTION
Backports the Playwright half of #30191 to `1.13`. 1.13 carries the same `mlflow-skinny>=3.13.0,<3.15` bump, so the AutoPilot E2E fails here the same way.

## What

`MlFlowIngestionClass` filled placeholder connection strings that MLflow resolved to a local file store, so the agent walked an empty registry and the test passed. MLflow 3.13 put the file store into maintenance mode and now raises instead:

```
MlflowException: The filesystem tracking backend (e.g., './mlruns') is in maintenance mode
and will not receive further updates. ... set `MLFLOW_ALLOW_FILE_STORE=true` to opt out.
```

The agent throws on connect, the AutoPilot workflow never completes successfully, and the run-completed banner never renders. Verified against the pinned version:

| mlflow-skinny | `search_registered_models()` with a placeholder URI |
| --- | --- |
| 3.11.1 (old ceiling) | OK — file store accepted |
| 3.13.0 (new floor) | raises `MlflowException` |

The fields now hold sqlite DSNs. SQLite is a supported backend that bootstraps its own schema, so it keeps the "empty registry, agent succeeds" semantics the test already relied on — as a deliberate choice rather than a side effect of MLflow's string parsing. Both fields are plain `type: string` in the schema, so no schema or UI change is needed.

## Scope

Playwright only, and intentionally byte-identical to the change already merged on `main` so the branches do not diverge.

Greptile flagged that the fixed `/tmp` paths are shared across services in the ingestion container (possible lock contention on concurrent first-time schema creation). That is a fair point but applies equally to `main`, which already merged these paths — so it should be hardened there first and backported, not introduced here as a divergence.

The connector-side version-selection fix from #30191 and its regression test are **not** included here, by request — 1.13 still carries that bug (a registered model is dropped after its description/tags/aliases are edited). The test change is the regression guard for that fix, so both were dropped together; keeping the test without the code fix would leave a failing integration test.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates the MLflow Playwright setup for MLflow 3.13 compatibility. The main changes are:

- Replaces placeholder tracking and registry URIs with SQLite DSNs.
- Preserves the empty-registry behavior without requiring a live MLflow service.
- Limits the backport to the Playwright fixture.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issue qualifies for this follow-up review.

- No distinct unresolved failure remains after excluding the already reported SQLite isolation issue.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MlFlowIngestionClass.ts | Updates the MLflow Playwright connection fields to use SQLite tracking and registry backends supported by MLflow 3.13. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): unbreak the Mlflow AutoPilot E2..."](https://github.com/open-metadata/openmetadata/commit/05a1423f17733ebdb4d51476c9999ee8159f21cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45575591)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))

<!-- /greptile_comment -->