### PR TITLE
fix(ci): install the ANTLR CLI from the distro archive when available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,15 @@ install_antlr_cli:  ## Install antlr CLI locally
 		case "$$candidate" in \
 			$(ANTLR_VERSION)|$(ANTLR_VERSION)[-+~]*) \
 				if apt-get install -y -qq antlr4 > /dev/null 2>&1; then \
-					echo "Installed ANTLR $$candidate from the distro archive."; \
-					exit 0; \
+					if command -v antlr4 > /dev/null 2>&1 \
+						&& antlr4 2>&1 | grep -q "Version $(ANTLR_VERSION)"; then \
+						echo "Installed ANTLR $$candidate from the distro archive."; \
+						exit 0; \
+					fi; \
+					echo "Distro package installed, but antlr4 on PATH resolves to $$(command -v antlr4 2>/dev/null || echo none) which is not $(ANTLR_VERSION); falling back to pinned download." >&2; \
+				else \
+					echo "apt-get install antlr4 failed; falling back to pinned download." >&2; \
 				fi; \
-				echo "apt-get install antlr4 failed; falling back to pinned download." >&2; \
 				;; \
 			*) \
 				echo "Distro ANTLR candidate '$$candidate' is not $(ANTLR_VERSION); using pinned download." >&2; \

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ install_antlr_cli:  ## Install antlr CLI locally
 			candidate=$$(apt-cache policy antlr4 2>/dev/null | awk '/Candidate:/ {print $$2}'); \
 		fi; \
 		case "$$candidate" in \
-			$(ANTLR_VERSION)*) \
+			$(ANTLR_VERSION)|$(ANTLR_VERSION)[-+~]*) \
 				if apt-get install -y -qq antlr4 > /dev/null 2>&1; then \
 					echo "Installed ANTLR $$candidate from the distro archive."; \
 					exit 0; \

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,15 @@ generate:  ## Generate the pydantic models from the JSON Schemas to the ingestio
 
 .PHONY: install_antlr_cli
 ANTLR_VERSION := 4.9.2
-ANTLR_COMPLETE_JAR_URL := https://repo1.maven.org/maven2/org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
+# Override ANTLR_MAVEN_BASE to pull from an internal Maven mirror (e.g. the
+# in-cluster Pulp proxy) instead of Maven Central, which rate-limits shared CI
+# egress IPs. The fallback base is tried if the primary is unreachable, so the
+# default (both = Central) stays correct on GitHub-hosted runners and locally.
+ANTLR_MAVEN_BASE ?= https://repo1.maven.org/maven2
+ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
+ANTLR_COMPLETE_JAR_PATH := org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
+ANTLR_COMPLETE_JAR_URL := $(ANTLR_MAVEN_BASE)/$(ANTLR_COMPLETE_JAR_PATH)
+ANTLR_COMPLETE_JAR_FALLBACK_URL := $(ANTLR_MAVEN_FALLBACK_BASE)/$(ANTLR_COMPLETE_JAR_PATH)
 ANTLR_COMPLETE_JAR_SHA256 := bb117b1476691dc2915a318efd36f8957c0ad93447fb1dac01107eb15fe137cd
 ANTLR_INSTALL_DIR ?= /usr/local/bin
 
@@ -70,16 +78,20 @@ install_antlr_cli:  ## Install antlr CLI locally
 	jar_file=$$(mktemp); \
 	cli_file=$$(mktemp "$(ANTLR_INSTALL_DIR)/.antlr4.XXXXXX"); \
 	trap 'rm -f "$$jar_file" "$$cli_file"' EXIT; \
+	urls=$$(printf '%s\n%s\n' "$(ANTLR_COMPLETE_JAR_URL)" "$(ANTLR_COMPLETE_JAR_FALLBACK_URL)" | awk 'NF && !seen[$$0]++'); \
 	attempt=1; \
 	while :; do \
