### PR TITLE
fix(security): bump log4j 2.25.4 → 2.25.5 (CVE-2026-49844)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
     <spring.version>6.2.19</spring.version>
-    <log4j.version>2.25.4</log4j.version>
+    <log4j.version>2.25.5</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>


### PR DESCRIPTION
## What

Bumps `log4j.version` `2.25.4` → `2.25.5` (single property in root `pom.xml`; drives both `log4j-core` and `log4j-api`).

Closes #30299.

## Why

`log4j-core`/`log4j-api` 2.25.4 is flagged for **CVE-2026-49844** — a Medium (CWE-116) issue where `MapMessageJsonFormatter` serializes non-finite floats as bare `NaN`/`Infinity`/`-Infinity`, producing non-RFC-8259 JSON. Fixed upstream in 2.25.5.

## Impact assessment

**OpenMetadata is not exploitable by this CVE.** The vulnerable path requires log4j2's `JsonTemplateLayout`/`MapMessage.asJson()`. In this codebase:

- Logging runs through **Logback** (`logback.xml` in service + tests); there is no `log4j2.xml`/`.properties` anywhere.
- No `JsonTemplateLayout` or `MapMessage` usage — the only `org.apache.logging.log4j` imports are `...log4j.util.Strings` in two secrets managers (a string helper, unrelated to log output).

This bump simply clears the dependency-scanner flag. It stays on the 2.25.x patch line, so there is no behavioral change.

## Note for maintainers

Collate tracks OpenMetadata as a submodule pinned to the **`1.13`** branch, so this fix should also be backported to `1.13` for the submodule pointer to pick it up.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates Log4j to the patched 2.25.5 release. The main change is:

- Bumps the shared `log4j.version` property from 2.25.4 to 2.25.5.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates the shared Log4j version from 2.25.4 to 2.25.5 for the managed API and Core dependencies. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into douala"](https://github.com/open-metadata/openmetadata/commit/c6fd6823f749f6a4924493f4a07b94c2cd78b986) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46052381)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->