### PR TITLE
fix(security): bump calcite-core 1.36.0 -> 1.42.0 (CVE-2026-46718)

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -1012,11 +1012,11 @@
       <version>${jena.version}</version>
     </dependency>
     
-    <!-- Apache Calcite for SQL parsing -->
+    <!-- Apache Calcite for SQL parsing. 1.42.0 fixes CVE-2026-46718 (unsafe reflection). -->
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
-      <version>1.36.0</version>
+      <version>1.42.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-lang</groupId>


### PR DESCRIPTION
## Summary

- Bump `calcite-core` from 1.36.0 to 1.42.0 in `openmetadata-service/pom.xml`.
- Clears CVE-2026-46718 (Use of Externally-Controlled Input to Select Classes or Code — Unsafe Reflection, CWE-470). Affects calcite 1.5.0 through 1.41.x.

## Verification

- `mvn clean install -DskipTests` on `openmetadata-service`: **SUCCESS** (52.9 s).
- Downstream Collate service compiles cleanly against calcite 1.42 (verified).
- No API breakage encountered in OM Service code paths despite 1.36 → 1.42 span; SQL parser & lineage compile without changes.

## Test plan

- [ ] CI green on 1.13
- [ ] Sanity: run existing SQL-parsing / lineage integration tests

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates Apache Calcite to address unsafe reflection in older releases. The main changes are:

- Bump `calcite-core` from 1.36.0 to 1.42.0.
- Document the security reason for the dependency update.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.
- No blocking issues remain in the changed code.
- The earlier parser compatibility concern does not apply because Calcite uses JavaCC rather than ANTLR.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/pom.xml | Updates `calcite-core` to 1.42.0 and documents the related security fix. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;1.13&#39; into bump-calcite-1...."](https://github.com/open-metadata/openmetadata/commit/71a0247e9fe82c05a88e74235edf3e6156de1c79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46207439)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->