-		if curl --fail --location --silent --show-error \
-			--retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 120 \
-			--connect-timeout 15 --max-time 60 \
-			--output "$$jar_file" "$(ANTLR_COMPLETE_JAR_URL)" \
-			&& printf '%s  %s\n' "$(ANTLR_COMPLETE_JAR_SHA256)" "$$jar_file" | shasum -a 256 --check \
-			&& jar tf "$$jar_file" > /dev/null; then \
-			break; \
-		fi; \
+		for url in $$urls; do \
+			if curl --fail --location --silent --show-error \
+				--retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 120 \
+				--connect-timeout 15 --max-time 60 \
+				--output "$$jar_file" "$$url" \
+				&& printf '%s  %s\n' "$(ANTLR_COMPLETE_JAR_SHA256)" "$$jar_file" | shasum -a 256 --check \
+				&& jar tf "$$jar_file" > /dev/null; then \
+				break 2; \
+			fi; \
+			echo "ANTLR $(ANTLR_VERSION) download failed from $$url (attempt $$attempt)" >&2; \
+		done; \
 		if [ "$$attempt" -ge 3 ]; then \
 			echo "Failed to download a valid ANTLR $(ANTLR_VERSION) CLI after $$attempt attempts" >&2; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -61,14 +61,23 @@ generate:  ## Generate the pydantic models from the JSON Schemas to the ingestio
 
 .PHONY: install_antlr_cli
 ANTLR_VERSION := 4.9.2
-# Prefer an ANTLR already on PATH (e.g. `apt-get install antlr4`, which ships
-# exactly 4.9.2 on Ubuntu noble and later) so CI never downloads the jar at all -
-# public artifact hosts rate-limit our shared CI egress IP.
+# install_antlr_cli resolves the CLI in three steps, cheapest first:
 #
-# When a download is still required (macOS, non-Debian images), override
-# ANTLR_MAVEN_BASE to pull from an internal Maven mirror instead of Central. The
-# fallback base is tried if the primary is unreachable, so the default
-# (both = Central) stays correct on GitHub-hosted runners and locally.
+#   1. Already on PATH at the pinned version -> nothing to do.
+#   2. Distro package, when apt offers exactly $(ANTLR_VERSION). Ubuntu noble and
+#      later ship 4.9.2, matching the pinned antlr4-python3-runtime and the JS
+#      antlr4 runtimes, so CI never touches a public artifact host - those
+#      rate-limit our shared CI egress IP and have broken the build repeatedly.
+#   3. Pinned, checksum-verified download (macOS, non-Debian images, or a distro
+#      carrying a different ANTLR such as jammy's 4.7.2).
+#
+# The version match in step 2 is exact. A distro shipping a different ANTLR falls
+# through to the download rather than silently generating parsers that the pinned
+# runtimes will reject.
+#
+# For step 3, override ANTLR_MAVEN_BASE to pull from an internal Maven mirror
+# instead of Central. The fallback base is tried if the primary is unreachable,
+# so the default (both = Central) stays correct everywhere else.
 ANTLR_MAVEN_BASE ?= https://repo1.maven.org/maven2
 ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
 ANTLR_COMPLETE_JAR_PATH := org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
@@ -81,8 +90,27 @@ install_antlr_cli:  ## Install antlr CLI locally
 	@set -eu; \
 	if command -v antlr4 > /dev/null 2>&1 \
 		&& antlr4 2>&1 | grep -q "Version $(ANTLR_VERSION)"; then \
-		echo "ANTLR $(ANTLR_VERSION) already available at $$(command -v antlr4); skipping download."; \
+		echo "ANTLR $(ANTLR_VERSION) already available at $$(command -v antlr4); nothing to do."; \
 		exit 0; \
