### PR TITLE
Fixes #30305: Remove stale PR merge-commit guards

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -79,12 +79,6 @@ jobs:
               - '.github/scripts/classify_test_outcome.py'
               - '.github/workflows/integration-tests-mysql-elasticsearch.yml'
 
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.backend == 'true' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
   integration-test-build:
     name: Build Integration Test Runtime
     needs: changes

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -94,12 +94,6 @@ jobs:
               - '.github/scripts/classify_test_outcome.py'
               - '.github/workflows/integration-tests-postgres-elasticsearch-redis.yml'
 
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.backend == 'true' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
   integration-test-build:
     name: Build Integration Test Runtime
     needs: changes

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -79,12 +79,6 @@ jobs:
               - '.github/scripts/classify_test_outcome.py'
               - '.github/workflows/integration-tests-postgres-opensearch.yml'
 
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.backend == 'true' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
   integration-test-build:
     name: Build Integration Test Runtime
     needs: changes

--- a/.github/workflows/playwright-integration-tests-mysql.yml
+++ b/.github/workflows/playwright-integration-tests-mysql.yml
@@ -36,12 +36,6 @@ jobs:
         browser-type: ["chromium"]
     environment: test
     steps:
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/playwright-integration-tests-postgres.yml
+++ b/.github/workflows/playwright-integration-tests-postgres.yml
@@ -36,12 +36,6 @@ jobs:
         browser-type: ["chromium"]
     environment: test
     steps:
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -61,12 +61,6 @@ jobs:
         shardIndex: [1, 2]
         shardTotal: [2]
     steps:
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -87,12 +87,6 @@ jobs:
        needs.check-changes.outputs.e2e == 'true' || needs.check-changes.outputs.docker-compose == 'true') &&
       (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     steps:
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/.github/workflows/playwright-sso-tests.yml
+++ b/.github/workflows/playwright-sso-tests.yml
@@ -87,12 +87,6 @@ jobs:
         provider: ${{ github.event_name == 'pull_request_target' && fromJSON('["mock-oidc"]') || github.event.inputs.sso_provider && fromJSON(format('["{0}"]', github.event.inputs.sso_provider)) || fromJSON('["mock-oidc"]') }}
 
     steps:
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
         with:

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -75,12 +75,6 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           disable-reviews: true
 
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.python == 'true' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
   py-integration-tests:
     name: "Integration Tests (${{ matrix.shard.name }}, ${{ matrix.py-version }})"
     needs: changes

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -85,12 +85,6 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           disable-reviews: true
 
-      - name: Verify PR merge commit is available
-        if: ${{ github.event_name == 'pull_request_target' && steps.filter.outputs.python == 'true' && github.event.pull_request.merge_commit_sha == '' }}
-        run: |
-          echo "The PR has no merge commit to test. Resolve merge conflicts and rerun the workflow."
-          exit 1
-
   py-unit-tests:
     name: Unit Tests & Static Checks
     needs: changes


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30305

Removes obsolete `merge_commit_sha` availability checks from the Java integration, Playwright, and Python workflows that now explicitly test `github.event.pull_request.head.sha`. This prevents transient GitHub test-merge calculation state from failing change-detection jobs and skipping their test matrices.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

The ten affected workflows keep their existing PR-head checkout and merge-queue behavior while dropping the unrelated synthetic-merge prerequisite. Aggregate required-check jobs and the legitimate merged-PR use of `merge_commit_sha` in the auto-cherry-pick workflow remain unchanged.

#
### Tests:

#### Use cases covered

- Existing or newly synchronized PRs can proceed to Java, Playwright, and Python tests while GitHub computes the synthetic test merge commit.
- Required aggregate jobs continue to report upstream build and test outcomes.

#### Unit tests

- [x] Not applicable — workflow-only change.

#### Backend integration tests

- [x] Not applicable — no backend API changes.

#### Ingestion integration tests

- [x] Not applicable — no ingestion code changes.

#### Playwright (UI) tests

- [x] Not applicable — no UI behavior changes.

#### Manual testing performed

1. Ran `actionlint` on all ten changed workflows, filtering only the pre-existing local metadata warning for `allow-unsafe-pr-checkout`.
2. Ran `git diff --check origin/main...HEAD`.
3. Confirmed the only remaining workflow use of `merge_commit_sha` is the auto-cherry-pick flow for an already merged PR.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] Not applicable: no complex code requiring comments.
- [x] Not applicable: no JSON Schema changes.
- [x] Not applicable: no UI changes.
- [x] I validated the changed workflows with `actionlint` and Git diff checks.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes stale synthetic merge-commit checks from CI workflows. The main changes are:

- Removes the guard from three Java integration workflows.
- Removes the guard from five Playwright workflows.
- Removes the guard from two Python test workflows.
- Keeps PR-head checkout, merge-group checkout, label checks, and aggregate status jobs unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The workflows already select the PR head explicitly for pull request runs.
- Label checks and merge-group revision selection remain unchanged.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-tests-mysql-elasticsearch.yml | Removes the synthetic merge-commit guard while retaining PR-head checkout and downstream test gates. |
| .github/workflows/integration-tests-postgres-elasticsearch-redis.yml | Removes the synthetic merge-commit guard without changing revision selection or job dependencies. |
| .github/workflows/integration-tests-postgres-opensearch.yml | Removes the synthetic merge-commit guard while preserving merge-group behavior. |
| .github/workflows/playwright-integration-tests-mysql.yml | Removes the merge-state check while retaining label verification before PR-head execution. |
| .github/workflows/playwright-integration-tests-postgres.yml | Removes the merge-state check without changing the existing authorization path. |
| .github/workflows/playwright-mysql-e2e.yml | Removes the merge-state check while preserving checkout selection and environment use. |
| .github/workflows/playwright-postgresql-e2e.yml | Removes the merge-state check while retaining change detection and result aggregation. |
| .github/workflows/playwright-sso-tests.yml | Removes the merge-state check without changing label verification or SSO test aggregation. |
| .github/workflows/py-tests-postgres.yml | Removes the merge-state check while preserving Python path filtering and aggregate status handling. |
| .github/workflows/py-tests.yml | Removes the merge-state check while retaining the existing Python test matrices and authorization gates. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 30305: Remove stale PR merge-commi..."](https://github.com/open-metadata/openmetadata/commit/2b7016737f8b906b37cbbfe5d971d09acc7b39ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46142717)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->