### PR TITLE
ci: respect dorny paths-filter on merge_group events

### DIFF
--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -52,16 +52,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    # pull_request_target uses the GitHub API and does not require a checkout. Pushes are
-    # already scoped by the trigger paths above; merge queue and manual runs exercise the
-    # full suite. Keep the trigger paths and filter list in sync.
+    # pull_request_target uses the GitHub API and does not require a checkout. Merge
+    # queue runs check out the merge-queue commit so dorny can diff against
+    # merge_group.base_sha and skip the heavy work when nothing backend-relevant
+    # changed. Push and workflow_dispatch remain force-true — push is already
+    # gated by the trigger paths above, and workflow_dispatch is an explicit
+    # "run the full suite" request. Keep the trigger paths and filter list in sync.
     outputs:
-      backend: ${{ github.event_name != 'pull_request_target' && 'true' || steps.filter.outputs.backend }}
+      backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             backend:
               - 'openmetadata-service/**'

--- a/.github/workflows/integration-tests-mysql-elasticsearch.yml
+++ b/.github/workflows/integration-tests-mysql-elasticsearch.yml
@@ -62,7 +62,7 @@ jobs:
       backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -77,7 +77,7 @@ jobs:
       backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
+++ b/.github/workflows/integration-tests-postgres-elasticsearch-redis.yml
@@ -67,16 +67,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    # pull_request_target uses the GitHub API and does not require a checkout. Pushes are
-    # already scoped by the trigger paths above; merge queue and manual runs exercise the
-    # full suite. Keep the trigger paths and filter list in sync.
+    # pull_request_target uses the GitHub API and does not require a checkout. Merge
+    # queue runs check out the merge-queue commit so dorny can diff against
+    # merge_group.base_sha and skip the heavy work when nothing backend-relevant
+    # changed. Push and workflow_dispatch remain force-true — push is already
+    # gated by the trigger paths above, and workflow_dispatch is an explicit
+    # "run the full suite" request. Keep the trigger paths and filter list in sync.
     outputs:
-      backend: ${{ github.event_name != 'pull_request_target' && 'true' || steps.filter.outputs.backend }}
+      backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             backend:
               - 'openmetadata-service/**'

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -52,16 +52,27 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    # pull_request_target uses the GitHub API and does not require a checkout. Pushes are
-    # already scoped by the trigger paths above; merge queue and manual runs exercise the
-    # full suite. Keep the trigger paths and filter list in sync.
+    # pull_request_target uses the GitHub API and does not require a checkout. Merge
+    # queue runs check out the merge-queue commit so dorny can diff against
+    # merge_group.base_sha and skip the heavy work when nothing backend-relevant
+    # changed. Push and workflow_dispatch remain force-true — push is already
+    # gated by the trigger paths above, and workflow_dispatch is an explicit
+    # "run the full suite" request. Keep the trigger paths and filter list in sync.
     outputs:
-      backend: ${{ github.event_name != 'pull_request_target' && 'true' || steps.filter.outputs.backend }}
+      backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             backend:
               - 'openmetadata-service/**'