+	fi; \
+	if command -v apt-get > /dev/null 2>&1; then \
+		candidate=$$(apt-cache policy antlr4 2>/dev/null | awk '/Candidate:/ {print $$2}'); \
+		if [ -z "$$candidate" ] || [ "$$candidate" = "(none)" ]; then \
+			apt-get update -qq > /dev/null 2>&1 || true; \
+			candidate=$$(apt-cache policy antlr4 2>/dev/null | awk '/Candidate:/ {print $$2}'); \
+		fi; \
+		case "$$candidate" in \
+			$(ANTLR_VERSION)*) \
+				if apt-get install -y -qq antlr4 > /dev/null 2>&1; then \
+					echo "Installed ANTLR $$candidate from the distro archive."; \
+					exit 0; \
+				fi; \
+				echo "apt-get install antlr4 failed; falling back to pinned download." >&2; \
+				;; \
+			*) \
+				echo "Distro ANTLR candidate '$$candidate' is not $(ANTLR_VERSION); using pinned download." >&2; \
+				;; \
+		esac; \
 	fi; \
 	jar_file=$$(mktemp); \
 	cli_file=$$(mktemp "$(ANTLR_INSTALL_DIR)/.antlr4.XXXXXX"); \

--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,14 @@ generate:  ## Generate the pydantic models from the JSON Schemas to the ingestio
 
 .PHONY: install_antlr_cli
 ANTLR_VERSION := 4.9.2
-# Override ANTLR_MAVEN_BASE to pull from an internal Maven mirror (e.g. the
-# in-cluster Pulp proxy) instead of Maven Central, which rate-limits shared CI
-# egress IPs. The fallback base is tried if the primary is unreachable, so the
-# default (both = Central) stays correct on GitHub-hosted runners and locally.
+# Prefer an ANTLR already on PATH (e.g. `apt-get install antlr4`, which ships
+# exactly 4.9.2 on Ubuntu noble and later) so CI never downloads the jar at all -
+# public artifact hosts rate-limit our shared CI egress IP.
+#
+# When a download is still required (macOS, non-Debian images), override
+# ANTLR_MAVEN_BASE to pull from an internal Maven mirror instead of Central. The
+# fallback base is tried if the primary is unreachable, so the default
+# (both = Central) stays correct on GitHub-hosted runners and locally.
 ANTLR_MAVEN_BASE ?= https://repo1.maven.org/maven2
 ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
 ANTLR_COMPLETE_JAR_PATH := org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
@@ -75,6 +79,11 @@ ANTLR_INSTALL_DIR ?= /usr/local/bin
 
 install_antlr_cli:  ## Install antlr CLI locally
 	@set -eu; \
+	if command -v antlr4 > /dev/null 2>&1 \
+		&& antlr4 2>&1 | grep -q "Version $(ANTLR_VERSION)"; then \
+		echo "ANTLR $(ANTLR_VERSION) already available at $$(command -v antlr4); skipping download."; \
+		exit 0; \
+	fi; \
 	jar_file=$$(mktemp); \
 	cli_file=$$(mktemp "$(ANTLR_INSTALL_DIR)/.antlr4.XXXXXX"); \
 	trap 'rm -f "$$jar_file" "$$cli_file"' EXIT; \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ generate:  ## Generate the pydantic models from the JSON Schemas to the ingestio
 
 .PHONY: install_antlr_cli
 ANTLR_VERSION := 4.9.2
+# Dots escaped so the banner match below is a real version match, not a
+# regex wildcard, and so 4.9.20 cannot satisfy a 4.9.2 check.
+ANTLR_VERSION_RE := $(subst .,\.,$(ANTLR_VERSION))
 # install_antlr_cli resolves the CLI in three steps, cheapest first:
 #
 #   1. Already on PATH at the pinned version -> nothing to do.
@@ -89,7 +92,7 @@ ANTLR_INSTALL_DIR ?= /usr/local/bin
 install_antlr_cli:  ## Install antlr CLI locally
 	@set -eu; \
 	if command -v antlr4 > /dev/null 2>&1 \
