### PR TITLE
ci(sonar): pin sonarqube-scanner to ^4.3.0 to fix exit 127

### DIFF
--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -129,7 +129,7 @@ jobs:
           badge-title: Coverage
       - name: yarn add sonarqube-scanner
         working-directory: ${{ env.UI_WORKING_DIRECTORY }}
-        run: npm install -g sonarqube-scanner
+        run: npm install -g sonarqube-scanner@^4.3.0
         id: npm_install_sonar_scanner
       - name: SonarCloud Scan On PR
         if: github.event_name == 'pull_request_target' && steps.npm_install_sonar_scanner.outcome == 'success'


### PR DESCRIPTION
Fixes #30234

## Problem

`SonarCloud + Jest Coverage` fails on every PR that touches UI paths with:

```
sonar-scanner: command not found
##[error]Process completed with exit code 127.
```

Jest itself is fine — coverage is generated. The break is in the SonarCloud scan step.

## Root cause

`.github/workflows/yarn-coverage.yml` runs an **unpinned** global install:

```yaml
run: npm install -g sonarqube-scanner
```

`sonarqube-scanner` published **v5.0.0**, which renamed its CLI binary from `sonar-scanner` → `sonar-scanner-npm`. The two scan steps still invoke `sonar-scanner`, so they exit 127.

Bin field by version:
- `4.x` (through 4.3.0) → `sonar-scanner` ✅
- `5.0.0` → `sonar-scanner-npm` ❌

Because the workflow is `pull_request_target`, it runs **main's** copy of the yaml, so this affects all PRs, not any single branch.

## Fix

Pin below v5:

```yaml
run: npm install -g sonarqube-scanner@^4.3.0
```

`^4.3.0` keeps the `sonar-scanner` binary (last 4.x line that provides it) and still allows 4.x patches. Both scan invocations stay unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR constrains the Sonar scanner dependency to the 4.x release line. The main change is:

- Updates the global scanner installation to use `sonarqube-scanner@^4.3.0`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The workflow change is mergeable after making the scanner version deterministic.

- The range excludes the incompatible 5.x CLI rename.
- An exact version would prevent future 4.x packaging changes from breaking the workflow again.

.github/workflows/yarn-coverage.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/yarn-coverage.yml | Constrains the Sonar scanner installation to 4.x, but leaves the selected version mutable within that release line. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(sonar): pin sonarqube-scanner to ^4.3..."](https://github.com/open-metadata/openmetadata/commit/a45b7a2a3e3028c8be43b47b41d309604d9c8bf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45599618)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->