### PR TITLE
ci(playwright): capture full server log + OpenSearch stats on E2E failure

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -483,6 +483,20 @@ jobs:
               > "$DIAGNOSTICS_DIR/docker-compose-ps.txt" 2>&1 || true
             docker compose -f docker/development/docker-compose-postgres.yml logs --no-color --tail 5000 \
               > "$DIAGNOSTICS_DIR/docker-compose.log" 2>&1 || true
+            # The tailed all-services log above only covers the last ~minute of the
+            # chatty server on a multi-hour shard, which misses the failing test's
+            # window. Capture the full server log (untailed) so index/search
+            # behavior at the time of the failure is available.
+            docker compose -f docker/development/docker-compose-postgres.yml \
+              logs --no-color --no-log-prefix openmetadata-server \
+              > "$DIAGNOSTICS_DIR/openmetadata-server-full.log" 2>&1 || true
+            # OpenSearch thread-pool rejected/completed counters are cumulative over
+            # the whole run, so they reveal write/refresh/search rejections even when
+            # they happened before the tail window.
+            curl -s "http://localhost:9200/_cat/thread_pool/write,refresh,search,search_throttled?v&h=node_name,name,active,queue,rejected,completed" \
+              > "$DIAGNOSTICS_DIR/opensearch-thread-pool.txt" 2>&1 || true
+            curl -s "http://localhost:9200/_cat/indices?v&h=index,health,status,docs.count,store.size,refresh.total,refresh.total_time,search.query_total&s=index" \
+              > "$DIAGNOSTICS_DIR/opensearch-indices.txt" 2>&1 || true
           fi
 
       - name: Upload failure diagnostics


### PR DESCRIPTION
### Describe your changes:

Follow-up to the failure-diagnostics step added in #30120.

That step dumps `docker compose logs --tail 5000` on failure. On a ~2h shard the OpenMetadata server is chatty enough that **5000 lines only covers the last ~1 minute** (the job-teardown window). I confirmed this on a real chart-test failure: the captured `docker-compose.log` server section spanned only `19:09–19:10` (teardown), while the failing test ran ~20 min earlier — so the index writes and search queries needed to debug it were truncated away. (OpenSearch's own log, being far less chatty, *did* span the whole run and showed it healthy — no rejections/OOM/GC — which is why the **server** log is the missing piece.)

This adds, alongside the existing tailed all-services log:
- the **full (untailed) `openmetadata-server` log**, and
- OpenSearch `_cat/thread_pool` (cumulative `rejected`/`completed` counters for write/refresh/search — these survive the tail window and reveal any rejections over the whole run) and `_cat/indices` (per-index `docs.count` + refresh stats).

This makes the recurring chart custom-property E2E flakiness — where the server log is exactly what's missing — diagnosable on the next failure.

### Type of change:
- [x] Chore / CI

### Tests:

CI-only change (adds artifacts on `failure()`); no product code touched.

### Checklist:
- [x] I have read the **CONTRIBUTING** document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR expands failure diagnostics for PostgreSQL Playwright runs. The main changes are:

- Captures the complete `openmetadata-server` log.
- Records OpenSearch thread-pool counters.
- Records per-index OpenSearch statistics.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The workflow looks mergeable after hardening the full-log capture against runner disk exhaustion.

- Service names, OpenSearch connectivity, step ordering, and artifact paths match the existing workflow configuration.
- The full server log has no size bound and can consume the disk needed by later diagnostics and artifact upload.

.github/workflows/playwright-postgresql-e2e.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Adds full server logs and OpenSearch statistics to failure artifacts, with a possible runner-disk risk from the unbounded log copy. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): capture full server log ..."](https://github.com/open-metadata/openmetadata/commit/5bce32631ac0ec576fa9051f41a322dce919d6b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45731548)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->