### PR TITLE
test(e2e): disable ETag conditional reads for Playwright runs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomMetric.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomMetric.spec.ts
@@ -17,10 +17,7 @@ import {
   createCustomMetric,
   deleteCustomMetric,
 } from '../../utils/customMetric';
-import {
-  forceFreshTableReads,
-  waitForAllLoadersToDisappear,
-} from '../../utils/entity';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -28,7 +25,6 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 test('Table custom metric', async ({ page }) => {
   const table = new TableClass();
   await redirectToHomePage(page);
-  await forceFreshTableReads(page);
   const { afterAction, apiContext } = await getApiContext(page);
   await table.create(apiContext);
 
@@ -70,7 +66,6 @@ test('Table custom metric', async ({ page }) => {
 test('Column custom metric', async ({ page }) => {
   const table = new TableClass();
   await redirectToHomePage(page);
-  await forceFreshTableReads(page);
   const { afterAction, apiContext } = await getApiContext(page);
   await table.create(apiContext);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -18,10 +18,7 @@ import {
   ObservabilityFeature,
   selectAddObservabilityFeature,
 } from '../../utils/dataQuality';
-import {
-  forceFreshTableReads,
-  waitForAllLoadersToDisappear,
-} from '../../utils/entity';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   confirmIngestionPipelineHardDelete,
   submitTestCaseForm,
@@ -43,7 +40,6 @@ test(
     test.slow(true);
 
     await redirectToHomePage(page);
-    await forceFreshTableReads(page);
     const { apiContext, afterAction } = await getApiContext(page);
     const table = new TableClass(`multi pipeline !@#$%^&*()_-+=test-${uuid()}`);
     await table.create(apiContext);
@@ -246,7 +242,6 @@ test(
     test.slow(true);
 
     await redirectToHomePage(page);
-    await forceFreshTableReads(page);
     const { apiContext, afterAction } = await getApiContext(page);
     const table = new TableClass(`multi pipeline !@#$%^&*()_-+=test-${uuid()}`);
     await table.create(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { test as setup } from '@playwright/test';
+import { Page, test as setup } from '@playwright/test';
+import { DISABLE_ETAG_CONDITIONAL_READS_KEY } from '../../src/rest/etagInterceptor';
 import {
   EDIT_DESCRIPTION_RULE,
   EDIT_GLOSSARY_TERM_RULE,
@@ -21,6 +22,21 @@ import { AdminClass } from '../support/user/AdminClass';
 import { UserClass } from '../support/user/UserClass';
 import { getApiContext, uuid } from '../utils/common';
 import { loginAsAdmin } from '../utils/initialSetup';
+
+/**
+ * Opt every E2E session out of client-side conditional (If-None-Match) reads.
+ *
+ * The server ETag only covers the entity's version/updatedAt, so it does not change for
+ * relationship-only or child mutations (followers, votes, customMetrics, testSuite). A refetch
+ * racing such a mutation can be answered "not modified" and render a stale body, which surfaces
+ * as flaky assertions across the suite. Setting the flag here persists it into storageState, so
+ * every spec in both OpenMetadata and Collate inherits it without a per-test helper.
+ */
+const disableEtagConditionalReads = async (page: Page) => {
+  await page.evaluate((key) => {
+    localStorage.setItem(key, 'true');
+  }, DISABLE_ETAG_CONDITIONAL_READS_KEY);
+};
 
 const adminFile = 'playwright/.auth/admin.json';
 const dataConsumerFile = 'playwright/.auth/dataConsumer.json';
@@ -208,42 +224,50 @@ setup('authenticate all users', async ({ browser }) => {
     await adminPage.waitForTimeout(2000);
 
     // Save admin state
+    await disableEtagConditionalReads(newAdminPage);
     await newAdminPage
       .context()
       .storageState({ path: adminFile, indexedDB: true });
 
     // Save states for each user sequentially to avoid file operation conflicts
     await dataConsumer.login(dataConsumerPage);
+    await disableEtagConditionalReads(dataConsumerPage);
     await dataConsumerPage
       .context()
       .storageState({ path: dataConsumerFile, indexedDB: true });
 
     await dataSteward.login(dataStewardPage);
+    await disableEtagConditionalReads(dataStewardPage);
     await dataStewardPage
       .context()
       .storageState({ path: dataStewardFile, indexedDB: true });
 
     await editDescriptionUser.login(editDescriptionPage);
+    await disableEtagConditionalReads(editDescriptionPage);
     await editDescriptionPage
       .context()
       .storageState({ path: editDescriptionFile, indexedDB: true });
 
     await editTagsUser.login(editTagsPage);
+    await disableEtagConditionalReads(editTagsPage);
     await editTagsPage
       .context()
       .storageState({ path: editTagsFile, indexedDB: true });
 
     await editGlossaryTermUser.login(editGlossaryTermPage);
+    await disableEtagConditionalReads(editGlossaryTermPage);
     await editGlossaryTermPage
       .context()
       .storageState({ path: editGlossaryTermFile, indexedDB: true });
 
     await viewOnlyUser.login(viewOnlyPage);
+    await disableEtagConditionalReads(viewOnlyPage);
     await viewOnlyPage
       .context()
       .storageState({ path: viewOnlyFile, indexedDB: true });
 
     await ownerUser.login(ownerPage);
+    await disableEtagConditionalReads(ownerPage);
     await ownerPage
       .context()
       .storageState({ path: ownerFile, indexedDB: true });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -59,22 +59,6 @@ export const waitForAllLoadersToDisappear = async (
   await expect(loaders).toHaveCount(0, { timeout });
 };
 
-/**
- * Force fresh table reads by stripping the client `If-None-Match` header on
- * `/api/v1/tables/**` requests. The server ETag is derived only from the table's
- * version/updatedAt, which child mutations (custom metrics, executable test suites)
- * do not bump — so a post-mutation refetch can receive a not-modified response and
- * render stale data. Removing the conditional header makes the server always return
- * the current body, eliminating that stale-read flake in tests.
- */
-export const forceFreshTableReads = async (page: Page) => {
-  await page.route('**/api/v1/tables/**', async (route) => {
-    const headers = route.request().headers();
-    delete headers['if-none-match'];
-    await route.continue({ headers });
-  });
-};
-
 export const visitEntityPage = async (data: {
   page: Page;
   searchTerm: string;

--- a/openmetadata-ui/src/main/resources/ui/src/rest/etagInterceptor.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/etagInterceptor.ts
@@ -42,6 +42,18 @@ import Qs from 'qs';
  * GET response is 5-50 KB so the cap holds the cache to ~10 MB worst case.
  */
 
+/**
+ * localStorage flag that opts a session out of client-side conditional (If-None-Match) reads.
+ *
+ * The server ETag is derived from the entity's version/updatedAt only, so it does not move for
+ * relationship-only or child mutations (followers, votes, customMetrics, testSuite). A refetch
+ * that races such a mutation can therefore be answered "not modified" and render a stale body.
+ * E2E runs set this flag in the Playwright auth setup, where it is persisted via storageState and
+ * inherited by every spec. Remove once the ETag reflects the requested fields and child state.
+ */
+export const DISABLE_ETAG_CONDITIONAL_READS_KEY =
+  'OM_DISABLE_ETAG_CONDITIONAL_READS';
+
 interface CachedEntry {
   etag: string;
   data: unknown;

--- a/openmetadata-ui/src/main/resources/ui/src/rest/index.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/index.ts
@@ -14,7 +14,10 @@
 import axios from 'axios';
 import Qs from 'qs';
 import { getBasePath } from '../utils/HistoryUtils';
-import { attachEtagInterceptor } from './etagInterceptor';
+import {
+  attachEtagInterceptor,
+  DISABLE_ETAG_CONDITIONAL_READS_KEY,
+} from './etagInterceptor';
 
 const axiosClient = axios.create({
   baseURL: `${getBasePath()}/api/v1`,
@@ -25,6 +28,12 @@ const axiosClient = axios.create({
 // response body bytes + a JSON parse + a render on entity GET revisits within a session.
 // Attached here (before AuthProvider's interceptors) so it sits closest to the wire and
 // every other interceptor sees the resolved 304→200-with-cached-body translation.
-attachEtagInterceptor(axiosClient);
+// Skipped when the session opts out (see DISABLE_ETAG_CONDITIONAL_READS_KEY).
+if (
+  typeof localStorage === 'undefined' ||
+  localStorage.getItem(DISABLE_ETAG_CONDITIONAL_READS_KEY) !== 'true'
+) {
+  attachEtagInterceptor(axiosClient);
+}
 
 export default axiosClient;


### PR DESCRIPTION
## Problem

A large share of AUT failures share one root cause: **the ETag doesn't move when the response body does.**

`EntityETag.generateETag()` is `hash(version + "-" + updatedAt)`. Relationship-only and child mutations — `addFollower`, `removeFollower`, `updateVote`, `customMetric`, the executable `testSuite` — do **not** bump the parent's `version`/`updatedAt`. So after such a write the ETag is unchanged, the client's conditional refetch (`If-None-Match`, `etagInterceptor.ts`) is answered "not modified", and the UI renders a **stale body**.

Confirmed from a failing trace:
- `PUT /tables/{id}/customMetric` returned the table with `customMetrics: 1` at `version 0.1` / `updatedAt 1784239349138`. The very next table GET carried `If-None-Match`, came back with no body, and the UI rendered the cached copy with `customMetrics: 0` — same `version`/`updatedAt`, therefore identical ETag.
- The ETag also ignores `fields`: a `fields=testSuite` request and a `fields=customMetrics,columns` request produce the **same** ETag, so one can be served the other's body.

`ETagResponseFilter`'s own Javadoc names this hazard for `addFollower`/`removeFollower`/`updateVote` — matching the `UpVote & DownVote` (`1`→`0`) and `Follow & Un-follow` (`Unfollow`→`Follow`) failures seen in AUT.

It's load-dependent: the interceptor clears its cache on every mutation, so normally the refetch is unconditional. Under load a refetch dispatched around the mutation still carries a stale `If-None-Match`, so it fires often on slow AUT runs and almost never locally.

## Change

Opt E2E sessions out of client-side conditional reads:

- Export `DISABLE_ETAG_CONDITIONAL_READS_KEY` and skip `attachEtagInterceptor` when it is set (guarded with `typeof localStorage === 'undefined'` for non-browser contexts).
- Set the flag in `auth.setup.ts` before each `storageState()` write, so it persists via storageState and is inherited by **every spec** — no per-test helper, and it covers both OpenMetadata and Collate (both run off the same `setup` project).
- Drop the now-redundant `forceFreshTableReads` helper and its call sites.

Why storageState rather than a fixture or a shared helper: 99/341 OM specs (and 71/130 Collate specs) never call `redirectToHomePage`, and 69 specs import `test` straight from `@playwright/test`, so neither a helper nor a fixture reaches full coverage without touching dozens of files.

## Validation

- Flag is present in the regenerated `playwright/.auth/admin.json`, confirming it persists via storageState.
- `CustomMetric.spec.ts` passes with the per-test helper removed — the global flag does the work.
- `TestSuiteMultiPipeline.spec.ts` fails locally at an unrelated step (the test-case drawer's `Enter a Count` field). Verified against a **clean baseline with these changes stashed** — it fails identically, so it is pre-existing in this environment (`@ingestion`-tagged, needs Airflow) and not caused by this change.
- Checkstyle clean: eslint exit 0, prettier clean, `tsc --noEmit` reports nothing on the touched files.

## Follow-up

This is containment for the test suite. The ETag itself should still be fixed so it reflects the requested `fields` and child state — e.g. fold `fields` into the ETag, skip ETag/304 for GETs carrying child-resolved fields, or stamp child changes onto the parent. Happy to split that into a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables conditional ETag reads for Playwright sessions. The main changes are:

- Persists an ETag opt-out flag in every generated user storage state.
- Skips ETag interceptor registration when the flag is present.
- Removes the table-specific request workaround from two E2E specs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts | Stores the ETag opt-out flag in each role-specific Playwright storage state. |
| openmetadata-ui/src/main/resources/ui/src/rest/index.ts | Skips ETag interceptor registration when the restored session contains the opt-out flag. |
| openmetadata-ui/src/main/resources/ui/src/rest/etagInterceptor.ts | Exports the shared localStorage key used by the application and Playwright setup. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts | Removes the superseded table-only request interception helper. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CustomMetric.spec.ts | Removes the per-test fresh-table-read setup. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts | Removes the per-test fresh-table-read setup. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(e2e): disable ETag conditional read..."](https://github.com/open-metadata/openmetadata/commit/5b5437b8a636e6db9250919be66aae66973ae798) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45622437)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->