### PR TITLE
fix(ui-core-components): dismiss non-modal popovers outside

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
@@ -1,38 +1,77 @@
-import type { RefAttributes } from 'react';
+import { useObjectRef } from '@react-aria/utils';
+import { forwardRef } from 'react';
+import { useInteractOutside } from 'react-aria';
 import type { PopoverProps as AriaPopoverProps } from 'react-aria-components';
 import { Popover as AriaPopover } from 'react-aria-components';
 import { cx } from '@/utils/cx';
 
-interface PopoverProps extends AriaPopoverProps, RefAttributes<HTMLElement> {
+interface PopoverProps extends AriaPopoverProps {
+  /**
+   * Whether a non-modal popover closes when the user interacts outside it.
+   * Modal popovers already provide this behavior through React Aria.
+   * @default false
+   */
+  isDismissable?: boolean;
+  /**
+   * Filters which outside elements may dismiss an open popover.
+   * Return false for trigger elements or other interactions that should keep it open.
+   */
+  shouldCloseOnInteractOutside?: AriaPopoverProps['shouldCloseOnInteractOutside'];
   size: 'sm' | 'md';
 }
 
-export const Popover = (props: PopoverProps) => {
-  return (
-    <AriaPopover
-      containerPadding={0}
-      offset={4}
-      placement="bottom"
-      {...props}
-      className={(state) =>
-        cx(
-          // Outline instead of a ring (WebKit does not pixel-snap box-shadow, so rings
-          // thin/vanish in Safari when zoomed out). This ring had no `ring-inset`, so it
-          // drew outward from the border-box edge — outline-offset 0 (the default) matches
-          // that exactly. `outline-hidden` is gone: it would suppress this border.
-          'tw:max-h-64! tw:w-(--trigger-width) tw:origin-(--trigger-anchor-point) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:py-1 tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+export const Popover = forwardRef<HTMLElement, PopoverProps>(
+  ({ isDismissable = false, ...props }, ref) => {
+    const popoverRef = useObjectRef(ref);
 
-          state.isEntering &&
-            'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
-          state.isExiting &&
-            'tw:duration-100 tw:ease-in tw:animate-out tw:fade-out tw:placement-right:slide-out-to-left-0.5 tw:placement-top:slide-out-to-bottom-0.5 tw:placement-bottom:slide-out-to-top-0.5',
-          props.size === 'md' && 'tw:max-h-80!',
+    // React Aria intentionally keeps non-modal popovers open during outside
+    // interaction. Opt into dismissal while preserving its standard filter.
+    useInteractOutside({
+      ref: popoverRef,
+      isDisabled: !isDismissable || !props.isNonModal,
+      onInteractOutside: (event) => {
+        const target = event.target;
 
-          typeof props.className === 'function'
-            ? props.className(state)
-            : props.className
-        )
-      }
-    />
-  );
-};
+        if (
+          target instanceof Element &&
+          props.shouldCloseOnInteractOutside?.(target) === false
+        ) {
+          return;
+        }
+
+        props.onOpenChange?.(false);
+      },
+    });
+
+    return (
+      <AriaPopover
+        containerPadding={0}
+        offset={4}
+        placement="bottom"
+        ref={popoverRef}
+        {...props}
+        className={(state) =>
+          cx(
+            // Outline instead of a ring (WebKit does not pixel-snap box-shadow, so rings
+            // thin/vanish in Safari when zoomed out). This ring had no `ring-inset`, so it
+            // drew outward from the border-box edge — outline-offset 0 (the default) matches
+            // that exactly. `outline-hidden` is gone: it would suppress this border.
+            'tw:max-h-64! tw:w-(--trigger-width) tw:origin-(--trigger-anchor-point) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:py-1 tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+
+            state.isEntering &&
+              'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
+            state.isExiting &&
+              'tw:duration-100 tw:ease-in tw:animate-out tw:fade-out tw:placement-right:slide-out-to-left-0.5 tw:placement-top:slide-out-to-bottom-0.5 tw:placement-bottom:slide-out-to-top-0.5',
+            props.size === 'md' && 'tw:max-h-80!',
+
+            typeof props.className === 'function'
+              ? props.className(state)
+              : props.className
+          )
+        }
+      />
+    );
+  }
+);
+
+Popover.displayName = 'Popover';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
@@ -1,5 +1,5 @@
 import { useObjectRef } from '@react-aria/utils';
