### PR TITLE
fix(ui): show inline name error for duplicate Domain/Data Product instead of toast

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/hooks/useDataProductCreateDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/hooks/useDataProductCreateDrawer.tsx
@@ -21,7 +21,10 @@ import {
   patchDataProduct,
 } from '../../../rest/dataProductAPI';
 import { createEntityWithCoverImage } from '../../../utils/CoverImageUploadUtils';
-import { submitAndClose } from '../../../utils/FormDrawerUtils';
+import {
+  setCreateEntityFieldError,
+  submitAndClose,
+} from '../../../utils/FormDrawerUtils';
 import { useFormDrawerWithHook } from '../../common/atoms/drawer';
 import AddDomainForm, {
   DOMAIN_FORM_DEFAULTS,
@@ -62,7 +65,22 @@ export const useDataProductCreateDrawer = (onCreated?: () => void) => {
             form.reset();
           },
           t,
+          suppressErrorToast: true,
         });
+      } catch (error) {
+        setCreateEntityFieldError(
+          error,
+          form,
+          'name',
+          t('message.entity-with-name-already-exists', {
+            entity: t('label.data-product'),
+          }),
+          t('server.add-entity-error', {
+            entity: t('label.data-product').toLowerCase(),
+          })
+        );
+
+        throw error;
       } finally {
         setIsLoading(false);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -91,7 +91,10 @@ import {
   fetchEntityTaskCountsInto,
   getFeedCounts,
 } from '../../../utils/FeedUtilsPure';
-import { submitAndClose } from '../../../utils/FormDrawerUtils';
+import {
+  setCreateEntityFieldError,
+  submitAndClose,
+} from '../../../utils/FormDrawerUtils';
 import Fqn from '../../../utils/Fqn';
 import { getEntityAvatarProps } from '../../../utils/IconUtils';
 import {
@@ -397,7 +400,22 @@ const DomainDetails = ({
             dataProductForm.reset();
           },
           t,
+          suppressErrorToast: true,
         });
+      } catch (error) {
+        setCreateEntityFieldError(
+          error,
+          dataProductForm,
+          'name',
+          t('message.entity-with-name-already-exists', {
+            entity: t('label.data-product'),
+          }),
+          t('server.add-entity-error', {
+            entity: t('label.data-product').toLowerCase(),
+          })
+        );
+
+        throw error;
       } finally {
         setIsDataProductLoading(false);
       }
@@ -556,7 +574,22 @@ const DomainDetails = ({
             subDomainForm.reset();
           },
           t,
+          suppressErrorToast: true,
         });
+      } catch (error) {
+        setCreateEntityFieldError(
+          error,
+          subDomainForm,
+          'name',
+          t('message.entity-with-name-already-exists', {
+            entity: t('label.sub-domain'),
+          }),
+          t('server.add-entity-error', {
+            entity: t('label.sub-domain').toLowerCase(),
+          })
+        );
+
+        throw error;
       } finally {
         setIsSubDomainLoading(false);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/hooks/useDomainCreateDrawer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/hooks/useDomainCreateDrawer.tsx
@@ -18,7 +18,10 @@ import { EntityType } from '../../../enums/entity.enum';
 import { CreateDomain } from '../../../generated/api/domains/createDomain';
 import { addDomains, patchDomains } from '../../../rest/domainAPI';
 import { createEntityWithCoverImage } from '../../../utils/CoverImageUploadUtils';
-import { submitAndClose } from '../../../utils/FormDrawerUtils';
+import {
+  setCreateEntityFieldError,
+  submitAndClose,
+} from '../../../utils/FormDrawerUtils';
 import { useFormDrawerWithHook } from '../../common/atoms/drawer';
 import AddDomainForm, {
   DOMAIN_FORM_DEFAULTS,
@@ -59,7 +62,22 @@ export const useDomainCreateDrawer = (onCreated?: () => void) => {
             form.reset();
           },
           t,
+          suppressErrorToast: true,
         });