--- a/.github/workflows/integration-tests-postgres-opensearch.yml
+++ b/.github/workflows/integration-tests-postgres-opensearch.yml
@@ -62,7 +62,7 @@ jobs:
       backend: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && 'true' || steps.filter.outputs.backend }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -49,10 +49,18 @@ jobs:
       e2e: ${{ steps.filter.outputs.e2e }}
       docker-compose: ${{ steps.filter.outputs.docker-compose }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             e2e:
               - 'openmetadata-service/**'
@@ -89,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' ||
        needs.check-changes.outputs.e2e == 'true' || needs.check-changes.outputs.docker-compose == 'true') &&
       (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     steps:
@@ -150,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' ||
        needs.check-changes.outputs.e2e == 'true' || needs.check-changes.outputs.docker-compose == 'true') &&
       (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     outputs:
@@ -595,8 +603,7 @@ jobs:
             const labelName = context.payload.label?.name ?? '';
             const isDraft = context.payload.pull_request?.draft === true;
             const isNonTestLabelEvent = eventAction === 'labeled' && labelName !== 'safe to test';
-            const testsRequired = context.eventName === 'merge_group' ||
-              context.eventName === 'workflow_dispatch' ||
+            const testsRequired = context.eventName === 'workflow_dispatch' ||
               process.env.E2E_CHANGED === 'true' ||
               process.env.DOCKER_COMPOSE_CHANGED === 'true';
 

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -50,7 +50,7 @@ jobs:
       docker-compose: ${{ steps.filter.outputs.docker-compose }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -35,7 +35,7 @@ jobs:
       python: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.python }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/py-tests-postgres.yml
+++ b/.github/workflows/py-tests-postgres.yml
@@ -32,12 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     outputs:
-      python: ${{ github.event_name != 'pull_request_target' && 'true' || steps.filter.outputs.python }}
+      python: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.python }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             python:
               - 'ingestion/**'

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -45,7 +45,7 @@ jobs:
       python: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.python }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/py-tests.yml