-import { forwardRef, useContext } from 'react';
+import { forwardRef, useCallback, useContext } from 'react';
 import { useInteractOutside } from 'react-aria';
 import type { PopoverProps as AriaPopoverProps } from 'react-aria-components';
 import {
@@ -32,9 +32,16 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>((props, ref) => {
   const isDismissable = props.isDismissable ?? false;
   const isNonModal = props.isNonModal ?? popoverContext?.isNonModal;
   const triggerRef = props.triggerRef ?? popoverContext?.triggerRef;
-  const shouldCloseOnInteractOutside =
+  const contextShouldCloseOnInteractOutside =
     props.shouldCloseOnInteractOutside ??
     popoverContext?.shouldCloseOnInteractOutside;
+
+  const shouldCloseOnInteractOutside = useCallback(
+    (target: Element) =>
+      !triggerRef?.current?.contains(target) &&
+      (contextShouldCloseOnInteractOutside?.(target) ?? true),
+    [contextShouldCloseOnInteractOutside, triggerRef]
+  );
 
   // React Aria intentionally keeps non-modal popovers open during outside
   // interaction. Opt into dismissal while preserving its standard filter.
@@ -46,8 +53,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>((props, ref) => {
 
       if (
         target instanceof Element &&
-        (triggerRef?.current?.contains(target) ||
-          shouldCloseOnInteractOutside?.(target) === false)
+        shouldCloseOnInteractOutside(target) === false
       ) {
         return;
       }
@@ -88,6 +94,7 @@ export const Popover = forwardRef<HTMLElement, PopoverProps>((props, ref) => {
             : props.className
         )
       }
+      shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
     />
   );
 });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx
@@ -1,8 +1,13 @@
 import { useObjectRef } from '@react-aria/utils';
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import { useInteractOutside } from 'react-aria';
 import type { PopoverProps as AriaPopoverProps } from 'react-aria-components';
-import { Popover as AriaPopover } from 'react-aria-components';
+import {
+  OverlayTriggerStateContext,
+  Popover as AriaPopover,
+  PopoverContext,
+  useSlottedContext,
+} from 'react-aria-components';
 import { cx } from '@/utils/cx';
 
 interface PopoverProps extends AriaPopoverProps {
@@ -20,58 +25,71 @@ interface PopoverProps extends AriaPopoverProps {
   size: 'sm' | 'md';
 }
 
-export const Popover = forwardRef<HTMLElement, PopoverProps>(
-  ({ isDismissable = false, ...props }, ref) => {
-    const popoverRef = useObjectRef(ref);
+export const Popover = forwardRef<HTMLElement, PopoverProps>((props, ref) => {
+  const popoverRef = useObjectRef(ref);
+  const popoverContext = useSlottedContext(PopoverContext, props.slot);
+  const overlayState = useContext(OverlayTriggerStateContext);
+  const isDismissable = props.isDismissable ?? false;
+  const isNonModal = props.isNonModal ?? popoverContext?.isNonModal;
+  const triggerRef = props.triggerRef ?? popoverContext?.triggerRef;
+  const shouldCloseOnInteractOutside =
+    props.shouldCloseOnInteractOutside ??
+    popoverContext?.shouldCloseOnInteractOutside;
 
-    // React Aria intentionally keeps non-modal popovers open during outside
-    // interaction. Opt into dismissal while preserving its standard filter.
-    useInteractOutside({
-      ref: popoverRef,
-      isDisabled: !isDismissable || !props.isNonModal,
-      onInteractOutside: (event) => {
-        const target = event.target;
+  // React Aria intentionally keeps non-modal popovers open during outside
+  // interaction. Opt into dismissal while preserving its standard filter.
+  useInteractOutside({
+    ref: popoverRef,
+    isDisabled: !isDismissable || !isNonModal,
+    onInteractOutside: (event) => {
+      const target = event.target;
 
-        if (
-          target instanceof Element &&
-          props.shouldCloseOnInteractOutside?.(target) === false
-        ) {
-          return;
-        }
+      if (
+        target instanceof Element &&
+        (triggerRef?.current?.contains(target) ||
+          shouldCloseOnInteractOutside?.(target) === false)
+      ) {
+        return;
+      }
 
+      if (props.isOpen != null || props.defaultOpen != null || !overlayState) {
         props.onOpenChange?.(false);
-      },
-    });
 
-    return (
-      <AriaPopover
-        containerPadding={0}
-        offset={4}
-        placement="bottom"
-        ref={popoverRef}
-        {...props}
-        className={(state) =>
-          cx(
-            // Outline instead of a ring (WebKit does not pixel-snap box-shadow, so rings
-            // thin/vanish in Safari when zoomed out). This ring had no `ring-inset`, so it
-            // drew outward from the border-box edge — outline-offset 0 (the default) matches
-            // that exactly. `outline-hidden` is gone: it would suppress this border.
-            'tw:max-h-64! tw:w-(--trigger-width) tw:origin-(--trigger-anchor-point) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:py-1 tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+        return;
+      }
 
-            state.isEntering &&
-              'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
-            state.isExiting &&
-              'tw:duration-100 tw:ease-in tw:animate-out tw:fade-out tw:placement-right:slide-out-to-left-0.5 tw:placement-top:slide-out-to-bottom-0.5 tw:placement-bottom:slide-out-to-top-0.5',
-            props.size === 'md' && 'tw:max-h-80!',
+      overlayState.close();
+    },
+  });
 
-            typeof props.className === 'function'
-              ? props.className(state)
-              : props.className
-          )
-        }
-      />
-    );
-  }
-);
+  return (
+    <AriaPopover
+      containerPadding={0}
+      offset={4}
+      placement="bottom"
+      ref={popoverRef}
+      {...props}
+      className={(state) =>
+        cx(
+          // Outline instead of a ring (WebKit does not pixel-snap box-shadow, so rings
+          // thin/vanish in Safari when zoomed out). This ring had no `ring-inset`, so it
+          // drew outward from the border-box edge — outline-offset 0 (the default) matches
+          // that exactly. `outline-hidden` is gone: it would suppress this border.
+          'tw:max-h-64! tw:w-(--trigger-width) tw:origin-(--trigger-anchor-point) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-primary tw:py-1 tw:shadow-lg tw:outline-1 tw:outline-secondary_alt tw:will-change-transform',
+
+          state.isEntering &&
+            'tw:duration-150 tw:ease-out tw:animate-in tw:fade-in tw:placement-right:slide-in-from-left-0.5 tw:placement-top:slide-in-from-bottom-0.5 tw:placement-bottom:slide-in-from-top-0.5',
+          state.isExiting &&
+            'tw:duration-100 tw:ease-in tw:animate-out tw:fade-out tw:placement-right:slide-out-to-left-0.5 tw:placement-top:slide-out-to-bottom-0.5 tw:placement-bottom:slide-out-to-top-0.5',
+          props.size === 'md' && 'tw:max-h-80!',
+
+          typeof props.className === 'function'
+            ? props.className(state)
+            : props.className
+        )
+      }
+    />
+  );
+});
 
 Popover.displayName = 'Popover';

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/SelectPopover.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/SelectPopover.stories.tsx
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
+import { Dialog as AriaDialog } from 'react-aria-components';
+import { PopoverTrigger } from '../components/application/popover/popover';
+import { Button } from '../components/base/buttons/button';
+import { Popover as SelectPopover } from '../components/base/select/popover';
+
+const POPOVER_LABEL = 'Select popover';
+const TRIGGER_LABEL = 'Open select popover';
+
+interface SelectPopoverExampleProps {
+  isDismissable: boolean;
+  shouldCloseOnInteractOutside?: (element: Element) => boolean;
+  showFilteredOutsideActions?: boolean;
+}
+
+// Keeps the trigger and popover markup identical so each story isolates only
+// the outside-interaction configuration it demonstrates.
+const SelectPopoverExample = ({
+  isDismissable,
+  shouldCloseOnInteractOutside,
+  showFilteredOutsideActions = false,
+}: SelectPopoverExampleProps) => (
+  <div className="tw:flex tw:items-center tw:gap-4">
+    <PopoverTrigger>
+      <Button color="secondary">{TRIGGER_LABEL}</Button>
+      <SelectPopover
+        isNonModal
+        isDismissable={isDismissable}
+        shouldCloseOnInteractOutside={shouldCloseOnInteractOutside}
+        size="sm">
+        <AriaDialog
+          aria-label={POPOVER_LABEL}
+          className="tw:min-w-60 tw:p-4 tw:outline-hidden">
+          Use the outside actions to test this popover.
+        </AriaDialog>
+      </SelectPopover>
+    </PopoverTrigger>
+
+    {showFilteredOutsideActions ? (
+      <>
+        <Button color="tertiary">Ignored outside action</Button>
+        <Button data-dismiss-popover color="tertiary">
+          Dismiss outside action
+        </Button>
+      </>
+    ) : (
+      <Button color="tertiary">Outside action</Button>
+    )}
+  </div>
+);
+
+const meta = {
+  title: 'Components/SelectPopover',
+  component: SelectPopover,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SelectPopover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Enabling dismissal without a custom filter closes the popover for any
+// interaction outside the popover and its trigger.
+export const Dismissible: Story = {
+  render: () => <SelectPopoverExample isDismissable />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: TRIGGER_LABEL }));
+    expect(
+      await body.findByRole('dialog', { name: POPOVER_LABEL })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Outside action' })
+    );
+    await waitFor(() =>
+      expect(
+        body.queryByRole('dialog', { name: POPOVER_LABEL })
+      ).not.toBeInTheDocument()
+    );
+  },
+};
+
+// This filter acts as an allow-list: only the explicitly marked outside action
+// may dismiss the popover.
+const shouldCloseOnMarkedOutsideAction = (element: Element) =>
+  element.closest('[data-dismiss-popover]') !== null;
+
+// Demonstrates that ignored outside targets keep the popover open while an
+// approved outside target closes it.
+export const FilteredOutsideInteraction: Story = {
+  render: () => (
+    <SelectPopoverExample
+      isDismissable
+      showFilteredOutsideActions
+      shouldCloseOnInteractOutside={shouldCloseOnMarkedOutsideAction}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+
+    await userEvent.click(canvas.getByRole('button', { name: TRIGGER_LABEL }));
+    expect(
+      await body.findByRole('dialog', { name: POPOVER_LABEL })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Ignored outside action' })
+    );
+    expect(
+      body.getByRole('dialog', { name: POPOVER_LABEL })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Dismiss outside action' })
+    );
+    await waitFor(() =>
+      expect(
+        body.queryByRole('dialog', { name: POPOVER_LABEL })
+      ).not.toBeInTheDocument()
+    );
+  },
+};
+
+// Disabling dismissal and rejecting every outside target keeps the popover
+// open after outside interaction.
+export const NonDismissible: Story = {
+  render: () => (
+    <SelectPopoverExample
+      isDismissable={false}
+      shouldCloseOnInteractOutside={() => false}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(document.body);
+    const trigger = canvas.getByRole('button', {
+      name: TRIGGER_LABEL,
+    });
+
+    await userEvent.click(trigger);
+    expect(
+      await body.findByRole('dialog', { name: POPOVER_LABEL })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole('button', { name: 'Outside action' })
+    );
+    expect(
+      body.getByRole('dialog', { name: POPOVER_LABEL })
+    ).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
### Describe your changes

Adds opt-in outside-interaction dismissal for non-modal core select popovers. The behavior honors `shouldCloseOnInteractOutside` filters and preserves the existing Safari-safe outline styling from current `main`.

### Type of change

- [x] Bug fix

### Tests

#### Use cases covered

- A dismissible non-modal popover requests closure after an allowed outside interaction.
- Trigger or filtered outside interactions can keep the popover open.
- Modal and non-dismissible popovers retain React Aria's existing behavior.

#### Verification performed

- ESLint on the changed core-components file
- Prettier check on the changed core-components file
- Core-components TypeScript check (`tsc --noEmit`)
- Core-components production build (`vite build`)
- `git diff --check`

#### Unit tests

Not added: the core-components package does not currently expose a unit-test runner.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright tests

- [x] Not applicable (core primitive behavior only).

### UI screen recording / screenshots

Not applicable — this changes dismissal behavior without changing visuals.

### Checklist

- [x] No JSON Schema or migration changes are required.
- [x] The transferred change was rebased onto current `main` styling.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in outside-interaction dismissal for non-modal select popovers. The main changes are:

- Routes context-owned popover closure through React Aria overlay state.
- Preserves trigger exclusions and custom outside-interaction filters.
- Adds Storybook coverage for dismissible, filtered, and non-dismissible behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The context-owned close path now updates the inherited React Aria overlay state.
- Trigger interactions and custom filters retain their expected behavior.
- No blocking issue was found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/popover.tsx | Adds filtered outside-interaction handling and closes context-owned popovers through the inherited overlay state. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/SelectPopover.stories.tsx | Adds interaction stories for enabled, filtered, and disabled outside dismissal. |

</details>

<sub>Reviews (3): Last reviewed commit: ["add storybook"](https://github.com/open-metadata/openmetadata/commit/b7a0e734740a0e17ff41123b37b668b71b2754d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46328664)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->