+      } catch (error) {
+        setCreateEntityFieldError(
+          error,
+          form,
+          'name',
+          t('message.entity-with-name-already-exists', {
+            entity: t('label.domain'),
+          }),
+          t('server.add-entity-error', {
+            entity: t('label.domain').toLowerCase(),
+          })
+        );
+
+        throw error;
       } finally {
         setIsLoading(false);
       }

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "يجب أن يكون حجم {{entity}} بين 2 و 64",
     "entity-transfer-confirmation-message": "للمتابعة، أكد أنك تفهم أن حالة <0>{{from}}</0> ستتغير إلى",
     "entity-transfer-message": "انقر على تأكيد إذا كنت ترغب في نقل {{entity}} <0>{{from}}</0> تحت {{entity}} <0>{{to}}</0>.",
+    "entity-with-name-already-exists": "{{entity}} بهذا الاسم موجود بالفعل.",
     "enum-property-update-message": "بدأ تحديث قيم التعداد. سيتم إخطارك بمجرد الانتهاء.",
     "enum-with-description-update-note": "غير مسموح بتحديث مفاتيح القيم الحالية؛ يمكن تعديل الوصف فقط. ومع ذلك، يُسمح بإضافة قيم جديدة.",
     "error-generating-export-type": "خطأ أثناء إنشاء {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} Größe muss zwischen 2 und 64 liegen.",
     "entity-transfer-confirmation-message": "Um fortzufahren, bestätigen Sie, dass Sie verstehen, dass sich der Status von <0>{{from}}</0> ändern wird zu",
     "entity-transfer-message": "Klicken Sie auf Bestätigen, wenn Sie {{entity}} von <0>{{from}}</0> unter <0>{{to}}</0> {{entity}} verschieben möchten.",
+    "entity-with-name-already-exists": "{{entity}} mit diesem Namen existiert bereits.",
     "enum-property-update-message": "Die Aktualisierung der Enum-Werte wurde gestartet. Sie werden benachrichtigt, sobald sie abgeschlossen ist.",
     "enum-with-description-update-note": "Das Aktualisieren bestehender Werteschlüssel ist nicht erlaubt; nur die Beschreibung kann bearbeitet werden. Das Hinzufügen neuer Werte ist jedoch möglich.",
     "error-generating-export-type": "Fehler beim Erzeugen der {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} size must be between 2 and 64",
     "entity-transfer-confirmation-message": "To proceed, confirm that you understand the status of <0>{{from}}</0> will change to",
     "entity-transfer-message": "Click on Confirm if you’d like to move <0>{{from}}</0> {{entity}} under <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} with this name already exists.",
     "enum-property-update-message": "Enum values update started. You will be notified once it's done.",
     "enum-with-description-update-note": "Updating existing value keys is not allowed; only the description can be edited. However, adding new values is allowed.",
     "error-generating-export-type": "Error while generating {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "El tamaño de {{entity}} debe estar entre 2 y 64",
     "entity-transfer-confirmation-message": "Para continuar, confirma que entiendes que el estado de <0>{{from}}</0> cambiará a",
     "entity-transfer-message": "Haz clic en Confirmar si desea mover <0>{{from}}</0> {{entity}} debajo de <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} con este nombre ya existe.",
     "enum-property-update-message": "La actualización de valores enum ha comenzado. Se le notificará cuando esté terminada.",
     "enum-with-description-update-note": "No está permitido actualizar valores clave existentes; sólo la descripción puede ser editada. Sin embargo, añadir nuevos valores está permitido.",
     "error-generating-export-type": "Error al generar el {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} taille doit être comprise entre 2 et 64",
     "entity-transfer-confirmation-message": "Pour continuer, confirmez que vous comprenez que le statut de <0>{{from}}</0> changera en",
     "entity-transfer-message": "Cliquer sur Confirmer si vous souhaitez déplacer <0>{{from}}</0> {{entity}} sous <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} portant ce nom existe déjà.",
     "enum-property-update-message": "La mise à jour des valeurs enum a commencé. Vous serez notifié une fois terminée.",
     "enum-with-description-update-note": "La mise à jour des clés de valeur existantes n'est pas autorisée ; seule la description peut être modifiée. Cependant, l'ajout de nouvelles valeurs est autorisé.",
     "error-generating-export-type": "Erreur lors de la génération du {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "O tamaño de {{entity}} debe estar entre 2 e 64",
     "entity-transfer-confirmation-message": "Para continuar, confirma que entendes que o estado de <0>{{from}}</0> cambiará a",
     "entity-transfer-message": "Fai clic en Confirmar se desexas mover <0>{{from}}</0> {{entity}} baixo <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} con este nome xa existe.",
     "enum-property-update-message": "Iniciouse a actualización dos valores enum. Notificaráselle cando remate.",
     "enum-with-description-update-note": "Non está permitido actualizar as claves de valores existentes; só se pode editar a descrición. Con todo, está permitido engadir novos valores.",
     "error-generating-export-type": "Erro ao xerar o {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} יכול להיות בגודל בין 2 ל-64",
     "entity-transfer-confirmation-message": "כדי להמשיך, אשר שאתה מבין שהמצב של <0>{{from}}</0> ישתנה ל",
     "entity-transfer-message": "לחץ על אישור אם ברצונך להעביר <0>{{from}}</0> {{entity}} מתחת ל-<0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} בשם זה כבר קיימת.",
     "enum-property-update-message": "עדכון ערכי enum החל. תקבל הודעה כשזה יסתיים.",
     "enum-with-description-update-note": "עדכון מפתחות ערך קיימים אינו מותר; רק את התיאור ניתן לערוך. עם זאת, הוספת ערכים חדשים מותרת.",
     "error-generating-export-type": "שגיאה ביצירת {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} のサイズは 2 文字以上 64 文字以下でなければなりません",
     "entity-transfer-confirmation-message": "続行するには、<0>{{from}}</0> のステータスが変更されることを理解していることを確認してください",
     "entity-transfer-message": "「確認」をクリックすると、<0>{{from}}</0> {{entity}} を <0>{{to}}</0> {{entity}} に移動できます。",
