### PR TITLE
fix(ui): restore dropdown scroll broken by overflow-hidden in popover

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
@@ -123,7 +123,7 @@ const DropdownMenu = <T extends object>(props: DropdownMenuProps<T>) => {
       {...props}
       className={(state) =>
         cx(
-          'tw:py-1 tw:outline-hidden tw:select-none',
+          'tw:h-min tw:overflow-y-auto tw:py-1 tw:outline-hidden tw:select-none',
           typeof props.className === 'function'
             ? props.className(state)
             : props.className
@@ -144,7 +144,7 @@ const DropdownPopover = (props: DropdownPopoverProps) => {
       {...rest}
       className={(state) =>
         cx(
-          'tw:w-62 tw:max-h-none! tw:origin-(--trigger-anchor-point) tw:overflow-hidden tw:rounded-lg tw:bg-primary tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+          'tw:w-62 tw:origin-(--trigger-anchor-point) tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
           state.isEntering &&
             'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
           state.isExiting &&

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/dropdown/dropdown.tsx
@@ -123,7 +123,7 @@ const DropdownMenu = <T extends object>(props: DropdownMenuProps<T>) => {
       {...props}
       className={(state) =>
         cx(
-          'tw:h-min tw:overflow-y-auto tw:py-1 tw:outline-hidden tw:select-none',
+          'tw:py-1 tw:outline-hidden tw:select-none',
           typeof props.className === 'function'
             ? props.className(state)
             : props.className
@@ -144,7 +144,7 @@ const DropdownPopover = (props: DropdownPopoverProps) => {
       {...rest}
       className={(state) =>
         cx(
-          'tw:w-62 tw:origin-(--trigger-anchor-point) tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+          'tw:w-62 tw:max-h-none! tw:origin-(--trigger-anchor-point) tw:overflow-hidden tw:rounded-lg tw:bg-primary tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
           state.isEntering &&
             'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
           state.isExiting &&

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -740,7 +740,7 @@ const ContextCenterMemoriesPage: FC = () => {
                       strokeWidth={2.5}
                     />
                   </AriaButton>
-                  <Dropdown.Popover>
+                  <Dropdown.Popover className="tw:flex tw:flex-col tw:max-h-80!">
                     <div className="tw:p-2 tw:border-b tw:border-secondary">
                       <Input
                         autoFocus
@@ -756,6 +756,7 @@ const ContextCenterMemoriesPage: FC = () => {
                       />
                     </div>
                     <Dropdown.Menu
+                      className="tw:min-h-0 tw:flex-1 tw:overflow-y-auto"
                       selectedKeys={selectedAuthor ? [selectedAuthor.id] : []}
                       selectionMode="single"
                       onAction={(key) => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -756,7 +756,7 @@ const ContextCenterMemoriesPage: FC = () => {
                       />
                     </div>
                     <Dropdown.Menu
-                      className="tw:max-h-64 tw:overflow-y-auto"
+                      className="tw:max-h-90 tw:overflow-y-auto"
                       selectedKeys={selectedAuthor ? [selectedAuthor.id] : []}
                       selectionMode="single"
                       onAction={(key) => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -740,23 +740,24 @@ const ContextCenterMemoriesPage: FC = () => {
                       strokeWidth={2.5}
                     />
                   </AriaButton>
-                  <Dropdown.Popover className="tw:flex tw:flex-col tw:max-h-80!">
-                    <div className="tw:p-2 tw:border-b tw:border-secondary">
-                      <Input
-                        autoFocus
-                        className="tw:w-full"
-                        icon={SearchLg}
-                        placeholder={t('label.search-entity', {
-                          entity: t('label.author'),
-                        })}
-                        value={authorSearch}
-                        onChange={(value) => {
-                          setAuthorSearch(value);
-                        }}
-                      />
-                    </div>
+                  <Dropdown.Popover>
+                    <div className="tw:flex tw:flex-col tw:max-h-80 tw:overflow-hidden">
+                      <div className="tw:shrink-0 tw:p-2 tw:border-b tw:border-secondary">
+                        <Input
+                          autoFocus
+                          className="tw:w-full"
+                          icon={SearchLg}
+                          placeholder={t('label.search-entity', {
+                            entity: t('label.author'),
+                          })}
+                          value={authorSearch}
+                          onChange={(value) => {
+                            setAuthorSearch(value);
+                          }}
+                        />
+                      </div>
+                      <div className="tw:min-h-0 tw:flex-1 tw:overflow-y-auto">
                     <Dropdown.Menu
-                      className="tw:min-h-0 tw:flex-1 tw:overflow-y-auto"
                       selectedKeys={selectedAuthor ? [selectedAuthor.id] : []}
                       selectionMode="single"
                       onAction={(key) => {
@@ -826,6 +827,8 @@ const ContextCenterMemoriesPage: FC = () => {
                         </Typography>
                       </Box>
                     )}
+                      </div>
+                    </div>
                   </Dropdown.Popover>
                 </Dropdown.Root>
               </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -741,23 +741,22 @@ const ContextCenterMemoriesPage: FC = () => {
                     />
                   </AriaButton>
                   <Dropdown.Popover>
-                    <div className="tw:flex tw:flex-col tw:max-h-80 tw:overflow-hidden">
-                      <div className="tw:shrink-0 tw:p-2 tw:border-b tw:border-secondary">
-                        <Input
-                          autoFocus
-                          className="tw:w-full"
-                          icon={SearchLg}
-                          placeholder={t('label.search-entity', {
-                            entity: t('label.author'),
-                          })}
-                          value={authorSearch}
-                          onChange={(value) => {
-                            setAuthorSearch(value);
-                          }}
-                        />
-                      </div>
-                      <div className="tw:min-h-0 tw:flex-1 tw:overflow-y-auto">
+                    <div className="tw:p-2 tw:border-b tw:border-secondary">
+                      <Input
+                        autoFocus
+                        className="tw:w-full"
+                        icon={SearchLg}
+                        placeholder={t('label.search-entity', {
+                          entity: t('label.author'),
+                        })}
+                        value={authorSearch}
+                        onChange={(value) => {
+                          setAuthorSearch(value);
+                        }}
+                      />
+                    </div>
                     <Dropdown.Menu
+                      className="tw:max-h-64 tw:overflow-y-auto"
                       selectedKeys={selectedAuthor ? [selectedAuthor.id] : []}
                       selectionMode="single"
                       onAction={(key) => {
@@ -827,8 +826,6 @@ const ContextCenterMemoriesPage: FC = () => {
                         </Typography>
                       </Box>
                     )}
-                      </div>
-                    </div>
                   </Dropdown.Popover>
                 </Dropdown.Root>
               </Box>


### PR DESCRIPTION
### Describe your changes:

I fixed the owner/author filter dropdown in `ContextCenterMemoriesPage` losing scroll because commit `1373fe285b` changed `DropdownPopover` from `overflow-auto` to `overflow-hidden` and added `max-h-none!`, which overrode React Aria's built-in height-constraining logic and removed all scroll capability.

- Removed `tw:max-h-none!` from `DropdownPopover` so React Aria can constrain height near viewport edges via `--available-height`
- Changed `tw:overflow-hidden` → `tw:overflow-y-auto` on `DropdownPopover` so the container scrolls when constrained
- Restored `tw:h-min tw:overflow-y-auto` on `DropdownMenu` so long lists scroll internally

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Author/owner filter dropdown on ContextCenterMemoriesPage scrolls when there are many authors
- Dropdown opened near the bottom of the viewport is height-constrained by React Aria and scrollable (not a tiny unscrollable clip)

#### Unit tests
- [ ] Not applicable (CSS class change only, no logic change).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [ ] Not applicable (CSS class change, visual regression only).

#### Manual testing performed
1. Open ContextCenterMemoriesPage
2. Click the Author filter dropdown — list scrolls when there are more authors than fit in the popover

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.

----
## Summary by Gitar

- **CSS adjustments:**
    - Applied `tw:flex tw:flex-col tw:max-h-80!` to `Dropdown.Popover` to constrain height.
    - Set `tw:min-h-0 tw:flex-1 tw:overflow-y-auto` on `Dropdown.Menu` to enable internal scrolling.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores scrolling for long owner and author dropdowns in the context center. The main changes are:

- Adds a maximum height to the author menu.
- Enables vertical scrolling on the constrained menu.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The menu now owns both its height constraint and vertical scrolling.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx | Constrains the author dropdown menu height and makes that menu vertically scrollable. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ui): increase author dropdown max he..."](https://github.com/open-metadata/openmetadata/commit/5d2b9e0e2b5dcca65dd84a2a09140f1c34b6686c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46204067)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->