-		&& antlr4 2>&1 | grep -q "Version $(ANTLR_VERSION)"; then \
+		&& antlr4 2>&1 | grep -Eq 'Version $(ANTLR_VERSION_RE)([^0-9]|$$)'; then \
 		echo "ANTLR $(ANTLR_VERSION) already available at $$(command -v antlr4); nothing to do."; \
 		exit 0; \
 	fi; \
@@ -103,7 +106,7 @@ install_antlr_cli:  ## Install antlr CLI locally
 			$(ANTLR_VERSION)|$(ANTLR_VERSION)[-+~]*) \
 				if apt-get install -y -qq antlr4 > /dev/null 2>&1; then \
 					if command -v antlr4 > /dev/null 2>&1 \
-						&& antlr4 2>&1 | grep -q "Version $(ANTLR_VERSION)"; then \
+						&& antlr4 2>&1 | grep -Eq 'Version $(ANTLR_VERSION_RE)([^0-9]|$$)'; then \
 						echo "Installed ANTLR $$candidate from the distro archive."; \
 						exit 0; \
 					fi; \
@@ -120,6 +123,14 @@ install_antlr_cli:  ## Install antlr CLI locally
 	jar_file=$$(mktemp); \
 	cli_file=$$(mktemp "$(ANTLR_INSTALL_DIR)/.antlr4.XXXXXX"); \
 	trap 'rm -f "$$jar_file" "$$cli_file"' EXIT; \
+	if command -v shasum > /dev/null 2>&1; then \
+		sha_check="shasum -a 256 --check"; \
+	elif command -v sha256sum > /dev/null 2>&1; then \
+		sha_check="sha256sum --check"; \
+	else \
+		echo "Neither shasum nor sha256sum is available; cannot verify the ANTLR download." >&2; \
+		exit 1; \
+	fi; \
 	urls=$$(printf '%s\n%s\n' "$(ANTLR_COMPLETE_JAR_URL)" "$(ANTLR_COMPLETE_JAR_FALLBACK_URL)" | awk 'NF && !seen[$$0]++'); \
 	attempt=1; \
 	while :; do \
@@ -128,7 +139,7 @@ install_antlr_cli:  ## Install antlr CLI locally
 				--retry 3 --retry-all-errors --retry-delay 2 --retry-max-time 120 \
 				--connect-timeout 15 --max-time 60 \
 				--output "$$jar_file" "$$url" \
-				&& printf '%s  %s\n' "$(ANTLR_COMPLETE_JAR_SHA256)" "$$jar_file" | shasum -a 256 --check \
+				&& printf '%s  %s\n' "$(ANTLR_COMPLETE_JAR_SHA256)" "$$jar_file" | $$sha_check \
 				&& jar tf "$$jar_file" > /dev/null; then \
 				break 2; \
 			fi; \


### PR DESCRIPTION
## Problem

`make install_antlr_cli` downloads the ANTLR 4.9.2 CLI from a public host at build time, and that download keeps getting rate-limited.

#30120 moved it from `www.antlr.org` (GitHub Pages) to Maven Central and added SHA256 verification. Central then rate-limited us from the same shared CI egress IP. Nightly run [29776192824](https://github.com/open-metadata/openmetadata-nightly/actions/runs/29776192824) started ~7h after that merge and failed with 12 × HTTP 429 from `repo1.maven.org`. Runs are still failing today, and it also breaks collate PR checks.

Relocating the download between public hosts doesn't help — the throttling follows it.

## Why fix it here

Every consumer already calls this one target:

| Repo | Call sites | Covered by this PR? |
|---|---|---|
| OpenMetadata | 20 — 16 workflows + the 3 shared composite actions | ✅ all |
| openmetadata-collate | 3 Dockerfiles that run OpenMetadata's Makefile (`WORKDIR openmetadata/` or `cd ../OpenMetadata`) | ✅ via `git submodule update --init --remote`, which tracks OpenMetadata `main` |
| openmetadata-collate | root `Makefile` target + its caller `ui-checkstyle.yml` | ❌ **not covered — separate collate PR needed** |
| openmetadata-nightly | 7 | n/a — fixed directly in openmetadata-nightly#260 (merged) |

