### PR TITLE
ci(external-it): serialize runs with a concurrency group

### DIFF
--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -125,6 +125,15 @@ permissions:
   contents: read
   checks: write
 
+# All jobs hit ONE shared external cluster, and every job's purge-it step hard-deletes each
+# test-namespace root by the generic __<32hex>__ signature (ClusterPurgeIT) — NOT scoped to this
+# run. Two overlapping runs therefore delete each other's live data mid-seed (observed: a
+# concurrent run's purge 404'd a scale seed's schema). Serialize to at most one external run at a
+# time; a new run queues behind the current one rather than cancelling a multi-hour scale run.
+concurrency:
+  group: java-it-external-cluster
+  cancel-in-progress: false
+
 jobs:
   ui-it-external:
     if: ${{ github.event.inputs.runUiIt != 'false' }}


### PR DESCRIPTION
## Why
All three jobs (`ui-it` → `search-it` → `scale-it`) hit **one shared external cluster**, and every job's `purge-it` step runs `ClusterPurgeIT`, which hard-deletes **every** test-namespace root matching the generic `__<32hex>__` signature — it is **not scoped to the current run** (by design, to clear orphans from cancelled runs).

With no concurrency guard, two overlapping runs delete each other's live data. Observed directly:
- Run `29948057110` (18:45→01:32) and run `29969365375` (started 00:32) **overlapped for ~1h**.
- Run 1's `ServiceDeleteSearchCleanupScaleIT` failed at 01:31 with `404 Entity not found: databaseSchema …ServiceDeleteSearchCleanupScaleIT…` — its schema was hard-deleted mid-seed by the other run's purge.

## Fix
A workflow-level `concurrency` group so at most one external run touches the cluster at a time. `cancel-in-progress: false` → a new run **queues** behind the current one rather than killing a multi-hour scale run. (Manual cancel still works now that the `always()`→`!cancelled()` fix landed.)

This eliminates the concurrent-purge-deletes-live-data class of failures and reduces cross-run orphan churn (which also confounds the delta-based search assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR serializes external integration-test runs that share one cluster. The main changes are:

- Adds a workflow-level concurrency group.
- Queues new runs instead of cancelling an active run.
- Documents why overlapping purge steps corrupt live test state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- The static group correctly covers every branch because all runs use the same external cluster.
- No other current workflow uses this concurrency group or external-cluster configuration.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-playwright-external.yml | Adds valid workflow-level serialization for scheduled and manually dispatched runs that use the shared external cluster. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(external-it): serialize runs with a c..."](https://github.com/open-metadata/openmetadata/commit/983a882107833240f2a3f90321adaab203a87601) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46567583)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->