### PR TITLE
Fixes #30228: Remove test-connection error rules that cannot fire

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -117,12 +117,6 @@ ATHENA_ERRORS = ErrorPack(
         "s3StagingDir, and if the bucket requires encryption, use a workgroup that sets "
         "server-side encryption on query results.",
     ),
-    # By message, not by type: pyathena renders EndpointConnectionError into the
-    # SQLAlchemy error it raises, so the original type does not survive the chain.
-    when(Matchers.contains("could not connect to the endpoint")).diagnose(
-        "Cannot reach the AWS Athena endpoint",
-        fix="Check that awsRegion is correct and that the Athena endpoint is reachable from where ingestion runs.",
-    ),
 ).including(AWS_ERRORS)
 
 

--- a/ingestion/tests/unit/source/database/athena/test_connection.py
+++ b/ingestion/tests/unit/source/database/athena/test_connection.py
@@ -14,11 +14,13 @@ import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, EndpointConnectionError
+from sqlalchemy import create_engine
 
 from metadata.core.connections.lifetime import Borrowed
 from metadata.core.connections.test_connection.check import collect_checks
 from metadata.core.connections.test_connection.checks.database import DatabaseStep
+from metadata.core.connections.test_connection.classifier import exception_chain
 from metadata.core.connections.test_connection.records import Evidence
 from metadata.generated.schema.entity.services.connections.database.athenaConnection import (
     AthenaConnection as AthenaConnectionConfig,
@@ -188,11 +190,28 @@ def test_error_pack_classifies_an_unusable_result_bucket():
     assert diagnosis.title == "Query result bucket not usable"
 
 
-def test_error_pack_classifies_unreachable_endpoint():
-    error = RuntimeError('Could not connect to the endpoint URL: "https://athena.bad.amazonaws.com/"')
-    diagnosis = ATHENA_ERRORS.classify(error)
+def test_a_real_unreachable_endpoint_is_diagnosed_by_the_aws_pack():
+    """Drives the real driver stack against a closed loopback port.
+
+    pyathena chains the botocore ``EndpointConnectionError`` through the
+    SQLAlchemy error, so the shared AWS_ERRORS rule matches it by type and Athena
+    needs no message rule of its own.
+    """
+    engine = create_engine(
+        "awsathena+rest://key:secret@athena.us-east-1.amazonaws.com:443/default"
+        "?s3_staging_dir=s3://bucket/prefix&endpoint_url=https://127.0.0.1:1/"
+        "&region_name=us-east-1&connect_timeout=1&retries=0"
+    )
+
+    with pytest.raises(Exception) as raised, engine.connect() as connection:
+        connection.exec_driver_sql("SELECT 1")
+
+    chained = [type(error) for error in exception_chain(raised.value)]
+    assert EndpointConnectionError in chained
+
+    diagnosis = ATHENA_ERRORS.classify(raised.value)
     assert diagnosis is not None
-    assert diagnosis.title == "Cannot reach the AWS Athena endpoint"
+    assert diagnosis.title == "Cannot reach the AWS endpoint"
 
 
 def test_error_pack_classifies_not_authorized():


### PR DESCRIPTION
Fixes #30228

Re-verified every suspected-dead test-connection error rule against the **real driver** — constructing the failure the way the driver stack actually produces it, not by handing a fabricated exception to `pack.classify()`. Only what was provably unreachable was removed.

Most of the original candidate list turned out to be already fixed on `main`. One rule survived audit as genuinely redundant.

## Verdicts

| Rule | Verdict | Evidence |
| --- | --- | --- |
| athena `contains("could not connect to the endpoint")` | **Removed** | Driven against a closed loopback endpoint, the real chain is `sqlalchemy.exc.DatabaseError → pyathena.error.DatabaseError → botocore.exceptions.EndpointConnectionError → urllib3.NewConnectionError → ConnectionRefusedError`. The botocore type survives, so `AWS_ERRORS`' `Matchers.exception(EndpointConnectionError)` already owns it. The comment claiming pyathena flattens the type was wrong — pyathena only drops the cause for query-*state* failures (`cursor.py` raises those from a `StateChangeReason` string), which cannot carry a connect error. |
| databricks `contains("forbidden")` | Kept — already gone | Removed on `main`; an explanatory comment now records that databricks-sql keeps the status in `error.context["http-code"]`. |
| looker `NETWORK_ERRORS` fold | Kept — already gone | Not folded in on `main`; `connection.py:202` records why. Its tests drive the real `RequestsTransport` and assert the flattened-text path, so they are not fake fixtures — left alone. |
| dbtcloud `NETWORK_ERRORS` fold | Kept — already gone | Not folded in on `main`; `connection.py:127` records why. |
| redshift `_sqlstate("28000", "28P01")` | Kept — already gone | Removed on `main`. |
| `requests` timeout/connection matcher on the dashboard/pipeline transport | **Not added — proven unnecessary** | `ometa/client.py:339-346` already catches the `requests` transport exceptions and raises `RestTransportError(...) from exc`. Against real unroutable hosts on the pinned `requests 2.33.1` / `urllib3 2.7.0`, every leg chains a builtin socket type the pack already matches: connect-timeout → `TimeoutError`, read-timeout → `TimeoutError`, DNS → `socket.gaierror`, refused → `ConnectionRefusedError`. Verified end-to-end: powerbi, dbtcloud and tableau all classify all three. `exception_chain` follows `__context__` as well as `__cause__`, so tableau's `raise ... # noqa: B904` in `get_connection` does not break it either. Adding a `requests`-typed rule would be defensive, not corrective. |

## Test methodology

`test_error_pack_classifies_unreachable_endpoint` fed a hand-made `RuntimeError` carrying the message text — it would have passed whether or not any driver ever produces that shape, which is why the rule survived this long. It is replaced by `test_a_real_unreachable_endpoint_is_diagnosed_by_the_aws_pack`, which drives SQLAlchemy → pyathena → botocore against a closed loopback port (no external network), asserts the real `EndpointConnectionError` is in the chain, and asserts the shared AWS diagnosis.

## Out of scope

Deferred pending a live repro, untouched: redshift `42P01` on Serverless, snowflake server-side MFA text, athena `"writing to location"`, the `_clock_skew` Glue/Athena leg.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes a redundant Athena endpoint-error rule and replaces its synthetic test with a real driver failure path. The main changes are:

- Delegate endpoint connection failures to the shared AWS error pack.
- Exercise SQLAlchemy, PyAthena, and botocore against a closed loopback port.
- Verify that `EndpointConnectionError` survives the exception chain.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The production change looks safe to merge; the new test has a non-blocking proxy-isolation issue.

- The shared AWS pack matches `EndpointConnectionError` before generic network rules.
- The new test verifies that the current driver stack preserves that exception type.
- Ambient proxy settings can make the test produce a different exception chain.

ingestion/tests/unit/source/database/athena/test_connection.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/athena/connection.py | Removes the Athena-specific text matcher because the included AWS pack already matches the preserved botocore exception type. |
| ingestion/tests/unit/source/database/athena/test_connection.py | Adds a real driver-level endpoint failure test whose outcome can depend on ambient proxy settings. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): drop athena&#39;s redundant ..."](https://github.com/open-metadata/openmetadata/commit/ea7dc1fcba7f0e733b5ac9463334f0a36da5b7fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45595358)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->