+    "entity-with-name-already-exists": "この名前の {{entity}} はすでに存在しています。",
     "enum-property-update-message": "列挙型の値の更新が開始されました。完了後に通知されます。",
     "enum-with-description-update-note": "既存の値キーの更新はできませんが、説明の編集と新しい値の追加は可能です。",
     "error-generating-export-type": "{{exportType}} の生成中にエラーが発生しました",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} 크기는 2에서 64 사이여야 합니다",
     "entity-transfer-confirmation-message": "계속하려면 <0>{{from}}</0>의 상태가 변경됨을 확인하세요.",
     "entity-transfer-message": "<0>{{from}}</0> {{entity}}을(를) <0>{{to}}</0> {{entity}} 아래로 이동하려면 확인을 클릭하세요.",
+    "entity-with-name-already-exists": "이 이름의 {{entity}}이(가) 이미 존재합니다.",
     "enum-property-update-message": "열거형 값 업데이트가 시작되었습니다. 완료되면 알림을 받게 됩니다.",
     "enum-with-description-update-note": "기존 값 키를 업데이트하는 것은 허용되지 않습니다; 설명만 편집할 수 있습니다. 그러나 새로운 값을 추가하는 것은 허용됩니다.",
     "error-generating-export-type": "{{exportType}} 생성 중 오류가 발생했습니다.",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} आकार 2 आणि 64 दरम्यान असणे आवश्यक आहे",
     "entity-transfer-confirmation-message": "पुढे जाण्यासाठी, <0>{{from}}</0> ची स्थिती बदलणार आहे हे तुम्हाला समजले आहे हे निश्चित करा",
     "entity-transfer-message": "तुम्हाला <0>{{from}}</0> {{entity}} ला <0>{{to}}</0> {{entity}} अंतर्गत हलवायचे असल्यास पुष्टीवर क्लिक करा.",
+    "entity-with-name-already-exists": "या नावाचा {{entity}} आधीच अस्तित्वात आहे.",
     "enum-property-update-message": "इनम व्हॅल्यूज अपडेट सुरू झाले आहे. संपल्यानंतर तुम्हाला सूचित केले जाईल.",
     "enum-with-description-update-note": "विद्यमान मूल्य की अद्यतनित करणे अनुमत नाही; फक्त वर्णन संपादित केले जाऊ शकते. तथापि, नवीन मूल्ये जोडणे अनुमत आहे.",
     "error-generating-export-type": "{{exportType}} तयार करताना त्रुटी",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} grootte moet tussen 2 en 64 liggen",
     "entity-transfer-confirmation-message": "Om door te gaan, bevestig dat je begrijpt dat de status van <0>{{from}}</0> zal veranderen naar",
     "entity-transfer-message": "Klik op Bevestigen als je <0>{{from}}</0> {{entity}} wilt verplaatsen naar <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} met deze naam bestaat al.",
     "enum-property-update-message": "Enum-waardenupdate is gestart. U krijgt een melding zodra het klaar is.",
     "enum-with-description-update-note": "Het bijwerken van bestaande waardesleutels is niet toegestaan; alleen de beschrijving kan worden bewerkt. Het toevoegen van nieuwe waarden is wel toegestaan.",
     "error-generating-export-type": "Fout bij het genereren van de {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "اندازه {{entity}} باید بین 2 تا 64 کاراکتر باشد.",
     "entity-transfer-confirmation-message": "Para continuar, confirme que compreende que o estado de <0>{{from}}</0> será alterado para",
     "entity-transfer-message": "برای انتقال <0>{{from}}</0> {{entity}} به <0>{{to}}</0> {{entity}}، روی تأیید کلیک کنید.",
