### PR TITLE
fix(external-it): scale-it token refresh + honor run cancellation

### DIFF
--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -301,10 +301,12 @@ jobs:
   search-it-external:
     # These suites trigger the server-global SearchIndexingApplication, which is a singleton per
     # instance (one run at a time). Since all external jobs hit the SAME cluster, they must run
-    # serially or they collide with "Job is already running". `needs` enforces ordering; `always()`
-    # keeps each job's own toggle independent (so it still runs if ui-it was skipped/failed).
+    # serially or they collide with "Job is already running". `needs` enforces ordering;
+    # `!cancelled()` keeps each job's own toggle independent (so it still runs if ui-it was
+    # skipped/failed) while STILL honoring a manual cancel — plain `always()` forces the job to
+    # start even when you cancel the run, which is why cancelling never stopped search-it/scale-it.
     needs: [ui-it-external]
-    if: ${{ always() && github.event.inputs.runSearchIt != 'false' }}
+    if: ${{ !cancelled() && github.event.inputs.runSearchIt != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -437,7 +439,7 @@ jobs:
     # cancelled every night without ever completing. Larger sizes can still be requested on demand
     # via the scaleSeeds dispatch input (e.g. [100000, 500000]).
     needs: [search-it-external]
-    if: ${{ always() && github.event.inputs.runScaleIt != 'false' }}
+    if: ${{ !cancelled() && github.event.inputs.runScaleIt != 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 360
     strategy:

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
-import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.Entity;
 import org.slf4j.Logger;
@@ -100,7 +99,6 @@ class ServiceDeleteSearchCleanupScaleIT {
   void recursiveServiceHardDelete_clearsTableAndColumnDocsAtScale(final TestNamespace ns)
       throws Exception {
     final int tableCount = Integer.getInteger("scale.tables", DEFAULT_TABLES);
-    final OpenMetadataClient client = SdkClients.adminClient();
 
     final DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     final DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
@@ -114,7 +112,7 @@ class ServiceDeleteSearchCleanupScaleIT {
     final String columnIndex = indexAliases.indexNameFor(Entity.TABLE_COLUMN);
 
     final long seedStart = System.currentTimeMillis();
-    seedTables(ns, client, schema.getFullyQualifiedName(), tableCount);
+    seedTables(ns, schema.getFullyQualifiedName(), tableCount);
     LOG.info(
         "Seeded {} tables ({} columns each) in {} ms",
         tableCount,
@@ -131,7 +129,7 @@ class ServiceDeleteSearchCleanupScaleIT {
         expectedColumns);
 
     final long deleteStart = System.currentTimeMillis();
-    recursiveHardDelete(client, serviceId);
+    recursiveHardDelete(serviceId);
     awaitCount(tableIndex, serviceId, 0);
     awaitCount(columnIndex, serviceId, 0);
     final long deleteMs = System.currentTimeMillis() - deleteStart;
@@ -142,11 +140,7 @@ class ServiceDeleteSearchCleanupScaleIT {
         deleteMs);
   }
 
-  private void seedTables(
-      final TestNamespace ns,
-      final OpenMetadataClient client,
-      final String schemaFqn,
-      final int count) {
+  private void seedTables(final TestNamespace ns, final String schemaFqn, final int count) {
     final String namePrefix = ns.prefix("scale_tbl") + "_";
     final ExecutorService executor = Executors.newFixedThreadPool(LOAD_WORKERS);
     try {
@@ -156,7 +150,11 @@ class ServiceDeleteSearchCleanupScaleIT {
         futures.add(
             executor.submit(
                 () -> {
-                  client
+                  // Fetch the admin client fresh per task: a 100k seed outlives the operator
+                  // token's ~1h TTL, and ExternalTokenRefresher rebuilds SdkClients' cached client
+                  // on re-login. A captured reference would pin the pre-refresh (expired) token and
+                  // fail mid-seed with "401 Expired token!".
+                  SdkClients.adminClient()
                       .tables()
                       .create(
                           new CreateTable()
@@ -184,13 +182,14 @@ class ServiceDeleteSearchCleanupScaleIT {
     return columns;
   }
 
-  private void recursiveHardDelete(final OpenMetadataClient client, final String serviceId) {
+  private void recursiveHardDelete(final String serviceId) {
     // Mirror the UI's service delete: hit the async endpoint (DELETE /databaseServices/async/{id})
     // so the recursive hard delete runs on the server's background executor instead of blocking the
     // request thread — a synchronous 100k-table delete can exceed a proxied cluster's gateway
     // timeout. The endpoint returns 202 immediately; the awaitCount(...) assertions confirm the
-    // delete's search cascade actually cleared both indexes.
-    client
+    // delete's search cascade actually cleared both indexes. Fetch the admin client fresh (not a
+    // captured reference) so the refreshed token is used after a long-running seed.
+    SdkClients.adminClient()
         .getHttpClient()
         .execute(
             HttpMethod.DELETE,


### PR DESCRIPTION
Two independent reliability fixes for the `Java Integration Tests (External Cluster)` workflow.

## 1. scale-it token expiry (test code)
`ServiceDeleteSearchCleanupScaleIT` fails at 100k with `AuthenticationException (401): Expired token!` ~1h into the seed.

**Root cause:** the test captured `SdkClients.adminClient()` into a local **once**, then reused it for the entire ~1h seed. In external mode `ExternalTokenRefresher` re-logs-in every ~30m and **rebuilds** `SdkClients`' cached client, but the captured local pinned the original operator token, which expires at ~1h. `SdkClients`' javadoc already tells callers to fetch fresh, and `ServerHandle.sdk()` / `SearchClient` already do — this test was the one place that broke the contract.

**Fix:** fetch `SdkClients.adminClient()` fresh at each long-running use (seed workers + async delete). +12 −13, test-only.

## 2. Cancellation never stopped search-it / scale-it (workflow)
Cancelling a run left `search-it-external` / `scale-it-external` running.

**Root cause:** their job gates used `if: ${{ always() && ... }}`. `always()` is true even when the run is cancelled, so GitHub started them anyway.

**Fix:** `always()` → `!cancelled()` on the two job gates — same intent (run independent of ui-it's skipped/failed result) but a manual cancel now actually stops them. Step-level `always()` (artifact/report uploads) left as-is.

## Verification
- `mvn spotless:apply` — clean
- `mvn -DskipTests install -pl :openmetadata-integration-tests -am` — exit 0 (compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps long-running external integration tests working across token refreshes and improves workflow cancellation behavior. The main changes are:

- Fetches the current admin client inside each scale-seed task.
- Fetches the current admin client before recursive service deletion.
- Stops dependent external test jobs when the workflow is cancelled.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The scale test now follows the documented client-refresh lifecycle.
- No blocking incomplete or unsafe fix was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-playwright-external.yml | Changes dependent search and scale jobs to honor workflow cancellation. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java | Obtains the current admin client at each long-running use instead of retaining a stale client. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(external): honor run cancellation for..."](https://github.com/open-metadata/openmetadata/commit/ba4934906e7d5192c79e541fa985cfde36bfa403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46209835)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->