### PR TITLE
ci(playwright): skip HTML report upload on successful shards

### DIFF
--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -198,9 +198,14 @@ jobs:
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only humans consume this artifact — nothing in .github/ downloads
+      # playwright-report-*, and they only look at it when debugging a
+      # failure. Skipping upload on success saves ~1 minute per green shard
+      # (report + traces run 50-100MB after retries) without losing any
+      # programmatic data.
       - name: Upload Playwright HTML report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure() || cancelled()
         continue-on-error: true
         with:
           name: playwright-report--${{ matrix.shardIndex }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -447,9 +447,15 @@ jobs:
               }
             }' > "$STATUS_DIR/ci-status.json"
 
+      # Only humans consume this artifact — nothing in .github/ downloads
+      # playwright-report-* — and they only look at it when debugging a
+      # failure. Skipping upload on success saves ~1 minute per green shard
+      # (report is 10-50MB after retries) without losing any programmatic
+      # data — results.json is uploaded unconditionally below for the
+      # summary job.
       - name: Upload Playwright HTML report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure() || cancelled()
         continue-on-error: true
         with:
           name: playwright-report-${{ matrix.shardIndex }}


### PR DESCRIPTION
## Summary

The `playwright-report-<shard>` artifacts on the postgresql-e2e and mysql-e2e workflows are consumed **only by humans debugging failures**. Nothing else in `.github/` downloads them — the summary job pulls only `playwright-results-json-*`. Gating the upload on failure saves the zip+upload cost on every green shard.

## Change

Two workflow files, one-line-plus-comment change each:

- `.github/workflows/playwright-postgresql-e2e.yml` — HTML report step: `if: always()` → `if: failure() || cancelled()`
- `.github/workflows/playwright-mysql-e2e.yml` — same (this workflow bundles `playwright-report/` + `test-results/` into one artifact, so both are gated together)

`results.json` and `ci-status.json` uploads are **unchanged** (`if: always()`) so the summary job still gets everything it needs to render the PR comment and gate the check.

## Verification of \"nothing consumes it\"

```
$ grep -rn \"download-artifact.*playwright-report\" .github/
# no matches
```

Only two upload sites reference the `playwright-report-<shard>` name pattern; no download-artifact step anywhere references it. Human maintainers download it from the run's Artifacts panel, which naturally only happens when a failure needs investigating.

## Impact estimate

From [postgresql-e2e run 29881625038](https://github.com/open-metadata/OpenMetadata/actions/runs/29881625038): HTML upload step took ~1.1 min on the shard that failed (heaviest report + traces), and 0.0 min on truly clean shards. Real savings sit between — flaky-but-passed shards with retry traces run 20-50 MB and take 30-60 s. On a typical 7-shard run with 1-2 flaky shards, expect ~1-2 runner-minutes saved. On the mysql-e2e workflow the artifact is larger (report + test-results bundled) so the win is bigger there.

## Trade-off

A shard that passes with flakes no longer uploads its trace bundle to the artifacts panel. If someone wants to inspect why a specific test flaked-and-recovered, they now have to re-run to get traces. This is intentional — the flaky list in the summary PR comment still identifies which specs to fix; deeper investigation moves to a rerun. If this hurts in practice, we can move to a middle ground later (e.g. upload only when \`totalFlaky > 0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR reduces artifact uploads for successful Playwright shards. The main changes are:

- Upload MySQL HTML reports and test results only after failure or cancellation.
- Upload PostgreSQL HTML reports only after failure or cancellation.
- Keep PostgreSQL summary JSON and test-result artifacts unconditional.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- Failed shards still upload diagnostic reports.
- PostgreSQL summary inputs remain available on every shard outcome.
- The loss of retry diagnostics from successful MySQL shards is an explicit trade-off.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-mysql-e2e.yml | Gates the combined HTML report and test-results artifact on shard failure or cancellation. |
| .github/workflows/playwright-postgresql-e2e.yml | Gates the HTML report while preserving unconditional summary JSON and test-result uploads. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): skip HTML report upload ..."](https://github.com/open-metadata/openmetadata/commit/829e9b73a8c8e191410fae7868bc8149897c4ce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46319879)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->