### PR TITLE
MINOR - Fix CI on fork

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -89,7 +89,6 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -114,8 +113,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -134,7 +132,7 @@ jobs:
       - name: Build and Bundle Integration Test Runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          SOURCE_SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           project_version="$(mvn --quiet --non-recursive help:evaluate \
             -Dexpression=project.version -DforceStdout -Dstyle.color=never)"
@@ -219,8 +217,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -89,6 +89,7 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -114,6 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -218,6 +220,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -104,6 +104,7 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -131,6 +132,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -235,6 +237,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -104,7 +104,6 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -131,8 +130,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -151,7 +149,7 @@ jobs:
       - name: Build and Bundle Integration Test Runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          SOURCE_SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           project_version="$(mvn --quiet --non-recursive help:evaluate \
             -Dexpression=project.version -DforceStdout -Dstyle.color=never)"
@@ -236,8 +234,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -89,7 +89,6 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -114,8 +113,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -134,7 +132,7 @@ jobs:
       - name: Build and Bundle Integration Test Runtime
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SOURCE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          SOURCE_SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           project_version="$(mvn --quiet --non-recursive help:evaluate \
             -Dexpression=project.version -DforceStdout -Dstyle.color=never)"
@@ -219,8 +217,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -89,6 +89,7 @@ jobs:
     name: Build Integration Test Runtime
     needs: changes
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     timeout-minutes: 60
     if: ${{ needs.changes.outputs.backend == 'true' }}
     steps:
@@ -114,6 +115,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4
@@ -218,6 +220,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven dependencies
         uses: actions/cache@v4

--- a/.github/workflows/playwright-integration-tests-mysql.yml
+++ b/.github/workflows/playwright-integration-tests-mysql.yml
@@ -14,6 +14,7 @@
 
 name: MySQL Playwright Integration Tests
 on:
+  merge_group:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
 
@@ -70,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
       - name: Cache Maven Dependencies
         id: cache-output
         uses: actions/cache@v4

--- a/.github/workflows/playwright-integration-tests-postgres.yml
+++ b/.github/workflows/playwright-integration-tests-postgres.yml
@@ -14,6 +14,7 @@
 
 name: Postgres Playwright Integration Tests
 on:
+  merge_group:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, ready_for_review]
 
@@ -70,7 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
       - name: Cache Maven Dependencies
         id: cache-output
         uses: actions/cache@v4

--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -43,7 +43,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'playwright-ci-mysql (ignored label)' || 'playwright-ci-mysql' }}
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    environment: test
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || 'test' }}
     permissions:
       contents: read
       pull-requests: read
@@ -98,6 +98,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Detect ingestion-only changes
         id: changes

--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -14,6 +14,7 @@
 
 name: MySQL PR Playwright E2E Tests
 on:
+  merge_group:
   workflow_dispatch:
   pull_request_target:
     types:
@@ -43,7 +44,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'playwright-ci-mysql (ignored label)' || 'playwright-ci-mysql' }}
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || 'test' }}
+    environment: test
     permissions:
       contents: read
       pull-requests: read
@@ -97,8 +98,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Detect ingestion-only changes
         id: changes

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -81,7 +81,6 @@ jobs:
   build:
     needs: check-changes
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     if: |
       !github.event.pull_request.draft &&
       (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' ||
@@ -115,8 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Setup JDK 21
         uses: actions/setup-java@v4
@@ -246,8 +244,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Download Maven build artifact
         id: download-build
@@ -535,7 +532,7 @@ jobs:
         env:
           EXPECTED_MATRIX: ${{ needs.detect-changes.outputs.matrix }}
           MATRIX_OUTCOME: ${{ needs.playwright-ci-postgresql.result }}
-          SOURCE_SHA: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          SOURCE_SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           python3 .github/scripts/classify_playwright_outcome.py \
             --report-glob 'results/playwright-results-json-*/results.json' \

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -81,6 +81,7 @@ jobs:
   build:
     needs: check-changes
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     if: |
       !github.event.pull_request.draft &&
       (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' ||
@@ -115,6 +116,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup JDK 21
         uses: actions/setup-java@v4
@@ -245,6 +247,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Download Maven build artifact
         id: download-build

--- a/.github/workflows/playwright-sso-tests.yml
+++ b/.github/workflows/playwright-sso-tests.yml
@@ -26,6 +26,7 @@
 name: SSO Playwright E2E Tests
 
 on:
+  merge_group:
   pull_request_target:
     types:
       - labeled
@@ -78,7 +79,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'sso-auth-tests (ignored label)' || 'sso-auth-tests' }}
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || 'test' }}
+    environment: test
 
     strategy:
       fail-fast: false