+++ b/.github/workflows/py-tests.yml
@@ -42,12 +42,20 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     outputs:
-      python: ${{ github.event_name != 'pull_request_target' && 'true' || steps.filter.outputs.python }}
+      python: ${{ github.event_name == 'workflow_dispatch' && 'true' || steps.filter.outputs.python }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             python:
               - 'ingestion/**'

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -42,9 +42,17 @@ jobs:
     outputs:
       ui-changed: ${{ steps.filter.outputs.ui }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             ui:
               - 'openmetadata-ui/src/main/resources/ui/**'
@@ -55,9 +63,9 @@ jobs:
   authorize:
     needs: check-changes
     if: |
-      github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request_target' && needs.check-changes.outputs.ui-changed == 'true' &&
-      (github.event.action != 'labeled' || github.event.label.name == 'safe to test'))
+      needs.check-changes.outputs.ui-changed == 'true' &&
+      (github.event_name != 'pull_request_target' ||
+       (github.event.action != 'labeled' || github.event.label.name == 'safe to test'))
     runs-on: ubuntu-latest
     steps:
       - name: Wait for the labeler

--- a/.github/workflows/ui-checkstyle.yml
+++ b/.github/workflows/ui-checkstyle.yml
@@ -43,7 +43,7 @@ jobs:
       ui-changed: ${{ steps.filter.outputs.ui }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -30,7 +30,7 @@ jobs:
       ui-changed: ${{ steps.filter.outputs.ui }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: ${{ github.event_name == 'merge_group' }}
         with:
           fetch-depth: 0

--- a/.github/workflows/yarn-coverage.yml
+++ b/.github/workflows/yarn-coverage.yml
@@ -29,9 +29,17 @@ jobs:
     outputs:
       ui-changed: ${{ steps.filter.outputs.ui }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
             ui:
               - 'openmetadata-ui/src/main/resources/ui/src/**'
@@ -48,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.ui-changed == 'true') &&
+      (github.event_name == 'workflow_dispatch' || needs.check-changes.outputs.ui-changed == 'true') &&
       (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     steps:
       - name: Wait for the labeler


### PR DESCRIPTION
## Summary

Every workflow that runs in the GitHub merge queue currently executes the **full suite**, regardless of what the batched PRs actually touched. This PR wires `dorny/paths-filter` into the `merge_group` event so groups without relevant changes **skip the heavy jobs** and the required status check still reports green.

## Why

GitHub's `on: pull_request: paths:` filter **does not apply to `merge_group` events**. Workflows that only relied on the top-level `paths:` filter, or that had explicit `github.event_name == 'merge_group' || …` bypasses in their in-workflow gating, ran the whole suite on every queue entry — even when the group's combined diff didn't touch the areas a given workflow cares about.

Concretely, for a group whose combined diff is purely **UI-only** (touches only `openmetadata-ui/**` — a common frontend-refactor case), the actual per-workflow filters map like this:

| Workflow | Filter includes | Before | After |
|---|---|---|---|
| UI Checkstyle | `openmetadata-ui/**` | runs (~5 min) | **runs** — correctly still needed |
| Yarn Coverage | `openmetadata-ui/src/main/resources/ui/**` | runs (~10 min) | **runs** — correctly still needed |
| Playwright E2E (7 shards) | `openmetadata-ui/**`, `openmetadata-service/**`, `ingestion/**`, … | runs (~1 h wall-clock) | **runs** — correctly still needed |
| py-tests | `ingestion/**`, `openmetadata-service/**`, schemas | runs (~1 h) | **skipped** ✅ |
| py-tests-postgres | `ingestion/**`, `openmetadata-service/**`, schemas | runs (~3 h) | **skipped** ✅ |
| integration-tests-* (×3) | `openmetadata-service/**`, `openmetadata-integration-tests/**`, spec, sdk, … | runs (~1 h each) | **skipped** ✅ |

Symmetrically, a **backend-only Java** PR (`openmetadata-service/**` only) still runs Playwright / py-tests / integration-tests (they legitimately depend on service code), but skips UI Checkstyle and Yarn Coverage.

The savings compound because the merge queue serializes groups: any minute a group holds a runner is a minute the next group waits. The point of the change is to **run every workflow exactly when it's needed and never when it isn't** — the mapping from diff → which workflow runs is already encoded in each workflow's dorny filter today; we just weren't consulting it on merge_group.

## How

The uniform pattern applied to each `check-changes` job:

```yaml
- name: Checkout
  uses: actions/checkout@v4
  if: ${{ github.event_name == 'merge_group' }}
  with:
    fetch-depth: 0
    filter: blob:none
    persist-credentials: false
- uses: dorny/paths-filter@v4
  id: filter
  if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
  with:
    base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
    filters: |
      …
```

And the downstream jobs' `if:` conditions had `github.event_name == 'merge_group' ||` bypasses removed so the `steps.filter.outputs.*` values now govern both `pull_request_target` and `merge_group`.

**Why `base: merge_group.base_sha`** — dorny needs a base commit to diff against. In merge_group events the queue-built commit sits on top of `main`, and `github.event.merge_group.base_sha` is the `main` tip at the moment the group was created, i.e. exactly the diff we want to filter on. This covers the combined delta of every PR in the batch, not just the last one.

**Why keep force-true for `push` / `workflow_dispatch`** — `push` on `main` is already gated by the workflow's top-level `on: push: paths:` filter (so a push that reaches the job is by definition relevant), and `workflow_dispatch` is an explicit human "run the full suite" request. Only the `merge_group` and `pull_request_target` events now depend on the in-workflow filter.

## Files touched (8)

| Workflow | Nature of change |
|---|---|
| `integration-tests-mysql-elasticsearch.yml` | Add merge_group checkout + dorny path; force-true narrowed from "non-PR" → `push` / `workflow_dispatch` |
| `integration-tests-postgres-elasticsearch-redis.yml` | Same |
| `integration-tests-postgres-opensearch.yml` | Same |
| `py-tests.yml` | Same (no `push` trigger, so narrowed to `workflow_dispatch` only) |
| `py-tests-postgres.yml` | Same |
| `playwright-postgresql-e2e.yml` | `check-changes` gets merge_group support + drop `merge_group \|\|` bypass from `build`, `detect-changes`, and the summary's `testsRequired` JS gate |
| `ui-checkstyle.yml` | Add merge_group checkout + `base`; rewrite `authorize.if` to require `ui-changed == 'true'` regardless of event source |
| `yarn-coverage.yml` | Add merge_group checkout + `base`; drop `merge_group \|\|` bypass from `ui-coverage-tests.if` |

## Required-check safety

Every affected required check either:

- **Is the job itself** and skips cleanly (`if:` skipped jobs report as "Success") — e.g. `ui-checkstyle`, `ui-coverage`.
- **Is a summary job** with `if: always()` that already treats a skipped upstream as pass — the exit-0 branches on `BACKEND_CHANGED != 'true'` / `PYTHON_CHANGED = 'false'` / `!testsRequired` were already there for the PR path and now cover merge_group too.

So a group whose paths don't match still reports the required check green and merges normally.

## Scope explicitly deferred

Workflows that rely purely on `on: pull_request: paths:` (with no in-workflow filter) are **untouched** in this PR — they need an in-workflow `changes` job added and, in some cases, a new summary job so the required check stays reportable when skipped. Those changes carry more design risk, so I'd rather land Category A first and validate merge-queue behavior in the wild before touching them. Category B for a follow-up PR:

- `java-checkstyle.yml`
- `py-checkstyle.yml`
- `typescript-type-generation.yml`
- `validate-jsons-yamls.yml`
- `playwright-sso-tests.yml`
- `playwright-integration-tests-mysql.yml`
- `playwright-integration-tests-postgres.yml`
- `playwright-mysql-e2e.yml`

`openmetadata-service-unit-tests.yml` was already correctly wired — no change needed.

## Test plan

- [ ] YAML parses (verified locally with `yaml.safe_load`).
- [ ] Land, then observe the next merge-queue run: `check-changes` should complete quickly and its outputs should reflect the group's actual diff.
- [ ] Verify a paths-irrelevant merge-queue entry (e.g. a UI-only PR bundled alone) skips py-tests / integration-tests and the required checks still report green.
- [ ] Verify a paths-relevant merge-queue entry (any UI change → UI checks; any backend Java change → backend suite) still runs those workflows exactly as before.
- [ ] Confirm PR path (`pull_request_target`) behavior is unchanged (dorny already ran there; only merge_group semantics were altered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR applies path filtering to merge-queue runs across eight CI workflows. The main changes are:

- Checks out the merge-group commit before filtering paths.
- Compares the combined queue change with `merge_group.base_sha`.
- Skips path-irrelevant integration, Python, UI, coverage, and Playwright jobs.
- Keeps required summary checks successful when heavy jobs are intentionally skipped.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Intentional job skips are handled by the required summary checks.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/integration-tests-mysql-elasticsearch.yml | Adds merge-group backend path filtering for the MySQL and Elasticsearch integration suite. |
| .github/workflows/integration-tests-postgres-elasticsearch-redis.yml | Adds merge-group backend path filtering for the PostgreSQL, Elasticsearch, and Redis integration suite. |
| .github/workflows/integration-tests-postgres-opensearch.yml | Adds merge-group backend path filtering for the PostgreSQL and OpenSearch integration suite. |
| .github/workflows/playwright-postgresql-e2e.yml | Uses path-filter outputs to gate merge-group builds, change detection, Playwright shards, and summary handling. |
| .github/workflows/py-tests-postgres.yml | Uses the merge-group diff to gate PostgreSQL Python tests. |
| .github/workflows/py-tests.yml | Uses the merge-group diff to gate Python unit and integration tests. |
| .github/workflows/ui-checkstyle.yml | Runs merge-group UI checkstyle only when matching UI paths changed. |
| .github/workflows/yarn-coverage.yml | Runs merge-group Yarn coverage only when matching UI source paths changed. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Merge-group event] --> B[Checkout queue commit]
  B --> C[Compare with base SHA]
  C --> D{Relevant paths changed?}
  D -->|Yes| E[Run test jobs]
  D -->|No| F[Skip test jobs]
  E --> G[Required summary check]
  F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: bump merge\_group checkout action to ..."](https://github.com/open-metadata/openmetadata/commit/5fdc168e7c1ca419cee45752a5713fde9953940d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46203317)</sub>

<!-- /greptile_comment -->