### PR TITLE
fix(ui): align Explore layout spacing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less
@@ -18,12 +18,21 @@
 .column-detail-panel-container {
   height: 100%;
   background: var(--tw-color-bg-primary);
-  &.explore,
+
+  &.explore {
+    background: transparent;
+  }
+
   &.lineage,
   &.glossary-term-assets-tab,
   &.ontology-explorer {
     background: var(--tw-color-utility-gray-blue-50);
+  }
 
+  &.explore,
+  &.lineage,
+  &.glossary-term-assets-tab,
+  &.ontology-explorer {
     .summary-panel-container.drawer-summary-panel-container {
       flex: 1;
       min-width: 0;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/exploreV1.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/exploreV1.less
@@ -23,6 +23,10 @@
   }
 }
 
+[data-testid='page-layout-v1']:has(.explore-page) {
+  padding-bottom: 20px;
+}
+
 .explore-page {
   .content-height-with-resizable-panel {
     height: calc(

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/exploreV1.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/exploreV1.less
@@ -23,11 +23,9 @@
   }
 }
 
-[data-testid='page-layout-v1']:has(.explore-page) {
-  padding-bottom: 20px;
-}
-
 .explore-page {
+  margin-bottom: 20px;
+
   .content-height-with-resizable-panel {
     height: calc(
       100vh - @om-navbar-height - @quick-filters-container-height - @size-xs

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
@@ -48,7 +48,7 @@ const HeaderShell = ({
   meta,
   hasStats = false,
   actions,
-  actionsClassName = 'tw:shrink-0',
+  actionsClassName,
   footer,
   variant = 'flat',
   padding = 'default',
@@ -103,7 +103,7 @@ const HeaderShell = ({
           {actions && (
             <Box
               align="center"
-              className={classNames('tw:ml-auto', actionsClassName)}
+              className={classNames('tw:ml-auto tw:shrink-0', actionsClassName)}
               direction="row"
               gap={4}>
               {actions}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
@@ -48,6 +48,7 @@ const HeaderShell = ({
   meta,
   hasStats = false,
   actions,
+  actionsLayout = 'auto',
   footer,
   variant = 'flat',
   padding = 'default',
@@ -102,7 +103,12 @@ const HeaderShell = ({
           {actions && (
             <Box
               align="center"
-              className="tw:ml-auto tw:shrink-0"
+              className={classNames(
+                'tw:ml-auto',
+                actionsLayout === 'fill'
+                  ? 'tw:min-w-0 tw:flex-1'
+                  : 'tw:shrink-0'
+              )}
               direction="row"
               gap={4}>
               {actions}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx
@@ -48,7 +48,7 @@ const HeaderShell = ({
   meta,
   hasStats = false,
   actions,
-  actionsLayout = 'auto',
+  actionsClassName = 'tw:shrink-0',
   footer,
   variant = 'flat',
   padding = 'default',
@@ -103,12 +103,7 @@ const HeaderShell = ({
           {actions && (
             <Box
               align="center"
-              className={classNames(
-                'tw:ml-auto',
-                actionsLayout === 'fill'
-                  ? 'tw:min-w-0 tw:flex-1'
-                  : 'tw:shrink-0'
-              )}
+              className={classNames('tw:ml-auto', actionsClassName)}
               direction="row"
               gap={4}>
               {actions}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.interface.ts
@@ -17,8 +17,6 @@ export type HeaderShellVariant = 'flat' | 'gradient';
 
 export type HeaderShellPadding = 'default' | 'comfortable';
 
-export type HeaderShellActionsLayout = 'auto' | 'fill';
-
 export interface HeaderShellProps {
   /** Leading visual: featured icon tile, service logo, or avatar. */
   leading?: ReactNode;
@@ -39,8 +37,8 @@ export interface HeaderShellProps {
   hasStats?: boolean;
   /** Right-aligned actions (search, buttons, view toggle). */
   actions?: ReactNode;
-  /** Controls whether actions shrink to their content or fill the remaining row. */
-  actionsLayout?: HeaderShellActionsLayout;
+  /** Classes applied to the actions container. */
+  actionsClassName?: string;
   /** Footer row rendered full-width under the header, typically the tab strip. */
   footer?: ReactNode;
   /** Visual treatment. 'gradient' applies the brand-tinted card per Figma. */

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.interface.ts
@@ -17,6 +17,8 @@ export type HeaderShellVariant = 'flat' | 'gradient';
 
 export type HeaderShellPadding = 'default' | 'comfortable';
 
+export type HeaderShellActionsLayout = 'auto' | 'fill';
+
 export interface HeaderShellProps {
   /** Leading visual: featured icon tile, service logo, or avatar. */
   leading?: ReactNode;
@@ -37,6 +39,8 @@ export interface HeaderShellProps {
   hasStats?: boolean;
   /** Right-aligned actions (search, buttons, view toggle). */
   actions?: ReactNode;
+  /** Controls whether actions shrink to their content or fill the remaining row. */
+  actionsLayout?: HeaderShellActionsLayout;
   /** Footer row rendered full-width under the header, typically the tab strip. */
   footer?: ReactNode;
   /** Visual treatment. 'gradient' applies the brand-tinted card per Figma. */

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
@@ -95,9 +95,7 @@ describe('HeaderShell', () => {
 
     expect(container.querySelector('.tw\\:ml-auto')).toHaveClass(
       'tw:min-w-0',
-      'tw:flex-1'
-    );
-    expect(container.querySelector('.tw\\:ml-auto')).not.toHaveClass(
+      'tw:flex-1',
       'tw:shrink-0'
     );
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
@@ -84,12 +84,12 @@ describe('HeaderShell', () => {
     expect(screen.getByTestId('actions')).toBeInTheDocument();
   });
 
-  it('allows the actions container to fill the remaining row', () => {
+  it('applies a custom class name to the actions container', () => {
     const { container } = render(
       <HeaderShell
         actions={<button data-testid="actions">Add</button>}
-        actionsLayout="fill"
-        title="With Fill Actions"
+        actionsClassName="tw:min-w-0 tw:flex-1"
+        title="With Custom Actions"
       />
     );
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
@@ -80,7 +80,7 @@ describe('HeaderShell', () => {
       />
     );
 
-    expect(container.querySelector('.tw\\:ml-auto')).not.toBeNull();
+    expect(container.querySelector('.tw\\:ml-auto')).toHaveClass('tw:shrink-0');
     expect(screen.getByTestId('actions')).toBeInTheDocument();
   });
 
@@ -95,8 +95,7 @@ describe('HeaderShell', () => {
 
     expect(container.querySelector('.tw\\:ml-auto')).toHaveClass(
       'tw:min-w-0',
-      'tw:flex-1',
-      'tw:shrink-0'
+      'tw:flex-1'
     );
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx
@@ -84,6 +84,24 @@ describe('HeaderShell', () => {
     expect(screen.getByTestId('actions')).toBeInTheDocument();
   });
 
+  it('allows the actions container to fill the remaining row', () => {
+    const { container } = render(
+      <HeaderShell
+        actions={<button data-testid="actions">Add</button>}
+        actionsLayout="fill"
+        title="With Fill Actions"
+      />
+    );
+
+    expect(container.querySelector('.tw\\:ml-auto')).toHaveClass(
+      'tw:min-w-0',
+      'tw:flex-1'
+    );
+    expect(container.querySelector('.tw\\:ml-auto')).not.toHaveClass(
+      'tw:shrink-0'
+    );
+  });
+
   it('applies the Figma gradient and brand border on the gradient variant', () => {
     render(<HeaderShell title="Gradient" variant="gradient" />);
 


### PR DESCRIPTION
### Describe your changes:

- Remove the background color from Explore entity summary panels so they inherit the page surface.
- Add 20px bottom padding to `PageLayoutV1` only when it contains the Explore page.
- HeaderShell component changes are required so that the searchbar (right side action area) in explore header in collate AI side occupies all the space rather than moving to right.

<img width="1918" height="927" alt="Screenshot 2026-07-21 at 4 35 51 PM" src="https://github.com/user-attachments/assets/bfd67a2f-2b33-4835-820a-1533c4f34b84" />
<img width="1504" height="155" alt="Screenshot 2026-07-22 at 1 22 14 PM" src="https://github.com/user-attachments/assets/c8c82831-b765-4ebc-adf0-6842c9af8132" />

# ### Type of change:

- [x] Bug fix

# ### High-level design:

N/A — small, Explore-scoped LESS update.

# ### Tests:

#### Use cases covered

- Explore summary panels no longer render an additional background color.
- Explore page layout keeps 20px bottom spacing.

#### Unit tests

- [ ] No unit tests added; this is a style-only change.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [ ] No Playwright tests added; this is a style-only change.

#### Manual testing performed

- Compiled both changed LESS files with `lessc --js`.
- Ran `ExploreV1.test.tsx` (15 tests passed).
- Ran Prettier and `git diff --check`.

# ### UI screen recording / screenshots:

Not attached.

# ### Checklist:

- [x] My changes are limited to the Explore layout.
- [x] No unit tests were added for styles.


----
## Summary by Gitar

- **UI components:**
    - Added `actionsLayout` property to `HeaderShell` allowing the actions container to fill available row space.
    - Included unit tests in `HeaderShell.test.tsx` to verify the new `fill` layout behavior.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts spacing and action sizing in the Explore interface. The main changes are:

- Makes Explore summary panels inherit the page background.
- Adds bottom spacing to the Explore page.
- Lets `HeaderShell` callers add layout classes to the actions container.
- Adds unit coverage for custom action-container classes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues were found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/entity-summary-panel.less | Makes the Explore summary panel transparent while preserving shared drawer sizing styles. |
| openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/exploreV1.less | Adds 20px of bottom spacing to the Explore page. |
| openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.component.tsx | Applies an optional caller-provided class name to the actions container. |
| openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.interface.ts | Adds the optional `actionsClassName` property to the component API. |
| openmetadata-ui/src/main/resources/ui/src/components/common/HeaderShell/HeaderShell.test.tsx | Tests the default actions layout classes and custom class forwarding. |

</details>

<sub>Reviews (6): Last reviewed commit: ["test(ui): fix HeaderShell action class a..."](https://github.com/open-metadata/openmetadata/commit/3d2edfeab66f1d2b10018fcba2cca82fc3efb65a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45912073)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->