### PR TITLE
fix(ui): prevent Safari inflating Data Quality failed/aborted reason row height

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
@@ -464,19 +464,26 @@ const DataQualityTab: React.FC<DataQualityTabProps> = ({
   ) => {
     return result?.result &&
       result.testCaseStatus !== TestCaseStatus.Success ? (
-      <Tooltip
-        containerClassName="tw:break-all"
-        placement="top"
-        title={result.result}>
-        <TooltipTrigger>
-          <Typography
-            className="tw:m-0 tw:max-w-54 tw:line-clamp-2 tw:break-all tw:overflow-hidden tw:whitespace-normal"
-            data-testid={`reason-text-${record.name}`}
-            size="text-sm">
-            {result.result}
-          </Typography>
-        </TooltipTrigger>
-      </Tooltip>
+      // Safari sizes a `display: table-cell` to the unclamped intrinsic height
+      // of a `-webkit-line-clamp` descendant, inflating the row to the full
+      // message height. This wrapper must stay the direct child of the cell
+      // (outside the Tooltip's w-max/h-max button) so its max-height + overflow
+      // actually clip the cell height. Chromium/Firefox are unaffected.
+      <div className="tw:max-h-11 tw:overflow-hidden">
+        <Tooltip
+          containerClassName="tw:break-all"
+          placement="top"
+          title={result.result}>
+          <TooltipTrigger>
+            <Typography
+              className="tw:m-0 tw:max-w-54 tw:w-54 tw:line-clamp-2 tw:break-all tw:whitespace-normal"
+              data-testid={`reason-text-${record.name}`}
+              size="text-sm">
+              {result.result}
+            </Typography>
+          </TooltipTrigger>
+        </Tooltip>
+      </div>
     ) : (
       '--'
     );


### PR DESCRIPTION
## Description

A long failed/aborted reason inflated the Data Quality test-case row to the **full message height in Safari**. Safari sizes a `display: table-cell` to the *unclamped* intrinsic height of a `-webkit-line-clamp` descendant, ignoring `max-height`/`overflow` on in-flow ancestors — so the row ballooned to ~800px while the text was visibly clamped to 2 lines.

The fix wraps the clamped reason in a `max-h-11 overflow-hidden` container placed as the **direct child of the cell** (outside the tooltip's `w-max`/`h-max` button) so the clip actually constrains the cell height. Because it's a `max-height`, short one-line reasons still shrink. Chromium/Firefox were unaffected.

Fixes #30351

## Changes

- `DataQualityTab.tsx` `renderReasonCell`: add the clipping wrapper; keep `line-clamp-2` + `break-all`; comment the Safari rationale and why the wrapper must stay the cell's direct child.

## Testing

- **Safari**: reason row 832px → 76px ✅
- **Chromium**: unchanged (76px, 2-line clamp + tooltip intact) ✅
- Prettier ✅ / ESLint ✅

## Screenshots

| Before (Safari) | After (Safari) |
|---|---|
| <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/9e16731a-9610-404b-9e5f-2bfeae5b4ff0" /> | <img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/36baf4b9-c2c9-446f-9769-c6f59fd7305f" /> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