@@ -124,8 +125,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Cache Maven Dependencies
         id: cache-output
@@ -297,7 +297,7 @@ jobs:
         continue-on-error: true
         env:
           MATRIX_OUTCOME: ${{ needs.sso-auth-tests.result }}
-          SOURCE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          SOURCE_SHA: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
         run: |
           python3 .github/scripts/classify_playwright_outcome.py \
             --report-glob 'results/sso-results-json-*/sso-results.json' \

--- a/.github/workflows/playwright-sso-tests.yml
+++ b/.github/workflows/playwright-sso-tests.yml
@@ -78,7 +78,7 @@ jobs:
     name: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'sso-auth-tests (ignored label)' || 'sso-auth-tests' }}
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    environment: test
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || 'test' }}
 
     strategy:
       fail-fast: false
@@ -125,6 +125,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Cache Maven Dependencies
         id: cache-output

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -87,7 +87,6 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -124,8 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Use runner data disk for Docker
         if: matrix.shard.name == 'shard-2'

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -87,6 +87,7 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -124,6 +125,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Use runner data disk for Docker
         if: matrix.shard.name == 'shard-2'

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -97,6 +97,7 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +107,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -179,6 +181,7 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
+    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -216,6 +219,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Use runner data disk for Docker
         if: matrix.shard.name == 'shard-2'
@@ -385,6 +389,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
           filter: blob:none
 

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -97,7 +97,6 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,8 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Setup Openmetadata Test Environment
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -181,7 +179,6 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    environment: ${{ github.event.pull_request.head.repo.fork && 'fork-pr-ci' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -218,8 +215,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
 
       - name: Use runner data disk for Docker
         if: matrix.shard.name == 'shard-2'
@@ -388,8 +384,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha || github.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'merge_group' && github.sha || github.event.pull_request.head.sha }}
           fetch-depth: 0
           filter: blob:none
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
remove `merge_commit_sha` to allow fork PR to run checks. Instead rely on merge queue to test the changes against the latest from main. This prevents triggering the checkout guards

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **CI configuration:**
    - Updated `actions/checkout` ref logic across multiple workflow files to support GitHub merge groups.
    - Synchronized `SOURCE_SHA` environment variable to ensure consistency with the checkout ref in build steps.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates CI revision selection and expands merge-queue coverage. The main changes are:

- Checkout pull-request head commits instead of synthetic merge commits.
- Use merge-group SHAs for queued revisions.
- Add merge-group triggers to several Playwright workflows.
- Align reported source SHAs with the selected checkout.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Existing push and manual CI paths can receive empty revision values and need fixes before merging.

- Merge-group events select the intended queue SHA.
- Push events in the integration workflows lose both checkout and artifact SHAs.
- Manual runs across several workflows lose their checkout ref.

The changed integration, Playwright, and Python workflows that use the two-branch SHA expression.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-tests-mysql-elasticsearch.yml | The new SHA expression works for PR and merge-group events but becomes empty on push and manual runs. |
| .github/workflows/integration-tests-postgres-elasticsearch-redis.yml | The checkout and artifact source SHA become empty on existing push and manual triggers. |
| .github/workflows/integration-tests-postgres-opensearch.yml | The checkout and artifact source SHA become empty on existing push and manual triggers. |
| .github/workflows/playwright-mysql-e2e.yml | Merge-group checkout is supported, but manual dispatch no longer supplies a valid ref. |
| .github/workflows/playwright-postgresql-e2e.yml | The changed checkout works for PR and merge-group events but not manual dispatch. |
| .github/workflows/playwright-sso-tests.yml | Merge-group support is added, while manual dispatch can produce empty checkout and reporting SHAs. |
| .github/workflows/py-tests.yml | The changed checkout expressions do not preserve a valid SHA for manual runs. |
| .github/workflows/py-tests-postgres.yml | The changed checkout expression does not preserve a valid SHA for manual runs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: reverted checkout + enabled merge g..."](https://github.com/open-metadata/openmetadata/commit/2661091621d318666f0af4965f4a7c8f406d876f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45786145)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->