+    "entity-with-name-already-exists": "{{entity}} با این نام از قبل موجود است.",
     "enum-property-update-message": "به روز رسانی مقادیر enum شروع شد. پس از اتمام به شما اطلاع داده خواهد شد.",
     "enum-with-description-update-note": "به‌روزرسانی کلیدهای مقدار موجود مجاز نیست؛ فقط توضیحات قابل ویرایش است. با این حال، افزودن مقادیر جدید مجاز است.",
     "error-generating-export-type": "خطا در تولید {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "O tamanho de {{entity}} deve ser entre 2 e 64",
     "entity-transfer-confirmation-message": "Para continuar, confirme que compreende que o estado de <0>{{from}}</0> será alterado para",
     "entity-transfer-message": "Clique em Confirmar se deseja mover <0>{{from}}</0> {{entity}} para <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} com este nome já existe.",
     "enum-property-update-message": "A atualização dos valores enum começou. Você será notificado quando estiver concluída.",
     "enum-with-description-update-note": "A atualização de chaves de valor existentes não é permitida; somente a descrição pode ser editada. No entanto, a adição de novos valores é permitida.",
     "error-generating-export-type": "Erro ao gerar o {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "O tamanho de {{entity}} deve ser entre 2 e 64",
     "entity-transfer-confirmation-message": "Para continuar, confirme que compreende que o estado de <0>{{from}}</0> será alterado para",
     "entity-transfer-message": "Clique em Confirmar se deseja mover <0>{{from}}</0> {{entity}} para <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} com este nome já existe.",
     "enum-property-update-message": "A atualização dos valores enum começou. Será notificado quando estiver concluída.",
     "enum-with-description-update-note": "A atualização de chaves de valor existentes não é permitida; apenas a descrição pode ser editada. No entanto, a adição de novos valores é permitida.",
     "error-generating-export-type": "Erro ao gerar o {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "Размер объекта «{{entity}}» должен быть от 2 до 64",
     "entity-transfer-confirmation-message": "Чтобы продолжить, подтвердите, что вы понимаете: статус <0>{{from}}</0> изменится на",
     "entity-transfer-message": "Переместить «<0>{{from}}</0>» в «<0>{{to}}</0>»?",
+    "entity-with-name-already-exists": "{{entity}} с таким именем уже существует.",
     "enum-property-update-message": "Началось обновление значений перечисления. Вы получите уведомление после завершения.",
     "enum-with-description-update-note": "Нельзя обновить существующие ключи значений. Вы можете редактировать их описание или добавить новые значения.",
     "error-generating-export-type": "Ошибка при генерации {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "Storleken på {{entity}} måste vara mellan 2 och 64",
     "entity-transfer-confirmation-message": "För att fortsätta, bekräfta att du förstår att statusen för <0>{{from}}</0> kommer att ändras till",
     "entity-transfer-message": "Klicka på Bekräfta om du vill flytta <0>{{from}}</0> {{entity}} under <0>{{to}}</0> {{entity}}.",
+    "entity-with-name-already-exists": "{{entity}} med detta namn finns redan.",
     "enum-property-update-message": "Uppdatering av enum-värden har startat. Du meddelas när den är klar.",
     "enum-with-description-update-note": "Det är inte tillåtet att uppdatera befintliga värdenycklar; endast beskrivningen kan redigeras. Det är dock tillåtet att lägga till nya värden.",
     "error-generating-export-type": "Fel vid generering av {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "ขนาดของ {{entity}} ต้องอยู่ระหว่าง 2 และ 64",
     "entity-transfer-confirmation-message": "เพื่อดำเนินการต่อ โปรดยืนยันว่าคุณเข้าใจว่าสถานะของ <0>{{from}}</0> จะเปลี่ยนเป็น",
     "entity-transfer-message": "คลิกที่ยืนยันหากคุณต้องการย้าย <0>{{from}}</0> {{entity}} ไปยัง <0>{{to}}</0> {{entity}}",
