### PR TITLE
test(search): make ranking tokens collision-free and stop swallowing poll errors (1.13)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntityRankingSeeders.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntityRankingSeeders.java
@@ -128,12 +128,12 @@ final class EntityRankingSeeders {
           new CreateTable()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withDatabaseSchema(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withColumns(
                   List.of(
                       new Column()
-                          .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                          .withName(EntitySeeder.distinctiveFor(token, placement))
                           .withDataType(ColumnDataType.VARCHAR)
                           .withDataLength(64)));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
@@ -186,8 +186,8 @@ final class EntityRankingSeeders {
           new CreateDashboard()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement));
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement));
       if (placement == Placement.DISTINCTIVE) {
         create.withCharts(List.of(createChart(client, ns, parent, token, placement)));
       }
@@ -206,7 +206,7 @@ final class EntityRankingSeeders {
         Placement placement) {
       CreateChart createChart =
           new CreateChart()
-              .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+              .withName(EntitySeeder.distinctiveFor(token, placement))
               .withService(service)
               .withChartType(ChartType.Other);
       return client.charts().create(createChart).getFullyQualifiedName();
@@ -254,15 +254,15 @@ final class EntityRankingSeeders {
               .withSchemaFields(
                   List.of(
                       new Field()
-                          .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                          .withName(EntitySeeder.distinctiveFor(token, placement))
                           .withDataType(FieldDataType.STRING)));
       CreateTopic create =
           new CreateTopic()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
               .withPartitions(1)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withMessageSchema(schema);
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
@@ -313,10 +313,10 @@ final class EntityRankingSeeders {
           new CreatePipeline()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withTasks(
-                  List.of(new Task().withName(EntitySeeder.distinctiveFor(ns, token, placement))));
+                  List.of(new Task().withName(EntitySeeder.distinctiveFor(token, placement))));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
         create.withTags(tags);
@@ -366,12 +366,12 @@ final class EntityRankingSeeders {
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
               .withAlgorithm("regression")
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withMlFeatures(
                   List.of(
                       new MlFeature()
-                          .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                          .withName(EntitySeeder.distinctiveFor(token, placement))
                           .withDataType(MlFeatureDataType.Numerical)));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
@@ -421,14 +421,14 @@ final class EntityRankingSeeders {
           new CreateContainer()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withDataModel(
                   new ContainerDataModel()
                       .withColumns(
                           List.of(
                               new Column()
-                                  .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                                  .withName(EntitySeeder.distinctiveFor(token, placement))
                                   .withDataType(ColumnDataType.VARCHAR)
                                   .withDataLength(64))));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
@@ -483,13 +483,13 @@ final class EntityRankingSeeders {
           new CreateDashboardDataModel()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withDataModelType(DataModelType.LookMlView)
               .withColumns(
                   List.of(
                       new Column()
-                          .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                          .withName(EntitySeeder.distinctiveFor(token, placement))
                           .withDataType(ColumnDataType.VARCHAR)
                           .withDataLength(64)));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
@@ -533,10 +533,10 @@ final class EntityRankingSeeders {
       CreateQuery create =
           new CreateQuery()
               .withName(EntitySeeder.nameFor(ns, token, placement))
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withService(parent)
-              .withQuery("SELECT " + EntitySeeder.distinctiveFor(ns, token, placement) + " FROM t");
+              .withQuery("SELECT " + EntitySeeder.distinctiveFor(token, placement) + " FROM t");
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
         create.withTags(tags);
@@ -573,8 +573,8 @@ final class EntityRankingSeeders {
           new CreateStoredProcedure()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withDatabaseSchema(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withStoredProcedureCode(
                   new StoredProcedureCode()
                       .withLanguage(StoredProcedureLanguage.SQL)
@@ -620,12 +620,12 @@ final class EntityRankingSeeders {
           new CreateSearchIndex()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withFields(
                   List.of(
                       new SearchIndexField()
-                          .withName(RankingSupport.uniqueTerm(ns))
+                          .withName(RankingSupport.uniqueTerm())
                           .withDataType(SearchIndexDataType.TEXT)));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
@@ -672,9 +672,9 @@ final class EntityRankingSeeders {
           new CreateGlossaryTerm()
               .withGlossary(parent)
               .withName(EntitySeeder.nameFor(ns, token, placement))
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
-              .withSynonyms(List.of(EntitySeeder.distinctiveFor(ns, token, placement)));
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
+              .withSynonyms(List.of(EntitySeeder.distinctiveFor(token, placement)));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
         create.withTags(tags);
@@ -711,8 +711,8 @@ final class EntityRankingSeeders {
       CreateMetric create =
           new CreateMetric()
               .withName(EntitySeeder.nameFor(ns, token, placement))
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement));
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
         create.withTags(tags);
@@ -763,14 +763,14 @@ final class EntityRankingSeeders {
           new CreateAPIEndpoint()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withApiCollection(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
               .withRequestSchema(
                   new APISchema()
                       .withSchemaFields(
                           List.of(
                               new Field()
-                                  .withName(EntitySeeder.distinctiveFor(ns, token, placement))
+                                  .withName(EntitySeeder.distinctiveFor(token, placement))
                                   .withDataType(FieldDataType.STRING))));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
@@ -818,9 +818,9 @@ final class EntityRankingSeeders {
           new CreateDirectory()
               .withName(EntitySeeder.nameFor(ns, token, placement))
               .withService(parent)
-              .withDisplayName(EntitySeeder.displayNameFor(ns, token, placement))
-              .withDescription(EntitySeeder.descriptionFor(ns, token, placement))
-              .withPath("/" + EntitySeeder.distinctiveFor(ns, token, placement));
+              .withDisplayName(EntitySeeder.displayNameFor(token, placement))
+              .withDescription(EntitySeeder.descriptionFor(token, placement))
+              .withPath("/" + EntitySeeder.distinctiveFor(token, placement));
       List<TagLabel> tags = EntitySeeder.tierTags(tier1);
       if (tags != null) {
         create.withTags(tags);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntitySeeder.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntitySeeder.java
@@ -62,27 +62,27 @@ interface EntitySeeder {
 
   /** Unique entity name; the token is the leading clean sub-token only for {@code NAME}. */
   static String nameFor(TestNamespace ns, String token, Placement placement) {
-    String lead = placement == Placement.NAME ? token : RankingSupport.uniqueTerm(ns);
+    String lead = placement == Placement.NAME ? token : RankingSupport.uniqueTerm();
     return ns.prefix(lead + "-" + ns.uniqueShortId());
   }
 
-  static String displayNameFor(TestNamespace ns, String token, Placement placement) {
+  static String displayNameFor(String token, Placement placement) {
     return switch (placement) {
       case DISPLAY_NAME_EXACT -> token;
       case DISPLAY_NAME_PHRASE -> token + " reporting warehouse";
-      default -> "gd " + RankingSupport.uniqueTerm(ns);
+      default -> "gd " + RankingSupport.uniqueTerm();
     };
   }
 
-  static String descriptionFor(TestNamespace ns, String token, Placement placement) {
+  static String descriptionFor(String token, Placement placement) {
     return placement == Placement.DESCRIPTION
         ? "this asset mentions " + token + " once in prose"
-        : "generic description body " + RankingSupport.uniqueTerm(ns);
+        : "generic description body " + RankingSupport.uniqueTerm();
   }
 
   /** The token to write into the distinctive nested field, or a generic value for other placements. */
-  static String distinctiveFor(TestNamespace ns, String token, Placement placement) {
-    return placement == Placement.DISTINCTIVE ? token : "generic_" + RankingSupport.uniqueTerm(ns);
+  static String distinctiveFor(String token, Placement placement) {
+    return placement == Placement.DISTINCTIVE ? token : "generic_" + RankingSupport.uniqueTerm();
   }
 
   static List<TagLabel> tierTags(boolean tier1) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupport.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupport.java
@@ -6,7 +6,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
 import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
@@ -31,6 +33,8 @@ final class RankingSupport {
 
   static final String TIER1_TAG = "Tier.Tier1";
   private static final Duration INDEX_WAIT = Duration.ofSeconds(30);
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+  private static final int TERM_HEX_LENGTH = 16;
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   /** A hit's name + fqn + score — enough to assert relative ranking. */
@@ -87,18 +91,48 @@ final class RankingSupport {
     return new SearchResult(hits);
   }
 
-  /** Poll (never sleep) until {@code condition} holds; returns {@code false} on timeout. */
-  static boolean awaitTrue(Callable<Boolean> condition) {
+  /**
+   * Poll (never sleep) until {@code condition} holds. Returns {@code null} once satisfied, or a
+   * description of why it never became true.
+   *
+   * <p>Transient errors while a document is still being indexed are expected, so polling keeps
+   * tolerating them — but the last one is retained and reported. Without that, a condition failing
+   * on every single poll (a 4xx, a bad index name, a deserialization error) is indistinguishable
+   * from genuine indexing lag: both surface only as "not indexed in time".
+   */
+  static String awaitOrReason(Callable<Boolean> condition) {
+    AtomicReference<Exception> lastError = new AtomicReference<>();
+    String reason = null;
     try {
       Awaitility.await()
           .atMost(INDEX_WAIT)
-          .pollInterval(Duration.ofMillis(500))
+          .pollInterval(POLL_INTERVAL)
           .ignoreExceptions()
-          .until(condition);
-      return true;
+          .until(() -> evaluate(condition, lastError));
     } catch (ConditionTimeoutException timeout) {
-      return false;
+      reason = describeTimeout(lastError.get());
     }
+    return reason;
+  }
+
+  private static boolean evaluate(Callable<Boolean> condition, AtomicReference<Exception> lastError)
+      throws Exception {
+    boolean satisfied;
+    try {
+      satisfied = Boolean.TRUE.equals(condition.call());
+    } catch (Exception pollFailure) {
+      lastError.set(pollFailure);
+      throw pollFailure;
+    }
+    return satisfied;
+  }
+
+  private static String describeTimeout(Exception lastError) {
+    String reason = "not satisfied within " + INDEX_WAIT;
+    if (lastError != null) {
+      reason = reason + "; last error: " + lastError;
+    }
+    return reason;
   }
 
   /** Create a database service + database + schema and return the schema FQN entities hang off. */
@@ -107,13 +141,20 @@ final class RankingSupport {
   }
 
   /**
-   * A unique, <b>hex-free</b> search term (letters g–v). OpenMetadata embeds a hex run-id in every
-   * entity name, so a hex query token ngram-matches those names and adds variable text score that
-   * breaks controlled score-ties. Mapping each hex digit into g–v yields a token that cannot collide
-   * with the hex names, keeping the text match exactly equal across seeded entities.
+   * A unique, <b>hex-free</b> search term (letters g–v), drawn from its own full-entropy source.
+   *
+   * <p>The token must avoid two different collisions, and needs both to keep a scored tie exact.
+   * OpenMetadata embeds a hex run-id in every entity name, so a hex token ngram-matches those names
+   * — hence the g–v mapping. The token must equally not collide with the <em>other</em> tokens
+   * minted for the same test, which is why the entropy is drawn here rather than from {@link
+   * TestNamespace#uniqueShortId()}: that varies only in its last 4 of 16 characters, so tokens
+   * derived from it shared a 14-character prefix. Seeders place a sibling token in every entity
+   * name, so that shared prefix leaked a variable {@code name.ngram} / {@code displayName.ngram}
+   * contribution into scores the ranking cases require to be exactly tied — measured at a ~12%
+   * inversion rate on the tier-boost tie case.
    */
-  static String uniqueTerm(TestNamespace ns) {
-    String hex = ns.uniqueShortId();
+  static String uniqueTerm() {
+    String hex = UUID.randomUUID().toString().replace("-", "").substring(0, TERM_HEX_LENGTH);
     StringBuilder term = new StringBuilder("zz");
     for (int i = 0; i < hex.length(); i++) {
       term.append((char) ('g' + Character.digit(hex.charAt(i), 16)));

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupportTest.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupportTest.java
@@ -1,0 +1,65 @@
+package org.openmetadata.it.tests.search;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the two collision properties {@link RankingSupport#uniqueTerm()} must hold for the ranking
+ * suite's controlled score-ties to stay exactly tied. Both have been broken before: first by hex
+ * tokens matching the run-id in entity names, then by tokens derived from {@code
+ * TestNamespace.uniqueShortId()}, which varies only in its last 4 of 16 characters and so shared a
+ * 14-character prefix with every sibling token in the same test.
+ *
+ * <p>Either collision leaks a variable {@code *.ngram} contribution into scores the ranking cases
+ * require to be equal, which silently inverts the tier-boost tie case.
+ */
+class RankingSupportTest {
+
+  private static final int SAMPLE_SIZE = 200;
+  private static final int MAX_SHARED_PREFIX = 8;
+
+  @Test
+  void uniqueTerm_containsNoHexCharacters() {
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      String term = RankingSupport.uniqueTerm();
+      assertTrue(
+          term.chars().noneMatch(character -> Character.digit(character, 16) >= 0),
+          "token must be hex-free or it ngram-matches the run-id in entity names: " + term);
+    }
+  }
+
+  @Test
+  void uniqueTerm_doesNotShareLongPrefixBetweenCalls() {
+    List<String> terms = new ArrayList<>();
+    for (int i = 0; i < SAMPLE_SIZE; i++) {
+      terms.add(RankingSupport.uniqueTerm());
+    }
+    for (int i = 0; i < terms.size(); i++) {
+      for (int j = i + 1; j < terms.size(); j++) {
+        int shared = sharedPrefixLength(terms.get(i), terms.get(j));
+        assertTrue(
+            shared <= MAX_SHARED_PREFIX,
+            "sibling tokens must not share a long prefix or they ngram-match each other: "
+                + terms.get(i)
+                + " / "
+                + terms.get(j)
+                + " share "
+                + shared
+                + " characters");
+      }
+    }
+  }
+
+  private static int sharedPrefixLength(String left, String right) {
+    int shared = 0;
+    while (shared < left.length()
+        && shared < right.length()
+        && left.charAt(shared) == right.charAt(shared)) {
+      shared++;
+    }
+    return shared;
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchEntityRankingIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchEntityRankingIT.java
@@ -107,17 +107,17 @@ class SearchEntityRankingIT {
       String parent,
       Case testCase,
       List<String> failures) {
-    String term = RankingSupport.uniqueTerm(ns);
+    String term = RankingSupport.uniqueTerm();
     String high = seeder.seed(client, ns, parent, term, testCase.high(), testCase.tierHigh());
     String low = seeder.seed(client, ns, parent, term, testCase.low(), testCase.tierLow());
-    boolean bothIndexed =
-        RankingSupport.awaitTrue(
+    String notIndexed =
+        RankingSupport.awaitOrReason(
             () -> {
               SearchResult polled = RankingSupport.search(client, seeder.index(), term);
               return polled.contains(high) && polled.contains(low);
             });
-    if (!bothIndexed) {
-      failures.add(testCase.label() + ": both documents were not indexed in time");
+    if (notIndexed != null) {
+      failures.add(testCase.label() + ": both documents were not indexed — " + notIndexed);
       return;
     }
     SearchResult result = RankingSupport.search(client, seeder.index(), term);
@@ -148,16 +148,18 @@ class SearchEntityRankingIT {
       EntitySeeder seeder,
       String parent,
       List<String> failures) {
-    String term = RankingSupport.uniqueTerm(ns);
+    String term = RankingSupport.uniqueTerm();
     String name = seeder.seed(client, ns, parent, term, Placement.DISTINCTIVE, false);
-    boolean found =
-        RankingSupport.awaitTrue(
+    String notFound =
+        RankingSupport.awaitOrReason(
             () -> RankingSupport.search(client, seeder.index(), term).contains(name));
-    if (!found) {
+    if (notFound != null) {
       failures.add(
           "distinctive field: ["
               + name
-              + "] not found by its nested-field token -> "
+              + "] not found by its nested-field token ("
+              + notFound
+              + ") -> "
               + RankingSupport.search(client, seeder.index(), term).names());
     }
   }


### PR DESCRIPTION
### Describe your changes:

Full fix for the `SearchEntityRankingIT` ranking failures on `1.13`. Keeps both parts: the collision-free token change **and** the `awaitOrReason` poll-error surfacing.

> **Note:** on `main` the token-collision half was superseded by #30120 (`tokenFreeValue`, a disjoint-alphabet filler), so the `main` PR #30250 was narrowed to just `awaitOrReason`. **#30120 is not on `1.13`**, so this branch still needs the token fix — hence it carries the full change, standalone rather than a cherry-pick of #30250.

**1.13 is where this actually bites.** Main is green today only because its post-#29903 Tier1 boost of `0.5` sits above the noise ceiling; 1.13 ships `0.05`, which sits inside it, so the tie case inverts at a measured ~12% rate per entity type. This is the fix for the `SearchEntityRankingIT` ranking failures on the 1.13 CI runs.

---

`SearchEntityRankingIT`'s **"Tier1 > untagged on a text tie"** case seeds two documents with an identical `displayName` so their text scores are equal, then asserts the `Tier.Tier1` global term boost breaks the tie. **The tie was never actually exact.**

`RankingSupport.uniqueTerm()` derived its token from `TestNamespace.uniqueShortId()`, which is `RUN_ID.substring(0,8)` + `methodHash` + 4 random chars — only **4 of 16 characters vary within a test method**. Every token minted for one test therefore shared a 14-character prefix, and `EntitySeeder.nameFor()` places a *sibling* token in each entity's name, so the query ngram-matched both documents' names by differing amounts. That leaked a variable `name.ngram` / `displayName.ngram` contribution into scores the case requires to be equal.

The signature is visible in the failing output — three documents in a result set where the case seeded two:

```
zzorhlgutmhtng|hhok      <- 14-char shared prefix, 4 random chars
zzorhlgutmhtng|ojpl
zzorhlgutmhtng|sukm      <- bleed from an earlier case in the same method
```

`explain=true` confirms the text-match components are byte-identical on both documents (`displayName.keyword` 21.5011, `displayName` 8.0629) — the entire delta comes from the ngram subqueries.

**Why main is green today and 1.13 is not.** The noise ratio is bounded around 1.17, because the ngram terms sit in the `max plus 0.3 times others` bucket while `displayName.keyword` dominates at boost 26.4. Main's post-#29903 Tier1 boost of `0.5` (1.5x) sits above that ceiling; 1.13 ships `0.05` (1.05x), which sits inside it. **The defect is present on main too — just out of range.** Measured on a live 1.13.1 server, varying only the boost:

| Tier1 boost | inversions |
|---|---|
| `0.05` (1.13 ships) | **3/25** |
| `0.5` (main ships, post-#29903) | 0/25 |

Drawing the token from its own full-entropy source removes the overlap at source rather than relying on a boost margin to outweigh it.

**Also: stop swallowing poll errors.** `awaitTrue` reported every timeout as a flat "not indexed in time". `ignoreExceptions()` is correct while polling a document that is still being indexed, but discarding the exception made a condition that threw on *every* poll indistinguishable from genuine indexing lag. `awaitOrReason()` keeps the tolerance and reports the last error alongside the timeout, so real failures identify themselves instead of hiding behind a generic message.

#### How I tested

- `RankingSupportTest` covers both collision properties (hex-free, and no long shared prefix between sibling tokens). **Negative control:** patched `uniqueTerm` back to the old scheme and the test fails with `share 14 characters` — matching the CI signature exactly.
- End-to-end against a live 1.13.1 server at 1.13's shipped `0.05` boost: **3/25 inversions before the fix, 0/25 after.** The fix stands on its own and does not depend on backporting #29903.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes ranking-token overlap and improves search polling diagnostics. The main changes are:

- Generate independent, hex-free ranking terms from UUIDs.
- Update entity seeders to use the new token helper.
- Preserve the last polling exception in timeout messages.
- Add tests for token alphabet and shared prefixes.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The token changes look sound, but the new test file can fail repository checks and contains a nondeterministic assertion.

- Namespace cleanup remains tied to tracked entities rather than search tokens.
- The UUID mapping removes the shared-prefix and hexadecimal overlap that affected ranking scores.
- The new source file is missing its required license header.
- Poll diagnostics retain the wrapper exception but omit its nested cause.

openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupportTest.java and openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupport.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupport.java | Adds independent ranking tokens and retains polling exceptions, but the timeout text omits nested cause details. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntitySeeder.java | Updates generated field values to use independent tokens while preserving namespace-prefixed entity names. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/EntityRankingSeeders.java | Updates all entity-specific seeders to the revised helper signatures. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/RankingSupportTest.java | Adds token regression tests but lacks the required source header and includes a probabilistic assertion. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/SearchEntityRankingIT.java | Uses independent terms and includes polling timeout reasons in accumulated ranking failures. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(search): make ranking tokens collis..."](https://github.com/open-metadata/openmetadata/commit/959f08562369d2f30a010ecfd67fd732aa8d4d3e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45735171)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->
