### PR TITLE
fix(superset): populate datamodel sql, description, sourceUrl and real column names

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/superset/api_source.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/superset/api_source.py
@@ -31,6 +31,7 @@ from metadata.generated.schema.type.basic import (
     FullyQualifiedEntityName,
     Markdown,
     SourceUrl,
+    SqlQuery,
 )
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.source.dashboard.superset.mixin import SupersetSourceMixin
@@ -228,11 +229,19 @@ class SupersetAPISource(SupersetSourceMixin):
                             datasource_json.result.table_name,
                             "Data model filtered out.",
                         )
+                    result = datasource_json.result
                     data_model_request = CreateDashboardDataModelRequest(
                         name=EntityName(str(datasource_json.id)),
-                        displayName=datasource_json.result.table_name,
+                        displayName=result.table_name,
+                        description=Markdown(result.description) if result.description else None,
+                        sql=SqlQuery(result.sql) if result.sql else None,
+                        sourceUrl=(
+                            SourceUrl(f"{clean_uri(self.service_connection.hostPort)}{result.url}")
+                            if result.url
+                            else None
+                        ),
                         service=FullyQualifiedEntityName(self.context.get().dashboard_service),
-                        columns=self.get_column_info(datasource_json.result.columns),
+                        columns=self.get_column_info(result.columns),
                         dataModelType=DataModelType.SupersetDataModel.value,
                     )
                     yield Either(right=data_model_request)

--- a/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
@@ -400,7 +400,7 @@ class SupersetSourceMixin(DashboardServiceSource):
                         dataType=col_parse["dataType"],
                         arrayDataType=self.parse_array_data_type(col_parse),
                         children=self.parse_row_data_type(col_parse),
-                        name=truncate_column_name(str(field.id)),
+                        name=truncate_column_name(field.column_name),
                         displayName=field.column_name,
                         description=field.description,
                         dataLength=int(col_parse.get("dataLength", 0)),

--- a/ingestion/tests/integration/superset/test_superset.py
+++ b/ingestion/tests/integration/superset/test_superset.py
@@ -218,6 +218,20 @@ MOCK_DATASOURCE_RESPONSE = SupersetDatasource(
 )
 MOCK_DATABASE_RESPONSE = ListDatabaseResult(result=DatabaseResult(database_name="examples", id=1, parameters=None))
 
+MOCK_DATASOURCE_RESPONSE_WITH_SQL = SupersetDatasource(
+    id=99,
+    result=DataSourceResult.model_validate(
+        {
+            "table_name": "sample_table",
+            "sql": "SELECT id FROM sample_table",
+            "description": "rollup dataset",
+            "url": "/tablemodelview/edit/99",
+            "schema": "main",
+            "columns": [{"id": 11, "column_name": "Population", "type": "INT"}],
+        }
+    ),
+)
+
 
 def setup_sample_data(postgres_container):
     engine = sqlalchemy.create_engine(postgres_container.get_connection_url())
@@ -631,6 +645,24 @@ class SupersetUnitTest(TestCase):
         self.superset_db.prepare()
         parsed_datasource = self.superset_db.get_column_info(MOCK_DATASOURCE)
         assert parsed_datasource[0].dataType.value == "INT"
+        # column name is the real column_name, not the numeric superset column id
+        assert parsed_datasource[0].name.root == "Population"
+
+    def test_datamodel_fields_api(self):
+        """
+        API datamodel carries sql, description and sourceUrl from the dataset payload
+        """
+        self.superset_api.all_charts = {69: MOCK_CHART}
+        with patch.object(
+            self.superset_api.client,
+            "fetch_datasource",
+            return_value=MOCK_DATASOURCE_RESPONSE_WITH_SQL,
+        ):
+            data_model = next(self.superset_api.yield_datamodel(MOCK_DASHBOARD)).right
+        assert data_model.sql.root == "SELECT id FROM sample_table"
+        assert data_model.description.root == "rollup dataset"
+        assert str(data_model.sourceUrl.root).endswith("/tablemodelview/edit/99")
+        assert data_model.columns[0].name.root == "Population"
 
     def test_is_table_to_table_lineage(self):
         table = Table(name="table_name", schema=Schema(name="schema_name"))


### PR DESCRIPTION
Superset API-mode `yield_datamodel` dropped `sql`, `description` and the source URL from the dataset payload, and `get_column_info` used the numeric Superset column id as the OM column name (columns showed up as `11799`, `11800`…).

This threads `sql`, `description` and `sourceUrl` through into the `CreateDashboardDataModelRequest`, and keys the column `name` on `column_name` (real names) instead of the numeric id.

FIX #29945

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR enriches Superset API data models with dataset metadata and real column names. The main changes are:

- Adds SQL, description, and source URL to API-mode data-model requests.
- Uses Superset `column_name` values instead of numeric column IDs.
- Adds tests for the populated fields and column names.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The nullable column-name path needs a fix before merging.

- SQL, description, and source URL map to the expected request fields.
- A null Superset column name now reaches a string-only helper and aborts ingestion.
- Falling back to the numeric column ID preserves the old behavior for unnamed columns.

ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/dashboard/superset/api_source.py | Adds optional SQL, description, and source URL fields to API-mode data-model requests. |
| ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py | Uses real column names but can fail when Superset returns a null column name. |
| ingestion/tests/integration/superset/test_superset.py | Adds tests for the new data-model fields and real column names. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(superset): populate datamodel sql, d..."](https://github.com/open-metadata/openmetadata/commit/92d7660fbf4a00012e105d78b3c89878bc350b59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45888559)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->