+    "entity-with-name-already-exists": "{{entity}} ที่มีชื่อนี้มีอยู่แล้ว",
     "enum-property-update-message": "การอัปเดตค่า enum เริ่มต้นแล้ว คุณจะได้รับแจ้งเมื่อเสร็จสิ้น",
     "enum-with-description-update-note": "การอัปเดตคีย์ค่าที่มีอยู่ไม่อนุญาต; สามารถปรับแต่งได้เพียงคำอธิบายเท่านั้น อย่างไรก็ตาม การเพิ่มค่าผลใหม่เป็นสิ่งที่อนุญาต",
     "error-generating-export-type": "เกิดข้อผิดพลาดขณะสร้าง {{exportType}}",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} boyutu 2 ile 64 arasında olmalıdır",
     "entity-transfer-confirmation-message": "Devam etmek için, <0>{{from}}</0> durumunun şuna değişeceğini anladığınızı onaylayın:",
     "entity-transfer-message": "<0>{{from}}</0> {{entity}} öğesini <0>{{to}}</0> {{entity}} altına taşımak isterseniz Onayla'ya tıklayın.",
+    "entity-with-name-already-exists": "Bu ada sahip {{entity}} zaten mevcut.",
     "enum-property-update-message": "Sıralı değerler güncellemesi başlatıldı. Tamamlandığında bilgilendirileceksiniz.",
     "enum-with-description-update-note": "Mevcut değer anahtarlarını güncellemeye izin verilmez; yalnızca açıklama düzenlenebilir. Ancak, yeni değerler eklemeye izin verilir.",
     "error-generating-export-type": "{{exportType}} oluşturulurken hata oluştu",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}}大小必须介于2和64之间",
     "entity-transfer-confirmation-message": "若要继续，请确认您了解 <0>{{from}}</0> 的状态将更改为",
     "entity-transfer-message": "如果您想将<0>{{from}}</0> {{entity}} 移动到<0>{{to}}</0> {{entity}}中, 请单击确认",
+    "entity-with-name-already-exists": "此名称的{{entity}}已存在",
     "enum-property-update-message": "枚举值更新已开始。完成后您将收到通知。",
     "enum-with-description-update-note": "不允许更新现有值键；只能编辑描述。但是，允许添加新值。",
     "error-generating-export-type": "生成 {{exportType}} 时出错",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -3326,6 +3326,7 @@
     "entity-size-must-be-between-2-and-64": "{{entity}} 大小必須介於 2 和 64 之間",
     "entity-transfer-confirmation-message": "若要繼續，請確認您了解 <0>{{from}}</0> 的狀態將變更為",
     "entity-transfer-message": "如果您想將 <0>{{from}}</0> {{entity}} 移動到 <0>{{to}}</0> {{entity}} 下，請點擊「確認」。",
+    "entity-with-name-already-exists": "此名稱的 {{entity}} 已存在。",
     "enum-property-update-message": "列舉值更新已開始。完成後將會通知您。",
     "enum-with-description-update-note": "不允許更新現有的值鍵；只能編輯描述。但是，允許新增新值。",
     "error-generating-export-type": "產生 {{exportType}} 時發生錯誤",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CoverImageUploadUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CoverImageUploadUtils.tsx
