### PR TITLE
fix(workflow): wire server-side search for Tags in Detect Field Changes node

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
@@ -305,18 +305,16 @@ describe('ConditionBuilder — server-side tag search', () => {
     });
 
     // Before debounce fires, fetchOptions should not have been called again
-    const callCountBeforeDebounce = (
-      tagFieldDef.fetchOptions as jest.Mock
-    ).mock.calls.length;
+    const callCountBeforeDebounce = (tagFieldDef.fetchOptions as jest.Mock).mock
+      .calls.length;
 
     // Fire debounce
     await act(async () => {
       jest.runAllTimers();
     });
 
-    const callCountAfterDebounce = (
-      tagFieldDef.fetchOptions as jest.Mock
-    ).mock.calls.length;
+    const callCountAfterDebounce = (tagFieldDef.fetchOptions as jest.Mock).mock
+      .calls.length;
 
     expect(callCountAfterDebounce).toBeGreaterThan(callCountBeforeDebounce);
 
@@ -428,8 +426,8 @@ describe('ConditionBuilder — server-side tag search', () => {
       jest.runAllTimers();
     });
 
-    expect(
-      (tagFieldDef.fetchOptions as jest.Mock).mock.calls.length
-    ).toBe(callsAfterSearch);
+    expect((tagFieldDef.fetchOptions as jest.Mock).mock.calls.length).toBe(
+      callsAfterSearch
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { ConditionBuilder } from './ConditionBuilder';
 import type { ConditionFieldDefinition } from './ConditionBuilder.interface';
@@ -187,6 +187,13 @@ const makeTagFieldDef = (
   ...override,
 });
 
