### PR TITLE
chore(ingestion): fix reportOptionalIterable in sql_column_handler

### DIFF
--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -58518,14 +58518,6 @@
                 }
             },
             {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 83,
-                    "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 34,

--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -184,11 +184,7 @@ class SqlColumnHandlerMixin:
             )
             pk_constraints = {}
 
-        pk_columns = (
-            pk_constraints.get("constrained_columns")
-            if len(pk_constraints) > 0 and pk_constraints.get("constrained_columns")
-            else {}
-        )
+        pk_constraint_columns = pk_constraints.get("constrained_columns") if len(pk_constraints) > 0 else None
 
         foreign_columns = []
         for foreign_constraint in foreign_constraints:
@@ -217,7 +213,9 @@ class SqlColumnHandlerMixin:
                     ]
                 )
 
-        pk_columns = [clean_up_starting_ending_double_quotes_in_string(pk_column) for pk_column in pk_columns]
+        pk_columns = [
+            clean_up_starting_ending_double_quotes_in_string(pk_column) for pk_column in pk_constraint_columns or []
+        ]
 
         return pk_columns, unique_columns, foreign_columns
 

--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -352,12 +352,13 @@ class SqlColumnHandlerMixin:
                 col_obj = self._process_complex_col_type(column=column, parsed_string=parsed_string)
                 om_column = col_obj
 
-                if column.get("children"):
+                source_children = column.get("children")
+                if source_children:
                     # Prioritize source-provided children for column processing.
                     # If 'children' are directly provided in the source metadata,
                     # process and assign them to the output column, overriding any derived children.
                     # Currently, this is only used for BigQuery.
-                    om_column.children = [process_column(children) for children in column.get("children")]
+                    om_column.children = [process_column(child) for child in source_children]
             om_column.tags = self.get_column_tag_labels(table_name=table_name, column=column)
             return om_column
 


### PR DESCRIPTION
### Describe your changes:

Type-only cleanup in `SqlColumnHandlerMixin._get_columns_with_constraints`. No behaviour change.

`basedpyright` reports `reportOptionalIterable` on the primary-key comprehension:

```
src/metadata/ingestion/source/database/sql_column_handler.py:220:99
  - error: Object of type "None" cannot be used as iterable value (reportOptionalIterable)
```

Two things caused it:

- `pk_constraints.get("constrained_columns")` returns `Optional[list]`, and the ternary that guarded it
  called `.get()` a second time instead of binding the result. A repeated call is not a narrowable
  expression, so `None` stayed in the type and flowed into `for pk_column in pk_columns`.
- The falsy branch produced `{}` — a dict for a slot declared `List` in the `Tuple[List, List, List]`
  return annotation. It happened to work only because iterating an empty dict yields nothing.

Now the lookup is bound once and defaulted with `or []`, so the value is a list on every path and the
annotation is honoured.

The `len(pk_constraints) > 0` short-circuit is deliberately kept: `HiveMetastoreDialectMixin.get_pk_constraint`
returns a **list**, not a dict, and only that check stops `.get()` from raising `AttributeError` on it.

Also drops the corresponding entry from `.basedpyright/baseline.json`, matching the precedent in a88ceeaf23.

#
### Type of change:

- [x] Improvement

#
### Tests:

Verified equivalence of the old and new expressions across every shape `get_pk_constraint` returns —
single PK, composite PK, quoted identifiers, Oracle's `{'name': None, 'constrained_columns': []}` default,
the `{}` set by the except arm, a missing key, an explicit `None` value, and Hive's `[]`. All eight match,
zero mismatches.

`basedpyright -p pyproject.toml` on the file: `reportOptionalIterable` gone, no new diagnostics.
`ruff check` and `ruff format --check` clean.

#
### UI screen recording / screenshots:

Not applicable.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR cleans up optional iterable handling in the SQL column handler. The main changes are:

- Binds primary-key columns once and defaults missing values to an empty list.
- Binds source-provided child columns before checking and processing them.
- Removes the resolved basedpyright baseline entry.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated expressions preserve behavior for the supported constraint and child-column shapes.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/sql_column_handler.py | Binds optional primary-key and child-column values before iteration while preserving existing behavior. |
| ingestion/.basedpyright/baseline.json | Removes the baseline entry for the resolved optional-iterable diagnostic. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Fix reportOptionalIterable on column chi..."](https://github.com/open-metadata/openmetadata/commit/fbbfca257e234ee27ee576b7045c9c08b170a468) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45887414)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->