Fixing the target here covers the OpenMetadata call sites and the collate Docker builds, instead of editing ~25 call sites across two repositories.

### Scope gap (collate)

Collate has its **own** root `Makefile` with a duplicate `install_antlr_cli` that is still the original pre-#30120 version — it downloads from `antlr.org` and has no `curl --fail`, so a 429 response body gets appended into the jar and fails later with an unrelated error. Its only caller is `.github/workflows/ui-checkstyle.yml`.

Nothing in this PR touches that. It needs a separate collate PR, ideally deleting the duplicate so there is one implementation rather than two that drift. Thanks @ayush for catching that this PR's description previously overstated its collate coverage.

## Change

`install_antlr_cli` now resolves in three steps, cheapest first:

1. **Already on PATH** at the pinned version → nothing to do.
2. **Distro package**, when apt offers exactly `4.9.2`. Ubuntu noble and later ship 4.9.2 — matching every pinned runtime in this repo — so no public host is involved.
3. **Pinned, checksum-verified download**, unchanged.

The version pins step 2 has to satisfy:

| Pin | Location |
|---|---|
| `antlr4-python3-runtime==4.9.2` | `ingestion/setup.py:147` |
| `"antlr4": "4.9.2"` | `openmetadata-ui/.../package.json:100` |

The match is exact and checked with `apt-cache policy` *before* installing, so a distro carrying a different ANTLR (jammy ships 4.7.2) falls through to the pinned download rather than silently generating parsers those runtimes reject. apt failures — no root, unreachable archive — fall through too.

Step 3 keeps `ANTLR_MAVEN_BASE` so environments without a distro package (macOS, non-Debian images) can point at an internal Maven mirror instead of Central.

## Testing

| Scenario | Result |
|---|---|
| 4.9.2 already on PATH | skipped, nothing written |
| apt offers 4.9.2 (noble) | installed via apt, **no download** |
| apt offers 4.7.2 (jammy) | rejected, fell through to download, checksum `OK` |
| apt install fails (no root) | fell through to download, checksum `OK` |
| no apt at all (macOS) | download, checksum `OK` |
| 4.7.2 binary on PATH | did not skip, downloaded 4.9.2 |
| stale 4.7.2 shadowing apt's 4.9.2 on PATH | detected, reported the shadowing path, fell back to download |
| mirror unreachable | fell back to Central, checksum `OK` |
| all sources 404 | exit 2, no partial install |

The apt branches were exercised with stubbed `apt-get`/`apt-cache` (this was developed on macOS), so the branch logic is verified but **real apt behaviour on a noble runner is not**. Worth confirming on CI before merge.

Pinned hash verified against the published artifact: `bb117b1476691dc2915a318efd36f8957c0ad93447fb1dac01107eb15fe137cd`.

## Notes

- Version stays 4.9.2. Aligning with the Java side's `antlr.version` of 4.13.2 would need the Python and JS runtimes bumped and parsers regenerated — separate change.
- open-metadata/openmetadata-nightly#260 fixes the nightly workflows directly so AUT is unblocked without waiting for this.
- Credit to @matias for suggesting the distro package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes ANTLR CLI installation prefer local and distro-provided copies before downloading. The main changes are:

- Reuses an existing ANTLR 4.9.2 executable on `PATH`.
- Installs the exact pinned version from apt when available.
- Verifies the resolved executable after apt installation.
- Retains checksum-verified downloads with configurable primary and fallback Maven sources.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The apt path now verifies the executable selected by `PATH` before returning success.
- An incompatible shadowing executable causes the recipe to continue to the pinned download.
- No blocking issue remains in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Adds exact-version PATH and apt resolution, post-install verification, and a configurable verified download fallback. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): portable checksum tool and anch..."](https://github.com/open-metadata/openmetadata/commit/259ad45269bea45909e2df51ffbcd59992a6e91c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45866084)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->