+const selectTagsField = async () => {
+  const select = screen.getByTestId('condition-builder-row-0-field');
+  await act(async () => {
+    fireEvent.change(select, { target: { value: 'tags' } });
+  });
+};
+
 describe('ConditionBuilder — server-side tag search', () => {
   beforeEach(() => {
     capturedOnSearchChange = undefined;
@@ -211,15 +218,7 @@ describe('ConditionBuilder — server-side tag search', () => {
       );
     });
 
-    // Select the tags field
-    const select = screen.getByTestId('condition-builder-row-0-field');
-    await act(async () => {
-      select.dispatchEvent(
-        Object.assign(new Event('change', { bubbles: true }), {
-          target: { value: 'tags' },
-        })
-      );
-    });
+    await selectTagsField();
 
     expect(tagFieldDef.fetchOptions).toHaveBeenCalledWith('');
   });
@@ -282,16 +281,13 @@ describe('ConditionBuilder — server-side tag search', () => {
       render(
         <ConditionBuilder
           fieldDefinitions={[tagFieldDef]}
-          value={{
-            config: {
-              condition: 'AND',
-              rules: { tags: [] },
-            },
-          }}
+          value={null}
           onChange={onChange}
         />
       );
     });
+
+    await selectTagsField();
 
     await act(async () => {
       jest.runAllTimers();
@@ -389,16 +385,13 @@ describe('ConditionBuilder — server-side tag search', () => {
       render(
         <ConditionBuilder
           fieldDefinitions={[tagFieldDef]}
-          value={{
-            config: {
-              condition: 'AND',
-              rules: { tags: [] },
-            },
-          }}
+          value={null}
           onChange={onChange}
         />
       );
     });
+
+    await selectTagsField();
 
     // Wait for the initial mount load (empty string call)
     await act(async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
@@ -1,0 +1,384 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ConditionBuilder } from './ConditionBuilder';
+import type { ConditionFieldDefinition } from './ConditionBuilder.interface';
+
+// Capture onSearchChange passed to Autocomplete so tests can invoke it
+let capturedOnSearchChange: ((search: string) => void) | undefined;
+let capturedFilterOption: (() => boolean) | undefined;
+
+jest.mock('@openmetadata/ui-core-components', () => {
+  const AutocompleteItem = ({
+    label,
+    id,
+  }: {
+    label?: string;
+    id: string | number;
+  }) => <div data-testid={`item-${id}`}>{label}</div>;
+
+  const Autocomplete = (props: {
+    items: Array<{ id: string | number; label?: string }>;
+    selectedItems: { items: Array<{ id: string; label?: string }> };
+    'data-testid'?: string;
+    filterOption?: () => boolean;
+    onSearchChange?: (search: string) => void;
+    onItemInserted?: (key: string | number) => void;
+    onItemCleared?: (key: string | number) => void;
+    children?: React.ReactNode;
+  }) => {
+    capturedOnSearchChange = props.onSearchChange;
+    capturedFilterOption = props.filterOption;
+
+    return (
+      <div data-testid={props['data-testid'] ?? 'autocomplete'}>
+        {props.items.map((item) => (
+          <button
+            data-testid={`option-${item.id}`}
+            key={item.id}
+            onClick={() => props.onItemInserted?.(item.id)}>
+            {item.label ?? item.id}
+          </button>
+        ))}
+      </div>
+    );
+  };
+
+  Autocomplete.Item = AutocompleteItem;
+
+  const Card = ({
+    children,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => <div {...rest}>{children}</div>;
+
+  const Input = (props: {
+    value?: string;
+    isDisabled?: boolean;
+    'data-testid'?: string;
+    onChange?: (v: string) => void;
+  }) => (
+    <input
+      data-testid={props['data-testid']}
+      disabled={props.isDisabled}
+      value={props.value ?? ''}
+      onChange={(e) => props.onChange?.(e.target.value)}
+    />
+  );
+
+  const Toggle = (props: {
+    isSelected?: boolean;
+    isDisabled?: boolean;
+    'data-testid'?: string;
+    onChange?: (checked: boolean) => void;
+  }) => (
+    <input
+      checked={props.isSelected ?? false}
+      data-testid={props['data-testid'] ?? 'toggle'}
+      disabled={props.isDisabled}
+      type="checkbox"
+      onChange={(e) => props.onChange?.(e.target.checked)}
+    />
+  );
+
+  const Button = (props: {
+    children?: React.ReactNode;
+    onPress?: () => void;
+    isDisabled?: boolean;
+    'data-testid'?: string;
+  }) => (
+    <button
+      data-testid={props['data-testid']}
+      disabled={props.isDisabled}
+      onClick={props.onPress}>
+      {props.children}
+    </button>
+  );
+
+  const Select = Object.assign(
+    (props: {
+      children?: React.ReactNode;
+      value?: string;
+      'data-testid'?: string;
+      onChange?: (key: string) => void;
+    }) => (
+      <select
+        data-testid={props['data-testid']}
+        value={props.value}
+        onChange={(e) => props.onChange?.(e.target.value)}>
+        {props.children}
+      </select>
+    ),
+    {
+      Item: ({
+        id,
+        label,
+      }: {
+        id: string | number;
+        label?: string;
+        key?: string | number;
+      }) => <option value={String(id)}>{label ?? id}</option>,
+    }
+  );
+
+  return { Autocomplete, Button, Card, Input, Select, Toggle };
+});
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('contexts/WorkflowModeContext', () => ({
+  useWorkflowModeContext: jest.fn(() => ({
+    isFormDisabled: false,
+    canSave: true,
+    allowStructuralGraphEdits: true,
+  })),
+}));
+
+// Stub useListData so selectedItems behaves predictably
+jest.mock('react-stately', () => ({
+  useListData: () => {
+    const items: Array<{ id: string; label?: string }> = [];
+
+    return {
+      items,
+      append: (item: { id: string; label?: string }) => items.push(item),
+      remove: (id: string) => {
+        const idx = items.findIndex((i) => i.id === id);
+        if (idx !== -1) {
+          items.splice(idx, 1);
+        }
+      },
+    };
+  },
+}));
+
+jest.useFakeTimers();
+
+const onChange = jest.fn();
+
+const makeTagFieldDef = (
+  override: Partial<ConditionFieldDefinition> = {}
+): ConditionFieldDefinition => ({
+  value: 'tags',
+  label: 'label.tag-plural',
+  values: [],
+  valueType: 'dropdown',
+  fetchOptions: jest.fn().mockResolvedValue([
+    { value: 'PII.Sensitive', label: 'PII.Sensitive' },
+    { value: 'Tier.Tier1', label: 'Tier.Tier1' },
+  ]),
+  supportsSearch: true,
+  ...override,
+});
+
+describe('ConditionBuilder — server-side tag search', () => {
+  beforeEach(() => {
+    capturedOnSearchChange = undefined;
+    capturedFilterOption = undefined;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('calls fetchOptions with empty string on mount to load initial options', async () => {
+    const tagFieldDef = makeTagFieldDef();
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[tagFieldDef]}
+          value={null}
+          onChange={onChange}
+        />
+      );
+    });
+
+    // Select the tags field
+    const select = screen.getByTestId('condition-builder-row-0-field');
+    await act(async () => {
+      select.dispatchEvent(
+        Object.assign(new Event('change', { bubbles: true }), {
+          target: { value: 'tags' },
+        })
+      );
+    });
+
+    expect(tagFieldDef.fetchOptions).toHaveBeenCalledWith('');
+  });
+
+  it('passes onSearchChange to Autocomplete for fields with supportsSearch=true', async () => {
+    const tagFieldDef = makeTagFieldDef({ supportsSearch: true });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[tagFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { tags: ['PII.Sensitive'] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(capturedOnSearchChange).toBeDefined();
+  });
+
+  it('passes filterOption=()=>true to Autocomplete for fields with supportsSearch=true', async () => {
+    const tagFieldDef = makeTagFieldDef({ supportsSearch: true });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[tagFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { tags: ['PII.Sensitive'] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(capturedFilterOption).toBeDefined();
+    expect(capturedFilterOption?.()).toBe(true);
+  });
+
+  it('calls fetchOptions with search text when user types (debounced)', async () => {
+    const tagFieldDef = makeTagFieldDef({ supportsSearch: true });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[tagFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { tags: [] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    // Simulate user typing via onSearchChange
+    expect(capturedOnSearchChange).toBeDefined();
+
+    await act(async () => {
+      capturedOnSearchChange?.('PII');
+    });
+
+    // Before debounce fires, fetchOptions should not have been called again
+    const callCountBeforeDebounce = (
+      tagFieldDef.fetchOptions as jest.Mock
+    ).mock.calls.length;
+
+    // Fire debounce
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const callCountAfterDebounce = (
+      tagFieldDef.fetchOptions as jest.Mock
+    ).mock.calls.length;
+
+    expect(callCountAfterDebounce).toBeGreaterThan(callCountBeforeDebounce);
+
+    const calls = (tagFieldDef.fetchOptions as jest.Mock).mock.calls;
+    const lastCall = calls[calls.length - 1];
+
+    expect(lastCall[0]).toBe('PII');
+  });
+
+  it('does NOT pass onSearchChange for fields with supportsSearch=false', async () => {
+    const certFieldDef = makeTagFieldDef({
+      value: 'certification',
+      supportsSearch: false,
+    });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[certFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { certification: [] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(capturedOnSearchChange).toBeUndefined();
+  });
+
+  it('does NOT pass filterOption for fields with supportsSearch=false', async () => {
+    const certFieldDef = makeTagFieldDef({
+      value: 'certification',
+      supportsSearch: false,
+    });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[certFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { certification: [] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(capturedFilterOption).toBeUndefined();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
@@ -381,4 +381,55 @@ describe('ConditionBuilder — server-side tag search', () => {
 
     expect(capturedFilterOption).toBeUndefined();
   });
+
+  it('does NOT re-load full list when a search returns zero results', async () => {
+    const tagFieldDef = makeTagFieldDef({
+      fetchOptions: jest.fn().mockResolvedValue([]),
+    });
+
+    await act(async () => {
+      render(
+        <ConditionBuilder
+          fieldDefinitions={[tagFieldDef]}
+          value={{
+            config: {
+              condition: 'AND',
+              rules: { tags: [] },
+            },
+          }}
+          onChange={onChange}
+        />
+      );
+    });
+
+    // Wait for the initial mount load (empty string call)
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const callsAfterMount = (tagFieldDef.fetchOptions as jest.Mock).mock.calls
+      .length;
+
+    // Simulate typing a search that yields no results — already resolved to []
+    await act(async () => {
+      capturedOnSearchChange?.('nonexistent-tag-xyz');
+    });
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const callsAfterSearch = (tagFieldDef.fetchOptions as jest.Mock).mock.calls
+      .length;
+
+    expect(callsAfterSearch).toBe(callsAfterMount + 1);
+
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(
+      (tagFieldDef.fetchOptions as jest.Mock).mock.calls.length
+    ).toBe(callsAfterSearch);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
@@ -211,9 +211,7 @@ function ConditionBuilderValueControl(
         });
         onChange([...selectedItems.items.map((i) => i.id), String(key)]);
       }}
-      onSearchChange={
-        supportsSearch ? debouncedLoadAsyncOptions : undefined
-      }>
+      onSearchChange={supportsSearch ? debouncedLoadAsyncOptions : undefined}>
       {(item) => (
         <Autocomplete.Item
           id={item.id}

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
@@ -118,10 +118,11 @@ function ConditionBuilderValueControl(
   );
 
   useEffect(() => {
-    if (hasFetchOptions && asyncOptions.length === 0) {
+    if (hasFetchOptions) {
+      setAsyncOptions([]);
       loadAsyncOptions('');
     }
-  }, [hasFetchOptions, asyncOptions.length, loadAsyncOptions]);
+  }, [hasFetchOptions, loadAsyncOptions]);
 
   // useListData for the multi-select controls
   const selectedItems = useListData<SelectItemType>({ initialItems: [] });

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx
@@ -21,6 +21,7 @@ import {
   Toggle,
 } from '@openmetadata/ui-core-components';
 import { Plus, Trash01 } from '@untitledui/icons';
+import { debounce } from 'lodash';
 import React, {
   useCallback,
   useEffect,
@@ -80,6 +81,8 @@ function ConditionBuilderValueControl(
     }));
   }, [fieldDef, t]);
 
+  const supportsSearch = hasFetchOptions && fieldDef?.supportsSearch !== false;
+
   const loadAsyncOptions = useCallback(
     async (search: string) => {
       if (!fieldDef?.fetchOptions) {
@@ -100,6 +103,18 @@ function ConditionBuilderValueControl(
       }
     },
     [fieldDef]
+  );
+
+  const debouncedLoadAsyncOptions = useMemo(
+    () => debounce((search: string) => loadAsyncOptions(search), 300),
+    [loadAsyncOptions]
+  );
+
+  useEffect(
+    () => () => {
+      debouncedLoadAsyncOptions.cancel();
+    },
+    [debouncedLoadAsyncOptions]
   );
 
   useEffect(() => {
@@ -175,6 +190,7 @@ function ConditionBuilderValueControl(
     <Autocomplete
       className="tw:w-full"
       data-testid={dataTestId}
+      filterOption={supportsSearch ? () => true : undefined}
       isDisabled={disabled ?? false}
       items={items}
       maxVisibleItems={1}
@@ -193,7 +209,10 @@ function ConditionBuilderValueControl(
           label: opt?.label ?? String(key),
         });
         onChange([...selectedItems.items.map((i) => i.id), String(key)]);
-      }}>
+      }}
+      onSearchChange={
+        supportsSearch ? debouncedLoadAsyncOptions : undefined
+      }>
       {(item) => (
         <Autocomplete.Item
           id={item.id}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:
Issue - #30366 

In the Detect Field Changes node (Workflows), the Tags dropdown search only filtered the initially-loaded items client-side. Typing “PII” would only narrow the small set of tags already in the dropdown — it never made an API call to search all tags in the system.

The supportsSearch flag was already defined in ConditionFieldDefinition and set correctly in ConditionBuilder.constants.ts (all fields except Certification support search), but it was never used — the Autocomplete in ConditionBuilderValueControl had no onSearchChange handler.


https://github.com/user-attachments/assets/205ca6d5-dc68-4f4a-8a44-6d05b09d67e2



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds server-side option search to searchable fields in the workflow condition builder. The main changes are:

- Adds debounced remote searches from the Autocomplete input.
- Disables local filtering when remote search is active.
- Cancels pending debounced searches during cleanup.
- Adds tests for initial loading, search behavior, unsupported fields, and empty results.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the updated code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.tsx | Adds debounced server-side option loading and connects it to searchable Autocomplete fields. |
| openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx | Adds unit coverage for remote search wiring, debounce behavior, initial loading, and empty results. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix unit test"](https://github.com/open-metadata/openmetadata/commit/691d0e4809682a0c2a184b801e124a964477ea7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46365882)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->