### PR TITLE
fix(ui): resolve app mode at login redirect so AI-preferred users land on /

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -55,7 +55,7 @@ import { withActivePersonaHeader } from '../../../hoc/withActivePersonaHeader';
 import { withDomainFilter } from '../../../hoc/withDomainFilter';
 import { withLanguageHeader } from '../../../hoc/withLanguageHeader';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
-import { clearAppMode, useAppModeStore } from '../../../hooks/useAppMode';
+import { clearAppMode, resolveInitialAppMode } from '../../../hooks/useAppMode';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
 import { useExploreCache } from '../../../hooks/useExploreCache';
 import { queryClient } from '../../../queryClient';
@@ -261,11 +261,20 @@ export const AuthProvider = ({
       // shell and land pages — navigating to /my-data would drop the
       // user on the Classic My Data page even though their tab is in
       // AI mode. Route to `/` and let the mode-specific route tree
-      // render its own landing page. The mode value here comes from
-      // the useAppMode store, which is hydrated at module load from
-      // sessionStorage / the cross-tab hint (see useAppMode.ts) and
-      // then refined by useResolvedAppMode against persona / user pref.
-      const appMode = useAppModeStore.getState().currentMode;
+      // render its own landing page.
+      //
+      // At post-login redirect time `useResolvedAppMode` has not yet
+      // run, so the useAppMode store alone only reflects the
+      // sessionStorage tuple (empty on a fresh login). `resolveInitialAppMode`
+      // consults the same synchronously-available signals as the
+      // resolver — session tuple → fresh cross-tab hint → user's
+      // stored preference — so a user whose "remember" checkbox is on
+      // AI or whose sibling tab is in AI lands on `/` from the start
+      // instead of being bounced through `/my-data` and then flipped
+      // to AI by the resolver a tick later. Persona (async) stays
+      // with the resolver.
+      const userName = useApplicationStore.getState().currentUser?.name;
+      const appMode = resolveInitialAppMode(userName);
       if (appMode !== DEFAULT_APP_MODE) {
         navigate(ROUTES.HOME);
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
@@ -19,11 +19,13 @@ import {
   APP_MODE_SESSION_KEY,
   DEFAULT_APP_MODE,
 } from '../constants/appMode.constants';
+import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 import {
   clearAppMode,
   isAppModeHintFresh,
   readAppModeHint,
   readAppModeSession,
+  resolveInitialAppMode,
   useAppMode,
   useAppModeStore,
   writeAppMode,
@@ -341,5 +343,117 @@ describe('readAppModeSession', () => {
     );
 
     expect(readAppModeSession()).toBeNull();
+  });
+});
+
+describe('resolveInitialAppMode', () => {
+  const TEST_USER = 'test-user';
+
+  beforeEach(() => {
+    resetStore();
+    // Persistent user-prefs store is not cleared by resetStore — clear
+    // any lingering preference so tests are hermetic.
+    usePersistentStorage.getState().clearUserPreference(TEST_USER);
+  });
+
+  it('returns DEFAULT_APP_MODE when no signal is present', () => {
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('returns the session tuple mode when present (mid-session re-auth in AI tab)', () => {
+    act(() => {
+      writeAppMode('ai');
+    });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
+  });
+
+  it('returns the hint mode when session is empty and hint is fresh (sibling AI tab)', () => {
+    // Simulate a sibling AI tab having written the hint — but this tab
+    // has no session tuple yet (fresh open).
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({ mode: 'ai', ts: Date.now() })
+    );
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
+  });
+
+  it('ignores a stale hint (past TTL) and falls through', () => {
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({
+        mode: 'ai',
+        ts: Date.now() - APP_MODE_HINT_TTL_MS - 1_000,
+      })
+    );
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('ignores a fresh DEFAULT-mode hint (no positive AI signal)', () => {
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({ mode: DEFAULT_APP_MODE, ts: Date.now() })
+    );
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('returns the stored user preference when no session and no fresh hint', () => {
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: 'ai' });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
+  });
+
+  it('ignores a DEFAULT-valued preference (falls through to default)', () => {
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: DEFAULT_APP_MODE });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('ignores a null-valued preference', () => {
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: null });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('returns default when userName is undefined (skips the preference lookup)', () => {
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: 'ai' });
+
+    expect(resolveInitialAppMode(undefined)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('session tuple wins over a conflicting hint', () => {
+    act(() => {
+      writeAppMode('ai');
+    });
+    // Force-overwrite the hint written by writeAppMode with a conflict.
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({ mode: DEFAULT_APP_MODE, ts: Date.now() })
+    );
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
+  });
+
+  it('fresh hint wins over a conflicting stored user preference', () => {
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({ mode: 'ai', ts: Date.now() })
+    );
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: DEFAULT_APP_MODE });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
@@ -445,6 +445,36 @@ describe('resolveInitialAppMode', () => {
     expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
   });
 
+  // Regression: an explicit Classic session tuple must win over a
+  // fresh AI hint from a sibling tab. Reading only in-memory
+  // `currentMode` conflates "no session" with "explicit Classic
+  // session" (both return DEFAULT_APP_MODE), which used to let a
+  // stray AI hint reroute a Classic re-auth to `/`.
+  it('explicit Classic session tuple wins over a fresh AI hint', () => {
+    act(() => {
+      writeAppMode(DEFAULT_APP_MODE);
+    });
+    // Overwrite the hint that writeAppMode just wrote (also DEFAULT)
+    // with a conflicting AI hint from a hypothetical sibling tab.
+    globalThis.window.localStorage.setItem(
+      APP_MODE_HINT_STORAGE_KEY,
+      JSON.stringify({ mode: 'ai', ts: Date.now() })
+    );
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('explicit Classic session tuple wins over a conflicting stored AI preference', () => {
+    act(() => {
+      writeAppMode(DEFAULT_APP_MODE);
+    });
+    usePersistentStorage
+      .getState()
+      .setUserPreference(TEST_USER, { appMode: 'ai' });
+
+    expect(resolveInitialAppMode(TEST_USER)).toBe(DEFAULT_APP_MODE);
+  });
+
   it('fresh hint wins over a conflicting stored user preference', () => {
     globalThis.window.localStorage.setItem(
       APP_MODE_HINT_STORAGE_KEY,

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
@@ -19,6 +19,7 @@ import {
   APP_MODE_SESSION_KEY,
   DEFAULT_APP_MODE,
 } from '../constants/appMode.constants';
+import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 
 /**
  * Payload persisted in `sessionStorage[APP_MODE_SESSION_KEY]`.
@@ -321,3 +322,42 @@ export const isAppModeHintFresh = (hint: AppModeHint | null): boolean =>
  * active mode is the default.
  */
 export const useIsAiMode = (): boolean => useAppMode() !== DEFAULT_APP_MODE;
+
+/**
+ * Synchronously resolve the app mode a freshly-authenticated user should
+ * land in, using the same precedence as {@link useResolvedAppMode} minus
+ * the async persona lookup:
+ *
+ *   1. `sessionStorage` tuple (mid-session re-auth in an already-AI tab)
+ *   2. Fresh cross-tab hint (a sibling tab in this browser is in AI)
+ *   3. User's stored `preferences.appMode` (the "remember" checkbox)
+ *   4. `DEFAULT_APP_MODE`
+ *
+ * Persona-based resolution requires an API call and is deferred to
+ * `useResolvedAppMode`, which runs after login and will re-write the mode
+ * if the persona disagrees. This helper only exists so the post-login
+ * redirect can pick the right landing route (`/` for non-default modes,
+ * `/my-data` for Classic) without waiting for the async resolver.
+ *
+ * Pure — no side effects. Safe to call from event handlers.
+ */
+export const resolveInitialAppMode = (userName?: string): string => {
+  const sessionMode = useAppModeStore.getState().currentMode;
+  if (sessionMode !== DEFAULT_APP_MODE) {
+    return sessionMode;
+  }
+
+  const hint = readHint();
+  if (isHintFresh(hint) && hint && hint.mode !== DEFAULT_APP_MODE) {
+    return hint.mode;
+  }
+
+  if (userName) {
+    const pref = usePersistentStorage.getState().getUserPreference(userName);
+    if (pref?.appMode && pref.appMode !== DEFAULT_APP_MODE) {
+      return pref.appMode;
+    }
+  }
+
+  return DEFAULT_APP_MODE;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
@@ -342,9 +342,14 @@ export const useIsAiMode = (): boolean => useAppMode() !== DEFAULT_APP_MODE;
  * Pure — no side effects. Safe to call from event handlers.
  */
 export const resolveInitialAppMode = (userName?: string): string => {
-  const sessionMode = useAppModeStore.getState().currentMode;
-  if (sessionMode !== DEFAULT_APP_MODE) {
-    return sessionMode;
+  // Distinguish "explicit session tuple" from "no session at all" by
+  // reading the raw sessionStorage payload. `useAppModeStore.currentMode`
+  // returns `DEFAULT_APP_MODE` in BOTH cases, which would let a
+  // sibling-tab AI hint override an explicit Classic session — exactly
+  // what the resolver's `validSession` check guards against.
+  const session = readSession();
+  if (session) {
+    return session.mode;
   }
 
   const hint = readHint();


### PR DESCRIPTION
## Summary

Follow-up to #30231. `handledVerifiedUser` (the post-login redirect in `AuthProvider.tsx`) previously only checked `useAppModeStore.getState().currentMode`, which reflects the sessionStorage tuple alone. On a fresh login the tuple is empty, so the AI branch was skipped and non-OIDC providers (Basic / Azure / Auth0 / SAML) navigated to `/my-data` — even for a user whose stored preference is AI. `useResolvedAppMode` then ran a tick later and correctly wrote `AI_APP_MODE`, but the URL was already `/my-data`.

## Fix

Add a synchronous `resolveInitialAppMode(userName?)` helper in `useAppMode.ts` that consults the same precedence as the resolver, minus the async persona lookup:

1. sessionStorage tuple  (mid-session re-auth in an already-AI tab)
2. Fresh cross-tab hint  (a sibling tab in this browser is in AI)
3. User's stored ``preferences.appMode``  (the \"remember\" checkbox)
4. ``DEFAULT_APP_MODE``

Persona-based resolution still lives in ``useResolvedAppMode`` — it requires an API call — and will re-write the mode after login if the persona disagrees.

``AuthProvider.tsx`` now calls this helper before falling through to the OIDC/non-OIDC branching, using ``useApplicationStore.getState().currentUser?.name`` (set synchronously moments earlier by ``setCurrentUser(userDetails)``).

## Safety

If the stored preference is AI but the plugin is uninstalled: ``ROUTES.HOME`` (\`/\`) in Classic mode already redirects to ``/my-data``, and ``useResolvedAppMode``'s install gate keeps the mode as Classic. Worst case: one extra client-side redirect hop. No new failure mode.

## Tests

11 new cases in ``useAppMode.test.ts``:

- returns default with no signal
- returns session tuple mode when present
- returns hint mode when session empty and hint is fresh
- ignores stale (past-TTL) hint
- ignores fresh ``DEFAULT``-mode hint
- returns stored user preference when no session and no fresh hint
- ignores ``DEFAULT``-valued preference
- ignores null-valued preference
- returns default when userName is undefined
- session tuple wins over conflicting hint
- fresh hint wins over conflicting user preference

All 37 tests pass (11 new + 26 pre-existing). ``AuthProvider.test.tsx`` (12 tests) and ``useResolvedAppMode.test.ts`` (16 tests) still green.

## Test plan

- [x] ``useAppMode.test.ts`` — jest
- [x] ``AuthProvider.test.tsx`` — jest
- [x] ``useResolvedAppMode.test.ts`` — jest
- [x] tsc --noEmit on modified files
- [x] prettier --check on modified files
- [ ] Manual verify on staging: user with ``preferences.appMode = 'ai'`` logging in via Basic auth lands on ``/`` (AI shell) instead of ``/my-data``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR resolves the app mode before choosing the post-login route. The main changes are:

- Add synchronous resolution for session, cross-tab, and saved preference signals.
- Use the resolved mode in the post-login redirect.
- Add tests for precedence, missing values, and stale hints.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated session check preserves explicit Classic mode before reading hints or preferences.
- The new imports and synchronous store access do not introduce a supported initialization failure.
- No blocking issue was found in the latest changes.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Uses the synchronously resolved app mode to choose the post-login landing route. |
| openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts | Adds app-mode resolution with session, hint, preference, and default precedence. |
| openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts | Adds tests for app-mode resolution and explicit Classic session precedence. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): distinguish explicit Classic se..."](https://github.com/open-metadata/openmetadata/commit/60c3d85fb776522d83c6b6604a216f7a8edc47fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46231961)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->