@@ -134,6 +134,11 @@ export interface CreateEntityWithCoverImageOptions<TFormData, TEntity> {
   patchEntity: (entityId: string, patch: Operation[]) => Promise<TEntity>;
   onSuccess: (entity: TEntity) => void | Promise<void>;
   t: (key: string, options?: Record<string, unknown>) => string;
+  /**
+   * When true, the create-error toast is skipped so the caller can surface the
+   * failure itself (e.g. as an inline field error). The error is still rethrown.
+   */
+  suppressErrorToast?: boolean;
 }
 
 /**
@@ -178,6 +183,7 @@ export async function createEntityWithCoverImage<TFormData, TEntity>(
     patchEntity,
     onSuccess,
     t,
+    suppressErrorToast = false,
   } = options;
 
   try {
@@ -261,23 +267,24 @@ export async function createEntityWithCoverImage<TFormData, TEntity>(
 
     return finalEntity;
   } catch (error) {
-    // Error handling
-    showErrorToast(
-      getIsErrorMatch(error as AxiosError, ERROR_MESSAGE.alreadyExist) ? (
-        <Typography className="tw:font-bold">
-          {t('server.entity-already-exist', {
-            entity: entityLabel,
-            entityPlural: entityPluralLabel,
-            name: (formData as { name?: string }).name,
-          })}
-        </Typography>
-      ) : (
-        (error as AxiosError)
-      ),
-      t('server.add-entity-error', {
-        entity: entityLabel.toLowerCase(),
-      })
-    );
+    if (!suppressErrorToast) {
+      showErrorToast(
+        getIsErrorMatch(error as AxiosError, ERROR_MESSAGE.alreadyExist) ? (
+          <Typography className="tw:font-bold">
+            {t('server.entity-already-exist', {
+              entity: entityLabel,
+              entityPlural: entityPluralLabel,
+              name: (formData as { name?: string }).name,
+            })}
+          </Typography>
+        ) : (
+          (error as AxiosError)
+        ),
+        t('server.add-entity-error', {
+          entity: entityLabel.toLowerCase(),
+        })
+      );
+    }
 
     throw error;
   }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.test.ts
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { AxiosError } from 'axios';
+import { UseFormReturn } from 'react-hook-form';
+import { setCreateEntityFieldError } from './FormDrawerUtils';
+import { showErrorToast } from './ToastUtils';
+
+jest.mock('./ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+const DUPLICATE_MESSAGE = 'Domain already exists.';
+const FALLBACK_TOAST = 'Error while adding domain!';
+
+const buildForm = (setError: jest.Mock) =>
+  ({ setError } as unknown as UseFormReturn<{ name: string }>);
+
+const buildError = (message: string): AxiosError =>
+  ({ response: { data: { message } } } as AxiosError);
+
+describe('setCreateEntityFieldError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set an inline name error and skip the toast for a duplicate-name error', () => {
+    const setError = jest.fn();
+    const error = buildError("Domain with name 'Finance' already exists.");
+
+    setCreateEntityFieldError(
+      error,
+      buildForm(setError),
+      'name',
+      DUPLICATE_MESSAGE,
+      FALLBACK_TOAST
+    );
+
+    expect(setError).toHaveBeenCalledWith('name', {
+      type: 'manual',
+      message: DUPLICATE_MESSAGE,
+    });
+    expect(showErrorToast).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to a toast and skip the inline error for a non-duplicate error', () => {
+    const setError = jest.fn();
+    const error = buildError('Internal server error');
+
+    setCreateEntityFieldError(
+      error,
+      buildForm(setError),
+      'name',
+      DUPLICATE_MESSAGE,
+      FALLBACK_TOAST
+    );
+
+    expect(showErrorToast).toHaveBeenCalledWith(error, FALLBACK_TOAST);
+    expect(setError).not.toHaveBeenCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.ts
@@ -11,6 +11,12 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
+import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { ERROR_MESSAGE } from '../constants/constants';
+import { getIsErrorMatch } from './APIUtils';
+import { showErrorToast } from './ToastUtils';
+
 /**
  * Awaits the submit handler, then closes the drawer and runs the optional
  * post-success callback. If the submit handler throws or rejects,
@@ -26,4 +32,24 @@ export const submitAndClose = async <T>(
   await handler(data);
   closeDrawer();
   onSuccess?.();
+};
+
+/**
+ * Maps a failed entity-create error onto the form: a duplicate-name
+ * ("already exists") error becomes an inline validation error on the name
+ * field; any other error falls back to a toast. Callers must rethrow so the
+ * drawer stays open (see submitAndClose).
+ */
+export const setCreateEntityFieldError = <T extends FieldValues>(
+  error: unknown,
+  form: UseFormReturn<T>,
+  nameField: Path<T>,
+  duplicateNameMessage: string,
+  fallbackToastText: string
+): void => {
+  if (getIsErrorMatch(error as AxiosError, ERROR_MESSAGE.alreadyExist)) {
+    form.setError(nameField, { type: 'manual', message: duplicateNameMessage });
+  } else {
+    showErrorToast(error as AxiosError, fallbackToastText);
+  }
 };


