### PR TITLE
fix: mysql client build fix

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get -qq update \
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget -> tracked; upstream fix pending, no-op until Debian ships it).
   # --only-upgrade is a no-op for packages not present in the base image.
-  # Upgrade libmariadb3 together with the mysqlclient dev packages that
+  # Upgrade libmariadb3 together with the mysqlclient dev packages that,
   # exact-pin it, so apt keeps them consistent instead of removing
   # libmariadb-dev / default-libmysqlclient-dev (which drops pkg-config's
   # .pc files and breaks the mysqlclient source build later).

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get -qq update \
   libkrb5-dev \
   default-jre-headless \
   openssl \
+  pkg-config \
   # To ensure compatibility with unixodbc package
   odbcinst=2.3.11-2+deb12u1 \
   postgresql \
@@ -48,10 +49,15 @@ RUN apt-get -qq update \
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget -> tracked; upstream fix pending, no-op until Debian ships it).
   # --only-upgrade is a no-op for packages not present in the base image.
+  # Upgrade libmariadb3 together with the mysqlclient dev packages that
+  # exact-pin it, so apt keeps them consistent instead of removing
+  # libmariadb-dev / default-libmysqlclient-dev (which drops pkg-config's
+  # .pc files and breaks the mysqlclient source build later).
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+       libmariadb-dev default-libmysqlclient-dev \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -29,6 +29,7 @@ RUN dpkg --configure -a \
   libkrb5-dev \
   default-jre-headless \
   openssl \
+  pkg-config \
   # To ensure compatibility with unixodbc package
   odbcinst=2.3.11-2+deb12u1 \
   postgresql \
@@ -47,10 +48,15 @@ RUN dpkg --configure -a \
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
   # wget -> tracked; upstream fix pending, no-op until Debian ships it).
   # --only-upgrade is a no-op for packages not present in the base image.
+  # Upgrade libmariadb3 together with the mysqlclient dev packages that
+  # exact-pin it, so apt keeps them consistent instead of removing
+  # libmariadb-dev / default-libmysqlclient-dev (which drops pkg-config's
+  # .pc files and breaks the mysqlclient source build later).
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+       libmariadb-dev default-libmysqlclient-dev \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN dpkg --configure -a \
     libkrb5-dev \
     default-jre-headless \
     openssl \
+    pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
     postgresql \
@@ -51,10 +52,15 @@ RUN dpkg --configure -a \
     # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
     # wget -> tracked; upstream fix pending, no-op until Debian ships it).
     # --only-upgrade is a no-op for packages not present in the base image.
+    # Upgrade libmariadb3 together with the mysqlclient dev packages that
+    # exact-pin it, so apt keeps them consistent instead of removing
+    # libmariadb-dev / default-libmysqlclient-dev (which drops pkg-config's
+    # .pc files and breaks the mysqlclient source build later).
     && apt-get -qq install -y --only-upgrade \
          libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
          libpam0g libpam-modules libpam-modules-bin libpam-runtime \
          curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+         libmariadb-dev default-libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -32,6 +32,7 @@ RUN apt-get -qq update \
     libkrb5-dev \
     default-jre-headless \
     openssl \
+    pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
     postgresql \
@@ -50,10 +51,15 @@ RUN apt-get -qq update \
     # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
     # wget -> tracked; upstream fix pending, no-op until Debian ships it).
     # --only-upgrade is a no-op for packages not present in the base image.
+    # Upgrade libmariadb3 together with the mysqlclient dev packages that
+    # exact-pin it, so apt keeps them consistent instead of removing
+    # libmariadb-dev / default-libmysqlclient-dev (which drops pkg-config's
+    # .pc files and breaks the mysqlclient source build later).
     && apt-get -qq install -y --only-upgrade \
          libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
          libpam0g libpam-modules libpam-modules-bin libpam-runtime \
          curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+         libmariadb-dev default-libmysqlclient-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq


### PR DESCRIPTION
### fix(ingestion): restore pkg-config + mysqlclient dev headers so mysqlclient builds
#### Problem
- The ingestion Docker image build fails at RUN pip install ".[${INGESTION_DEPENDENCY}]" when building mysqlclient from source:

```
/bin/sh: 1: pkg-config: not found
Trying pkg-config --exists mysqlclient / mariadb / libmariadb / perconaserverclient   (all: status 127)
Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
ERROR: Failed to build 'mysqlclient' when getting requirements to build wheel
mysqlclient's build backend shells out to pkg-config to locate the MySQL/MariaDB headers. In the image, pkg-config is missing, so every lookup returns exit 127 and the wheel build aborts. Fails on both linux/amd64 and linux/arm64.
```
### Root cause
Regression introduced by #30024 ("fix(security): trim vulnerable apt packages from ingestion Docker images").

- pkg-config was never listed explicitly in the Dockerfile — it only came in transitively as a dependency of default-libmysqlclient-dev. #30024 added a security upgrade:


- apt-get install -y --only-upgrade ... libmariadb3 ...   # -> 1:10.11.18-0+deb12u1
On Debian bookworm, default-libmysqlclient-dev → libmariadb-dev, which exact-pins libmariadb3 (= <version>). Upgrading libmariadb3 to the security build forces apt to drop libmariadb-dev / default-libmysqlclient-dev to resolve the version conflict. The subsequent apt-get autoremove --purge then sweeps the now-orphaned pkg-config and the mariadb .pc files. By pip install time, neither pkg-config nor the .pc files exist, so mysqlclient can't build.

### Fix
- Two minimal, complementary changes to both ingestion Dockerfiles:

- Add pkg-config explicitly to the apt install list, so it's marked manually-installed and autoremove --purge won't sweep it.
- Add libmariadb-dev default-libmysqlclient-dev to the --only-upgrade line, so the dev packages are upgraded together with libmariadb3 and kept consistent instead of being removed.
- The security intent of #30024 is preserved — libmariadb3 still lands at 1:10.11.18-0+deb12u1; we only prevent the dev/tooling packages from being collaterally removed.

### Files changed
- ingestion/operators/docker/Dockerfile.ci
- ingestion/Dockerfile.ci (same latent bug, fixed identically)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the packages needed to build the MySQL client in ingestion images. The main changes are:

- Installs `pkg-config` explicitly in all four ingestion Dockerfiles.
- Upgrades the MariaDB runtime and development packages together.
- Preserves the security package upgrades and cleanup steps.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated package transaction keeps the MariaDB runtime and development packages aligned.
- Explicitly installing `pkg-config` prevents cleanup from removing the required build tool.
- No blocking issue remains in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/Dockerfile | Adds pkg-config and keeps the MariaDB development packages aligned with libmariadb3. |
| ingestion/Dockerfile.ci | Applies the MySQL client build dependency fix to the CI ingestion image. |
| ingestion/operators/docker/Dockerfile | Adds the required build tooling and aligned MariaDB package upgrades to the operator image. |
| ingestion/operators/docker/Dockerfile.ci | Mirrors the operator image package fix in the CI Dockerfile. |

</details>

<sub>Reviews (3): Last reviewed commit: ["minor: edit comment"](https://github.com/open-metadata/openmetadata/commit/e5103eb9b65a95288ec2812e06cb2ee1eca8b580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45849687)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->