### PR TITLE
fix(1.13): backport orphaned-column-doc cleanup (#29549) + external-it flake fixes

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
@@ -51,7 +51,6 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 
 /**
  * Integration tests for DatabaseService entity operations.
@@ -499,17 +498,15 @@ public class DatabaseServiceResourceIT
                     .withDatabaseSchema(schema.getFullyQualifiedName())
                     .withColumns(
                         List.of(new Column().withName("c1").withDataType(ColumnDataType.INT))));
-    // Column docs live in a separate column_search_index pruned only by the per-table search
-    // dispatch — which the recursive service hard delete skips — so guard it here to catch
-    // orphaned column docs that the ancestor service.id cascade must also remove.
-    String columnDocId =
-        ColumnSearchIndex.generateColumnId(table.getColumns().getFirst().getFullyQualifiedName());
+    // The column_search_index cleanup on recursive hard delete is covered by the unit test
+    // SearchRepositoryBehaviorTest and the scale IT ServiceDeleteSearchCleanupScaleIT. It is not
+    // asserted here: under the full concurrent IT suite the per-delete column delete-by-query
+    // contends on the shared column_search_index, delaying visibility of a freshly indexed column
+    // doc past the precondition timeout and flaking this otherwise-unrelated regression.
     return new DeletableSubtree(
         service.getId().toString(),
         List.of(database.getId().toString(), schema.getId().toString(), table.getId().toString()),
-        List.of(
-            new SearchDoc("table_search_index", table.getId().toString()),
-            new SearchDoc("column_search_index", columnDocId)));
+        List.of(new SearchDoc("table_search_index", table.getId().toString())));
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java
@@ -51,6 +51,7 @@ import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.csv.CsvImportResult;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 
 /**
  * Integration tests for DatabaseService entity operations.
@@ -498,10 +499,17 @@ public class DatabaseServiceResourceIT
                     .withDatabaseSchema(schema.getFullyQualifiedName())
                     .withColumns(
                         List.of(new Column().withName("c1").withDataType(ColumnDataType.INT))));
+    // Column docs live in a separate column_search_index pruned only by the per-table search
+    // dispatch — which the recursive service hard delete skips — so guard it here to catch
+    // orphaned column docs that the ancestor service.id cascade must also remove.
+    String columnDocId =
+        ColumnSearchIndex.generateColumnId(table.getColumns().getFirst().getFullyQualifiedName());
     return new DeletableSubtree(
         service.getId().toString(),
         List.of(database.getId().toString(), schema.getId().toString(), table.getId().toString()),
-        List.of(new SearchDoc("table_search_index", table.getId().toString())));
+        List.of(
+            new SearchDoc("table_search_index", table.getId().toString()),
+            new SearchDoc("column_search_index", columnDocId)));
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
@@ -44,7 +44,6 @@ import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
-import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.Entity;
 import org.slf4j.Logger;
@@ -100,7 +99,6 @@ class ServiceDeleteSearchCleanupScaleIT {
   void recursiveServiceHardDelete_clearsTableAndColumnDocsAtScale(final TestNamespace ns)
       throws Exception {
     final int tableCount = Integer.getInteger("scale.tables", DEFAULT_TABLES);
-    final OpenMetadataClient client = SdkClients.adminClient();
 
     final DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     final DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
@@ -114,7 +112,7 @@ class ServiceDeleteSearchCleanupScaleIT {
     final String columnIndex = indexAliases.indexNameFor(Entity.TABLE_COLUMN);
 
     final long seedStart = System.currentTimeMillis();
-    seedTables(ns, client, schema.getFullyQualifiedName(), tableCount);
+    seedTables(ns, schema.getFullyQualifiedName(), tableCount);
     LOG.info(
         "Seeded {} tables ({} columns each) in {} ms",
         tableCount,
@@ -131,7 +129,7 @@ class ServiceDeleteSearchCleanupScaleIT {
         expectedColumns);
 
     final long deleteStart = System.currentTimeMillis();
-    recursiveHardDelete(client, serviceId);
+    recursiveHardDelete(serviceId);
     awaitCount(tableIndex, serviceId, 0);
     awaitCount(columnIndex, serviceId, 0);
     final long deleteMs = System.currentTimeMillis() - deleteStart;
@@ -142,11 +140,7 @@ class ServiceDeleteSearchCleanupScaleIT {
         deleteMs);
   }
 
-  private void seedTables(
-      final TestNamespace ns,
-      final OpenMetadataClient client,
-      final String schemaFqn,
-      final int count) {
+  private void seedTables(final TestNamespace ns, final String schemaFqn, final int count) {
     final String namePrefix = ns.prefix("scale_tbl") + "_";
     final ExecutorService executor = Executors.newFixedThreadPool(LOAD_WORKERS);
     try {
@@ -156,7 +150,11 @@ class ServiceDeleteSearchCleanupScaleIT {
         futures.add(
             executor.submit(
                 () -> {
-                  client
+                  // Fetch the admin client fresh per task: a 100k seed outlives the operator
+                  // token's ~1h TTL, and ExternalTokenRefresher rebuilds SdkClients' cached client
+                  // on re-login. A captured reference would pin the pre-refresh (expired) token and
+                  // fail mid-seed with "401 Expired token!".
+                  SdkClients.adminClient()
                       .tables()
                       .create(
                           new CreateTable()
@@ -184,13 +182,14 @@ class ServiceDeleteSearchCleanupScaleIT {
     return columns;
   }
 
-  private void recursiveHardDelete(final OpenMetadataClient client, final String serviceId) {
+  private void recursiveHardDelete(final String serviceId) {
     // Mirror the UI's service delete: hit the async endpoint (DELETE /databaseServices/async/{id})
     // so the recursive hard delete runs on the server's background executor instead of blocking the
     // request thread — a synchronous 100k-table delete can exceed a proxied cluster's gateway
     // timeout. The endpoint returns 202 immediately; the awaitCount(...) assertions confirm the
-    // delete's search cascade actually cleared both indexes.
-    client
+    // delete's search cascade actually cleared both indexes. Fetch the admin client fresh (not a
+    // captured reference) so the refreshed token is used after a long-running seed.
+    SdkClients.adminClient()
         .getHttpClient()
         .execute(
             HttpMethod.DELETE,

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java
@@ -5,6 +5,8 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.WaitForSelectorState;
+import java.time.Duration;
+import org.awaitility.Awaitility;
 import org.openmetadata.playwright.ui.UiSession;
 
 /**
@@ -17,6 +19,9 @@ public final class DataQualityListPage extends PageObject {
   private static final String API_LIST_SUITES = "/api/v1/dataQuality/testSuites/search/list";
   private static final String TESTID_TEST_SUITES_TAB = "test-suites";
   private static final String TESTID_TEST_SUITE_CONTAINER = "test-suite-container";
+  private static final Duration PAGE_SIZE_RETRY_TIMEOUT = Duration.ofSeconds(60);
+  private static final Duration PAGE_SIZE_RETRY_INTERVAL = Duration.ofSeconds(2);
+  private static final double PAGE_SIZE_MENU_TIMEOUT_MS = 5_000;
 
   private DataQualityListPage(final Page page, final UiSession session) {
     super(page, session);
@@ -186,18 +191,37 @@ public final class DataQualityListPage extends PageObject {
 
   /** Open the page-size dropdown and assert the standard 3 options render. */
   public DataQualityListPage assertPageSizeOptionsCount(final int expected) {
-    // Scope to the OPEN overlay: every Ant <Dropdown> on the page (nav bar, help, etc.) portals a
-    // .ant-dropdown-menu to <body> and keeps it in the DOM while hidden, so a bare
-    // .ant-dropdown-menu first-matches a foreign hidden menu and the visibility wait times out.
-    // :not(.ant-dropdown-hidden) pins it to the just-opened page-size menu (mirrors the
-    // .ant-select-dropdown idiom above).
+    // The single-click open of this Ant page-size dropdown races the still-loading, data-heavy DQ
+    // list under external-cluster latency and intermittently leaves the panel closed, timing out
+    // the
+    // menu wait. Retry the open+assert under a short per-attempt timeout, resetting any half-open
+    // panel between attempts — mirrors IncidentManagerPage.openDropdownAndSelectPageSize50, which
+    // drives the SAME dropdown resiliently.
+    Awaitility.await("page-size dropdown shows " + expected + " options")
+        .atMost(PAGE_SIZE_RETRY_TIMEOUT)
+        .pollInterval(PAGE_SIZE_RETRY_INTERVAL)
+        .pollDelay(Duration.ZERO)
+        .ignoreExceptions()
+        .untilAsserted(() -> openAndCountPageSizeOptions(expected));
+    return this;
+  }
+
+  private void openAndCountPageSizeOptions(final int expected) {
+    // Ant toggles this panel on trigger click, so a stuck-open menu from a prior attempt would be
+    // closed by the next click; Escape resets it (a no-op when nothing is open). The
+    // :not(.ant-dropdown-hidden) scope pins the wait to the just-opened page-size overlay rather
+    // than a foreign hidden .ant-dropdown-menu Ant leaves portaled in <body>.
+    page.keyboard().press("Escape");
     final Locator pageSizeMenu =
         page.locator(".ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu");
-    openMenu(byTestId("page-size-selection-dropdown"), pageSizeMenu);
+    byTestId("page-size-selection-dropdown").click();
+    pageSizeMenu.waitFor(
+        new Locator.WaitForOptions()
+            .setState(WaitForSelectorState.VISIBLE)
+            .setTimeout(PAGE_SIZE_MENU_TIMEOUT_MS));
     PlaywrightAssertions.assertThat(
             page.locator(".ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu-item"))
         .hasCount(expected);
-    return this;
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -37,6 +37,8 @@ import static org.openmetadata.service.search.SearchClient.UPDATE_ADDED_DELETE_G
 import static org.openmetadata.service.search.SearchClient.UPDATE_CERTIFICATION_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.UPDATE_PROPAGATED_ENTITY_REFERENCE_FIELD_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.UPDATE_TAGS_FIELD_SCRIPT;
+import static org.openmetadata.service.search.SearchConstants.DATABASE_ID;
+import static org.openmetadata.service.search.SearchConstants.DATABASE_SCHEMA_ID;
 import static org.openmetadata.service.search.SearchConstants.DOMAINS_ID;
 import static org.openmetadata.service.search.SearchConstants.ENTITY_TYPE;
 import static org.openmetadata.service.search.SearchConstants.FAILED_TO_CREATE_INDEX_MESSAGE;
@@ -933,6 +935,49 @@ public class SearchRepository {
         throw re;
       }
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Remove descendant column docs when a table's ancestor (databaseService / database /
+   * databaseSchema) is hard-deleted recursively.
+   *
+   * <p>Column docs live in a flat secondary index ({@code column_search_index}). A table's own
+   * delete prunes them via {@link #deleteTableColumns} (by {@code table.id}), but a recursive
+   * service/database/schema hard delete skips the per-table search dispatch
+   * ({@code descendantsCoveredByAncestorCascade}) and the ancestor's {@link #deleteOrUpdateChildren}
+   * cascade only targets the service childAliases, which do not include {@code tableColumn} — so
+   * without this prune the descendant column docs linger in search. Column docs carry
+   * {@code service.id} / {@code database.id} / {@code databaseSchema.id}, so delete by whichever
+   * ancestor the deleted entity is.
+   */
+  private void deleteDescendantColumns(EntityInterface entity, String entityType) {
+    String columnParentField =
+        switch (entityType) {
+          case Entity.DATABASE_SERVICE -> SERVICE_ID;
+          case Entity.DATABASE -> DATABASE_ID;
+          case Entity.DATABASE_SCHEMA -> DATABASE_SCHEMA_ID;
+          default -> null;
+        };
+    if (columnParentField != null) {
+      IndexMapping columnIndexMapping = entityIndexMap.get(Entity.TABLE_COLUMN);
+      if (columnIndexMapping != null) {
+        try {
+          searchClient.deleteEntityByFields(
+              List.of(getWriteIndexName(columnIndexMapping)),
+              List.of(new ImmutablePair<>(columnParentField, entity.getId().toString())));
+        } catch (Exception e) {
+          LOG.error(
+              "Issue deleting descendant columns for {} [{}]: {}",
+              entityType,
+              entity.getFullyQualifiedName(),
+              e.getMessage());
+          if (e instanceof RuntimeException re) {
+            throw re;
+          }
+          throw new RuntimeException(e);
+        }
+      }
     }
   }
 
@@ -2374,6 +2419,8 @@ public class SearchRepository {
       deleteOrUpdateChildren(entity, indexMapping);
       if (Entity.TABLE.equals(entityType)) {
         deleteTableColumns((Table) entity);
+      } else {
+        deleteDescendantColumns(entity, entityType);
       }
     } catch (Exception ie) {
       SearchIndexRetryQueue.enqueue(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -118,6 +118,30 @@ class SearchRepositoryBehaviorTest {
           .indexMappingFile("/elasticsearch/%s/database_service_index_mapping.json")
           .build();
 
+  private static final IndexMapping DATABASE_MAPPING =
+      IndexMapping.builder()
+          .indexName("database_search_index")
+          .alias("database")
+          .childAliases(List.of())
+          .indexMappingFile("/elasticsearch/%s/database_index_mapping.json")
+          .build();
+
+  private static final IndexMapping DATABASE_SCHEMA_MAPPING =
+      IndexMapping.builder()
+          .indexName("database_schema_search_index")
+          .alias("databaseSchema")
+          .childAliases(List.of())
+          .indexMappingFile("/elasticsearch/%s/database_schema_index_mapping.json")
+          .build();
+
+  private static final IndexMapping COLUMN_MAPPING =
+      IndexMapping.builder()
+          .indexName("column_search_index")
+          .alias("tableColumn")
+          .childAliases(List.of())
+          .indexMappingFile("/elasticsearch/%s/column_index_mapping.json")
+          .build();
+
   private static final IndexMapping PAGE_MAPPING =
       IndexMapping.builder()
           .indexName("page_search_index")
@@ -1200,6 +1224,52 @@ class SearchRepositoryBehaviorTest {
             List.of(
                 new org.apache.commons.lang3.tuple.ImmutablePair<>(
                     "table.id", table.getId().toString())));
+  }
+
+  /**
+   * Regression for the bulk-delete search gap: column docs live in a flat secondary index, and a
+   * recursive service/database/schema hard delete skips the per-table search dispatch
+   * ({@code descendantsCoveredByAncestorCascade}) while the ancestor's child cascade targets only
+   * the service childAliases (no {@code tableColumn}). Without an explicit prune the descendant
+   * column docs orphan in search. Each database-subtree ancestor must delete the column index by
+   * the parent id field its column docs carry.
+   */
+  @Test
+  void deleteEntityIndexRemovesDescendantColumnsForDatabaseSubtreeAncestors() throws Exception {
+    SearchRepository repo =
+        newRepository(
+            Map.of(
+                Entity.DATABASE_SERVICE, DATABASE_SERVICE_MAPPING,
+                Entity.DATABASE, DATABASE_MAPPING,
+                Entity.DATABASE_SCHEMA, DATABASE_SCHEMA_MAPPING,
+                Entity.TABLE_COLUMN, COLUMN_MAPPING),
+            "cluster");
+    EntityInterface service = mockEntity(Entity.DATABASE_SERVICE, UUID.randomUUID(), "svc");
+    EntityInterface database = mockEntity(Entity.DATABASE, UUID.randomUUID(), "db");
+    EntityInterface schema = mockEntity(Entity.DATABASE_SCHEMA, UUID.randomUUID(), "schema");
+
+    repo.deleteEntityIndex(service);
+    repo.deleteEntityIndex(database);
+    repo.deleteEntityIndex(schema);
+
+    verify(searchClient)
+        .deleteEntityByFields(
+            List.of("cluster_column_search_index"),
+            List.of(
+                new org.apache.commons.lang3.tuple.ImmutablePair<>(
+                    "service.id", service.getId().toString())));
+    verify(searchClient)
+        .deleteEntityByFields(
+            List.of("cluster_column_search_index"),
+            List.of(
+                new org.apache.commons.lang3.tuple.ImmutablePair<>(
+                    "database.id", database.getId().toString())));
+    verify(searchClient)
+        .deleteEntityByFields(
+            List.of("cluster_column_search_index"),
+            List.of(
+                new org.apache.commons.lang3.tuple.ImmutablePair<>(
+                    "databaseSchema.id", schema.getId().toString())));
   }
 
   @Test


### PR DESCRIPTION
Backports the **root-cause deletion fix** plus two external-IT flake fixes from `main` to `1.13`, so the **search-release-dev** nightly external run goes green and stops progressively overloading the shared cluster.

## 1. (root cause) Orphaned column docs on recursive service hard delete — backport #29549 (+ test-pair #29626)
`1.13` already has #29322, which made recursive service hard-delete fast by setting `descendantsCoveredByAncestorCascade=true` — this **skips the per-table `deleteFromSearch` dispatch** and relies on the root service's `deleteOrUpdateChildren` cascade. But that cascade only targets the service childAliases, which **do not include `tableColumn`**, and column docs live in a separate flat `column_search_index`. So on `1.13` every recursive service/database/schema hard delete **orphans every descendant column doc** (per #29549: a 20k-table service leaves ~100k stale column docs; the nightly **100k-table scale run** leaves ~500k every night). Run-over-run this bloats `column_search_index` until the cluster returns `504` at login and mid-reindex — the actual cause of the nightly failures, and why `ServiceDeleteSearchCleanupScaleIT` (which asserts those docs drop to zero) fails once it runs.

#29549 completes the hard-delete search cascade: `SearchRepository.deleteEntityIndex` now also prunes `column_search_index` for the `databaseService` / `database` / `databaseSchema` ancestor types by the `service.id` / `database.id` / `databaseSchema.id` field the column docs carry. #29626 is its test-pair (drops the flaky shared-index precondition from the recursive-hard-delete IT; coverage moved to the unit test). `1.13` already ships the newer `ServiceDeleteSearchCleanupScaleIT`, so only the `SearchRepository` fix, `SearchRepositoryBehaviorTest`, and the `DatabaseServiceResourceIT` guard land here.

## 2. scale-it token expiry (cherry-pick of the main fix)
`ServiceDeleteSearchCleanupScaleIT` captured `SdkClients.adminClient()` once and reused it across the ~1h 100k seed. In external mode `ExternalTokenRefresher` rebuilds the cached client on re-login, but the captured reference pinned the pre-refresh operator token → `401 Expired token!` mid-seed. Fetch the admin client fresh at each long-running use.

## 3. DQ page-size dropdown flake (cherry-pick of the main fix)
`DataQualityPaginationReindexUIIT` intermittently timed out opening the Ant page-size `<Dropdown>` — a single click races the still-loading list under WAN latency and leaves the panel closed. Mirror `IncidentManagerPage`'s proven retry (Awaitility + Escape reset + bounded per-attempt timeout).

Companion to the nightly-workflow fixes (cancellation + login retry + run-serialization concurrency guard): open-metadata/openmetadata-nightly#261.

## Verification
- `#29549` / `#29626` cherry-picked onto the branch; only the `ServiceDeleteSearchCleanupScaleIT` add/add conflict, resolved by keeping `1.13`'s existing superset. All symbols the fix references (`SERVICE_ID`/`DATABASE_ID`/`DATABASE_SCHEMA_ID`, `deleteTableColumns`, `deleteEntityByFields`, the #29322 cascade wiring) already exist on `1.13` — no prerequisite backfill.
- `mvn spotless:apply` / `spotless:check` — clean.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR backports search cleanup and stabilizes two external integration tests. The main changes are:

- Deletes descendant column documents during recursive database subtree deletion.
- Refreshes the admin client during long-running scale tests.
- Retries the data-quality page-size dropdown interaction.
- Adds focused cleanup coverage and adjusts the shared-suite test guard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The latest changes look safe to merge.
- No additional blocking issue qualifies for this follow-up review.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Deletes column index documents by service, database, or schema ID during recursive hard deletion. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java | Verifies the column cleanup request for each supported database ancestor. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java | Fetches the current admin client during seeding and recursive deletion. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/DataQualityListPage.java | Adds bounded retries when opening and checking the page-size dropdown. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseServiceResourceIT.java | Documents why column-index cleanup is covered outside the shared recursive-delete test. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;1.13&#39; into fix/1.13-extern..."](https://github.com/open-metadata/openmetadata/commit/4bd2ec5141f4fded9134ffb4d6e5af79d14d4963) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46262679)</sub>

<!-- /greptile_comment -->