### PR DESCRIPTION
## What & why

When creating a **Domain** or **Data Product** with a name that already exists, the failure was surfaced as a full-width toast on the shared (dark) notification bar. The toast is easy to miss, is not anchored to the field that is actually wrong, and in light mode reads as an out-of-place black bar.

This PR surfaces the duplicate-name failure as an **inline validation error directly under the Name field** (e.g. _"Domain with this name already exists."_), keeping the drawer open so the user can immediately correct the name. Any other create error (network / 5xx) still falls back to a toast.

This mirrors the existing inline-uniqueness pattern in `GlossaryTermRelationSettings` (catch the create error → `form.setError('name', …)`, otherwise `showErrorToast`).

## Behavior

All four create surfaces that use `AddDomainForm` are covered: the top-level **Domain** and **Data Product** drawers, and the in-domain **Sub Domain** and **Data Product** drawers (the Data Marketplace "Add New" entries reuse the same two hooks).

### Domain
| Before (toast) | After (inline error) |
|---|---|
| ![domain before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/domain-before.png) | ![domain after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/domain-after.png) |

### Data Product
| Before (toast) | After (inline error) |
|---|---|
| ![dp before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/dataproduct-before.png) | ![dp after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/dataproduct-after.png) |

### Sub Domain
| Before (toast) | After (inline error) |
|---|---|
| ![subdomain before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/subdomain-before.png) | ![subdomain after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/assets/inline-dup-name/subdomain-after.png) |

## Changes

- `createEntityWithCoverImage` gains a `suppressErrorToast` option so callers can handle the failure themselves (default `false` → all other callers unchanged).
- New shared helper `setCreateEntityFieldError` (in `FormDrawerUtils`): a duplicate-name (`already exists`) error → `form.setError('name', …)`; any other error → `showErrorToast`.
- Wired into all four submit handlers: `useDomainCreateDrawer`, `useDataProductCreateDrawer`, and the sub-domain + data-product handlers in `DomainDetails`.
- New i18n key `message.entity-with-name-already-exists` = _"{{entity}} with this name already exists."_, translated across all locales.

## Testing

- Unit test added for `setCreateEntityFieldError` (duplicate → inline `setError`, no toast; other → toast, no `setError`).
- Manually verified against a local stack for all four surfaces: inline error shows, drawer stays open, no toast; a non-duplicate error still toasts (screenshots above).
- `eslint`, `prettier`, `organize-imports`, `yarn i18n`, and `tsc` clean on all changed files.

## Notes

No backend change — the API already returns an "already exists" error, detected via the existing `getIsErrorMatch` / `ERROR_MESSAGE.alreadyExist`. Collate inherits this automatically via the OpenMetadata submodule (no Collate fork of these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR shows duplicate Domain and Data Product name errors directly under the Name field. The main changes are:

- Adds shared duplicate-name error mapping for create forms.
- Keeps affected drawers open after failed submissions.
- Preserves toast notifications for other create failures.
- Adds translated validation text across supported locales.
- Adds unit coverage for inline and toast error handling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- Duplicate failures are routed to the Name field across all four updated create flows.
- Other create failures still produce toast feedback.
- Failed submissions keep the drawer open, while existing callers retain the default toast behavior.
- No blocking issues were found in the changed code.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.ts | Adds shared mapping from duplicate create errors to form field errors, with toast fallback. |
| openmetadata-ui/src/main/resources/ui/src/utils/CoverImageUploadUtils.tsx | Adds an optional switch for callers that handle create errors themselves. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/hooks/useDomainCreateDrawer.tsx | Shows duplicate Domain names as inline form errors. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProduct/hooks/useDataProductCreateDrawer.tsx | Shows duplicate Data Product names as inline form errors. |
| openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx | Applies inline duplicate-name handling to nested Sub Domain and Data Product creation. |
| openmetadata-ui/src/main/resources/ui/src/utils/FormDrawerUtils.test.ts | Covers duplicate-name field errors and non-duplicate toast fallback. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into toast-black-bac..."](https://github.com/open-metadata/openmetadata/commit/c91c4125b26e38c74238e118838495456dd24e39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46567555)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->