### PR TITLE
fix(security): bump log4j 2.25.4 → 2.25.5 (CVE-2026-49844) [1.13]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <openapiswagger.version>2.2.25</openapiswagger.version>
     <httpclient.version>4.5.14</httpclient.version>
     <spring.version>6.2.19</spring.version>
-    <log4j.version>2.25.4</log4j.version>
+    <log4j.version>2.25.5</log4j.version>
     <org.junit.jupiter.version>5.11.4</org.junit.jupiter.version>
     <org.junit.platform.version>1.11.4</org.junit.platform.version>
     <dropwizard-health.version>5.0.0</dropwizard-health.version>


### PR DESCRIPTION
Backport of #30301 to the `1.13` release line.

## What

Bumps `log4j.version` `2.25.4` → `2.25.5` (single property in root `pom.xml`; drives both `log4j-core` and `log4j-api`).

Relates to #30299.

## Why

`log4j-core`/`log4j-api` 2.25.4 is flagged for **CVE-2026-49844** — a Medium (CWE-116) issue where `MapMessageJsonFormatter` serializes non-finite floats as bare `NaN`/`Infinity`/`-Infinity`, producing non-RFC-8259 JSON. Fixed upstream in 2.25.5. `main` gets it via #30301; `1.13` is a live release line and needs the same backport since it doesn't inherit main's fix.

## Impact assessment

**OpenMetadata is not exploitable by this CVE.** The vulnerable path requires log4j2's `JsonTemplateLayout`/`MapMessage.asJson()`; this codebase logs via **Logback** (no `log4j2.xml`, no `JsonTemplateLayout`/`MapMessage` usage). This bump only clears the dependency-scanner flag. Stays on the 2.25.x patch line — no behavioral change.

## Collate

Also covers Collate's `1.13` branch, which consumes OpenMetadata `1.13` as a submodule — its pointer just needs advancing after this merges.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the shared Log4j dependency to the patched release.

- Bumps `log4j.version` from 2.25.4 to 2.25.5.
- Keeps `log4j-core` and `log4j-api` on the same version.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates the shared Log4j version from 2.25.4 to 2.25.5 while preserving core/API alignment. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump log4j 2.25.4 -&gt; 2.25..."](https://github.com/open-metadata/openmetadata/commit/047b8e3121719c0af6ebf61954f761b6fd55204f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46188447)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->