### PR TITLE
test(e2e): strip ETag If-None-Match at the network layer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryExpandAllWithStatusFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryExpandAllWithStatusFilter.spec.ts
@@ -13,7 +13,10 @@
 import test, { expect, Page } from '@playwright/test';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
-import { createNewPage } from '../../../utils/common';
+import {
+  createNewPage,
+  stripEtagConditionalReads,
+} from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 
 test.use({
@@ -176,6 +179,7 @@ test.describe(
     });
 
     test.beforeEach(async ({ page }) => {
+      await stripEtagConditionalReads(page);
       await glossary.visitEntityPage(page);
       await expect(page.getByTestId('glossary-terms-table')).toBeVisible();
       await waitForAllLoadersToDisappear(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterLargeDataset.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterLargeDataset.spec.ts
@@ -13,7 +13,10 @@
 import test, { APIRequestContext, expect, Page } from '@playwright/test';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
-import { createNewPage } from '../../../utils/common';
+import {
+  createNewPage,
+  stripEtagConditionalReads,
+} from '../../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 
 test.use({
@@ -228,6 +231,7 @@ test.describe('Glossary Status Filter - Large Dataset', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await stripEtagConditionalReads(page);
     await glossary.visitEntityPage(page);
     await page.getByTestId('glossary-terms-table').waitFor();
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
@@ -13,7 +13,10 @@
 import test, { APIRequestContext, expect, Page } from '@playwright/test';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
-import { createNewPage } from '../../../utils/common';
+import {
+  createNewPage,
+  stripEtagConditionalReads,
+} from '../../../utils/common';
 
 test.use({
   storageState: 'playwright/.auth/admin.json',
@@ -307,6 +310,7 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
   });
 
   test.beforeEach(async ({ page }) => {
+    await stripEtagConditionalReads(page);
     await glossary.visitEntityPage(page);
     await page.getByTestId('glossary-terms-table').waitFor();
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import test, { APIRequestContext } from '@playwright/test';
+import test, { APIRequestContext, Browser } from '@playwright/test';
 import { searchRBACEntities } from '../../constant/searchRBAC';
 import { PolicyClass } from '../../support/access-control/PoliciesClass';
 import { RolesClass } from '../../support/access-control/RolesClass';
@@ -18,7 +18,7 @@ import { DashboardClass } from '../../support/entity/DashboardClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
-import { uuid } from '../../utils/common';
+import { stripEtagConditionalReads, uuid } from '../../utils/common';
 import { waitForSearchIndexed } from '../../utils/polling';
 import {
   enableDisableSearchRBAC,
@@ -27,6 +27,13 @@ import {
   searchForEntityShouldWork,
   searchForEntityShouldWorkShowNoResult,
 } from '../../utils/searchRBAC';
+
+const newStrippedPage = async (browser: Browser) => {
+  const page = await browser.newPage();
+  await stripEtagConditionalReads(page);
+
+  return page;
+};
 
 for (const entity of searchRBACEntities) {
   const entityObj = new entity.class();
@@ -122,7 +129,7 @@ for (const entity of searchRBACEntities) {
     });
 
     test(`User with permission`, async ({ browser }) => {
-      const userWithPermissionPage = await browser.newPage();
+      const userWithPermissionPage = await newStrippedPage(browser);
 
       await user1.login(userWithPermissionPage);
 
@@ -136,7 +143,7 @@ for (const entity of searchRBACEntities) {
     });
 
     test(`User without permission`, async ({ browser }) => {
-      const userWithoutPermissionPage = await browser.newPage();
+      const userWithoutPermissionPage = await newStrippedPage(browser);
 
       await user2.login(userWithoutPermissionPage);
 
@@ -229,7 +236,7 @@ test.describe.skip(`Table Column`, () => {
   });
 
   test(`User with permission`, async ({ browser }) => {
-    const userWithPermissionPage = await browser.newPage();
+    const userWithPermissionPage = await newStrippedPage(browser);
     const column = table.entityResponseData?.columns?.[0];
 
     await user1.login(userWithPermissionPage);
@@ -242,7 +249,7 @@ test.describe.skip(`Table Column`, () => {
   });
 
   test(`User without permission`, async ({ browser }) => {
-    const userWithoutPermissionPage = await browser.newPage();
+    const userWithoutPermissionPage = await newStrippedPage(browser);
     const column = table.entityResponseData?.columns?.[0];
 
     await user2.login(userWithoutPermissionPage);
@@ -366,7 +373,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
     browser,
   }) => {
     test.slow();
-    const page = await browser.newPage();
+    const page = await newStrippedPage(browser);
     await userAll.login(page);
 
     await exploreShouldShowEntity(page, tableFqn(), tableName(), true);
@@ -379,7 +386,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
     browser,
   }) => {
     test.slow();
-    const page = await browser.newPage();
+    const page = await newStrippedPage(browser);
     await userTableOnly.login(page);
 
     await exploreShouldShowEntity(page, tableFqn(), tableName(), true);
@@ -392,7 +399,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
     browser,
   }) => {
     test.slow();
-    const page = await browser.newPage();
+    const page = await newStrippedPage(browser);
     await userDashboardOnly.login(page);
 
     await exploreShouldShowEntity(page, dashboardFqn(), dashboardName(), true);
@@ -405,7 +412,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
     browser,
   }) => {
     test.slow();
-    const page = await browser.newPage();
+    const page = await newStrippedPage(browser);
     await userDenied.login(page);
 
     await exploreShouldShowEntity(page, tableFqn(), tableName(), false);
@@ -421,7 +428,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
 
     // A table-scoped user's tree has Databases but never Dashboards — the
     // Dashboards count is RBAC-filtered to zero, so the category drops out.
-    const tablePage = await browser.newPage();
+    const tablePage = await newStrippedPage(browser);
     await userTableOnly.login(tablePage);
     await exploreTreeCategories(tablePage, {
       visible: ['Databases'],
@@ -430,7 +437,7 @@ test.describe('Explore browse respects search RBAC across users', () => {
     await tablePage.close();
 
     // A dashboard-scoped user sees the mirror image — no Databases category.
-    const dashboardPage = await browser.newPage();
+    const dashboardPage = await newStrippedPage(browser);
     await userDashboardOnly.login(dashboardPage);
     await exploreTreeCategories(dashboardPage, {
       visible: ['Dashboards'],

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/fixtures/pages.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/fixtures/pages.ts
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Page, test as base } from '@playwright/test';
+import { Browser, Page, test as base } from '@playwright/test';
+import { stripEtagConditionalReads } from '../../utils/common';
 
 // Define the type for our custom fixtures
 export type CustomFixtures = {
@@ -24,69 +25,78 @@ export type CustomFixtures = {
   ownerPage: Page;
 };
 
+// Open a role page with the ETag conditional-read strip installed, so every
+// fixture-based spec gets fresh entity reads regardless of the deployed bundle
+// (see stripEtagConditionalReads in utils/common).
+const openRolePage = async (browser: Browser, storageState: string) => {
+  const page = await browser.newPage({ storageState });
+  await stripEtagConditionalReads(page);
+
+  return page;
+};
+
 // Create a new test object with our custom fixtures
 export const test = base.extend<CustomFixtures>({
   // Admin page as default page value
   page: async ({ browser }, use) => {
-    const adminPage = await browser.newPage({
-      storageState: 'playwright/.auth/admin.json',
-    });
+    const adminPage = await openRolePage(
+      browser,
+      'playwright/.auth/admin.json'
+    );
 
     await use(adminPage);
     await adminPage.close();
   },
   dataConsumerPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/dataConsumer.json',
-    });
+    const page = await openRolePage(
+      browser,
+      'playwright/.auth/dataConsumer.json'
+    );
 
     await use(page);
     await page.close();
   },
   dataStewardPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/dataSteward.json',
-    });
+    const page = await openRolePage(
+      browser,
+      'playwright/.auth/dataSteward.json'
+    );
 
     await use(page);
     await page.close();
   },
   ownerPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/owner.json',
-    });
+    const page = await openRolePage(browser, 'playwright/.auth/owner.json');
 
     await use(page);
     await page.close();
   },
   editDescriptionPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/editDescription.json',
-    });
+    const page = await openRolePage(
+      browser,
+      'playwright/.auth/editDescription.json'
+    );
 
     await use(page);
     await page.close();
   },
   editTagsPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/editTags.json',
-    });
+    const page = await openRolePage(browser, 'playwright/.auth/editTags.json');
 
     await use(page);
     await page.close();
   },
   editGlossaryTermPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/editGlossaryTerm.json',
-    });
+    const page = await openRolePage(
+      browser,
+      'playwright/.auth/editGlossaryTerm.json'
+    );
 
     await use(page);
     await page.close();
   },
   viewOnlyPage: async ({ browser }, use) => {
-    const page = await browser.newPage({
-      storageState: 'playwright/.auth/viewOnly.json',
-    });
+    const page = await openRolePage(browser, 'playwright/.auth/viewOnly.json');
 
     await use(page);
     await page.close();

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/userPages.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/userPages.ts
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { Browser, Page, test as base } from '@playwright/test';
+import { stripEtagConditionalReads } from '../../utils/common';
 
 // Declare the types of your fixtures
 type UserPages = {
@@ -30,6 +31,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/admin.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -38,6 +40,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/dataConsumer.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -46,6 +49,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/dataSteward.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -54,6 +58,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/owner.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -62,6 +67,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/editDescription.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -70,6 +76,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/editTags.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },
@@ -78,6 +85,7 @@ export const test = base.extend<UserPages>({
       storageState: 'playwright/.auth/editGlossaryTerm.json',
     });
     const page = await context.newPage();
+    await stripEtagConditionalReads(page);
     await use(page);
     await context.close();
   },

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -64,10 +64,39 @@ export const getAuthContext = async (token: string) => {
   });
 };
 
+// Pages that already have the network strip installed, so redirectToHomePage
+// (called many times per spec) does not stack duplicate routes.
+const etagStripInstalled = new WeakSet<Page>();
+
+/**
+ * Strip the client `If-None-Match` header from `/api/v1/**` requests at the
+ * Playwright network layer.
+ *
+ * The UI attaches an ETag conditional-GET interceptor; the server ETag only
+ * covers version/updatedAt, so a refetch racing a relationship-only or child
+ * mutation (followers, votes, customMetrics, testSuite) is answered 304 and the
+ * UI renders a stale body — a flaky-assertion source across the suite. Removing
+ * the header here forces the server to always return the current body, and it
+ * works regardless of the deployed bundle (unlike the localStorage opt-out,
+ * which depends on the bundle carrying the interceptor guard).
+ */
+export const stripEtagConditionalReads = async (page: Page) => {
+  if (etagStripInstalled.has(page)) {
+    return;
+  }
+  etagStripInstalled.add(page);
+  await page.route('**/api/v1/**', async (route) => {
+    const headers = route.request().headers();
+    delete headers['if-none-match'];
+    await route.continue({ headers });
+  });
+};
+
 export const redirectToHomePage = async (
   page: Page,
   _waitForLoaders = true
 ) => {
+  await stripEtagConditionalReads(page);
   await page.goto('/', {
     waitUntil: 'domcontentloaded',
   });


### PR DESCRIPTION
## Why

#30239 / #30292 added a localStorage opt-out so E2E sessions skip client-side conditional (`If-None-Match`) reads. That only works when the **running UI bundle contains the interceptor guard**.

In the upgrade AUT (`1.11.13 ➡ main`) it doesn't help. Trace evidence from a failing run (`TestSuiteMultiPipeline`):
- The flag is written correctly — storageState has `OM_DISABLE_ETAG_CONDITIONAL_READS: "true"` under the app origin.
- Yet the served bundle (`index-DWyuxoxX.js`) still sends `If-None-Match`; the response comes back `Content-Length: 0` (304) and the UI renders a stale body.
- The conditional request is client-JS-set (the response is `no-store`, so the browser would never revalidate; 1.11.13's UI has no interceptor at all).

So the guard is not taking effect in the deployed bundle, and a UI-side opt-out can't be relied on there.

## Change

Strip `If-None-Match` on `/api/v1/**` at the **Playwright network layer**:

```ts
await page.route('**/api/v1/**', (route) => {
  const headers = route.request().headers();
  delete headers['if-none-match'];
  return route.continue({ headers });
});
```

This sits **below the app**, so it works regardless of which bundle runs or whether its guard fires — the server always receives an unconditional GET and returns the current body, and the interceptor's 200-branch overwrites its own cache with fresh data.

Installed once per page (WeakSet-guarded) from `redirectToHomePage`. Every ETag-affected failing spec routes through it (2–13× each), and `createNewPage` calls it too. Kept alongside the existing localStorage opt-out as defense in depth.

## Validation

- `CustomMetric` + `FollowingWidget` (12 entity types) pass with the strip installed — auth and reads work fine through `route.continue`.
- Checkstyle clean (eslint exit 0, prettier clean).

**Honest limitation:** the underlying failure is a same-session refetch race that only manifests under AUT load — it does **not** reproduce locally (local reloads clear the interceptor's in-memory cache). So I can prove the strip is installed and non-breaking, but the end-to-end proof for the stale-read case is the next AUT run. The mechanism itself is HTTP-guaranteed: no `If-None-Match` → fresh `200`.

## Scope

Test-only; unblocks AUT. The underlying product defect — the ETag being derived from `version`/`updatedAt` only, so it ignores requested `fields` and child state — remains open and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables conditional ETag reads in Playwright API traffic. The main changes are:

- Adds a shared route handler that removes `If-None-Match` from `/api/v1/**` requests.
- Installs the handler during home-page navigation and page creation.
- Extends the handler to role fixtures, glossary tests, and Search RBAC tests.
- Retains the local-storage opt-out as an additional safeguard.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No additional blocking issue qualifies for this follow-up review.

- The latest changes broaden where the network handler is installed.
- No separate production failure remains after excluding issues already covered by the existing review feedback.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts | Adds the shared ETag header-removal route and installs it before home-page navigation. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/fixtures/pages.ts | Centralizes role-page creation and installs the ETag route before fixture use. |
| openmetadata-ui/src/main/resources/ui/playwright/support/fixtures/userPages.ts | Installs the ETag route on each role-specific fixture page. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts | Uses a shared helper to install the ETag route on newly created RBAC test pages. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(e2e): strip If-None-Match on specs ..."](https://github.com/open-metadata/openmetadata/commit/727a0571f0d1e0f85636a95f2a6c12d19bb4c877) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46571402)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))
- Context used - AGENTS.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=ef262f5f-911f-44f3-8d2d-e9cb1579c8c8))
</details>

<!-- /greptile_comment -->