### PR TITLE
fix(e2e): write the ETag opt-out flag under the correct localStorage key

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 import { Page, test as setup } from '@playwright/test';
-import { DISABLE_ETAG_CONDITIONAL_READS_KEY } from '../../src/rest/etagInterceptor';
 import {
   EDIT_DESCRIPTION_RULE,
   EDIT_GLOSSARY_TERM_RULE,
@@ -32,6 +31,11 @@ import { loginAsAdmin } from '../utils/initialSetup';
  * as flaky assertions across the suite. Setting the flag here persists it into storageState, so
  * every spec in both OpenMetadata and Collate inherits it without a per-test helper.
  */
+// Keep in sync with DISABLE_ETAG_CONDITIONAL_READS_KEY in src/rest/etagInterceptor.ts.
+// Inlined deliberately: importing it across the playwright -> src boundary resolves to
+// undefined at runtime, which silently wrote the flag under the key "undefined".
+const DISABLE_ETAG_CONDITIONAL_READS_KEY = 'OM_DISABLE_ETAG_CONDITIONAL_READS';
+
 const disableEtagConditionalReads = async (page: Page) => {
   await page.evaluate((key) => {
     localStorage.setItem(key, 'true');


### PR DESCRIPTION
## Problem

#30239 added a localStorage flag so E2E sessions skip client-side conditional (`If-None-Match`) reads. It never worked — it was a **silent no-op in every run**, which is why AUT still shows the stale-read failures it was meant to fix.

`auth.setup.ts` imported the key across the `playwright -> src` boundary:

```ts
import { DISABLE_ETAG_CONDITIONAL_READS_KEY } from '../../src/rest/etagInterceptor';
```

That import resolves to `undefined` at runtime, so setup executed `localStorage.setItem(undefined, 'true')` and the flag was persisted under the literal key `"undefined"`:

```
key='undefined'  value='true'     ← what actually landed in admin.json
```

The app then read the real key, got `null`, and attached the interceptor anyway.

## Change

Inline the key literal in `auth.setup.ts`, with a comment tying it to the app-side constant. One file, test-only, no product change.

## Verification

Against a local build **containing the guard** (`guard=1` in the served bundle):

| | before | after |
|---|---|---|
| table GETs with `If-None-Match` | 2 of 7 | **0 of 10** |
| empty-body (304-style) responses | 2 | **0** |
| repeat GET body size | `0` (transfer 240) | **1100–1245** (real bodies) |

Also verified:
- Flag lands with the correct key in storageState (`flag=['true']`, no `undefined` key)
- Readable at **document-start / module-init timing** — the moment the guard checks — for **all 8 roles**
- `browser.newPage()` / `createNewPage` contexts (91 + 76 + 13 specs) inherit it
- Every `storageState:` path used across OM and Collate specs maps to the 8 covered files
- **Collate side**: deleted its `.auth`, re-ran Collate's own config — all 8 files regenerated correctly, roles report the flag at init

`CustomMetric.spec.ts` passes relying solely on the global flag (its per-test helper was removed in #30239).

## Note

This restores the intended ETag opt-out. It should clear the stale-read class of AUT failures (`UpVote`/`DownVote`, `Follow`/`Un-follow`, `FollowingWidget`, `Tags`, `CustomMetric`, `TestSuiteMultiPipeline`, …) — but not the unrelated ones in the same list (`HybridRunner*`, `QueryRunner`, `DataContracts*` (#30179), `SearchRBAC`, `PersonaFlow`). Expect a partial reduction, not zero.

The underlying product defect — the ETag not reflecting requested `fields` or child state — is still open and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the ETag opt-out in Playwright authentication setup. The main changes are:

- Removes the ineffective import from application source code.
- Writes the exact application-side key into localStorage.
- Persists the flag in the generated role storage states.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The inlined value matches the application-side key.
- Removing the import does not remove required module initialization.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/auth.setup.ts | Replaces the broken cross-boundary key import with the matching localStorage key used by the application. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(e2e): write the ETag opt-out flag un..."](https://github.com/open-metadata/openmetadata/commit/e6642f2cafe3cc842509eab03cc00e7f812ddcfa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45964142)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->