### PR TITLE
fix(retention): Data Retention run fails on 2.0 with relation "thread_entity" does not exist

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataRetentionAppIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataRetentionAppIT.java
@@ -18,12 +18,14 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.awaitility.Awaitility;
+import org.jdbi.v3.core.Handle;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -126,16 +128,21 @@ public class DataRetentionAppIT {
   }
 
   /** Mirrors FeedRepository's resolution across the pre/post-migration thread table names. */
-  private String resolveThreadTableName() {
+  private String resolveThreadTableName() throws SQLException {
     return TestSuiteBootstrap.getJdbi()
         .withHandle(
             handle -> {
+              String tableExistsQuery =
+                  isPostgres(handle)
+                      ? "SELECT COUNT(*) FROM information_schema.tables "
+                          + "WHERE table_schema = current_schema() AND table_name = :name"
+                      : "SELECT COUNT(*) FROM information_schema.tables "
+                          + "WHERE table_schema = DATABASE() AND table_name = :name";
               for (String candidate :
                   List.of("thread_entity_legacy", "thread_entity_archived", "thread_entity")) {
                 Integer tableCount =
                     handle
-                        .createQuery(
-                            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = :name")
+                        .createQuery(tableExistsQuery)
                         .bind("name", candidate)
                         .mapTo(Integer.class)
                         .one();
@@ -161,15 +168,8 @@ public class DataRetentionAppIT {
                       .one();
               ObjectNode thread = (ObjectNode) MAPPER.readTree(json);
               thread.put("threadTs", createdAtMillis);
-              boolean isPostgres =
-                  handle
-                      .getConnection()
-                      .getMetaData()
-                      .getDatabaseProductName()
-                      .toLowerCase(Locale.ROOT)
-                      .contains("postgres");
               String update =
-                  isPostgres
+                  isPostgres(handle)
                       ? "UPDATE " + threadTable + " SET json = CAST(:json AS jsonb) WHERE id = :id"
                       : "UPDATE " + threadTable + " SET json = :json WHERE id = :id";
               handle
@@ -178,6 +178,15 @@ public class DataRetentionAppIT {
                   .bind("id", threadId.toString())
                   .execute();
             });
+  }
+
+  private boolean isPostgres(Handle handle) throws SQLException {
+    return handle
+        .getConnection()
+        .getMetaData()
+        .getDatabaseProductName()
+        .toLowerCase(Locale.ROOT)
+        .contains("postgres");
   }
 
   private int threadRowCount(String threadTable, UUID threadId) {

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataRetentionAppIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataRetentionAppIT.java
@@ -1,0 +1,238 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.openmetadata.it.bootstrap.TestSuiteBootstrap;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.factories.TableTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.feed.CreateThread;
+import org.openmetadata.schema.entity.app.AppRunRecord;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.feed.Thread;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.type.ThreadType;
+import org.openmetadata.sdk.fluent.Apps;
+import org.openmetadata.sdk.fluent.DatabaseSchemas;
+import org.openmetadata.sdk.fluent.Databases;
+import org.openmetadata.sdk.network.HttpClient;
+import org.openmetadata.sdk.network.HttpMethod;
+
+/**
+ * Integration tests for the Data Retention application.
+ *
+ * <p>Regression coverage for the 2.0 activity-storage migration: the migration renames
+ * thread_entity (e.g. to thread_entity_legacy) specifically to fail stale references, so the
+ * retention job must resolve the current thread storage table instead of hardcoding the old name.
+ * A failure in one cleanup step also aborts the steps after it, so a crash here silently disables
+ * test-case-result, profile-data, and audit-log retention as well.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@Isolated
+@ExtendWith(TestNamespaceExtension.class)
+public class DataRetentionAppIT {
+
+  private static final String APP_NAME = "DataRetentionApplication";
+  // Default activityThreadsRetentionPeriod is 60 days; 90 days is safely past it.
+  private static final long NINETY_DAYS_MILLIS = 90L * 24 * 60 * 60 * 1000;
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @BeforeAll
+  static void setup() {
+    Apps.setDefaultClient(SdkClients.adminClient());
+  }
+
+  @Test
+  void test_retentionRun_cleansOldConversationsFromThreadStorage(TestNamespace ns)
+      throws Exception {
+    assumeFalse(
+        TestSuiteBootstrap.isK8sEnabled(), "App trigger not compatible with K8s pipeline backend");
+
+    Table table = createTestTable(ns);
+    String about = String.format("<#E::table::%s>", table.getFullyQualifiedName());
+    Thread oldThread = createConversation(about, "conversation past retention period");
+    Thread recentThread = createConversation(about, "recent conversation");
+
+    String threadTable = resolveThreadTableName();
+    backdateThread(threadTable, oldThread.getId(), System.currentTimeMillis() - NINETY_DAYS_MILLIS);
+
+    AppRunRecord run = triggerAppAndWaitForCompletion();
+
+    assertEquals(
+        "success",
+        run.getStatus().value(),
+        () -> "Data retention run did not succeed. failureContext=" + run.getFailureContext());
+    assertEquals(
+        0,
+        threadRowCount(threadTable, oldThread.getId()),
+        "conversation older than the retention period must be deleted");
+    assertEquals(
+        1,
+        threadRowCount(threadTable, recentThread.getId()),
+        "recent conversation must be retained");
+  }
+
+  private Table createTestTable(TestNamespace ns) throws Exception {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    Database database =
+        Databases.create().name(ns.prefix("db")).in(service.getFullyQualifiedName()).execute();
+    DatabaseSchema schema =
+        DatabaseSchemas.create()
+            .name(ns.prefix("schema"))
+            .in(database.getFullyQualifiedName())
+            .execute();
+    return TableTestFactory.createSimple(ns, schema.getFullyQualifiedName());
+  }
+
+  private Thread createConversation(String about, String message) throws Exception {
+    CreateThread createThread =
+        new CreateThread().withMessage(message).withAbout(about).withType(ThreadType.Conversation);
+    return SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.POST, "/v1/feed", createThread, Thread.class);
+  }
+
+  /** Mirrors FeedRepository's resolution across the pre/post-migration thread table names. */
+  private String resolveThreadTableName() {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle -> {
+              for (String candidate :
+                  List.of("thread_entity_legacy", "thread_entity_archived", "thread_entity")) {
+                Integer tableCount =
+                    handle
+                        .createQuery(
+                            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = :name")
+                        .bind("name", candidate)
+                        .mapTo(Integer.class)
+                        .one();
+                if (tableCount != null && tableCount > 0) {
+                  return candidate;
+                }
+              }
+              throw new IllegalStateException("No thread storage table found in test database");
+            });
+  }
+
+  /** createdAt is a generated column over json->threadTs, so backdating rewrites the json. */
+  private void backdateThread(String threadTable, UUID threadId, long createdAtMillis)
+      throws Exception {
+    TestSuiteBootstrap.getJdbi()
+        .useHandle(
+            handle -> {
+              String json =
+                  handle
+                      .createQuery("SELECT json FROM " + threadTable + " WHERE id = :id")
+                      .bind("id", threadId.toString())
+                      .mapTo(String.class)
+                      .one();
+              ObjectNode thread = (ObjectNode) MAPPER.readTree(json);
+              thread.put("threadTs", createdAtMillis);
+              boolean isPostgres =
+                  handle
+                      .getConnection()
+                      .getMetaData()
+                      .getDatabaseProductName()
+                      .toLowerCase(Locale.ROOT)
+                      .contains("postgres");
+              String update =
+                  isPostgres
+                      ? "UPDATE " + threadTable + " SET json = CAST(:json AS jsonb) WHERE id = :id"
+                      : "UPDATE " + threadTable + " SET json = :json WHERE id = :id";
+              handle
+                  .createUpdate(update)
+                  .bind("json", thread.toString())
+                  .bind("id", threadId.toString())
+                  .execute();
+            });
+  }
+
+  private int threadRowCount(String threadTable, UUID threadId) {
+    return TestSuiteBootstrap.getJdbi()
+        .withHandle(
+            handle ->
+                handle
+                    .createQuery("SELECT COUNT(*) FROM " + threadTable + " WHERE id = :id")
+                    .bind("id", threadId.toString())
+                    .mapTo(Integer.class)
+                    .one());
+  }
+
+  private AppRunRecord triggerAppAndWaitForCompletion() {
+    HttpClient httpClient = SdkClients.adminClient().getHttpClient();
+    long triggerTime = System.currentTimeMillis();
+    Awaitility.await("Trigger " + APP_NAME)
+        .atMost(Duration.ofMinutes(2))
+        .pollInterval(Duration.ofSeconds(3))
+        .ignoreExceptionsMatching(
+            e -> e.getMessage() != null && e.getMessage().contains("already running"))
+        .until(
+            () -> {
+              Apps.trigger(APP_NAME).run();
+              return true;
+            });
+
+    AtomicReference<AppRunRecord> completedRun = new AtomicReference<>();
+    Awaitility.await("Wait for terminal run of " + APP_NAME)
+        .atMost(Duration.ofMinutes(5))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              AppRunRecord run =
+                  httpClient.execute(
+                      HttpMethod.GET,
+                      "/v1/apps/name/" + APP_NAME + "/runs/latest",
+                      null,
+                      AppRunRecord.class);
+              if (run == null
+                  || run.getStatus() == null
+                  || run.getTimestamp() == null
+                  // Allow modest clock skew between the test JVM and the server under test.
+                  || run.getTimestamp() < triggerTime - 60_000) {
+                return false;
+              }
+              String status = run.getStatus().value();
+              if ("running".equalsIgnoreCase(status) || "started".equalsIgnoreCase(status)) {
+                return false;
+              }
+              completedRun.set(run);
+              return true;
+            });
+    return completedRun.get();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java
@@ -48,7 +48,6 @@ public class DataRetention extends AbstractNativeApplication {
   private IndexingError failureDetails = null;
 
   private final FeedRepository feedRepository;
-  private final CollectionDAO.FeedDAO feedDAO;
 
   private final EntityTimeSeriesDAO testCaseResultsDAO;
   private final EntityTimeSeriesDAO profileDataDAO;
@@ -58,7 +57,6 @@ public class DataRetention extends AbstractNativeApplication {
     super(collectionDAO, searchRepository);
     this.eventSubscriptionDAO = collectionDAO.eventSubscriptionDAO();
     this.feedRepository = Entity.getFeedRepository();
-    this.feedDAO = Entity.getCollectionDAO().feedDAO();
     this.testCaseResultsDAO = collectionDAO.testCaseResultTimeSeriesDao();
     this.profileDataDAO = collectionDAO.profilerDataTimeSeriesDao();
     this.auditLogDAO = collectionDAO.auditLogDAO();
@@ -210,7 +208,7 @@ public class DataRetention extends AbstractNativeApplication {
     long cutoffMillis = getRetentionCutoffMillis(retentionPeriod);
 
     List<UUID> threadIdsToDelete =
-        feedDAO.fetchConversationThreadIdsOlderThan(cutoffMillis, BATCH_SIZE);
+        feedRepository.fetchConversationThreadIdsOlderThan(cutoffMillis, BATCH_SIZE);
 
     if (threadIdsToDelete.isEmpty()) {
       LOG.info(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -3233,11 +3233,6 @@ public interface CollectionDAO {
         @Bind("cutoffMillis") long cutoffMillis,
         @Bind("batchSize") int batchSize);
 
-    @SqlQuery(
-        "SELECT id FROM thread_entity WHERE type = 'Conversation' AND createdAt < :cutoffMillis LIMIT :batchSize")
-    List<UUID> fetchConversationThreadIdsOlderThan(
-        @Bind("cutoffMillis") long cutoffMillis, @Bind("batchSize") int batchSize);
-
     @ConnectionAwareSqlQuery(
         value =
             "SELECT count(id) FROM <tableName> <condition> "

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java
@@ -791,6 +791,19 @@ public class FeedRepository {
     return deleted;
   }
 
+  public List<UUID> fetchConversationThreadIdsOlderThan(long cutoffMillis, int batchSize) {
+    List<UUID> result = List.of();
+    if (isLegacyThreadStorageAvailable()) {
+      result =
+          dao.feedDAO()
+              .fetchConversationThreadIdsOlderThan(
+                  getLegacyThreadTableName(), cutoffMillis, batchSize);
+    } else {
+      LOG.debug("Skipping conversation retention fetch because thread storage is unavailable");
+    }
+    return result;
+  }
+
   public void deleteByAbout(UUID entityId) {
     deleteByAbout(List.of(entityId));
   }


### PR DESCRIPTION
## Describe your changes

Every Data Retention run on a 2.0-migrated instance fails with:

```
org.postgresql.util.PSQLException: ERROR: relation "thread_entity" does not exist
  at jdk.proxy2.$Proxy265.fetchConversationThreadIdsOlderThan(Unknown Source)
  at org.openmetadata.service.apps.bundles.dataRetention.DataRetention.cleanActivityThreads(DataRetention.java:213)
```

**Root cause:** the 2.0 migration renames `thread_entity` → `thread_entity_legacy` (PHASE 2E, "to fail stale references"; 2.1 renames it again to `thread_entity_archived`), but `DataRetention.cleanActivityThreads` still called a `FeedDAO` query with the old table name hardcoded. The query fails at parse time, so the run crashes even with zero threads, on both MySQL and PostgreSQL.

**Impact beyond the failed run:** the cleanup steps sequenced after activity threads — test case results, profile data, and audit log retention — never execute, so those retentions have been silently disabled on every migrated instance. Conversations older than the retention period are also never cleaned.

### Fix

- `FeedRepository`: new `fetchConversationThreadIdsOlderThan(cutoffMillis, batchSize)` that resolves the current thread storage table (`thread_entity_legacy` / `thread_entity_archived` / `thread_entity`) — the same resolution already used by feed reads, writes, and `deleteThreadsInBatch` — and skips quietly when no thread storage exists (conversations still live in this table on 2.0; only tasks and announcements moved to `task_entity` / `announcement_entity`).
- `DataRetention.cleanActivityThreads`: call the repository instead of the raw DAO; drop the now-unused `feedDAO` field.
- `CollectionDAO`: remove the hardcoded-table overload so the stale name cannot be reintroduced; the parameterized `@Define("tableName")` overload (previously dead code) is now the only one.

### Testing

New `DataRetentionAppIT` seeds two conversations via the feed API, backdates one past the 60-day default retention (rewriting `threadTs`, since `createdAt` is a generated column), triggers `DataRetentionApplication`, and asserts the run succeeds, the old conversation is deleted, and the recent one is retained. The test fails with the exact production stack trace without the fix and passes with it. Also reproduced/verified end-to-end on a local 1.13.1 → 2.0 migrated instance (run failed pre-fix with the same trace; change-event cleanup succeeded, thread cleanup crashed, downstream cleanups skipped).

**Follow-up (not in this PR):** `ActivityStreamPartitionManager.maintainPartitions()` (partition-based retention for `activity_stream`) currently has no callers and needs to be wired into a scheduled path — tracked in #30333.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes activity-thread retention after thread-storage migrations. The main changes are:

- Resolves the current legacy, archived, or original thread table through `FeedRepository`.
- Removes the DAO query that hardcoded `thread_entity`.
- Uses the repository from the data-retention workflow.
- Adds an integration test for deleting expired conversations while preserving recent ones.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The retention fetch and deletion paths use the same table resolver.
- The stale hardcoded query has been removed.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/dataRetention/DataRetention.java | Routes conversation retention through `FeedRepository` and removes the direct DAO dependency. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/FeedRepository.java | Adds retention lookup through the existing thread-storage table resolver. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Removes the stale query overload that hardcoded the original thread table. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataRetentionAppIT.java | Adds an end-to-end test for expired and recent conversation retention. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: match production schema filter in ..."](https://github.com/open-metadata/openmetadata/commit/8479de99d3ae365d162e7ec9b513588d66c7256b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46210236)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->