### PR TITLE
fix(migration): preserve task creator/comments/resolution and replay incident state on 2.0 upgrade

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -283,29 +283,13 @@ public class TestCaseResolutionStatusRepository
   }
 
   /**
-   * Reconcile an incident task's workflow to the latest recorded {@link TestCaseResolutionStatus}
-   * for its test case, using the same bridge ({@link #applyLegacyStatusToIncidentTask}) that
-   * advances the workflow on a live TCRS write. Idempotent: {@link #resolveLegacyTransitionId}
-   * returns null (no-op) when the task is already at the target stage. One caller is the v200
-   * migration, which starts incident workflows at NewStage and uses this to restore a pre-upgrade
-   * Ack/Assigned state that would otherwise come back as New / No Owners.
+   * Bridge a legacy-style {@link TestCaseResolutionStatus} onto the task-first incident workflow,
+   * advancing the workflow task to match the recorded status. Used by {@link #storeInternal} on
+   * live Ack/Assigned/Resolved writes so existing TCRS clients keep working while Task remains the
+   * source of truth. Idempotent: {@link #resolveLegacyTransitionId} returns null (no-op) when the
+   * task is already at the target stage.
    */
-  public boolean reconcileIncidentTaskToLatestStatus(Task task) {
-    if (task == null || task.getAbout() == null) {
-      return false;
-    }
-    String recordFQN = task.getAbout().getFullyQualifiedName();
-    if (recordFQN == null) {
-      return false;
-    }
-    TestCaseResolutionStatus latest = getLatestRecord(recordFQN);
-    if (latest == null) {
-      return false;
-    }
-    return applyLegacyStatusToIncidentTask(latest, recordFQN);
-  }
-
-  private boolean applyLegacyStatusToIncidentTask(
+  public boolean applyLegacyStatusToIncidentTask(
       TestCaseResolutionStatus recordEntity, String recordFQN) {
     Task incidentTask = findIncidentTaskForLegacyStatus(recordEntity, recordFQN);
     if (incidentTask == null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -282,6 +282,29 @@ public class TestCaseResolutionStatusRepository
         && message.contains(Relationship.PARENT_OF.value());
   }
 
+  /**
+   * Replay a migrated incident task's pre-upgrade resolution state onto its freshly-created
+   * workflow instance. The v200 migration starts every incident workflow at NewStage; without
+   * this, an incident that was Ack/Assigned before the upgrade comes back as New / No Owners.
+   * Reuses the same runtime bridge ({@link #applyLegacyStatusToIncidentTask}) that advances the
+   * workflow on a live TCRS write, keyed off the latest recorded status for the task's test case.
+   * Idempotent: {@link #resolveLegacyTransitionId} returns null (no-op) when already at the stage.
+   */
+  public boolean backfillMigratedIncidentTaskStage(Task task) {
+    if (task == null || task.getAbout() == null) {
+      return false;
+    }
+    String recordFQN = task.getAbout().getFullyQualifiedName();
+    if (recordFQN == null) {
+      return false;
+    }
+    TestCaseResolutionStatus latest = getLatestRecord(recordFQN);
+    if (latest == null) {
+      return false;
+    }
+    return applyLegacyStatusToIncidentTask(latest, recordFQN);
+  }
+
   private boolean applyLegacyStatusToIncidentTask(
       TestCaseResolutionStatus recordEntity, String recordFQN) {
     Task incidentTask = findIncidentTaskForLegacyStatus(recordEntity, recordFQN);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -283,14 +283,14 @@ public class TestCaseResolutionStatusRepository
   }
 
   /**
-   * Replay a migrated incident task's pre-upgrade resolution state onto its freshly-created
-   * workflow instance. The v200 migration starts every incident workflow at NewStage; without
-   * this, an incident that was Ack/Assigned before the upgrade comes back as New / No Owners.
-   * Reuses the same runtime bridge ({@link #applyLegacyStatusToIncidentTask}) that advances the
-   * workflow on a live TCRS write, keyed off the latest recorded status for the task's test case.
-   * Idempotent: {@link #resolveLegacyTransitionId} returns null (no-op) when already at the stage.
+   * Reconcile an incident task's workflow to the latest recorded {@link TestCaseResolutionStatus}
+   * for its test case, using the same bridge ({@link #applyLegacyStatusToIncidentTask}) that
+   * advances the workflow on a live TCRS write. Idempotent: {@link #resolveLegacyTransitionId}
+   * returns null (no-op) when the task is already at the target stage. One caller is the v200
+   * migration, which starts incident workflows at NewStage and uses this to restore a pre-upgrade
+   * Ack/Assigned state that would otherwise come back as New / No Owners.
    */
-  public boolean backfillMigratedIncidentTaskStage(Task task) {
+  public boolean reconcileIncidentTaskToLatestStatus(Task task) {
     if (task == null || task.getAbout() == null) {
       return false;
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -1628,15 +1628,16 @@ public class MigrationUtil {
    * falls back to the admin user, never a fabricated id. Throws only if admin is also unresolvable.
    */
   static EntityReference resolveUserReference(String userName) {
-    if (nullOrEmpty(userName)) {
-      return resolveAdminReference();
+    EntityReference reference = null;
+    if (!nullOrEmpty(userName)) {
+      try {
+        reference = Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
+      } catch (Exception e) {
+        LOG.debug(
+            "Unable to resolve user '{}', falling back to admin: {}", userName, e.getMessage());
+      }
     }
-    try {
-      return Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
-    } catch (Exception e) {
-      LOG.debug("Unable to resolve user '{}', falling back to admin: {}", userName, e.getMessage());
-      return resolveAdminReference();
-    }
+    return reference != null ? reference : resolveAdminReference();
   }
 
   private static EntityReference resolveAdminReference() {
@@ -1648,12 +1649,13 @@ public class MigrationUtil {
    * POJOs). Returns null only if even the admin fallback cannot be resolved.
    */
   private static ObjectNode buildUserRef(String userName) {
+    ObjectNode ref = null;
     try {
-      return userRefToJson(resolveUserReference(userName));
+      ref = userRefToJson(resolveUserReference(userName));
     } catch (Exception e) {
       LOG.warn("Could not resolve a user reference for '{}': {}", userName, e.getMessage());
-      return null;
     }
+    return ref;
   }
 
   private static ObjectNode userRefToJson(EntityReference ref) {
@@ -1672,26 +1674,34 @@ public class MigrationUtil {
     ArrayNode comments = JsonUtils.getObjectNode().arrayNode();
     if (posts != null && posts.isArray()) {
       for (JsonNode post : posts) {
-        if (!post.has("message")) {
-          continue;
+        ObjectNode comment = buildTaskComment(post);
+        if (comment != null) {
+          comments.add(comment);
         }
-        ObjectNode author = buildUserRef(post.path("from").asText(null));
-        if (author == null) {
-          continue;
-        }
-        ObjectNode comment = JsonUtils.getObjectNode();
-        comment.put("id", post.has("id") ? post.get("id").asText() : UUID.randomUUID().toString());
-        comment.put("message", post.get("message").asText());
-        comment.set("author", author);
-        comment.put("createdAt", post.has("postTs") ? post.get("postTs").asLong() : 0);
-        if (post.has("reactions") && post.get("reactions").isArray()) {
-          comment.set("reactions", post.get("reactions"));
-        }
-        comments.add(comment);
       }
     }
     taskJson.set("comments", comments);
     taskJson.put("commentCount", comments.size());
+  }
+
+  /**
+   * Build a {@code taskComment} from a legacy post, or {@code null} to skip it (no message, or an
+   * author that cannot be resolved even to the admin fallback). Per-post reactions are carried over.
+   */
+  private static ObjectNode buildTaskComment(JsonNode post) {
+    ObjectNode comment = null;
+    ObjectNode author = post.has("message") ? buildUserRef(post.path("from").asText(null)) : null;
+    if (author != null) {
+      comment = JsonUtils.getObjectNode();
+      comment.put("id", post.has("id") ? post.get("id").asText() : UUID.randomUUID().toString());
+      comment.put("message", post.get("message").asText());
+      comment.set("author", author);
+      comment.put("createdAt", post.has("postTs") ? post.get("postTs").asLong() : 0);
+      if (post.has("reactions") && post.get("reactions").isArray()) {
+        comment.set("reactions", post.get("reactions"));
+      }
+    }
+    return comment;
   }
 
   /**
@@ -2239,36 +2249,43 @@ public class MigrationUtil {
 
     private boolean startWorkflowInstanceForTask(Task task) {
       boolean started = false;
-      var workflowBinding =
+      var binding =
           TaskWorkflowLifecycleResolver.resolveBinding(
               task.getType(), task.getCategory(), task.getPayload());
-      WorkflowDefinition workflowDefinition =
-          workflowBinding.isEmpty()
+      WorkflowDefinition definition =
+          binding.isEmpty()
               ? null
               : workflowDefinitionRepository.findByNameOrNull(
-                  workflowBinding.get().workflowDefinitionRef(), Include.NON_DELETED);
-      if (workflowDefinition != null) {
-        Map<String, Object> variables = new LinkedHashMap<>();
-        variables.putAll(TaskWorkflowLifecycleResolver.buildWorkflowStartVariables(task));
-        variables.put(
-            getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
-            EntityUtil.buildEntityLink(
-                task.getAbout().getType(), task.getAbout().getFullyQualifiedName()));
-        variables.put(
-            getNamespacedVariableName(GLOBAL_NAMESPACE, UPDATED_BY_VARIABLE), task.getUpdatedBy());
-        variables.put("workflowDefinitionId", workflowDefinition.getId().toString());
-        if (workflowBinding.get().schema() != null
-            && workflowBinding.get().schema().getId() != null) {
-          variables.put("taskFormSchemaId", workflowBinding.get().schema().getId().toString());
-          variables.put("taskFormSchemaVersion", workflowBinding.get().schema().getVersion());
-        }
+                  binding.get().workflowDefinitionRef(), Include.NON_DELETED);
+      if (definition != null) {
         workflowHandler.triggerByKey(
-            getTriggerWorkflowId(workflowDefinition.getFullyQualifiedName()),
+            getTriggerWorkflowId(definition.getFullyQualifiedName()),
             task.getId().toString(),
-            variables);
+            buildBackfillWorkflowVariables(task, binding.get(), definition));
         started = true;
       }
       return started;
+    }
+
+    private Map<String, Object> buildBackfillWorkflowVariables(
+        Task task,
+        TaskWorkflowLifecycleResolver.TaskWorkflowBinding binding,
+        WorkflowDefinition definition) {
+      Map<String, Object> variables = new LinkedHashMap<>();
+      variables.putAll(TaskWorkflowLifecycleResolver.buildWorkflowStartVariables(task));
+      variables.put(
+          getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
+          EntityUtil.buildEntityLink(
+              task.getAbout().getType(), task.getAbout().getFullyQualifiedName()));
+      variables.put(
+          getNamespacedVariableName(GLOBAL_NAMESPACE, UPDATED_BY_VARIABLE), task.getUpdatedBy());
+      variables.put("workflowDefinitionId", definition.getId().toString());
+      var schema = binding.schema();
+      if (schema != null && schema.getId() != null) {
+        variables.put("taskFormSchemaId", schema.getId().toString());
+        variables.put("taskFormSchemaVersion", schema.getVersion());
+      }
+      return variables;
     }
 
     private boolean replayMigratedIncidentState(Task task) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -2204,66 +2204,74 @@ public class MigrationUtil {
 
     private int backfillOpenTasksToWorkflowInstances() {
       int backfilled = 0;
+      int failedIncidentReplays = 0;
       try {
         ListFilter filter = new ListFilter(Include.NON_DELETED);
         filter.addQueryParam("taskStatusGroup", "open");
         List<Task> openTasks =
             listOrEmpty(taskRepository.listAll(taskRepository.getFields("about,payload"), filter));
         for (Task task : openTasks) {
-          if (task.getWorkflowInstanceId() != null || task.getAbout() == null) {
+          if (task.getAbout() == null) {
             continue;
           }
-
-          var workflowBinding =
-              TaskWorkflowLifecycleResolver.resolveBinding(
-                  task.getType(), task.getCategory(), task.getPayload());
-          if (workflowBinding.isEmpty()) {
-            continue;
+          if (task.getWorkflowInstanceId() == null && startWorkflowInstanceForTask(task)) {
+            backfilled++;
           }
-
-          WorkflowDefinition workflowDefinition =
-              workflowDefinitionRepository.findByNameOrNull(
-                  workflowBinding.get().workflowDefinitionRef(), Include.NON_DELETED);
-          if (workflowDefinition == null) {
-            continue;
-          }
-
-          Map<String, Object> variables = new LinkedHashMap<>();
-          variables.putAll(TaskWorkflowLifecycleResolver.buildWorkflowStartVariables(task));
-          variables.put(
-              getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
-              EntityUtil.buildEntityLink(
-                  task.getAbout().getType(), task.getAbout().getFullyQualifiedName()));
-          variables.put(
-              getNamespacedVariableName(GLOBAL_NAMESPACE, UPDATED_BY_VARIABLE),
-              task.getUpdatedBy());
-          variables.put("workflowDefinitionId", workflowDefinition.getId().toString());
-          if (workflowBinding.get().schema() != null
-              && workflowBinding.get().schema().getId() != null) {
-            variables.put("taskFormSchemaId", workflowBinding.get().schema().getId().toString());
-            variables.put("taskFormSchemaVersion", workflowBinding.get().schema().getVersion());
-          }
-
-          workflowHandler.triggerByKey(
-              getTriggerWorkflowId(workflowDefinition.getFullyQualifiedName()),
-              task.getId().toString(),
-              variables);
-          backfilled++;
-
-          // Incident workflows start at NewStage. Replay the test case's pre-upgrade resolution
-          // state (Ack/Assigned + assignee) onto the just-started instance so a migrated incident
-          // is not reset to New / No Owners.
-          if (task.getCategory() == TaskCategory.Incident) {
-            replayMigratedIncidentState(task);
+          // Replay is idempotent (no-ops once the task is at its recorded stage), so re-attempt it
+          // on every migration run until it succeeds. The workflowInstanceId guard above only skips
+          // the one-shot instance creation, not the state replay, so a transient replay failure is
+          // recoverable by re-running the migration.
+          if (task.getCategory() == TaskCategory.Incident && !replayMigratedIncidentState(task)) {
+            failedIncidentReplays++;
           }
         }
       } catch (Exception e) {
         LOG.error("Failed to backfill open tasks to workflow instances", e);
       }
+      if (failedIncidentReplays > 0) {
+        LOG.warn(
+            "{} migrated incident task(s) could not replay their pre-upgrade state; re-run the migration or remediate manually",
+            failedIncidentReplays);
+      }
       return backfilled;
     }
 
-    private void replayMigratedIncidentState(Task task) {
+    private boolean startWorkflowInstanceForTask(Task task) {
+      boolean started = false;
+      var workflowBinding =
+          TaskWorkflowLifecycleResolver.resolveBinding(
+              task.getType(), task.getCategory(), task.getPayload());
+      WorkflowDefinition workflowDefinition =
+          workflowBinding.isEmpty()
+              ? null
+              : workflowDefinitionRepository.findByNameOrNull(
+                  workflowBinding.get().workflowDefinitionRef(), Include.NON_DELETED);
+      if (workflowDefinition != null) {
+        Map<String, Object> variables = new LinkedHashMap<>();
+        variables.putAll(TaskWorkflowLifecycleResolver.buildWorkflowStartVariables(task));
+        variables.put(
+            getNamespacedVariableName(GLOBAL_NAMESPACE, RELATED_ENTITY_VARIABLE),
+            EntityUtil.buildEntityLink(
+                task.getAbout().getType(), task.getAbout().getFullyQualifiedName()));
+        variables.put(
+            getNamespacedVariableName(GLOBAL_NAMESPACE, UPDATED_BY_VARIABLE), task.getUpdatedBy());
+        variables.put("workflowDefinitionId", workflowDefinition.getId().toString());
+        if (workflowBinding.get().schema() != null
+            && workflowBinding.get().schema().getId() != null) {
+          variables.put("taskFormSchemaId", workflowBinding.get().schema().getId().toString());
+          variables.put("taskFormSchemaVersion", workflowBinding.get().schema().getVersion());
+        }
+        workflowHandler.triggerByKey(
+            getTriggerWorkflowId(workflowDefinition.getFullyQualifiedName()),
+            task.getId().toString(),
+            variables);
+        started = true;
+      }
+      return started;
+    }
+
+    private boolean replayMigratedIncidentState(Task task) {
+      boolean succeeded = true;
       try {
         TestCaseResolutionStatusRepository incidentRepository =
             (TestCaseResolutionStatusRepository)
@@ -2276,7 +2284,9 @@ public class MigrationUtil {
             "Failed to replay pre-migration incident state for task {}: {}",
             task.getId(),
             e.getMessage());
+        succeeded = false;
       }
+      return succeeded;
     }
 
     private int rewriteRecognizerFeedbackDataQualityReviewTasks() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -1653,7 +1653,7 @@ public class MigrationUtil {
     try {
       EntityReference reference = resolveUserReference(userName);
       if (reference != null) {
-        ref = (ObjectNode) JsonUtils.readTree(JsonUtils.pojoToJson(reference));
+        ref = (ObjectNode) JsonUtils.valueToTree(reference);
       }
     } catch (Exception e) {
       LOG.warn("Could not resolve a user reference for '{}': {}", userName, e.getMessage());
@@ -2316,9 +2316,8 @@ public class MigrationUtil {
 
     private UUID incidentStateIdFromPayload(Task task) {
       UUID stateId = null;
-      if (task.getPayload() != null) {
-        Map<String, Object> payload = JsonUtils.readOrConvertValue(task.getPayload(), Map.class);
-        Object rawId = payload == null ? null : payload.get("testCaseResolutionStatusId");
+      if (task.getPayload() instanceof Map<?, ?> payload) {
+        Object rawId = payload.get("testCaseResolutionStatusId");
         if (rawId != null) {
           stateId = UUID.fromString(rawId.toString());
         }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -96,6 +96,7 @@ public class MigrationUtil {
   private static final String RDF_INDEX_APP_NAME = "RdfIndexApp";
   private static final String RDF_OLD_DAILY_CRON = "0 0 * * *";
   private static final String RDF_WEEKLY_CRON = "0 0 * * 6";
+  private static final String ADMIN_USER_NAME = "admin";
 
   /**
    * Per-migration cache of {@code (entityType, entityId) -> resolved domains}. Many migrated tasks
@@ -1637,11 +1638,10 @@ public class MigrationUtil {
             "Unable to resolve user '{}', falling back to admin: {}", userName, e.getMessage());
       }
     }
-    return reference != null ? reference : resolveAdminReference();
-  }
-
-  private static EntityReference resolveAdminReference() {
-    return Entity.getEntityReferenceByName(Entity.USER, "admin", Include.ALL);
+    if (reference == null) {
+      reference = Entity.getEntityReferenceByName(Entity.USER, ADMIN_USER_NAME, Include.ALL);
+    }
+    return reference;
   }
 
   /**
@@ -1651,15 +1651,14 @@ public class MigrationUtil {
   private static ObjectNode buildUserRef(String userName) {
     ObjectNode ref = null;
     try {
-      ref = userRefToJson(resolveUserReference(userName));
+      EntityReference reference = resolveUserReference(userName);
+      if (reference != null) {
+        ref = (ObjectNode) JsonUtils.readTree(JsonUtils.pojoToJson(reference));
+      }
     } catch (Exception e) {
       LOG.warn("Could not resolve a user reference for '{}': {}", userName, e.getMessage());
     }
     return ref;
-  }
-
-  private static ObjectNode userRefToJson(EntityReference ref) {
-    return ref == null ? null : (ObjectNode) JsonUtils.readTree(JsonUtils.pojoToJson(ref));
   }
 
   /**
@@ -1909,7 +1908,6 @@ public class MigrationUtil {
 
   /** Task workflow cutover + recognizer feedback rewrite + mention-alert wiring for 2.0.0. */
   public static class TaskWorkflow {
-    private static final String ADMIN_USER_NAME = "admin";
     private static final String USER_APPROVAL_TASK_SUBTYPE = "userApprovalTask";
     private static final String RECOGNIZER_APPROVAL_TASK_SUBTYPE =
         "createRecognizerFeedbackApprovalTask";

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -2290,11 +2290,15 @@ public class MigrationUtil {
       boolean succeeded = true;
       try {
         String recordFQN = task.getAbout() == null ? null : task.getAbout().getFullyQualifiedName();
-        if (recordFQN != null) {
+        UUID stateId = incidentStateIdFromPayload(task);
+        if (recordFQN != null && stateId != null) {
           TestCaseResolutionStatusRepository incidentRepository =
               (TestCaseResolutionStatusRepository)
                   Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-          TestCaseResolutionStatus latest = incidentRepository.getLatestRecord(recordFQN);
+          // Key off the incident's own stateId, not the test case's global latest: the migration
+          // starts a fresh workflow that writes a newer "New" record for the same test case, which
+          // would otherwise mask the pre-upgrade Ack/Assigned state we need to replay.
+          TestCaseResolutionStatus latest = incidentRepository.getLatestRecordForStateId(stateId);
           if (latest != null
               && incidentRepository.applyLegacyStatusToIncidentTask(latest, recordFQN)) {
             LOG.info("Replayed pre-migration incident state onto task {}", task.getId());
@@ -2308,6 +2312,18 @@ public class MigrationUtil {
         succeeded = false;
       }
       return succeeded;
+    }
+
+    private UUID incidentStateIdFromPayload(Task task) {
+      UUID stateId = null;
+      if (task.getPayload() != null) {
+        Map<String, Object> payload = JsonUtils.readOrConvertValue(task.getPayload(), Map.class);
+        Object rawId = payload == null ? null : payload.get("testCaseResolutionStatusId");
+        if (rawId != null) {
+          stateId = UUID.fromString(rawId.toString());
+        }
+      }
+      return stateId;
     }
 
     private int rewriteRecognizerFeedbackDataQualityReviewTasks() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -46,6 +46,7 @@ import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
 import org.openmetadata.schema.governance.workflows.elements.EdgeDefinition;
 import org.openmetadata.schema.governance.workflows.elements.WorkflowNodeDefinitionInterface;
 import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
 import org.openmetadata.schema.type.ActivityEventType;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
@@ -2273,11 +2274,16 @@ public class MigrationUtil {
     private boolean replayMigratedIncidentState(Task task) {
       boolean succeeded = true;
       try {
-        TestCaseResolutionStatusRepository incidentRepository =
-            (TestCaseResolutionStatusRepository)
-                Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-        if (incidentRepository.reconcileIncidentTaskToLatestStatus(task)) {
-          LOG.info("Replayed pre-migration incident state onto task {}", task.getId());
+        String recordFQN = task.getAbout() == null ? null : task.getAbout().getFullyQualifiedName();
+        if (recordFQN != null) {
+          TestCaseResolutionStatusRepository incidentRepository =
+              (TestCaseResolutionStatusRepository)
+                  Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+          TestCaseResolutionStatus latest = incidentRepository.getLatestRecord(recordFQN);
+          if (latest != null
+              && incidentRepository.applyLegacyStatusToIncidentTask(latest, recordFQN)) {
+            LOG.info("Replayed pre-migration incident state onto task {}", task.getId());
+          }
         }
       } catch (Exception e) {
         LOG.warn(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -75,6 +75,7 @@ import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.PolicyRepository;
 import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.jdbi3.TaskRepository;
+import org.openmetadata.service.jdbi3.TestCaseResolutionStatusRepository;
 import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
 import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
@@ -752,10 +753,13 @@ public class MigrationUtil {
         String updatedBy =
             threadJson.has("updatedBy") ? threadJson.get("updatedBy").asText() : createdByName;
 
-        // Look up createdBy user ID from user_entity by name
-        String createdByUserId = lookupUserId(handle, createdByName);
-        if (createdByUserId != null) {
+        // Preserve the original requester: createdBy ref + createdById for the filter.
+        ObjectNode createdByRef = buildUserRef(createdByName);
+        String createdByUserId = null;
+        if (createdByRef != null && createdByRef.has("id")) {
+          createdByUserId = createdByRef.get("id").asText();
           taskJson.put("createdById", createdByUserId);
+          taskJson.set("createdBy", createdByRef);
         }
 
         taskJson.put("createdAt", createdAt);
@@ -763,8 +767,9 @@ public class MigrationUtil {
         taskJson.put("updatedBy", updatedBy);
         taskJson.put("deleted", false);
         taskJson.put("version", 0.1);
-        taskJson.set("comments", JsonUtils.getObjectNode().arrayNode());
-        taskJson.put("commentCount", 0);
+        // Migrate posts -> comments (per-post reactions ride along in taskComment.reactions).
+        // Task has no top-level reactions field, so thread-level reactions are not carried over.
+        migrateThreadPostsToComments(threadJson, taskJson);
         taskJson.set("tags", JsonUtils.getObjectNode().arrayNode());
 
         String umbrellaWorkflowInstanceId = umbrellaWorkflowInstanceIds.get(threadId);
@@ -772,12 +777,15 @@ public class MigrationUtil {
           taskJson.put("workflowInstanceId", umbrellaWorkflowInstanceId);
         }
 
-        // Set resolution details for closed tasks
+        // Resolution for closed tasks: keep resolvedBy from the legacy closedBy.
         if ("Closed".equals(oldStatus)) {
           ObjectNode resolution = JsonUtils.getObjectNode();
           resolution.put("type", newStatus.equals("Approved") ? "Approved" : "Completed");
           if (taskDetails.has("closedBy")) {
-            resolution.put("comment", "Migrated from thread-based task system");
+            ObjectNode resolvedBy = buildUserRef(taskDetails.get("closedBy").asText());
+            if (resolvedBy != null) {
+              resolution.set("resolvedBy", resolvedBy);
+            }
           }
           if (taskDetails.has("closedAt")) {
             resolution.put("resolvedAt", taskDetails.get("closedAt").asLong());
@@ -1614,6 +1622,78 @@ public class MigrationUtil {
   }
 
   /**
+   * Resolve a legacy username to a user {@link EntityReference}; shared by both migration paths.
+   * A soft-deleted user keeps its real id; anything unresolvable (hard-deleted / "system" / null)
+   * falls back to the admin user, never a fabricated id. Throws only if admin is also unresolvable.
+   */
+  static EntityReference resolveUserReference(String userName) {
+    if (nullOrEmpty(userName)) {
+      return resolveAdminReference();
+    }
+    try {
+      return Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
+    } catch (Exception e) {
+      LOG.debug("Unable to resolve user '{}', falling back to admin: {}", userName, e.getMessage());
+      return resolveAdminReference();
+    }
+  }
+
+  private static EntityReference resolveAdminReference() {
+    return Entity.getEntityReferenceByName(Entity.USER, "admin", Include.ALL);
+  }
+
+  /**
+   * JSON-shaped {@link #resolveUserReference} for the static path (which builds task JSON, not
+   * POJOs). Returns null only if even the admin fallback cannot be resolved.
+   */
+  private static ObjectNode buildUserRef(String userName) {
+    try {
+      return userRefToJson(resolveUserReference(userName));
+    } catch (Exception e) {
+      LOG.warn("Could not resolve a user reference for '{}': {}", userName, e.getMessage());
+      return null;
+    }
+  }
+
+  private static ObjectNode userRefToJson(EntityReference ref) {
+    return ref == null ? null : (ObjectNode) JsonUtils.readTree(JsonUtils.pojoToJson(ref));
+  }
+
+  /**
+   * Migrate a legacy thread's {@code posts[]} (user replies + resolve/close records) into the new
+   * task's {@code comments[]} so the task discussion history survives, and sets {@code commentCount}.
+   * Each post maps to a {@code taskComment} ({id, message, author, createdAt, reactions}). The author
+   * is resolved via {@link #buildUserRef} (soft-deleted users keep their real id; unresolvable ones
+   * fall back to the admin user) — never a synthetic id. A post is skipped only if even that fails.
+   */
+  private static void migrateThreadPostsToComments(JsonNode threadJson, ObjectNode taskJson) {
+    JsonNode posts = threadJson.get("posts");
+    ArrayNode comments = JsonUtils.getObjectNode().arrayNode();
+    if (posts != null && posts.isArray()) {
+      for (JsonNode post : posts) {
+        if (!post.has("message")) {
+          continue;
+        }
+        ObjectNode author = buildUserRef(post.path("from").asText(null));
+        if (author == null) {
+          continue;
+        }
+        ObjectNode comment = JsonUtils.getObjectNode();
+        comment.put("id", post.has("id") ? post.get("id").asText() : UUID.randomUUID().toString());
+        comment.put("message", post.get("message").asText());
+        comment.set("author", author);
+        comment.put("createdAt", post.has("postTs") ? post.get("postTs").asLong() : 0);
+        if (post.has("reactions") && post.get("reactions").isArray()) {
+          comment.set("reactions", post.get("reactions"));
+        }
+        comments.add(comment);
+      }
+    }
+    taskJson.set("comments", comments);
+    taskJson.put("commentCount", comments.size());
+  }
+
+  /**
    * Resolve the domains of the target entity referenced by the task's `about` field.
    * Equivalent to {@code TaskRepository.inheritDomainsFromTargetEntity()} but uses the
    * {@link EntityRepository} layer so inherited domains (e.g. a glossary term inheriting from
@@ -2169,11 +2249,34 @@ public class MigrationUtil {
               task.getId().toString(),
               variables);
           backfilled++;
+
+          // Incident workflows start at NewStage. Replay the test case's pre-upgrade resolution
+          // state (Ack/Assigned + assignee) onto the just-started instance so a migrated incident
+          // is not reset to New / No Owners.
+          if (task.getCategory() == TaskCategory.Incident) {
+            replayMigratedIncidentState(task);
+          }
         }
       } catch (Exception e) {
         LOG.error("Failed to backfill open tasks to workflow instances", e);
       }
       return backfilled;
+    }
+
+    private void replayMigratedIncidentState(Task task) {
+      try {
+        TestCaseResolutionStatusRepository incidentRepository =
+            (TestCaseResolutionStatusRepository)
+                Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
+        if (incidentRepository.backfillMigratedIncidentTaskStage(task)) {
+          LOG.info("Replayed pre-migration incident state onto task {}", task.getId());
+        }
+      } catch (Exception e) {
+        LOG.warn(
+            "Failed to replay pre-migration incident state for task {}: {}",
+            task.getId(),
+            e.getMessage());
+      }
     }
 
     private int rewriteRecognizerFeedbackDataQualityReviewTasks() {
@@ -2498,20 +2601,7 @@ public class MigrationUtil {
     }
 
     private EntityReference resolveUserReference(String userName) {
-      if (nullOrEmpty(userName)) {
-        return getAdminReference();
-      }
-
-      try {
-        return Entity.getEntityReferenceByName(Entity.USER, userName, Include.ALL);
-      } catch (Exception e) {
-        LOG.debug("Unable to resolve user '{}': {}", userName, e.getMessage());
-        return getAdminReference();
-      }
-    }
-
-    private EntityReference getAdminReference() {
-      return Entity.getEntityReferenceByName(Entity.USER, ADMIN_USER_NAME, Include.ALL);
+      return MigrationUtil.resolveUserReference(userName);
     }
 
     private void upsertTaskMigrationMapping(UUID oldThreadId, UUID newTaskId) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -2276,7 +2276,7 @@ public class MigrationUtil {
         TestCaseResolutionStatusRepository incidentRepository =
             (TestCaseResolutionStatusRepository)
                 Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
-        if (incidentRepository.backfillMigratedIncidentTaskStage(task)) {
+        if (incidentRepository.reconcileIncidentTaskToLatestStatus(task)) {
           LOG.info("Replayed pre-migration incident state onto task {}", task.getId());
         }
       } catch (Exception e) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java
@@ -1121,7 +1121,10 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             resolvedPayload,
             comment,
             userName);
-    return Response.ok(resolvedTask).build();
+    // Change-event header so resolve fires task alerts.
+    return Response.ok(resolvedTask)
+        .header(RestUtil.CHANGE_CUSTOM_HEADER, EventType.ENTITY_UPDATED.value())
+        .build();
   }
 
   private ListFilter buildTaskListFilter(
@@ -1294,7 +1297,10 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
     repository.checkPermissionsForResolveTask(authorizer, task, true, securityContext);
 
     Task closedTask = repository.closeTask(task, userName, comment);
-    return Response.ok(closedTask).build();
+    // Change-event header so close fires task alerts.
+    return Response.ok(closedTask)
+        .header(RestUtil.CHANGE_CUSTOM_HEADER, EventType.ENTITY_UPDATED.value())
+        .build();
   }
 
   @DELETE
@@ -1385,7 +1391,10 @@ public class TaskResource extends EntityResource<Task, TaskRepository> {
             null,
             null,
             userName);
-    return Response.ok(resolvedTask).build();
+    // Change-event header so resolve fires task alerts.
+    return Response.ok(resolvedTask)
+        .header(RestUtil.CHANGE_CUSTOM_HEADER, EventType.ENTITY_UPDATED.value())
+        .build();
   }
 
   // ========================= Bulk Operations Endpoint =========================


### PR DESCRIPTION
## Problem

On a `1.12.1 / 1.13 → 2.0` upgrade, the thread→task migration preserves the task rows and their type/status mapping, but drops several fields and resets incident state. On migrated (pre-existing) data:

- **Created By is blank** — the migration never carries the original requester onto the task.
- **Completed tasks lose their resolver** — `resolution.resolvedBy` is empty and the comment is a generic `"Migrated from thread-based task system"`.
- **Task comments are dropped** — the thread's posts (replies + resolve/close records) don't reach `task_entity.comments`.
- **Migrated incidents reset to New / No Owners** — the incident workflow restarts at `NewStage` and never replays the recorded `test_case_resolution_status` lifecycle, so a pre-upgrade Ack/Assigned incident loses its stage and assignee (and the stale state then makes the "Update Status" resolve fail).

New tasks/incidents created *in* 2.0 are unaffected — this is migration-only.

## Fix

`v200/MigrationUtil.java` — in the thread→task migration:
- set `createdBy` (entityReference) in addition to `createdById`;
- set `resolution.resolvedBy` from the legacy `closedBy` (the original close note now survives as a migrated comment, so the placeholder is dropped);
- migrate the thread's `posts[]` into task `comments[]` (+ `commentCount`), with per-post reactions riding along in `taskComment.reactions`.

> Note: `Task` has no top-level `reactions` field, so thread-level task reactions are intentionally not carried over (only per-comment reactions survive). Writing a top-level `reactions` field corrupts the row on read — see the dedicated fix below.

For incidents, after `backfillOpenTasksToWorkflowInstances` starts the workflow, replay the test case's latest resolution status onto the instance, reusing the existing runtime bridge (`resolveLegacyTransitionId` / `buildLegacyResolvedPayload`) so migration and runtime stay consistent. New public entry point: `TestCaseResolutionStatusRepository.backfillMigratedIncidentTaskStage`. Idempotent — no-ops when the task is already at the recorded stage.

Complementary to #29978 (which restores the `ASSIGNED_TO` / `MENTIONED_IN` relationships on Postgres); this PR restores the field- and incident-state fidelity that #29978 does not cover. This branch is merged up to current `main`, so it already includes #29978.

## Additional fix: task resolve/close change events (2.0 regression)

**Symptom (verified on 1.12.1→2.0, Postgres, in the `change_event` table):** in 1.12.1, resolving/closing a task emitted change events (`taskResolved`, `taskClosed` under `entityType=THREAD`), which drove webhook/email/Slack alerts. After the 2.0 task refactor, resolving/closing a migrated task produces **zero** change events — so task-resolution alerts silently stop working after upgrade.

**Origin — PR #25894 (Task redesign):** the pre-redesign feed endpoints returned via RestUtil's `.toResponse()` wrapper, which sets the `X-OpenMetadata-Change` header automatically — so `ChangeEventHandler` recorded a `taskResolved`/`taskClosed` event. PR #25894's new `TaskResource` `resolveTask`/`closeTask`/`suggestion-apply` endpoints return a bare `Response.ok(task).build()`, so no change event is recorded. The `add-comment` endpoint (header added in #29023) proves the mechanism is intended for tasks; resolve/close were simply missed.

**Fix:** set `RestUtil.CHANGE_CUSTOM_HEADER = ENTITY_UPDATED` on the resolve/close/suggestion-apply responses, restoring task lifecycle events (and thus alerting). `create` already fires `entityCreated` via the 201 path.

## Testing

- `openmetadata-service` compiles (full `mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → BUILD SUCCESS); spotless applied.
- **Reviewers:** please verify the incident replay end-to-end on a migrated instance — a test case that was Ack/Assigned before upgrade should come back at the same stage with its assignee, and "Update Status" should transition without error.

---

Re-raised from the same-repo branch because the fork-based PR is blocked by GitHub's new `pull_request_target` fork-checkout guard. Supersedes #30213 (identical diff).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves legacy task and incident state during the 2.0 migration. The main changes are:

- Migrates task creators, resolvers, comments, and per-comment reactions.
- Replays recorded incident stages after workflow instances are created.
- Retries incident replay on later migration runs after transient failures.
- Restores change events for task resolution, closure, and suggestion application.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Incident replay now runs independently of one-time workflow creation.
- Exceptions during replay remain visible and can be retried on a later migration run.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java | Exposes the existing legacy-status bridge so migration code can replay recorded incident stages. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java | Preserves legacy task metadata and retries incident-state replay independently of workflow creation. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/tasks/TaskResource.java | Adds entity-update headers to task lifecycle responses so change events are emitted. |

</details>

<sub>Reviews (8): Last reviewed commit: ["refactor: drop heavy JSON conversions in..."](https://github.com/open-metadata/openmetadata/commit/e590b952caa6ef2f94053f432df19af9c6aca829) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45675772)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->