### PR TITLE
fix(tasks): delete tasks about an entity when the entity is hard deleted

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java
@@ -4057,6 +4057,88 @@ public class TaskResourceIT extends BaseEntityIT<Task, CreateTask> {
         "Deleting the bot creator should not apply the suggestion payload");
   }
 
+  @Test
+  void testHardDeletingAboutEntityDeletesItsTasks(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    Table table = TableTestFactory.createWithName(ns, schema.getFullyQualifiedName(), "deleted");
+    Table otherTable =
+        TableTestFactory.createWithName(ns, schema.getFullyQualifiedName(), "survivor");
+
+    Task openTask = createEntity(descriptionUpdateTaskAbout(ns, "orphan-open", table));
+    Task closedTask = createEntity(descriptionUpdateTaskAbout(ns, "orphan-closed", table));
+    closedTask = SdkClients.adminClient().tasks().close(closedTask.getId().toString());
+    assertEquals(TaskEntityStatus.Cancelled, closedTask.getStatus());
+    Task survivorTask = createEntity(descriptionUpdateTaskAbout(ns, "survivor", otherTable));
+
+    SdkClients.adminClient()
+        .tables()
+        .delete(table.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+
+    awaitTasksDeleted(table.getFullyQualifiedName(), openTask.getId(), closedTask.getId());
+
+    Task survivor = SdkClients.adminClient().tasks().get(survivorTask.getId().toString(), "about");
+    assertEquals(TaskEntityStatus.Open, survivor.getStatus());
+    assertNotNull(survivor.getAbout(), "Task about an unrelated entity must keep its target");
+    assertEquals(otherTable.getFullyQualifiedName(), survivor.getAbout().getFullyQualifiedName());
+  }
+
+  @Test
+  void testSoftDeletingAboutEntityKeepsTasks(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    Table table = TableTestFactory.createSimple(ns, schema.getFullyQualifiedName());
+
+    Task task = createEntity(descriptionUpdateTaskAbout(ns, "soft-delete-kept", table));
+
+    SdkClients.adminClient().tables().delete(table.getId().toString());
+
+    Task kept = SdkClients.adminClient().tasks().get(task.getId().toString());
+    assertEquals(
+        TaskEntityStatus.Open,
+        kept.getStatus(),
+        "Soft-deleting the target entity must not remove or resolve its tasks");
+  }
+
+  @Test
+  void testRecursiveHardDeleteOfParentDeletesDescendantTasks(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    Table table = TableTestFactory.createSimple(ns, schema.getFullyQualifiedName());
+
+    Task task = createEntity(descriptionUpdateTaskAbout(ns, "descendant-cleanup", table));
+
+    SdkClients.adminClient()
+        .databaseSchemas()
+        .delete(schema.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+
+    awaitTasksDeleted(table.getFullyQualifiedName(), task.getId());
+  }
+
+  private CreateTask descriptionUpdateTaskAbout(TestNamespace ns, String suffix, Table table) {
+    return new CreateTask()
+        .withName(ns.prefix(suffix))
+        .withDescription("Task about an entity that will be deleted")
+        .withCategory(TaskCategory.MetadataUpdate)
+        .withType(TaskEntityType.DescriptionUpdate)
+        .withAbout(entityLink("table", table.getFullyQualifiedName()));
+  }
+
+  private void awaitTasksDeleted(String aboutEntityFqn, UUID... taskIds) {
+    Awaitility.await("task cleanup for deleted entity " + aboutEntityFqn)
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofMillis(250))
+        .untilAsserted(
+            () -> {
+              for (UUID taskId : taskIds) {
+                assertThrows(
+                    ApiException.class,
+                    () -> SdkClients.adminClient().tasks().get(taskId.toString()),
+                    "Task about a hard-deleted entity should no longer be retrievable");
+              }
+            });
+  }
+
   private record BotWithUser(Bot bot, User user) {}
 
   private BotWithUser createBotWithJwtUser(TestNamespace ns, String suffix) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -4672,6 +4672,20 @@ public interface CollectionDAO {
     List<EntityDAO.EntityIdFqnPair> listIdAndFqnByCreatorAndCategory(
         @Bind("createdById") String createdById, @Bind("category") String category);
 
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, json_unquote(json_extract(json, '$.fullyQualifiedName')) AS fqn "
+                + "FROM task_entity WHERE aboutFqnHash IN (<aboutFqnHashes>)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlQuery(
+        value =
+            "SELECT id, json->>'fullyQualifiedName' AS fqn "
+                + "FROM task_entity WHERE aboutFqnHash IN (<aboutFqnHashes>)",
+        connectionType = POSTGRES)
+    @RegisterRowMapper(EntityDAO.EntityIdFqnPairMapper.class)
+    List<EntityDAO.EntityIdFqnPair> listIdAndFqnByAboutFqnHashes(
+        @BindList("aboutFqnHashes") List<String> aboutFqnHashes);
+
     @RegisterRowMapper(TaskCountSummaryMapper.class)
     @SqlQuery(
         // Row-aware bucketing so openCount + completedCount = total across mixed task types.

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4861,6 +4861,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   protected final void cleanup(String deletedBy, T entityInterface) {
+    List<EntityDAO.EntityIdFqnPair> deletedTasks = new ArrayList<>();
     Entity.getJdbi()
         .inTransaction(
             handle -> {
@@ -4898,6 +4899,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
               // Delete all the threads that are about this entity
               Entity.getFeedRepository().deleteByAbout(entityInterface.getId());
 
+              // Delete all the tasks that are about this entity so they don't outlive their
+              // target as unmanageable orphans (the relationship wipe above already removed
+              // their about link)
+              deletedTasks.addAll(
+                  taskRepository()
+                      .deleteTasksAboutEntities(List.of(entityInterface.getFullyQualifiedName())));
+
               // Drop cached state before the DB row goes away. A concurrent read arriving
               // between this invalidate and the dao.delete below would still observe the
               // entity in the DB; the post-commit invalidate below closes that window.
@@ -4914,6 +4922,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // (now empty) DB and observes the deletion.
     invalidate(entityInterface);
     markEntityNotFound(entityInterface);
+    taskRepository().invalidateTaskCaches(deletedTasks, "about-entity-delete");
+  }
+
+  private TaskRepository taskRepository() {
+    return (TaskRepository) Entity.getEntityRepository(Entity.TASK);
   }
 
   private void markEntityNotFound(T entity) {
@@ -6781,8 +6794,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
       // bulkCleanupReferences skips the FQN-keyed satellite deletes for cascade-covered types
       // (see descendantsCoveredByAncestorCascade) and batches usage by id-set. Children were
       // already deleted by the recursion above, so this transaction is bounded to this chunk.
-      bulkDeleteReferencesAndRows(entities);
+      List<EntityDAO.EntityIdFqnPair> deletedTasks = bulkDeleteReferencesAndRows(entities);
       bulkInvalidate(entities);
+      taskRepository().invalidateTaskCaches(deletedTasks, "about-entity-delete");
       // When an ancestor's deleteFromSearch cascade already removes these docs in a single
       // delete-by-query (SearchRepository.deleteOrUpdateChildren wipes child indexes by
       // service.id / parent.id — see the DATABASE_SERVICE / default cases), firing one
@@ -6850,22 +6864,25 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
   }
 
-  private void bulkDeleteReferencesAndRows(List<T> entities) {
+  private List<EntityDAO.EntityIdFqnPair> bulkDeleteReferencesAndRows(List<T> entities) {
+    List<EntityDAO.EntityIdFqnPair> deletedTasks;
     var jdbi = Entity.getJdbi();
     if (jdbi == null) {
-      bulkCleanupReferences(entities);
+      deletedTasks = bulkCleanupReferences(entities);
       bulkDeleteEntityRows(entities);
-      return;
+    } else {
+      deletedTasks =
+          jdbi.inTransaction(
+              handle -> {
+                List<EntityDAO.EntityIdFqnPair> tasks = bulkCleanupReferences(entities);
+                bulkDeleteEntityRows(entities);
+                return tasks;
+              });
     }
-    jdbi.inTransaction(
-        handle -> {
-          bulkCleanupReferences(entities);
-          bulkDeleteEntityRows(entities);
-          return null;
-        });
+    return deletedTasks;
   }
 
-  private void bulkCleanupReferences(List<T> entities) {
+  private List<EntityDAO.EntityIdFqnPair> bulkCleanupReferences(List<T> entities) {
     List<UUID> entityIds = new ArrayList<>(entities.size());
     List<String> entityIdStrings = new ArrayList<>(entities.size());
     for (T entity : entities) {
@@ -6904,6 +6921,13 @@ public abstract class EntityRepository<T extends EntityInterface> {
     try (var ignored = phase("bulkHardDeleteFeedThreads")) {
       Entity.getFeedRepository().deleteByAbout(entityIds);
     }
+    List<EntityDAO.EntityIdFqnPair> deletedTasks;
+    try (var ignored = phase("bulkHardDeleteTasks")) {
+      List<String> entityFqns =
+          entities.stream().map(EntityInterface::getFullyQualifiedName).toList();
+      deletedTasks = taskRepository().deleteTasksAboutEntities(entityFqns);
+    }
+    return deletedTasks;
   }
 
   private void bulkDeleteEntityRows(List<T> entities) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
@@ -58,6 +58,7 @@ import org.openmetadata.schema.type.TaskResolutionType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.events.lifecycle.handlers.IncidentTcrsSyncHandler;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -90,6 +91,7 @@ public class TaskRepository extends EntityRepository<Task> {
 
   public static final String COLLECTION_PATH = "/v1/tasks";
   private static final String NO_MATCH_DOMAIN_ID = "'00000000-0000-0000-0000-000000000000'";
+  private static final int ABOUT_FQN_HASH_IN_BATCH_SIZE = 500;
   public static final String FIELD_ASSIGNEES = "assignees";
 
   public static final String FIELD_REVIEWERS = "reviewers";
@@ -1313,6 +1315,65 @@ public class TaskRepository extends EntityRepository<Task> {
 
     Task patchedTask = patch(null, currentTask.getId(), updatedBy, patch).entity();
     WebsocketNotificationHandler.handleTaskNotification(patchedTask);
+  }
+
+  /**
+   * Hard-delete every task whose about target is one of the given entity FQNs. This is the Task
+   * 2.0 counterpart of {@link FeedRepository#deleteByAbout} — invoked from the entity hard-delete
+   * cleanup so tasks don't outlive their target entity as unmanageable orphans (the about
+   * relationship row is wiped by the generic relationship cleanup, leaving the task with no
+   * target). Uses direct SQL that bypasses {@link EntityRepository#delete} and its cache
+   * invalidation, so callers MUST pass the returned (id, fqn) pairs to
+   * {@link #invalidateTaskCaches} after their enclosing transaction commits.
+   */
+  public List<EntityDAO.EntityIdFqnPair> deleteTasksAboutEntities(List<String> entityFqns) {
+    List<EntityDAO.EntityIdFqnPair> deletedTasks = List.of();
+    List<String> aboutFqnHashes =
+        listOrEmpty(entityFqns).stream()
+            .filter(Objects::nonNull)
+            .map(FullyQualifiedName::buildHash)
+            .toList();
+    if (!aboutFqnHashes.isEmpty()) {
+      List<EntityDAO.EntityIdFqnPair> tasks = listTasksAboutFqnHashes(aboutFqnHashes);
+      if (!tasks.isEmpty()) {
+        List<UUID> taskIds = tasks.stream().map(task -> task.id).filter(Objects::nonNull).toList();
+        daoCollection.relationshipDAO().batchDeleteRelationships(taskIds, Entity.TASK);
+        daoCollection.taskDAO().deleteByIds(taskIds);
+        deletedTasks = tasks;
+      }
+    }
+    return deletedTasks;
+  }
+
+  private List<EntityDAO.EntityIdFqnPair> listTasksAboutFqnHashes(List<String> aboutFqnHashes) {
+    List<EntityDAO.EntityIdFqnPair> tasks = new ArrayList<>();
+    for (int i = 0; i < aboutFqnHashes.size(); i += ABOUT_FQN_HASH_IN_BATCH_SIZE) {
+      List<String> chunk =
+          aboutFqnHashes.subList(
+              i, Math.min(i + ABOUT_FQN_HASH_IN_BATCH_SIZE, aboutFqnHashes.size()));
+      tasks.addAll(daoCollection.taskDAO().listIdAndFqnByAboutFqnHashes(chunk));
+    }
+    return tasks;
+  }
+
+  /**
+   * Invalidate caches for tasks removed by a direct SQL delete. Task is in UNCACHED_ENTITY_TYPES,
+   * so invalidateCacheForEntity clears only the local L1 Guava cache and skips the pub/sub
+   * fan-out (deliberate perf optimization for cascade-heavy paths). In a multi-pod deployment,
+   * peer instances that previously read one of these tasks still hold it in their L1 cache and
+   * would serve the stale row after the bulk SQL DELETE. Publish each (id, fqn) explicitly so
+   * peers drop both their by-id and by-name L1 entries.
+   */
+  public void invalidateTaskCaches(List<EntityDAO.EntityIdFqnPair> tasks, String reason) {
+    var pubsub = CacheBundle.getCacheInvalidationPubSub();
+    for (EntityDAO.EntityIdFqnPair task : listOrEmpty(tasks)) {
+      if (task.id != null) {
+        invalidateCacheForEntity(Entity.TASK, task.id, task.fqn);
+        if (pubsub != null) {
+          pubsub.publish(Entity.TASK, task.id, task.fqn, reason);
+        }
+      }
+    }
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -81,7 +81,6 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
-import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.exception.BadRequestException;
 import org.openmetadata.service.exception.CatalogExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
@@ -1370,22 +1369,8 @@ public class UserRepository extends EntityRepository<User> {
   }
 
   private void invalidateTaskCacheForIds(List<EntityDAO.EntityIdFqnPair> tasks) {
-    // Task is in UNCACHED_ENTITY_TYPES, so invalidateCacheForEntity clears only the local L1
-    // Guava cache and skips the pub/sub fan-out (deliberate perf optimization for the
-    // cascade-heavy bot/domain/data-product paths). In a multi-pod deployment, peer instances
-    // that previously read one of these tasks still hold it in their L1 cache and would serve
-    // the stale "deleted" row after this bulk SQL DELETE. Publish each (id, fqn) explicitly so
-    // peers drop both their by-id and by-name L1 entries.
-    var pubsub = CacheBundle.getCacheInvalidationPubSub();
-    for (EntityDAO.EntityIdFqnPair task : tasks) {
-      if (task.id == null) {
-        continue;
-      }
-      EntityRepository.invalidateCacheForEntity(Entity.TASK, task.id, task.fqn);
-      if (pubsub != null) {
-        pubsub.publish(Entity.TASK, task.id, task.fqn, "bot-task-cleanup");
-      }
-    }
+    TaskRepository taskRepository = (TaskRepository) Entity.getEntityRepository(Entity.TASK);
+    taskRepository.invalidateTaskCaches(tasks, "bot-task-cleanup");
   }
 
   static long getTaskCleanupRetryDelayMillis(int attempt) {


### PR DESCRIPTION
## Describe your changes

Hard-deleting an entity (e.g. a glossary term) leaves its Task 2.0 tasks behind as orphans. The generic relationship cleanup in `EntityRepository.cleanup()` wipes the entity→task `MENTIONED_IN` row, so the surviving task loses its `about` target and can no longer be handled normally — it lingers in the inbox referencing a non-existent entity.

The legacy thread system already handles this: both hard-delete paths call `FeedRepository.deleteByAbout()`. Task 2.0 (first-class `task_entity`) had no equivalent hook. (Historical context for the thread-era symptom: #22097.)

### Fix

- **`TaskRepository.deleteTasksAboutEntities(entityFqns)`** — the Task 2.0 counterpart of `FeedRepository.deleteByAbout`. Looks tasks up via the denormalized, indexed `aboutFqnHash` column (the relationship row is already gone at cleanup time), deletes their `entity_relationship` rows and `task_entity` rows inside the same transaction as the entity delete, and returns `(id, fqn)` pairs so callers invalidate caches after commit.
- Wired into **both** hard-delete paths, right beside the existing feed-thread cleanup:
  - `EntityRepository.cleanup()` (direct entity hard delete)
  - `bulkCleanupReferences()` (recursive / bulk subtree hard delete)
- **Cache invalidation is shared**: the invalidation logic (local L1 + pub/sub fan-out, needed because Task is in `UNCACHED_ENTITY_TYPES`) moved to `TaskRepository.invalidateTaskCaches`; the existing bot-creator suggestion cleanup in `UserRepository` now delegates to it.

Soft delete is intentionally unaffected — the target entity still exists, so its tasks stay actionable (covered by a test).

Note: this prevents new orphans. Tasks already orphaned in existing databases are not retroactively cleaned; that would need a follow-up migration.

### Tests (`TaskResourceIT`)

- `testHardDeletingAboutEntityDeletesItsTasks` — open **and** closed tasks about the deleted table are removed; a task about an unrelated table survives with its `about` intact
- `testSoftDeletingAboutEntityKeepsTasks` — soft delete leaves tasks untouched
- `testRecursiveHardDeleteOfParentDeletesDescendantTasks` — recursive schema delete cleans tasks about descendant tables (bulk subtree path)

The recursive test fails without the fix (task remains retrievable). Full `TaskResourceIT` + `GlossaryTermResourceIT`: 554 tests, 0 failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes Task 2.0 tasks when their target entity is hard-deleted. The main changes are:

- Adds batched task lookup and deletion by target FQN hash.
- Wires cleanup into direct and recursive hard-delete paths.
- Centralizes local and cross-pod task-cache invalidation.
- Adds integration tests for hard, soft, and recursive deletion.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The deletion key and concurrent-creation path need fixes before merging.

- Same-FQN targets of different entity types can be deleted together.
- A task created between ID lookup and deletion can survive as an orphan.
- Transaction placement and post-commit cache invalidation otherwise follow the intended flow.

CollectionDAO.java and TaskRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds database-specific task lookup by target FQN hash, but the lookup does not distinguish target entity types. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Adds task cleanup to direct and recursive hard-delete transactions, followed by post-commit cache invalidation. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java | Adds task deletion and shared cache invalidation, but its select-then-delete sequence can miss concurrent task creation. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java | Delegates existing bot-task cache invalidation to the shared TaskRepository method. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TaskResourceIT.java | Adds outcome-based coverage for direct hard deletion, soft deletion, recursive deletion, and unrelated-task preservation. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant D as Entity hard delete
    participant R as Relationship DAO
    participant T as Task DAO
    participant C as Task cache
    D->>R: Remove entity relationships
    D->>T: Select tasks by aboutFqnHash
    T-->>D: Return task IDs and FQNs
    D->>R: Delete task relationships
    D->>T: Delete selected task rows
    D->>D: Delete entity and commit
    D->>C: Invalidate local and peer entries
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tasks): delete tasks about an entity..."](https://github.com/open-metadata/openmetadata/commit/d1c6d60e19439159c1adbdc51174922ae65b8368) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46309730)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->