### PR TITLE
fix(users): populate persona references to fix 500 on multi-persona update

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.api.teams.CreatePersona;
 import org.openmetadata.schema.api.teams.CreateTeam;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
 import org.openmetadata.schema.auth.JWTTokenExpiry;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
+import org.openmetadata.schema.entity.teams.Persona;
 import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityHistory;
@@ -50,6 +52,7 @@ import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.sdk.network.RequestOptions;
+import org.openmetadata.service.Entity;
 
 /**
  * Integration tests for User entity operations.
@@ -2197,6 +2200,55 @@ public class UserResourceIT extends BaseEntityIT<User, CreateUser> {
     return SdkClients.adminClient()
         .getHttpClient()
         .execute(HttpMethod.GET, "/v1/users/online", null, UserResultList.class, options);
+  }
+
+  @Test
+  void testPatchPersonasWithMinimalReferences(TestNamespace ns) {
+    // A persona reference only requires id and type, which is what a client typically PATCHes.
+    // The updater sorts personas by name, so two un-hydrated references used to fail with a 500.
+    Persona persona1 = createPersona(ns, "one");
+    Persona persona2 = createPersona(ns, "two");
+
+    CreateUser request =
+        new CreateUser()
+            .withName(ns.prefix("persona-user"))
+            .withEmail(toValidEmail(ns.prefix("persona-user")))
+            .withPersonas(List.of(persona1.getEntityReference()));
+    User user = createEntity(request);
+
+    String patch =
+        String.format(
+            "[{\"op\":\"replace\",\"path\":\"/personas\",\"value\":"
+                + "[{\"id\":\"%s\",\"type\":\"persona\"},{\"id\":\"%s\",\"type\":\"persona\"}]}]",
+            persona1.getId(), persona2.getId());
+
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/users/" + user.getId(),
+            patch,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+
+    User fetched = Users.get(user.getId().toString(), "personas");
+    assertEquals(2, fetched.getPersonas().size(), "Both personas should be persisted");
+    assertTrue(
+        fetched.getPersonas().stream().anyMatch(ref -> ref.getId().equals(persona1.getId())),
+        "First persona should be persisted");
+    assertTrue(
+        fetched.getPersonas().stream().anyMatch(ref -> ref.getId().equals(persona2.getId())),
+        "Second persona should be persisted");
+  }
+
+  private Persona createPersona(TestNamespace ns, String suffix) {
+    return ns.trackRoot(
+        Entity.PERSONA,
+        SdkClients.adminClient()
+            .personas()
+            .create(
+                new CreatePersona()
+                    .withName(ns.shortPrefix("persona_" + suffix))
+                    .withDescription("User personas NPE regression test")));
   }
 
   private static class UserResultList extends ResultList<User> {}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -245,6 +245,9 @@ public class UserRepository extends EntityRepository<User> {
   public void prepare(User user, boolean update) {
     validateTeams(user);
     validateRoles(user.getRoles());
+    // A reference is only required to carry id and type, so populate the rest before the updater
+    // diffs personas — it sorts them by name.
+    user.setPersonas(EntityUtil.populateEntityReferences(user.getPersonas()));
   }
 
   @Override


### PR DESCRIPTION
Fixes #30314

## Describe your changes

Updating a user's `personas` returns HTTP 500 whenever the resulting list has **two or more** entries:

```
java.lang.NullPointerException: Cannot invoke "java.lang.Comparable.compareTo(Object)"
  because the return value of "java.util.function.Function.apply(Object)" is null
  at UserRepository$UserUpdater.updatePersonas(UserRepository.java:1626)
```

The update aborts before anything is written, so the personas are left unchanged.

### Root cause

`personas` is an `entityReferenceList`, and `EntityReference` requires only `id` and `type` — `name` is optional. A client can therefore PATCH minimal references:

```json
[{"op":"replace","path":"/personas","value":[
  {"id":"<A>","type":"persona"},{"id":"<B>","type":"persona"}]}]
```

`UserRepository.prepare()` populates the user's teams and roles but never touches `personas`, so `name` stays `null`. `UserUpdater.updatePersonas()` then sorts with `EntityUtil.compareEntityReference` (`Comparator.comparing(EntityReference::getName)`) → NPE. Sorting a single-element list never invokes the comparator, which is why only 2+ personas fail. The two sibling fields on the same updater — `teams` and `roles` — are already populated in `prepare()`, so this is an omission for `personas` specifically.

Same class of bug as #30295 / #30291 (task assignees), found by auditing the other `compareEntityReference` sort sites.

### Fix

`prepare()` now populates personas through the existing `EntityUtil.populateEntityReferences()`, matching how teams and roles are handled. Three lines, no new helper.

### Tests

`UserResourceIT#testPatchPersonasWithMinimalReferences` — creates two personas, PATCHes `/personas` with bare `{id, type}` references, and asserts both persist. Verified against the failure first: on the unpatched build the test reproduces the 500 at `updatePersonas:1626`; with the fix it passes.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: no schema changes in this PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hydrates persona references before user updates and adds coverage for minimal PATCH references. The main changes are:

- Populate persona names before updater comparison and sorting.
- Add an integration test that PATCHes two minimal persona references.
- Track the test personas for cleanup.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

User creation can silently discard unresolved persona references.

- The PATCH path now receives populated names before sorting.
- The same unconditional population also runs during create and prunes references that cannot be resolved.
- The new test covers the intended update path but not this create behavior.

openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java | Hydrates persona references before updater sorting, but also changes create requests by silently pruning unresolved personas. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserResourceIT.java | Adds an isolated integration test for PATCHing two minimal persona references. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(users): populate persona references ..."](https://github.com/open-metadata/openmetadata/commit/46fb239a60a50d24d2285e9f5aec402c9017dda0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46191148)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))

<!-- /greptile_comment -->