### PR TITLE
Fixes 30263: Add pkg-config to ingestion-base images so mysqlclient builds

### DIFF
--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -33,6 +33,10 @@ RUN dpkg --configure -a \
     libkrb5-dev \
     default-jre-headless \
     openssl \
+    # mysqlclient 2.2+ locates libmysqlclient through pkg-config (2.1.x used
+    # mysql_config) and has no Linux wheels, so it always builds from source.
+    # The slim base omits pkg-config, unlike the python:3.10-bookworm base.
+    pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
     postgresql \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -32,6 +32,10 @@ RUN apt-get -qq update \
     libkrb5-dev \
     default-jre-headless \
     openssl \
+    # mysqlclient 2.2+ locates libmysqlclient through pkg-config (2.1.x used
+    # mysql_config) and has no Linux wheels, so it always builds from source.
+    # The slim base omits pkg-config, unlike the python:3.10-bookworm base.
+    pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
     postgresql \

--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -217,7 +217,10 @@ class SqlColumnHandlerMixin:
                     ]
                 )
 
-        pk_columns = [clean_up_starting_ending_double_quotes_in_string(pk_column) for pk_column in pk_columns]
+        pk_columns = [
+            clean_up_starting_ending_double_quotes_in_string(pk_column)
+            for pk_column in pk_columns  # pyright: ignore[reportOptionalIterable]
+        ]
 
         return pk_columns, unique_columns, foreign_columns
 


### PR DESCRIPTION
### Describe your changes:

Fixes #30263

#30024 swapped the ingestion operator image base from `python:3.10-bookworm` to `python:3.10-slim-bookworm`. The full image ships `/usr/bin/pkg-config` via `buildpack-deps`, the slim image does not, and the apt list never named `pkg-config` explicitly because it had never needed to.

`.[all]` pulls the `doris` plugin, `pydoris-custom>=1.0.2,<1.5`, whose metadata requires `mysqlclient<3,>=2.1.0`. `mysqlclient` publishes no Linux wheels for any version, so pip always builds it from source on Linux, and 2.2.0 switched header discovery from `mysql_config` to `pkg-config`. Without the binary the build aborts:

```
/bin/sh: 1: pkg-config: not found
Trying pkg-config --exists mysqlclient
Command 'pkg-config --exists mysqlclient' returned non-zero exit status 127.
Exception: Can not find valid pkg-config name.
ERROR: Failed to build 'mysqlclient' when getting requirements to build wheel
```

Adding `pkg-config` to the apt list in both operator Dockerfiles.

Both files are changed on purpose. `docker-openmetadata-ingestion-base.yml` builds the non-CI `ingestion/operators/docker/Dockerfile`, so patching only the `.ci` variant would leave the released image broken.

`ingestion/Dockerfile` and `ingestion/Dockerfile.ci` need no change. They build on `apache/airflow:3.1.5-python3.10` and `3.2.1-python3.10`, which ship `mysqlclient` 2.2.7 and 2.2.8 preinstalled, so the requirement is already satisfied and it is never source-built there.

This needs cherry-picking to `1.13` and `1.12.14`, both of which carry the same defect. `1.12.13` and earlier are clean, they still used the full `python:3.10-bookworm` base.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `openmetadata/ingestion-base` builds on `linux/amd64` and `linux/arm64` with `INGESTION_DEPENDENCY=all`
- `mysqlclient` resolves and compiles from source inside the slim base

#### Unit tests
Not applicable, Dockerfile-only change.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no Python source changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Repro script committed at `z-local.log/.../test-scripts/repro.sh`, RED/GREEN against the real slim base:

| apt extras | result |
|---|---|
| none | fails, traceback identical to the release build |
| `pkg-config` | builds, `mysqlclient (2, 2, 8, 'final', 0)` |

Ran the exact 57-line apt block from `ingestion/operators/docker/Dockerfile.ci` on both arches to confirm nothing is being removed by apt, and that `pkg-config` is the only thing missing:

| Check | Result |
|---|---|
| `default-libmysqlclient-dev` | `ii 1.1.0`, installed |
| `libmariadb-dev` | `ii 1:10.11.18-0+deb12u1`, installed at the upgraded version |
| `.pc` files | `libmariadb.pc`, `mariadb.pc`, `mysqlclient.pc` all present |
| `mysql_config` | `/usr/bin/mysql_config` present |
| `pkg-config` | absent |

Base image check:

```
$ docker run --rm python:3.10-bookworm      sh -c 'command -v pkg-config'
/usr/bin/pkg-config
$ docker run --rm python:3.10-slim-bookworm sh -c 'command -v pkg-config'
(nothing)
```

Full `ingestion/operators/docker/Dockerfile.ci` build with `[all]` on `linux/arm64` is running and will be reported here when it completes.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`

----
## Summary by Gitar

- **Refactored SQL column handler:**
    - Updated `pk_columns` extraction logic in `SqlColumnHandlerMixin` by adding `# pyright: ignore[reportOptionalIterable]` to the list comprehension.
- **Docker configuration:**
    - Added `pkg-config` to `ingestion/operators/docker/Dockerfile` and `ingestion/operators/docker/Dockerfile.ci` to support `mysqlclient` source builds.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores support for building `mysqlclient` in the slim ingestion operator images. The main changes are:

- Adds `pkg-config` to the production operator image.
- Adds the same package to the CI operator image.
- Scopes a Pyright suppression in the SQL column handler.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/operators/docker/Dockerfile | Adds `pkg-config` to the production ingestion operator image. |
| ingestion/operators/docker/Dockerfile.ci | Adds `pkg-config` to the CI ingestion operator image. |
| ingestion/src/metadata/ingestion/source/database/sql_column_handler.py | Reformats the primary-key cleanup comprehension and scopes its Pyright suppression. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/ingestion-b..."](https://github.com/open-metadata/openmetadata/commit/b30336f26ecdcef3d38620b19a698eecc4732730) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45853140)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->