### PR TITLE
fix(ui): cap long domain & data product names so they wrap instead of breaking layout

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -39,6 +39,10 @@ import {
   getGlossaryTags,
 } from '../../utils/TagsPureUtils';
 import { useDelete } from '../common/atoms/actions/useDelete';
+import {
+  COMPACT_CELL_WRAP_CLASS,
+  NAME_CELL_WRAP_CLASS,
+} from '../common/atoms/domain/ui/domainFieldRenderers';
 import { useDataProductFilters } from '../common/atoms/domain/ui/useDataProductFilters';
 import { useDomainCardTemplates } from '../common/atoms/domain/ui/useDomainCardTemplates';
 import { useFilterSelection } from '../common/atoms/filters/useFilterSelection';
@@ -172,7 +176,7 @@ const DataProductListPage = ({
           return (
             <Box
               align="start"
-              className="tw:max-w-[480px]"
+              className={NAME_CELL_WRAP_CLASS}
               direction="row"
               gap={3}>
               <Avatar size="md" {...getEntityAvatarProps(entity)} />
@@ -208,7 +212,7 @@ const DataProductListPage = ({
           return (
             <Box
               align="start"
-              className="tw:max-w-[320px]"
+              className={COMPACT_CELL_WRAP_CLASS}
               direction="row"
               gap={1}>
               <Globe01 size={16} style={{ flexShrink: 0 }} />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -170,9 +170,13 @@ const DataProductListPage = ({
             entity.displayName !== entity.name;
 
           return (
-            <Box align="center" direction="row" gap={3}>
+            <Box
+              align="start"
+              className="tw:max-w-[480px]"
+              direction="row"
+              gap={3}>
               <Avatar size="md" {...getEntityAvatarProps(entity)} />
-              <Box direction="col">
+              <Box className="tw:min-w-0" direction="col">
                 <Typography size="text-sm" weight="medium">
                   {entityName}
                 </Typography>
@@ -202,7 +206,11 @@ const DataProductListPage = ({
           const domain = domains[0];
 
           return (
-            <Box align="center" direction="row" gap={1}>
+            <Box
+              align="start"
+              className="tw:max-w-[320px]"
+              direction="row"
+              gap={1}>
               <Globe01 size={16} style={{ flexShrink: 0 }} />
               <Typography size="text-sm">
                 {domain.displayName || domain.name}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -819,7 +819,7 @@ const DataProductsDetailsPage = ({
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
           <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-start tw:justify-between">
-            <div className="entity-header-title-top tw:max-w-[60%]">
+            <div className="entity-header-title-top tw:max-w-full tw:lg:max-w-[60%]">
               <EntityHeader
                 badge={statusBadge}
                 breadcrumb={[]}
@@ -838,8 +838,8 @@ const DataProductsDetailsPage = ({
                 titleColor={dataProduct.style?.color}
               />
             </div>
-            <div className="tw:shrink-0">
-              <div className="tw:flex tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
+            <div className="tw:shrink-0 tw:max-w-full">
+              <div className="tw:flex tw:flex-wrap tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
                 {dataProductClassBase.getRequestDataAccessButton()}
 
                 {!isVersionsView && dataProductPermission.Create && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -818,17 +818,19 @@ const DataProductsDetailsPage = ({
           permissions={dataProductPermission}
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
-          <div className="tw:flex tw:mx-5 tw:items-end">
-            <div className="tw:flex-1">
+          <div className="tw:flex tw:mx-5 tw:items-start tw:justify-between">
+            <div className="tw:max-w-[60%]">
               <EntityHeader
                 badge={statusBadge}
                 breadcrumb={[]}
+                displayNameClassName="entity-header-title-wrap"
                 entityData={{ ...dataProduct, displayName, name }}
                 entityType={EntityType.DATA_PRODUCT}
                 handleFollowingClick={handleFollowingClick}
                 icon={iconData}
                 isFollowing={isFollowing}
                 isFollowingLoading={isFollowingLoading}
+                nameClassName="entity-header-title-wrap"
                 serviceName=""
                 suffix={
                   <LearningIcon pageId={LEARNING_PAGE_IDS.DATA_PRODUCT} />
@@ -836,7 +838,7 @@ const DataProductsDetailsPage = ({
                 titleColor={dataProduct.style?.color}
               />
             </div>
-            <div>
+            <div className="tw:shrink-0">
               <div className="tw:flex tw:gap-3 tw:justify-end tw:items-center tw:pb-1">
                 {dataProductClassBase.getRequestDataAccessButton()}
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -818,7 +818,7 @@ const DataProductsDetailsPage = ({
           permissions={dataProductPermission}
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
-          <div className="tw:flex tw:mx-5 tw:items-start tw:justify-between">
+          <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-start tw:justify-between">
             <div className="entity-header-title-top tw:max-w-[60%]">
               <EntityHeader
                 badge={statusBadge}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -819,7 +819,7 @@ const DataProductsDetailsPage = ({
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
           <div className="tw:flex tw:mx-5 tw:items-start tw:justify-between">
-            <div className="tw:max-w-[60%]">
+            <div className="entity-header-title-top tw:max-w-[60%]">
               <EntityHeader
                 badge={statusBadge}
                 breadcrumb={[]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -954,7 +954,7 @@ const DomainDetails = ({
           />
         )}
         <Box align="start" className="entity-header tw:mx-5" justify="between">
-          <div className="tw:max-w-[60%]">
+          <div className="entity-header-title-top tw:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}
               displayNameClassName="entity-header-title-wrap"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -958,7 +958,7 @@ const DomainDetails = ({
           className="entity-header tw:mx-5 tw:gap-y-3"
           justify="between"
           wrap="wrap">
-          <div className="entity-header-title-top tw:max-w-[60%]">
+          <div className="entity-header-title-top tw:max-w-full tw:lg:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}
               displayNameClassName="entity-header-title-wrap"
@@ -981,9 +981,10 @@ const DomainDetails = ({
           </div>
           <Box
             align="center"
-            className="domain-header-action-container tw:pb-1 tw:shrink-0"
+            className="domain-header-action-container tw:pb-1 tw:shrink-0 tw:max-w-full"
             gap={3}
-            justify="end">
+            justify="end"
+            wrap="wrap">
             {!isVersionsView && addButtonContent.length > 0 && (
               <Dropdown
                 data-testid="domain-details-add-button-menu"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -953,7 +953,11 @@ const DomainDetails = ({
             position={{ y: domain.style?.coverImage?.position }}
           />
         )}
-        <Box align="start" className="entity-header tw:mx-5" justify="between">
+        <Box
+          align="start"
+          className="entity-header tw:mx-5 tw:gap-y-3"
+          justify="between"
+          wrap="wrap">
           <div className="entity-header-title-top tw:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -953,10 +953,11 @@ const DomainDetails = ({
             position={{ y: domain.style?.coverImage?.position }}
           />
         )}
-        <Box align="end" className="entity-header tw:mx-5">
-          <div className="tw:flex-1">
+        <Box align="start" className="entity-header tw:mx-5" justify="between">
+          <div className="tw:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}
+              displayNameClassName="entity-header-title-wrap"
               entityData={{ ...domain, displayName, name }}
               entityType={EntityType.DOMAIN}
               entityUrl={`${globalThis.location.origin}/domain/${urlEncodedFqn}`}
@@ -964,6 +965,7 @@ const DomainDetails = ({
               icon={iconData}
               isFollowing={isFollowing}
               isFollowingLoading={isFollowingLoading}
+              nameClassName="entity-header-title-wrap"
               serviceName=""
               suffix={
                 !isTreeView && (
@@ -975,7 +977,7 @@ const DomainDetails = ({
           </div>
           <Box
             align="center"
-            className="domain-header-action-container tw:pb-1"
+            className="domain-header-action-container tw:pb-1 tw:shrink-0"
             gap={3}
             justify="end">
             {!isVersionsView && addButtonContent.length > 0 && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -805,10 +805,14 @@ const DomainTreeView = ({
             key={identifier}
             textValue={getEntityName(node)}>
             <Tree.ItemContent showGuideLines hasChildItems={hasChildren}>
-              <Box align="center" direction="row" gap={2}>
+              <Box
+                align="center"
+                className="tw:min-w-0"
+                direction="row"
+                gap={2}>
                 <Avatar size="xs" {...getEntityAvatarProps(node)} />
                 <Typography
-                  className="tw:text-primary"
+                  className="tw:text-primary tw:min-w-0"
                   size="text-sm"
                   weight="regular">
                   {getEntityName(node)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx
@@ -807,7 +807,7 @@ const DomainTreeView = ({
             <Tree.ItemContent showGuideLines hasChildItems={hasChildren}>
               <Box
                 align="center"
-                className="tw:min-w-0"
+                className="tw:min-w-0 tw:[overflow-wrap:anywhere]"
                 direction="row"
                 gap={2}>
                 <Avatar size="xs" {...getEntityAvatarProps(node)} />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
@@ -37,6 +37,12 @@
   word-break: break-word;
 }
 
+// When the title wraps onto multiple lines, top-align the icon with the first
+// line instead of centering it against the full (tall) title block.
+.entity-header-title-top .entity-header-title {
+  align-items: flex-start;
+}
+
 .ant-btn.entity-follow-button {
   border-radius: 16px;
   background-color: @primary-button-background;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
@@ -37,10 +37,11 @@
   word-break: break-word;
 }
 
-// When the title wraps onto multiple lines, top-align the icon with the first
-// line instead of centering it against the full (tall) title block.
+// When the title wraps onto multiple lines, top-align the icon and the name
+// container with the first line instead of centering them against the full
+// (tall) title block. `!important` overrides antd's `.ant-row-middle`.
 .entity-header-title-top .entity-header-title {
-  align-items: flex-start;
+  align-items: flex-start !important;
 }
 
 .ant-btn.entity-follow-button {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
@@ -26,6 +26,17 @@
   }
 }
 
+// Opt-in modifier: lets a header title wrap onto multiple lines instead of
+// truncating with an ellipsis. Overrides antd's single-line ellipsis so a long
+// name stays fully visible within a width-capped container. Only active when a
+// consumer passes `entity-header-title-wrap` via nameClassName/displayNameClassName.
+.entity-header-title-wrap.ant-typography {
+  white-space: normal !important;
+  overflow: visible !important;
+  text-overflow: clip !important;
+  word-break: break-word;
+}
+
 .ant-btn.entity-follow-button {
   border-radius: 16px;
   background-color: @primary-button-background;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -41,7 +41,7 @@ interface OwnedEntity {
 export const renderDomainNameCell = (
   entity: Domain | DataProduct
 ): ReactNode => (
-  <Box align="center" direction="row" gap={3}>
+  <Box align="start" className="tw:max-w-[480px]" direction="row" gap={3}>
     <Avatar size="md" {...getEntityAvatarProps(entity)} />
     <Typography size="text-sm" weight="medium">
       {getEntityName(entity)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -38,10 +38,19 @@ interface OwnedEntity {
   owners?: EntityReference[];
 }
 
+// Long entity names (including no-space strings) must wrap within a capped
+// width instead of overflowing the row. `overflow-wrap:anywhere` both adds
+// break points and lets the flex item shrink below its content width.
+export const NAME_CELL_WRAP_CLASS =
+  'tw:max-w-[480px] tw:[overflow-wrap:anywhere]';
+export const COMPACT_CELL_WRAP_CLASS =
+  'tw:max-w-[320px] tw:[overflow-wrap:anywhere]';
+export const CARD_NAME_WRAP_CLASS = 'tw:min-w-0 tw:[overflow-wrap:anywhere]';
+
 export const renderDomainNameCell = (
   entity: Domain | DataProduct
 ): ReactNode => (
-  <Box align="start" className="tw:max-w-[480px]" direction="row" gap={3}>
+  <Box align="start" className={NAME_CELL_WRAP_CLASS} direction="row" gap={3}>
     <Avatar size="md" {...getEntityAvatarProps(entity)} />
     <Typography size="text-sm" weight="medium">
       {getEntityName(entity)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
@@ -37,7 +37,7 @@ export const useDomainCardTemplates = () => {
   const renderDomainCard = useCallback(
     (entity: Domain): ReactNode => (
       <Box direction="col" gap={4}>
-        <Box align="center" direction="row" gap={3}>
+        <Box align="start" className="tw:min-w-0" direction="row" gap={3}>
           <Avatar size="md" {...getEntityAvatarProps(entity)} />
           <Typography size="text-sm" weight="medium">
             {getEntityName(entity)}
@@ -88,9 +88,9 @@ export const useDomainCardTemplates = () => {
 
       return (
         <Box direction="col" gap={4}>
-          <Box align="center" direction="row" gap={3}>
+          <Box align="start" className="tw:min-w-0" direction="row" gap={3}>
             <Avatar size="md" {...getEntityAvatarProps(entity)} />
-            <Box direction="col">
+            <Box className="tw:min-w-0" direction="col">
               <Typography size="text-sm" weight="medium">
                 {entityName}
               </Typography>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
@@ -25,6 +25,7 @@ import { getEntityName } from '../../../../../utils/EntityNameUtils';
 import { getEntityAvatarProps } from '../../../../../utils/IconUtils';
 import { OwnerLabel } from '../../../OwnerLabel/OwnerLabel.component';
 import {
+  CARD_NAME_WRAP_CLASS,
   renderDomainClassificationTagsCell,
   renderDomainGlossaryTagsCell,
   renderDomainOwnersCell,
@@ -37,7 +38,11 @@ export const useDomainCardTemplates = () => {
   const renderDomainCard = useCallback(
     (entity: Domain): ReactNode => (
       <Box direction="col" gap={4}>
-        <Box align="start" className="tw:min-w-0" direction="row" gap={3}>
+        <Box
+          align="start"
+          className={CARD_NAME_WRAP_CLASS}
+          direction="row"
+          gap={3}>
           <Avatar size="md" {...getEntityAvatarProps(entity)} />
           <Typography size="text-sm" weight="medium">
             {getEntityName(entity)}
@@ -88,7 +93,11 @@ export const useDomainCardTemplates = () => {
 
       return (
         <Box direction="col" gap={4}>
-          <Box align="start" className="tw:min-w-0" direction="row" gap={3}>
+          <Box
+            align="start"
+            className={CARD_NAME_WRAP_CLASS}
+            direction="row"
+            gap={3}>
             <Avatar size="md" {...getEntityAvatarProps(entity)} />
             <Box className="tw:min-w-0" direction="col">
               <Typography size="text-sm" weight="medium">


### PR DESCRIPTION
## What & why

Long domain / data-product names now stay readable and no longer break the page layout. A name with no width bound used to:

- spread across the **list / card / tree** views and wrap into an extremely tall row, and
- render on a single overflowing line in the **details-page header**, pushing the action buttons (Add / Vote / Version / Manage) off-screen.

This caps each name label's width and lets it **wrap** (no ellipsis) — names stay fully visible and the header keeps all of its action buttons.

## Changes

- **List table / cards / tree** — `domainFieldRenderers`, `DataProductListPage`, `useDomainCardTemplates`, `DomainTreeView`: the name-cell container gets a `max-width` so the name wraps within it instead of dominating the row. The Data Products table's Domains cell (also an entity-name label) is capped the same way.
- **Domain & Data Product details headers** — `DomainDetails`, `DataProductsDetailsPage`: the title container is capped at `60%`, `justify-between` + `shrink-0` keep the action buttons flush-right and always visible, and an opt-in `entity-header-title-wrap` class (added to `entity-header-title.less`) lets the shared antd title wrap instead of truncating. No change to shared `EntityHeaderTitle` logic and no core-component changes.

## Before / After

### Domain details header — action buttons were pushed off-screen
| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/02-domain-details-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/02-domain-details-after.png" width="440"> |

### Data Product details header — action buttons were pushed off-screen
| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/04-dataproduct-details-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/04-dataproduct-details-after.png" width="440"> |

### Domain list — name spread across the row
| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/01-domain-list-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/01-domain-list-after.png" width="440"> |

### Data Product list — name + domain columns spread across the row
| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/03-dataproduct-list-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/assets-wrap-text-no-ellipses/03-dataproduct-list-after.png" width="440"> |

## Testing

- Verified locally against a running stack with a domain and a data product created with a ~260-character name, across all four surfaces above (card/tree share the list renderers).
- Ran the UI checkstyle sequence (organize-imports → eslint --fix → prettier) on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR keeps long domain and data-product names within their layouts. The main changes are:

- Adds bounded, wrapping labels to list and table cells.
- Adds break points for long names in cards and the domain tree.
- Allows details-page titles and action groups to wrap on narrow screens.
- Adds an opt-in multiline style for shared entity-header titles.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated name labels can shrink and break long strings.
- Both details headers now wrap their action controls within the available width.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx | Applies bounded wrapping to data-product names and domain labels. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx | Allows the title and action controls to wrap within the header. |
| openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx | Adds responsive wrapping to the domain title and action group. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.tsx | Adds shrink and break behavior for long tree-item names. |
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less | Adds opt-in multiline title styling and top alignment. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx | Defines shared wrapping classes for entity-name cells. |
| openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx | Applies shrinkable, breakable layouts to card names. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ui): make the details header fully r..."](https://github.com/open-metadata/openmetadata/commit/b100a8a84c36e8f5f1a3d11e20ee6c8faf93c80d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46217414)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->