### PR TITLE
Fix SelectiveFieldReindexUIIT leaking its seed on the external cluster

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/scenarios/search/reindex/SelectiveFieldReindexUIIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/scenarios/search/reindex/SelectiveFieldReindexUIIT.java
@@ -58,6 +58,7 @@ import org.openmetadata.schema.type.TableConstraint;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.service.Entity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -355,7 +356,14 @@ class SelectiveFieldReindexUIIT {
     final String shortId = ns.uniqueShortId();
     LOG.info("Seeding entities for selective-field reindex coverage (shortId={})", shortId);
 
-    final DatabaseService dbService = createShortPostgresService(shortId);
+    // Track the two service roots so TestNamespaceExtension.afterEach recursively hard-deletes the
+    // whole seeded subtree (db/schema/table/query/testCase/testSuite and
+    // drive/spreadsheet/worksheet).
+    // Without this the seed leaks a full "Selective-field reindex seed" cohort on the shared
+    // cluster
+    // every run — the children all cascade from these two roots.
+    final DatabaseService dbService =
+        ns.trackRoot(Entity.DATABASE_SERVICE, createShortPostgresService(shortId));
     final DatabaseSchema schema = createShortSchema(shortId, dbService);
 
     final String tableColumnMarker = "tcol" + shortId;
@@ -364,7 +372,8 @@ class SelectiveFieldReindexUIIT {
     createQueryLinkedTo(shortId, dbService.getFullyQualifiedName(), table);
     final TestCaseSeed testCaseSeed = createTestCaseWithResult(shortId, table);
 
-    final DriveService driveService = createShortDriveService(shortId);
+    final DriveService driveService =
+        ns.trackRoot(Entity.DRIVE_SERVICE, createShortDriveService(shortId));
     final String worksheetColumnMarker = "wcol" + shortId;
     final String worksheetName =
         createWorksheetWithColumnMarker(


### PR DESCRIPTION
### Describe your changes:

<!-- CI/test-hygiene fix, no tracking issue. -->

`SelectiveFieldReindexUIIT.seed()` creates a `pg_*` DatabaseService and a `ds_*` DriveService (both described **"Selective-field reindex seed"**) plus a full subtree, but never called `ns.trackRoot(...)` — so `TestNamespaceExtension.afterEach` drained an empty root list and deleted nothing. Every run leaked the whole cohort on the shared external cluster (27+ services had accumulated), which also feeds the ngram-collision flakiness the sibling search tests fight. This tracks both service roots so `afterEach` recursively hard-deletes the subtree (db/schema/table/query/testCase/testSuite + drive/spreadsheet/worksheet all cascade from the two roots).

Verified against the external cluster: `databaseServices` and `driveServices` recursive `hardDelete` both return 200, and the ~62 already-accumulated orphans were purged out-of-band. `ShortStackFactory` ("short stack") was checked and already tracks its root correctly — its few stragglers were killed-run residue, not a tracking bug.

#
### Type of change:
- [x] Bug fix

#
### Tests:
Existing `SelectiveFieldReindexUIIT` now self-cleans; no new test needed (the fix *is* cleanup wiring). Manually confirmed the recursive delete paths return 200 and the cluster is clean afterward.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR wires selective-field reindex seed data into namespace cleanup. The main changes are:

- Tracks the seeded database service as a cleanup root.
- Tracks the seeded drive service as a cleanup root.
- Uses recursive hard deletion for their service-owned subtrees.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge after confirming or tracking the seeded test suite.

- The service roots use valid entity types and server-assigned IDs.
- Recursive cleanup covers service-owned descendants and partial seed failures.
- A standalone test suite would remain outside both tracked service trees.

SelectiveFieldReindexUIIT.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/scenarios/search/reindex/SelectiveFieldReindexUIIT.java | Tracks both seeded service roots, but cleanup may still omit a standalone test suite created under the database seed flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix SelectiveFieldReindexUIIT leaking it..."](https://github.com/open-metadata/openmetadata/commit/1269025f80404faccdb25e72ed41c6ae402c5cbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45589832)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->