### PR TITLE
test(playwright): skip flaky Article edits and navigation-flushed titles persist

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -811,7 +811,7 @@ test.describe('Context Center Articles', () => {
     await cleanupAfterAction();
   });
 
-  test('Article edits and navigation-flushed titles persist', async ({
+  test.skip('Article edits and navigation-flushed titles persist', async ({
     page,
     browser,
   }) => {


### PR DESCRIPTION
### Describe your changes:

I worked on skipping the flaky Playwright test `Article edits and navigation-flushed titles persist` in `ContextCenterArticles.spec.ts` because it is causing intermittent CI failures and needs further investigation before it can be reliably enabled.

### Type of change:
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Flaky test is skipped to unblock CI.

#### Unit tests
- [ ] Not applicable (no logic changes).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Marked `test.skip` on the flaky test in `ContextCenterArticles.spec.ts`.

#### Manual testing performed
N/A — single `test.skip` annotation.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables one flaky Context Center Playwright test. The change includes:

- An unconditional skip for article edit persistence.
- Removal of browser-back title-flush coverage from CI.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge, with a non-blocking gap in browser-back persistence coverage.

- No production code changes.
- The skipped test leaves one user workflow without automated coverage.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts | Unconditionally skips the test covering article edits and title persistence after browser-back navigation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(playwright): skip flaky &#39;Article ed..."](https://github.com/open-metadata/openmetadata/commit/00a6fcfbe96e9d471800585854f6ea3288560ef9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45988073)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->