### PR TITLE
fix(governance): route legacy-thread voter cleanup through FeedRepository resolver

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java
@@ -1000,15 +1000,10 @@ public class WorkflowHandler {
           taskThread.getTask().setAssignees(currentAssignees);
           taskThread.withUpdatedBy(currentUser).withUpdatedAt(System.currentTimeMillis());
 
-          // Persist the changes
-          org.openmetadata.schema.entity.feed.Thread finalTaskThread = taskThread;
-          Entity.getJdbi()
-              .useHandle(
-                  handle -> {
-                    CollectionDAO dao = handle.attach(CollectionDAO.class);
-                    dao.feedDAO()
-                        .update(finalTaskThread.getId(), JsonUtils.pojoToJson(finalTaskThread));
-                  });
+          // Route through FeedRepository so the write targets the resolver-picked legacy table
+          // (thread_entity_legacy on 2.0, thread_entity_archived on 2.1+) instead of the pre-2.0
+          // hardcoded 'thread_entity' overload which no longer exists after migration.
+          feedRepository.updateLegacyThread(taskThread);
 
           LOG.info(
               "[WorkflowTask] Successfully removed user '{}' from Thread '{}' assignees. Remaining assignees: {}",

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerLegacyThreadUpdateTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerLegacyThreadUpdateTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.governance.workflows;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression guard for the multi-reviewer intermediate-vote UX bug fixed by routing the legacy
+ * thread write through {@code FeedRepository.updateLegacyThread(...)}. Before the fix the write
+ * used the 2-arg {@code feedDAO().update(UUID id, String json)} overload whose SQL hardcodes
+ * {@code UPDATE thread_entity} — a table renamed to {@code thread_entity_legacy} by the 2.0
+ * migration. The write throws {@code Table 'thread_entity' doesn't exist} and gets silently
+ * swallowed by the surrounding catch, leaving the voter stuck in {@code task.assignees} and
+ * emitting an ERROR per vote. A full behavioural repro would require a live Flowable process
+ * instance plus a JDBC handle bound to the legacy schema; source-level assertions lock the fix
+ * cheaply against future regressions where an autocomplete or refactor slips the broken overload
+ * back in.
+ */
+class WorkflowHandlerLegacyThreadUpdateTest {
+
+  private static final Path WORKFLOW_HANDLER =
+      Paths.get("src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java");
+
+  private static final Pattern HARDCODED_UPDATE_CALL =
+      Pattern.compile("dao\\.feedDAO\\(\\)\\s*\\.update\\s*\\(\\s*finalTaskThread");
+
+  @Test
+  void removeTaskFromVoterFeedForLegacyThreadRoutesThroughFeedRepository() throws IOException {
+    String legacyBranch = extractLegacyBranch(Files.readString(WORKFLOW_HANDLER));
+
+    assertTrue(
+        legacyBranch.contains("feedRepository.updateLegacyThread(taskThread)"),
+        "removeTaskFromVoterFeedForLegacyThread must persist voter cleanup via "
+            + "feedRepository.updateLegacyThread(...) so the write hits the resolver-picked "
+            + "legacy table (thread_entity_legacy on 2.0, thread_entity_archived on 2.1+).");
+  }
+
+  @Test
+  void removeTaskFromVoterFeedForLegacyThreadDoesNotCallHardcodedFeedDAOUpdate()
+      throws IOException {
+    String legacyBranch = extractLegacyBranch(Files.readString(WORKFLOW_HANDLER));
+
+    assertFalse(
+        HARDCODED_UPDATE_CALL.matcher(legacyBranch).find(),
+        "removeTaskFromVoterFeedForLegacyThread must not call the 2-arg feedDAO().update("
+            + "UUID id, String json) overload — its SQL hardcodes 'UPDATE thread_entity' which "
+            + "no longer exists after the 2.0 migration renames the table.");
+  }
+
+  private static String extractLegacyBranch(String source) {
+    int start = source.indexOf("private void removeTaskFromVoterFeedForLegacyThread(");
+    assertTrue(start >= 0, "removeTaskFromVoterFeedForLegacyThread must exist in WorkflowHandler");
+    int end = source.indexOf("private void removeTaskFromVoterFeedForTaskEntity(", start);
+    assertTrue(end > start, "removeTaskFromVoterFeedForTaskEntity must follow the legacy branch");
+    return source.substring(start, end);
+  }
+}


### PR DESCRIPTION
## Summary

`WorkflowHandler.removeTaskFromVoterFeedForLegacyThread` (line 1009) wrote via the 2-arg `feedDAO().update(id, json)` overload whose SQL hardcodes `UPDATE thread_entity`. The 2.0 migration renames `thread_entity` → `thread_entity_legacy` (and 2.1+ → `thread_entity_archived`), so the write throws `Table 'thread_entity' doesn't exist` on any post-2.0 install.

The exception is swallowed by the surrounding try/catch (`Don't throw - this is a non-critical operation`) so the vote still counts, but:

- **Reviewer stays in `task.assignees`** — task remains in their pending list after voting.
- **`updateFlowableVoteTracking` never runs** — `votedUsers` process variable goes stale.
- **ERROR log line per intermediate vote** — noisy, misleading on-call.

Blast radius is narrow: only fires on legacy multi-reviewer approval tasks (threshold > 1) resolved via the legacy `PUT /v1/feed/tasks/{id}/resolve` endpoint at an *intermediate* vote. But every write on that path fails silently — governance UX degradation with zero signal to the user.

## Fix

Route the write through `FeedRepository.updateLegacyThread(taskThread)`, which already resolves the current legacy table name via `getResolvedLegacyThreadTableName()` (`thread_entity_legacy` → `thread_entity_archived` → `thread_entity` fallback chain). Same pattern every other write on this path already uses.

```diff
-          org.openmetadata.schema.entity.feed.Thread finalTaskThread = taskThread;
-          Entity.getJdbi()
-              .useHandle(
-                  handle -> {
-                    CollectionDAO dao = handle.attach(CollectionDAO.class);
-                    dao.feedDAO()
-                        .update(finalTaskThread.getId(), JsonUtils.pojoToJson(finalTaskThread));
-                  });
+          feedRepository.updateLegacyThread(taskThread);
```

## Verification

Reproduced the SQL failure on a live 2.0 MySQL DB:
```
ERROR 1146 (42S02): Table 'openmetadata_db.thread_entity' doesn't exist
```

Post-fix write targets `thread_entity_legacy` (the resolver-picked table on 2.0). Read path in the same method (`feedRepository.get(customTaskId)`) already goes through the resolver.

## Test plan

- [ ] Multi-reviewer approval workflow (`approvalThreshold=2`) on legacy thread-backed task.
- [ ] Cast intermediate vote via `PUT /v1/feed/tasks/{id}/resolve`.
- [ ] Confirm no `relation "thread_entity" does not exist` ERROR in server logs.
- [ ] Confirm voter removed from `task.assignees` after voting.
- [ ] Confirm final vote still closes task and workflow advances.

----
## Summary by Gitar

- **New tests:**
    - Added `WorkflowHandlerLegacyThreadUpdateTest` to prevent regressions by verifying the use of `feedRepository.updateLegacyThread` over the hardcoded DAO call.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes voter cleanup for legacy thread-backed governance tasks. The main changes are:

- Routes legacy-thread updates through the repository's table resolver.
- Supports renamed legacy thread tables on newer database schemas.
- Adds source-level guards against restoring the hardcoded DAO update.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated write uses the same legacy table resolution as the read path.
- No blocking issue remains in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/WorkflowHandler.java | Uses the resolver-backed repository update so legacy voter cleanup targets the active legacy thread table. |
| openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/WorkflowHandlerLegacyThreadUpdateTest.java | Adds source-level checks for the repository update and the removed hardcoded DAO pattern. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(governance): guard WorkflowHandler ..."](https://github.com/open-metadata/openmetadata/commit/70de1955128d86c7d299001ad990abafdf9db310) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46240279)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->