### PR TITLE
Backport #30201 to 1.13: Paginate glossary term relation settings

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/exception/SystemSettingsException.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/exception/SystemSettingsException.java
@@ -9,4 +9,8 @@ public class SystemSettingsException extends WebServiceException {
   public SystemSettingsException(String message) {
     super(Response.Status.BAD_REQUEST, ERROR_TYPE, message);
   }
+
+  public SystemSettingsException(Response.Status status, String message) {
+    super(status, ERROR_TYPE, message);
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -9352,6 +9352,14 @@ public interface CollectionDAO {
     @RegisterRowMapper(SettingsRowMapper.class)
     Settings getConfigWithKey(@Bind("configType") String configType) throws StatementException;
 
+    @SqlQuery("SELECT json FROM openmetadata_settings WHERE configType = :configType")
+    String getConfigJsonWithKey(@Bind("configType") String configType) throws StatementException;
+
+    @SqlQuery(
+        "SELECT json FROM openmetadata_settings "
+            + "WHERE configType = 'glossaryTermRelationSettings'")
+    String getGlossaryTermRelationSettingsJson() throws StatementException;
+
     @ConnectionAwareSqlUpdate(
         value =
             "INSERT into openmetadata_settings (configType, json)"
@@ -9363,6 +9371,39 @@ public interface CollectionDAO {
                 + "VALUES (:configType, :json :: jsonb) ON CONFLICT (configType) DO UPDATE SET json = EXCLUDED.json",
         connectionType = POSTGRES)
     void insertSettings(@Bind("configType") String configType, @Bind("json") String json);
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE openmetadata_settings SET json = :updatedJson "
+                + "WHERE configType = :configType "
+                + "AND SHA2(CAST(json AS CHAR), 256) = "
+                + "SHA2(CAST(CAST(:expectedJson AS JSON) AS CHAR), 256)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE openmetadata_settings SET json = (:updatedJson :: jsonb) "
+                + "WHERE configType = :configType AND json = (:expectedJson :: jsonb)",
+        connectionType = POSTGRES)
+    int updateSettingsIfCurrent(
+        @Bind("configType") String configType,
+        @Bind("expectedJson") String expectedJson,
+        @Bind("updatedJson") String updatedJson);
+
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE openmetadata_settings SET json = :updatedJson "
+                + "WHERE configType = 'glossaryTermRelationSettings' "
+                + "AND SHA2(CAST(json AS CHAR), 256) = "
+                + "SHA2(CAST(CAST(:expectedJson AS JSON) AS CHAR), 256)",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "UPDATE openmetadata_settings SET json = (:updatedJson :: jsonb) "
+                + "WHERE configType = 'glossaryTermRelationSettings' "
+                + "AND json = (:expectedJson :: jsonb)",
+        connectionType = POSTGRES)
+    int updateGlossaryTermRelationSettingsIfCurrent(
+        @Bind("expectedJson") String expectedJson, @Bind("updatedJson") String updatedJson);
 
     @SqlUpdate(value = "DELETE from openmetadata_settings WHERE configType = :configType")
     void delete(@Bind("configType") String configType);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -14,6 +14,7 @@ import com.unboundid.ldap.sdk.LDAPConnectionOptions;
 import com.unboundid.ldap.sdk.SearchResult;
 import com.unboundid.ldap.sdk.SearchScope;
 import com.unboundid.util.ssl.SSLUtil;
+import jakarta.json.JsonException;
 import jakarta.json.JsonPatch;
 import jakarta.json.JsonValue;
 import jakarta.ws.rs.core.Response;
@@ -42,6 +43,7 @@ import org.openmetadata.schema.api.security.ClientType;
 import org.openmetadata.schema.auth.LdapConfiguration;
 import org.openmetadata.schema.configuration.AssetCertificationSettings;
 import org.openmetadata.schema.configuration.ExecutorConfiguration;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.HistoryCleanUpConfiguration;
 import org.openmetadata.schema.configuration.SecurityConfiguration;
 import org.openmetadata.schema.configuration.WorkflowSettings;
@@ -75,6 +77,7 @@ import org.openmetadata.service.apps.bundles.searchIndex.OrphanedIndexCleaner;
 import org.openmetadata.service.events.scheduled.ServicesStatusJobHandler;
 import org.openmetadata.service.exception.CustomExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.exception.PreconditionFailedException;
 import org.openmetadata.service.fernet.Fernet;
 import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
@@ -104,6 +107,7 @@ import org.openmetadata.service.security.auth.validator.OidcDiscoveryValidator;
 import org.openmetadata.service.security.auth.validator.OktaAuthValidator;
 import org.openmetadata.service.security.auth.validator.SamlValidator;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.GlossaryTermRelationSettingsUtil;
 import org.openmetadata.service.util.LdapUtil;
 import org.openmetadata.service.util.OpenMetadataConnectionBuilder;
 import org.openmetadata.service.util.RestUtil;
@@ -114,6 +118,8 @@ import org.openmetadata.service.util.ValidationErrorBuilder.FieldPaths;
 @Repository
 public class SystemRepository {
   private static final String FAILED_TO_UPDATE_SETTINGS = "Failed to Update Settings {}";
+  private static final String GLOSSARY_TERM_RELATION_SETTINGS_CHANGED =
+      "Glossary term relation settings changed while the JSON Patch was being applied";
   public static final String INTERNAL_SERVER_ERROR_WITH_REASON = "Internal Server Error. Reason :";
   private static final String VECTOR_EMBEDDING_INDEX_KEY = "vectorEmbedding";
   private static final String REINDEX_STATUS_VALIDATION_KEY = "Search Reindex Status";
@@ -333,6 +339,9 @@ public class SystemRepository {
   }
 
   public Response patchSetting(String settingName, JsonPatch patch) {
+    if (SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value().equalsIgnoreCase(settingName)) {
+      return patchGlossaryTermRelationSettings(patch);
+    }
     Settings original = getConfigWithKey(settingName);
     // Apply JSON patch to the original entity to get the updated entity
     JsonValue updated = JsonUtils.applyPatch(original.getConfigValue(), patch);
@@ -348,6 +357,39 @@ public class SystemRepository {
       return Response.status(500, INTERNAL_SERVER_ERROR_WITH_REASON + ex.getMessage()).build();
     }
     return (new RestUtil.PutResponse<>(Response.Status.OK, original, ENTITY_UPDATED)).toResponse();
+  }
+
+  private Response patchGlossaryTermRelationSettings(JsonPatch patch) {
+    String expectedJson = dao.getGlossaryTermRelationSettingsJson();
+    if (expectedJson == null) {
+      throw EntityNotFoundException.byName(SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value());
+    }
+
+    GlossaryTermRelationSettings current =
+        JsonUtils.readValue(expectedJson, GlossaryTermRelationSettings.class);
+    JsonValue patched;
+    try {
+      patched = JsonUtils.applyPatch(current, patch);
+    } catch (JsonException exception) {
+      throw new PreconditionFailedException(GLOSSARY_TERM_RELATION_SETTINGS_CHANGED, exception);
+    }
+    GlossaryTermRelationSettings updated =
+        JsonUtils.readValue(patched.toString(), GlossaryTermRelationSettings.class);
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(current, updated);
+    GlossaryTermRelationSettingsUtil.normalize(updated);
+    GlossaryTermRelationSettingsUtil.validateUniqueNames(updated);
+    String updatedJson = JsonUtils.pojoToJson(updated);
+    int updatedRows = dao.updateGlossaryTermRelationSettingsIfCurrent(expectedJson, updatedJson);
+    if (updatedRows == 0) {
+      throw new PreconditionFailedException(GLOSSARY_TERM_RELATION_SETTINGS_CHANGED);
+    }
+
+    SettingsCache.invalidateSettings(SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value());
+    Settings response =
+        new Settings()
+            .withConfigType(SettingsType.GLOSSARY_TERM_RELATION_SETTINGS)
+            .withConfigValue(updated);
+    return (new RestUtil.PutResponse<>(Response.Status.OK, response, ENTITY_UPDATED)).toResponse();
   }
 
   private void postUpdate(SettingsType settingsType) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -18,12 +18,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.json.Json;
 import jakarta.json.JsonPatch;
 import jakarta.json.JsonValue;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
@@ -56,7 +62,6 @@ import org.openmetadata.schema.auth.EmailRequest;
 import org.openmetadata.schema.configuration.EntityRulesSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
 import org.openmetadata.schema.configuration.GlossaryTermRelationType;
-import org.openmetadata.schema.configuration.RelationCardinality;
 import org.openmetadata.schema.configuration.SecurityConfiguration;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
@@ -94,6 +99,7 @@ import org.openmetadata.service.security.auth.SecurityConfigurationManager;
 import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.EntityUtil;
+import org.openmetadata.service.util.GlossaryTermRelationSettingsUtil;
 import org.openmetadata.service.util.email.EmailUtil;
 
 @Path("/v1/system")
@@ -254,6 +260,138 @@ public class SystemResource {
       authorizer.authorizeAdmin(securityContext);
     }
     return systemRepository.getConfigWithKey(name);
+  }
+
+  @GET
+  @Path("/settings/glossaryTermRelationSettings/relationTypes")
+  @Operation(
+      operationId = "listGlossaryTermRelationTypes",
+      summary = "List glossary term relation types",
+      description = "Get a paginated list of configured glossary term relation types.")
+  public ResultList<GlossaryTermRelationType> listGlossaryTermRelationTypes(
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Limit records. (1 to 100, default = 15)")
+          @DefaultValue("15")
+          @QueryParam("limit")
+          @Min(1)
+          @Max(100)
+          int limit,
+      @Parameter(description = "Offset records. (0 or greater, default = 0)")
+          @DefaultValue("0")
+          @QueryParam("offset")
+          @Min(0)
+          @Max(1000000)
+          int offset) {
+    authorizer.authorizeAdmin(securityContext);
+    List<GlossaryTermRelationType> relationTypes =
+        SettingsCache.getSetting(
+                GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class)
+            .getRelationTypes();
+    if (relationTypes == null) {
+      relationTypes = List.of();
+    }
+
+    int total = relationTypes.size();
+    int fromIndex = Math.min(offset, total);
+    int toIndex = Math.min(fromIndex + limit, total);
+    List<GlossaryTermRelationType> page =
+        new ArrayList<>(relationTypes.subList(fromIndex, toIndex));
+
+    return new ResultList<>(page, offset, limit, total);
+  }
+
+  @POST
+  @Path("/settings/glossaryTermRelationSettings/relationTypes")
+  @Operation(
+      operationId = "createGlossaryTermRelationType",
+      summary = "Create a glossary term relation type")
+  public Response createGlossaryTermRelationType(
+      @Context SecurityContext securityContext, @Valid GlossaryTermRelationType relationType) {
+    authorizer.authorizeAdmin(securityContext);
+    if (relationType == null || nullOrEmpty(relationType.getName())) {
+      throw new BadRequestException("The relation type name is required.");
+    }
+
+    relationType.setIsSystemDefined(false);
+    GlossaryTermRelationSettingsUtil.normalize(relationType);
+    JsonValue relationTypeJson = JsonUtils.readJson(JsonUtils.pojoToJson(relationType));
+    JsonPatch patch = Json.createPatchBuilder().add("/relationTypes/-", relationTypeJson).build();
+
+    systemRepository.patchSetting(GLOSSARY_TERM_RELATION_SETTINGS.value(), patch);
+    return Response.status(Response.Status.CREATED).entity(relationType).build();
+  }
+
+  @PUT
+  @Path("/settings/glossaryTermRelationSettings/relationTypes/{name}")
+  @Operation(
+      operationId = "updateGlossaryTermRelationType",
+      summary = "Update a glossary term relation type")
+  public Response updateGlossaryTermRelationType(
+      @Context SecurityContext securityContext,
+      @PathParam("name") String name,
+      @Valid GlossaryTermRelationType relationType) {
+    authorizer.authorizeAdmin(securityContext);
+    if (relationType == null || nullOrEmpty(relationType.getName())) {
+      throw new BadRequestException("The relation type name is required.");
+    }
+    GlossaryTermRelationSettings currentSettings = getGlossaryTermRelationSettings();
+    int relationTypeIndex = findRelationTypeIndex(currentSettings, name);
+    GlossaryTermRelationType existing = currentSettings.getRelationTypes().get(relationTypeIndex);
+    if (Boolean.TRUE.equals(existing.getIsSystemDefined())) {
+      throw new SystemSettingsException("System-defined relation types cannot be updated.");
+    }
+    if (!name.equals(relationType.getName())) {
+      throw new BadRequestException("The relation type name cannot be changed.");
+    }
+
+    relationType.setIsSystemDefined(false);
+    GlossaryTermRelationSettingsUtil.normalize(relationType);
+    String relationTypePath = "/relationTypes/" + relationTypeIndex;
+    JsonPatch patch =
+        Json.createPatchBuilder()
+            .test(relationTypePath + "/name", existing.getName())
+            .replace(relationTypePath, JsonUtils.readJson(JsonUtils.pojoToJson(relationType)))
+            .build();
+
+    systemRepository.patchSetting(GLOSSARY_TERM_RELATION_SETTINGS.value(), patch);
+    return Response.ok(relationType).build();
+  }
+
+  @DELETE
+  @Path("/settings/glossaryTermRelationSettings/relationTypes/{name}")
+  @Operation(
+      operationId = "deleteGlossaryTermRelationType",
+      summary = "Delete a glossary term relation type")
+  public Response deleteGlossaryTermRelationType(
+      @Context SecurityContext securityContext, @PathParam("name") String name) {
+    authorizer.authorizeAdmin(securityContext);
+    GlossaryTermRelationSettings currentSettings = getGlossaryTermRelationSettings();
+    int relationTypeIndex = findRelationTypeIndex(currentSettings, name);
+    GlossaryTermRelationType existing = currentSettings.getRelationTypes().get(relationTypeIndex);
+    if (Boolean.TRUE.equals(existing.getIsSystemDefined())) {
+      throw new SystemSettingsException("System-defined relation types cannot be deleted.");
+    }
+
+    GlossaryTermRepository glossaryTermRepository =
+        (GlossaryTermRepository) Entity.getEntityRepository(Entity.GLOSSARY_TERM);
+    int usageCount =
+        glossaryTermRepository.getRelationTypeUsageCounts().getOrDefault(existing.getName(), 0);
+    if (usageCount > 0) {
+      throw new SystemSettingsException(
+          String.format(
+              "Cannot delete relation type %s (%d usage%s).",
+              existing.getName(), usageCount, usageCount == 1 ? "" : "s"));
+    }
+
+    String relationTypePath = "/relationTypes/" + relationTypeIndex;
+    JsonPatch patch =
+        Json.createPatchBuilder()
+            .test(relationTypePath + "/name", existing.getName())
+            .remove(relationTypePath)
+            .build();
+    systemRepository.patchSetting(GLOSSARY_TERM_RELATION_SETTINGS.value(), patch);
+
+    return Response.noContent().build();
   }
 
   @GET
@@ -473,7 +611,8 @@ public class SystemResource {
         .equalsIgnoreCase(settingName.getConfigType().toString())) {
       GlossaryTermRelationSettings relationSettings =
           JsonUtils.convertValue(settingName.getConfigValue(), GlossaryTermRelationSettings.class);
-      normalizeGlossaryTermRelationSettings(relationSettings);
+      GlossaryTermRelationSettingsUtil.normalize(relationSettings);
+      GlossaryTermRelationSettingsUtil.validateUniqueNames(relationSettings);
       settingName.setConfigValue(relationSettings);
       validateGlossaryTermRelationSettingsUpdate(settingName);
     }
@@ -1040,7 +1179,12 @@ public class SystemResource {
     GlossaryTermRelationSettings newConfig =
         JsonUtils.convertValue(newSettings.getConfigValue(), GlossaryTermRelationSettings.class);
 
-    if (currentConfig.getRelationTypes() == null || newConfig.getRelationTypes() == null) {
+    GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+        currentConfig, newConfig);
+    if (currentConfig == null
+        || newConfig == null
+        || currentConfig.getRelationTypes() == null
+        || newConfig.getRelationTypes() == null) {
       return;
     }
 
@@ -1056,23 +1200,6 @@ public class SystemResource {
 
     if (removedRelationTypes.isEmpty()) {
       return;
-    }
-
-    // System-defined relation types are part of the seeded contract and must never be deleted,
-    // even when no glossary term currently references them. The "in-use" check below is not
-    // enough on its own — a settings update submitted before any term uses the type would
-    // otherwise silently strip it from the cached settings.
-    List<String> removedSystemDefinedTypes =
-        currentConfig.getRelationTypes().stream()
-            .filter(rt -> !newRelationTypeNames.contains(rt.getName()))
-            .filter(rt -> Boolean.TRUE.equals(rt.getIsSystemDefined()))
-            .map(GlossaryTermRelationType::getName)
-            .toList();
-
-    if (!removedSystemDefinedTypes.isEmpty()) {
-      throw new SystemSettingsException(
-          "Cannot delete system-defined relation types: "
-              + String.join(", ", removedSystemDefinedTypes));
     }
 
     GlossaryTermRepository glossaryTermRepository =
@@ -1096,63 +1223,26 @@ public class SystemResource {
     }
   }
 
-  private void normalizeGlossaryTermRelationSettings(GlossaryTermRelationSettings settings) {
-    if (settings == null || settings.getRelationTypes() == null) {
-      return;
+  private GlossaryTermRelationSettings getGlossaryTermRelationSettings() {
+    Settings settings = systemRepository.getConfigWithKey(GLOSSARY_TERM_RELATION_SETTINGS.value());
+    if (settings == null || settings.getConfigValue() == null) {
+      throw new NotFoundException("Glossary term relation settings were not found.");
     }
 
-    for (GlossaryTermRelationType relationType : settings.getRelationTypes()) {
-      if (relationType == null) {
-        continue;
-      }
-
-      RelationCardinality cardinality = relationType.getCardinality();
-      if (cardinality == null) {
-        relationType.setCardinality(
-            deriveCardinality(relationType.getSourceMax(), relationType.getTargetMax()));
-        continue;
-      }
-
-      switch (cardinality) {
-        case ONE_TO_ONE -> {
-          relationType.setSourceMax(1);
-          relationType.setTargetMax(1);
-        }
-        case ONE_TO_MANY -> {
-          relationType.setSourceMax(1);
-          relationType.setTargetMax(null);
-        }
-        case MANY_TO_ONE -> {
-          relationType.setSourceMax(null);
-          relationType.setTargetMax(1);
-        }
-        case MANY_TO_MANY -> {
-          relationType.setSourceMax(null);
-          relationType.setTargetMax(null);
-        }
-        case CUSTOM -> {
-          // Keep explicit values as-is.
-        }
-        default -> {
-          // No-op for unknown values.
-        }
-      }
-    }
+    return JsonUtils.convertValue(settings.getConfigValue(), GlossaryTermRelationSettings.class);
   }
 
-  private RelationCardinality deriveCardinality(Integer sourceMax, Integer targetMax) {
-    if (sourceMax == null && targetMax == null) {
-      return RelationCardinality.MANY_TO_MANY;
+  private int findRelationTypeIndex(GlossaryTermRelationSettings settings, String name) {
+    List<GlossaryTermRelationType> relationTypes = settings.getRelationTypes();
+    if (relationTypes != null) {
+      for (int index = 0; index < relationTypes.size(); index++) {
+        GlossaryTermRelationType relationType = relationTypes.get(index);
+        if (relationType != null && name.equals(relationType.getName())) {
+          return index;
+        }
+      }
     }
-    if (Integer.valueOf(1).equals(sourceMax) && Integer.valueOf(1).equals(targetMax)) {
-      return RelationCardinality.ONE_TO_ONE;
-    }
-    if (Integer.valueOf(1).equals(sourceMax) && targetMax == null) {
-      return RelationCardinality.ONE_TO_MANY;
-    }
-    if (sourceMax == null && Integer.valueOf(1).equals(targetMax)) {
-      return RelationCardinality.MANY_TO_ONE;
-    }
-    return RelationCardinality.CUSTOM;
+
+    throw new NotFoundException(String.format("Relation type '%s' was not found.", name));
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import jakarta.ws.rs.core.Response;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.configuration.GlossaryTermRelationType;
+import org.openmetadata.schema.configuration.RelationCardinality;
+import org.openmetadata.service.exception.SystemSettingsException;
+
+public final class GlossaryTermRelationSettingsUtil {
+  private GlossaryTermRelationSettingsUtil() {}
+
+  public static void normalize(GlossaryTermRelationSettings settings) {
+    if (settings == null || settings.getRelationTypes() == null) {
+      return;
+    }
+
+    settings.getRelationTypes().forEach(GlossaryTermRelationSettingsUtil::normalize);
+  }
+
+  public static void normalize(GlossaryTermRelationType relationType) {
+    if (relationType == null) {
+      return;
+    }
+
+    RelationCardinality cardinality = relationType.getCardinality();
+    if (cardinality == null) {
+      relationType.setCardinality(
+          deriveCardinality(relationType.getSourceMax(), relationType.getTargetMax()));
+      return;
+    }
+
+    switch (cardinality) {
+      case ONE_TO_ONE -> {
+        relationType.setSourceMax(1);
+        relationType.setTargetMax(1);
+      }
+      case ONE_TO_MANY -> {
+        relationType.setSourceMax(1);
+        relationType.setTargetMax(null);
+      }
+      case MANY_TO_ONE -> {
+        relationType.setSourceMax(null);
+        relationType.setTargetMax(1);
+      }
+      case MANY_TO_MANY -> {
+        relationType.setSourceMax(null);
+        relationType.setTargetMax(null);
+      }
+      case CUSTOM -> {}
+    }
+  }
+
+  public static void validateUniqueNames(GlossaryTermRelationSettings settings) {
+    if (settings == null || settings.getRelationTypes() == null) {
+      return;
+    }
+
+    Set<String> relationTypeNames = new HashSet<>();
+    for (GlossaryTermRelationType relationType : settings.getRelationTypes()) {
+      if (relationType == null || relationType.getName() == null) {
+        continue;
+      }
+
+      String normalizedName = relationType.getName().toLowerCase(Locale.ROOT);
+      if (!relationTypeNames.add(normalizedName)) {
+        throw new SystemSettingsException(
+            Response.Status.CONFLICT,
+            String.format("Relation type '%s' already exists.", relationType.getName()));
+      }
+    }
+  }
+
+  public static void validateSystemDefinedRelationTypesPreserved(
+      GlossaryTermRelationSettings current, GlossaryTermRelationSettings updated) {
+    if (current == null || current.getRelationTypes() == null) {
+      return;
+    }
+
+    Set<String> updatedSystemDefinedNames = new HashSet<>();
+    if (updated != null && updated.getRelationTypes() != null) {
+      for (GlossaryTermRelationType relationType : updated.getRelationTypes()) {
+        if (relationType != null && Boolean.TRUE.equals(relationType.getIsSystemDefined())) {
+          updatedSystemDefinedNames.add(relationType.getName());
+        }
+      }
+    }
+
+    List<String> missingSystemDefinedNames =
+        current.getRelationTypes().stream()
+            .filter(relationType -> Boolean.TRUE.equals(relationType.getIsSystemDefined()))
+            .map(GlossaryTermRelationType::getName)
+            .filter(name -> !updatedSystemDefinedNames.contains(name))
+            .toList();
+    if (!missingSystemDefinedNames.isEmpty()) {
+      throw new SystemSettingsException(
+          "Cannot delete system-defined relation types: "
+              + String.join(", ", missingSystemDefinedNames));
+    }
+  }
+
+  private static RelationCardinality deriveCardinality(Integer sourceMax, Integer targetMax) {
+    if (sourceMax == null && targetMax == null) {
+      return RelationCardinality.MANY_TO_MANY;
+    }
+    if (Integer.valueOf(1).equals(sourceMax) && Integer.valueOf(1).equals(targetMax)) {
+      return RelationCardinality.ONE_TO_ONE;
+    }
+    if (Integer.valueOf(1).equals(sourceMax) && targetMax == null) {
+      return RelationCardinality.ONE_TO_MANY;
+    }
+    if (sourceMax == null && Integer.valueOf(1).equals(targetMax)) {
+      return RelationCardinality.MANY_TO_ONE;
+    }
+    return RelationCardinality.CUSTOM;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/SystemRepositoryPatchSettingTest.java
@@ -1,0 +1,188 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.exception.PreconditionFailedException;
+import org.openmetadata.service.exception.SystemSettingsException;
+import org.openmetadata.service.jdbi3.CollectionDAO.SystemDAO;
+import org.openmetadata.service.migration.MigrationValidationClient;
+import org.openmetadata.service.resources.settings.SettingsCache;
+
+class SystemRepositoryPatchSettingTest {
+  private static final String SETTING_NAME = SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value();
+  private static final String ORIGINAL_JSON = "{\"relationTypes\":[]}";
+
+  private MockedStatic<Entity> entityMock;
+  private MockedStatic<MigrationValidationClient> migrationMock;
+  private MockedStatic<SettingsCache> settingsCacheMock;
+  private SystemDAO systemDAO;
+  private SystemRepository systemRepository;
+
+  @BeforeEach
+  void setup() {
+    entityMock = mockStatic(Entity.class);
+    migrationMock = mockStatic(MigrationValidationClient.class);
+    settingsCacheMock = mockStatic(SettingsCache.class);
+
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    systemDAO = mock(SystemDAO.class);
+    when(collectionDAO.systemDAO()).thenReturn(systemDAO);
+    entityMock.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+    migrationMock
+        .when(MigrationValidationClient::getInstance)
+        .thenReturn(mock(MigrationValidationClient.class));
+
+    systemRepository = new SystemRepository();
+  }
+
+  @AfterEach
+  void tearDown() {
+    settingsCacheMock.close();
+    migrationMock.close();
+    entityMock.close();
+  }
+
+  @Test
+  void patchSettingUsesSnapshotCompareAndSet() {
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(ORIGINAL_JSON);
+    when(systemDAO.updateGlossaryTermRelationSettingsIfCurrent(eq(ORIGINAL_JSON), anyString()))
+        .thenReturn(1);
+
+    Response response = systemRepository.patchSetting(SETTING_NAME, appendRelationTypePatch());
+
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    Settings responseSettings = (Settings) response.getEntity();
+    assertEquals(SettingsType.GLOSSARY_TERM_RELATION_SETTINGS, responseSettings.getConfigType());
+    assertTrue(responseSettings.getConfigValue() instanceof GlossaryTermRelationSettings);
+    ArgumentCaptor<String> updatedJson = ArgumentCaptor.forClass(String.class);
+    verify(systemDAO)
+        .updateGlossaryTermRelationSettingsIfCurrent(eq(ORIGINAL_JSON), updatedJson.capture());
+    GlossaryTermRelationSettings updated =
+        JsonUtils.readValue(updatedJson.getValue(), GlossaryTermRelationSettings.class);
+    assertEquals(1, updated.getRelationTypes().size());
+    assertEquals("prescribes", updated.getRelationTypes().get(0).getName());
+    settingsCacheMock.verify(() -> SettingsCache.invalidateSettings(SETTING_NAME));
+  }
+
+  @Test
+  void patchSettingRejectsConcurrentSnapshotChange() {
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(ORIGINAL_JSON);
+    when(systemDAO.updateGlossaryTermRelationSettingsIfCurrent(eq(ORIGINAL_JSON), anyString()))
+        .thenReturn(0);
+
+    PreconditionFailedException failure =
+        assertThrows(
+            PreconditionFailedException.class,
+            () -> systemRepository.patchSetting(SETTING_NAME, appendRelationTypePatch()));
+
+    assertTrue(failure.getMessage().contains("Glossary term relation settings changed"));
+    assertEquals(
+        Response.Status.PRECONDITION_FAILED.getStatusCode(), failure.getResponse().getStatus());
+    settingsCacheMock.verifyNoInteractions();
+  }
+
+  @Test
+  void patchSettingRejectsDuplicateGlossaryTermRelationTypeNames() {
+    String existingJson = "{\"relationTypes\":[{\"name\":\"prescribes\"}]}";
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(existingJson);
+
+    SystemSettingsException failure =
+        assertThrows(
+            SystemSettingsException.class,
+            () -> systemRepository.patchSetting(SETTING_NAME, duplicateRelationTypePatch()));
+
+    assertTrue(failure.getMessage().contains("already exists"));
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), failure.getResponse().getStatus());
+    verify(systemDAO, never())
+        .updateGlossaryTermRelationSettingsIfCurrent(anyString(), anyString());
+    settingsCacheMock.verifyNoInteractions();
+  }
+
+  @Test
+  void patchSettingTranslatesStaleRelationIndexToPreconditionFailed() {
+    String existingJson = "{\"relationTypes\":[{\"name\":\"relatedTo\"}]}";
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(existingJson);
+
+    PreconditionFailedException failure =
+        assertThrows(
+            PreconditionFailedException.class,
+            () -> systemRepository.patchSetting(SETTING_NAME, staleRelationTypePatch()));
+
+    assertTrue(failure.getMessage().contains("settings changed"));
+    verify(systemDAO, never())
+        .updateGlossaryTermRelationSettingsIfCurrent(anyString(), anyString());
+    settingsCacheMock.verifyNoInteractions();
+  }
+
+  @Test
+  void patchSettingRejectsDeletingSystemDefinedRelationType() {
+    String existingJson = "{\"relationTypes\":[{\"name\":\"relatedTo\",\"isSystemDefined\":true}]}";
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(existingJson);
+
+    SystemSettingsException failure =
+        assertThrows(
+            SystemSettingsException.class,
+            () -> systemRepository.patchSetting(SETTING_NAME, removeFirstRelationTypePatch()));
+
+    assertTrue(failure.getMessage().contains("system-defined"));
+    verify(systemDAO, never())
+        .updateGlossaryTermRelationSettingsIfCurrent(anyString(), anyString());
+    settingsCacheMock.verifyNoInteractions();
+  }
+
+  @Test
+  void patchSettingRejectsMissingSetting() {
+    when(systemDAO.getGlossaryTermRelationSettingsJson()).thenReturn(null);
+
+    assertThrows(
+        EntityNotFoundException.class,
+        () -> systemRepository.patchSetting(SETTING_NAME, appendRelationTypePatch()));
+  }
+
+  private JsonPatch appendRelationTypePatch() {
+    return Json.createPatchBuilder()
+        .test("/relationTypes", Json.createArrayBuilder().build())
+        .add("/relationTypes/-", Json.createObjectBuilder().add("name", "prescribes").build())
+        .build();
+  }
+
+  private JsonPatch duplicateRelationTypePatch() {
+    return Json.createPatchBuilder()
+        .add("/relationTypes/-", Json.createObjectBuilder().add("name", "PRESCRIBES").build())
+        .build();
+  }
+
+  private JsonPatch staleRelationTypePatch() {
+    return Json.createPatchBuilder()
+        .test("/relationTypes/0/name", "synonym")
+        .remove("/relationTypes/0")
+        .build();
+  }
+
+  private JsonPatch removeFirstRelationTypePatch() {
+    return Json.createPatchBuilder().remove("/relationTypes/0").build();
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.configuration.GlossaryTermRelationType;
+import org.openmetadata.schema.configuration.RelationCardinality;
+import org.openmetadata.service.exception.SystemSettingsException;
+
+class GlossaryTermRelationSettingsUtilTest {
+  @Test
+  void validateUniqueNamesRejectsCaseInsensitiveDuplicates() {
+    GlossaryTermRelationSettings settings =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("dependsOn"), relationType("DEPENDSON")));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () -> GlossaryTermRelationSettingsUtil.validateUniqueNames(settings));
+
+    assertEquals("Relation type 'DEPENDSON' already exists.", exception.getMessage());
+    assertEquals(Response.Status.CONFLICT.getStatusCode(), exception.getResponse().getStatus());
+  }
+
+  @Test
+  void normalizeAppliesPresetCardinalityLimits() {
+    GlossaryTermRelationType relationType =
+        relationType("dependsOn")
+            .withCardinality(RelationCardinality.ONE_TO_MANY)
+            .withSourceMax(9)
+            .withTargetMax(9);
+
+    GlossaryTermRelationSettingsUtil.normalize(relationType);
+
+    assertEquals(1, relationType.getSourceMax());
+    assertNull(relationType.getTargetMax());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesRejectsDeletion() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(
+                List.of(
+                    relationType("relatedTo").withIsSystemDefined(true),
+                    relationType("dependsOn").withIsSystemDefined(false)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("dependsOn").withIsSystemDefined(false)));
+
+    SystemSettingsException exception =
+        assertThrows(
+            SystemSettingsException.class,
+            () ->
+                GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                    current, updated));
+
+    assertEquals("Cannot delete system-defined relation types: relatedTo", exception.getMessage());
+  }
+
+  @Test
+  void validateSystemDefinedRelationTypesRejectsDowngrade() {
+    GlossaryTermRelationSettings current =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("relatedTo").withIsSystemDefined(true)));
+    GlossaryTermRelationSettings updated =
+        new GlossaryTermRelationSettings()
+            .withRelationTypes(List.of(relationType("relatedTo").withIsSystemDefined(false)));
+
+    assertThrows(
+        SystemSettingsException.class,
+        () ->
+            GlossaryTermRelationSettingsUtil.validateSystemDefinedRelationTypesPreserved(
+                current, updated));
+  }
+
+  private GlossaryTermRelationType relationType(String name) {
+    return new GlossaryTermRelationType().withName(name);
+  }
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -1,0 +1,299 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import test, { APIRequestContext, expect, Page } from '@playwright/test';
+import { authenticateAdminPage } from '../../utils/admin';
+import { getApiContext, toastNotification, uuid } from '../../utils/common';
+
+const PAGE_SIZE_BASE = 15;
+const RELATION_SETTINGS_ROUTE = '/settings/governance/glossary-term-relations';
+const RELATION_TYPES_API =
+  '/api/v1/system/settings/glossaryTermRelationSettings/relationTypes';
+const SYSTEM_DEFINED_RELATION = 'relatedTo';
+
+type RelationTypePayload = {
+  name: string;
+  displayName: string;
+  category?: string;
+};
+
+const buildRelationName = () => `pwRel${uuid()}`;
+const CONFLICT_STATUS = 412;
+const CONFLICT_RETRY_LIMIT = 5;
+
+const createRelationTypeViaApi = async (
+  apiContext: APIRequestContext,
+  payload: RelationTypePayload
+) => {
+  for (let attempt = 0; attempt < CONFLICT_RETRY_LIMIT; attempt++) {
+    const response = await apiContext.post(RELATION_TYPES_API, {
+      data: {
+        category: 'associative',
+        ...payload,
+      },
+    });
+
+    if (response.status() !== CONFLICT_STATUS) {
+      expect(response.status()).toBe(201);
+
+      return;
+    }
+  }
+
+  throw new Error(
+    `Failed to create relation type '${payload.name}' after ${CONFLICT_RETRY_LIMIT} conflict retries`
+  );
+};
+
+const deleteRelationTypeViaApi = async (
+  apiContext: APIRequestContext,
+  name: string
+) => {
+  for (let attempt = 0; attempt < CONFLICT_RETRY_LIMIT; attempt++) {
+    const response = await apiContext.delete(`${RELATION_TYPES_API}/${name}`);
+
+    if (response.status() !== CONFLICT_STATUS) {
+      return;
+    }
+  }
+};
+
+const goToRelationSettings = async (page: Page) => {
+  const listResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/glossaryTermRelationSettings/relationTypes') &&
+      response.request().method() === 'GET'
+  );
+  await page.goto(RELATION_SETTINGS_ROUTE);
+  await listResponse;
+
+  await expect(page.getByTestId('relation-types-table')).toBeVisible();
+};
+
+const fillInput = async (page: Page, testId: string, value: string) => {
+  await page.getByTestId(testId).locator('input').fill(value);
+};
+
+const selectOption = async (page: Page, testId: string, option: string) => {
+  await page.getByTestId(testId).click();
+  await page.getByRole('option', { name: option, exact: true }).click();
+};
+
+// The drawer's save fires a single non-retrying write against the shared
+// settings singleton, so a peer worker committing in the same instant can make
+// it lose the compare-and-set (412). The drawer stays open on failure, so retry
+// the click until the mutation lands, matching how every other writer to this
+// singleton self-heals under parallel execution.
+const submitRelationForm = async (
+  page: Page,
+  method: 'POST' | 'PUT',
+  urlPart: string
+) => {
+  await expect(async () => {
+    const mutation = page.waitForResponse(
+      (response) =>
+        response.url().includes(urlPart) &&
+        response.request().method() === method
+    );
+    await page.getByTestId('save-btn').click();
+
+    expect((await mutation).status()).toBeLessThan(300);
+  }).toPass();
+};
+
+const deleteRelationInUi = async (page: Page, name: string) => {
+  await expect(async () => {
+    const mutation = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/relationTypes/${name}`) &&
+        response.request().method() === 'DELETE'
+    );
+    await page.getByTestId(`delete-${name}-btn`).click();
+
+    expect((await mutation).status()).toBeLessThan(300);
+  }).toPass();
+};
+
+test.describe('Glossary Term Relation Settings', () => {
+  test.beforeEach(async ({ page }) => {
+    await authenticateAdminPage(page);
+  });
+
+  test('creates a custom relation type via the drawer', async ({ page }) => {
+    const relationName = buildRelationName();
+    const displayName = `PW Relation ${uuid()}`;
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await goToRelationSettings(page);
+
+      await page.getByTestId('add-relation-type-btn').click();
+      await expect(page.getByTestId('relation-type-drawer')).toBeVisible();
+
+      await fillInput(page, 'name-input', relationName);
+      await fillInput(page, 'display-name-input', displayName);
+      await selectOption(page, 'category-select', 'Associative');
+      await selectOption(page, 'cardinality-select', 'One to Many');
+
+      await submitRelationForm(page, 'POST', '/relationTypes');
+
+      await toastNotification(page, 'Relation Type updated successfully.');
+
+      await expect(
+        page.getByTestId(`relation-name-${relationName}`)
+      ).toBeVisible();
+    } finally {
+      await deleteRelationTypeViaApi(apiContext, relationName);
+      await afterAction();
+    }
+  });
+
+  test('edits a custom relation type and keeps the name immutable', async ({
+    page,
+  }) => {
+    const relationName = buildRelationName();
+    const updatedDisplayName = `PW Updated ${uuid()}`;
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await createRelationTypeViaApi(apiContext, {
+        name: relationName,
+        displayName: 'PW Original',
+      });
+
+      await goToRelationSettings(page);
+
+      await page.getByTestId(`edit-${relationName}-btn`).click();
+      await expect(page.getByTestId('relation-type-drawer')).toBeVisible();
+
+      await expect(
+        page.getByTestId('name-input').locator('input')
+      ).toBeDisabled();
+
+      await fillInput(page, 'display-name-input', updatedDisplayName);
+
+      await submitRelationForm(page, 'PUT', `/relationTypes/${relationName}`);
+
+      await toastNotification(page, 'Relation Type updated successfully.');
+
+      await expect(page.getByText(updatedDisplayName)).toBeVisible();
+    } finally {
+      await deleteRelationTypeViaApi(apiContext, relationName);
+      await afterAction();
+    }
+  });
+
+  test('rejects duplicate relation-type names with an inline error', async ({
+    page,
+  }) => {
+    await goToRelationSettings(page);
+
+    await page.getByTestId('add-relation-type-btn').click();
+    await fillInput(page, 'name-input', SYSTEM_DEFINED_RELATION);
+    await fillInput(page, 'display-name-input', 'PW Duplicate Copy');
+    await selectOption(page, 'cardinality-select', 'Many to Many');
+
+    await page.getByTestId('save-btn').click();
+
+    await expect(page.getByText('Relation Type already exists.')).toBeVisible();
+    await expect(page.getByTestId('relation-type-drawer')).toBeVisible();
+  });
+
+  test('deletes a custom relation type', async ({ page }) => {
+    const relationName = buildRelationName();
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await createRelationTypeViaApi(apiContext, {
+        name: relationName,
+        displayName: 'PW Delete',
+      });
+
+      await goToRelationSettings(page);
+
+      await expect(
+        page.getByTestId(`relation-name-${relationName}`)
+      ).toBeVisible();
+
+      await deleteRelationInUi(page, relationName);
+
+      await toastNotification(page, 'Relation Type deleted successfully!');
+
+      await expect(
+        page.getByTestId(`relation-name-${relationName}`)
+      ).toHaveCount(0);
+    } finally {
+      await deleteRelationTypeViaApi(apiContext, relationName);
+      await afterAction();
+    }
+  });
+
+  test('locks system-defined relation types from edit and delete', async ({
+    page,
+  }) => {
+    await goToRelationSettings(page);
+
+    await expect(
+      page.getByTestId(`relation-name-${SYSTEM_DEFINED_RELATION}`)
+    ).toBeVisible();
+    await expect(
+      page.getByTestId(`edit-${SYSTEM_DEFINED_RELATION}-btn`)
+    ).toBeDisabled();
+    await expect(
+      page.getByTestId(`delete-${SYSTEM_DEFINED_RELATION}-btn`)
+    ).toBeDisabled();
+  });
+
+  test('paginates relation types when they exceed a page', async ({ page }) => {
+    const createdNames: string[] = [];
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      // Seed enough of our own types that they exceed a single page on their
+      // own. The 11 permanent system-defined types can never be deleted and
+      // peers only ever add more, so total always stays above PAGE_SIZE_BASE
+      // regardless of what else runs in parallel.
+      for (let index = 0; index < PAGE_SIZE_BASE + 1; index++) {
+        const name = buildRelationName();
+        await createRelationTypeViaApi(apiContext, {
+          name,
+          displayName: `PW Page ${index}`,
+        });
+        createdNames.push(name);
+      }
+
+      await goToRelationSettings(page);
+
+      await expect(page.getByLabel('Current page')).toBeVisible();
+      await expect(
+        page.getByTestId('relation-types-table').locator('tbody tr')
+      ).toHaveCount(PAGE_SIZE_BASE);
+
+      const nextPageResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/relationTypes') &&
+          response.url().includes(`offset=${PAGE_SIZE_BASE}`) &&
+          response.request().method() === 'GET'
+      );
+
+      await page.getByRole('button', { name: 'Next Page' }).first().click();
+
+      expect((await nextPageResponse).ok()).toBe(true);
+    } finally {
+      for (const name of createdNames) {
+        await deleteRelationTypeViaApi(apiContext, name);
+      }
+      await afterAction();
+    }
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/enums/Axios.enum.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/enums/Axios.enum.ts
@@ -17,6 +17,7 @@ export enum ClientErrors {
   PAYMENT_REQUIRED = 402,
   FORBIDDEN = 403,
   NOT_FOUND = 404,
+  CONFLICT = 409,
 }
 
 export enum ErrorTypes {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryTermRelationSettings/GlossaryTermRelationSettings.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryTermRelationSettings/GlossaryTermRelationSettings.test.tsx
@@ -1,0 +1,169 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { RelationCategory } from '../../generated/configuration/glossaryTermRelationSettings';
+import {
+  createGlossaryTermRelationType,
+  deleteGlossaryTermRelationType,
+  getGlossaryTermRelationTypes,
+} from '../../rest/glossaryAPI';
+import GlossaryTermRelationSettingsPage from './GlossaryTermRelationSettings';
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+  PaginationCardWithControls: ({
+    onPageChange,
+  }: {
+    onPageChange: (page: number) => void;
+  }) => (
+    <button data-testid="next-page" onClick={() => onPageChange(2)}>
+      Next page
+    </button>
+  ),
+}));
+
+jest.mock('../../components/PageLayoutV1/PageLayoutV1', () =>
+  jest.fn().mockImplementation(({ children }) => <div>{children}</div>)
+);
+
+jest.mock(
+  '../../components/common/TitleBreadcrumb/TitleBreadcrumb.component',
+  () => jest.fn().mockImplementation(() => <div>TitleBreadcrumb</div>)
+);
+
+jest.mock('../../hooks/authHooks', () => ({
+  useAuth: jest.fn().mockReturnValue({ isAdminUser: true }),
+}));
+
+jest.mock('../../rest/glossaryAPI', () => ({
+  createGlossaryTermRelationType: jest.fn(),
+  deleteGlossaryTermRelationType: jest.fn(),
+  getGlossaryTermRelationTypes: jest.fn(),
+  updateGlossaryTermRelationType: jest.fn(),
+}));
+
+jest.mock('../../utils/GlobalSettingsUtils', () => ({
+  getSettingPageEntityBreadCrumb: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+  showSuccessToast: jest.fn(),
+}));
+
+const mockGetGlossaryTermRelationTypes =
+  getGlossaryTermRelationTypes as jest.MockedFunction<
+    typeof getGlossaryTermRelationTypes
+  >;
+const mockCreateGlossaryTermRelationType =
+  createGlossaryTermRelationType as jest.MockedFunction<
+    typeof createGlossaryTermRelationType
+  >;
+const mockDeleteGlossaryTermRelationType =
+  deleteGlossaryTermRelationType as jest.MockedFunction<
+    typeof deleteGlossaryTermRelationType
+  >;
+
+describe('GlossaryTermRelationSettingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetGlossaryTermRelationTypes.mockImplementation(async ({ offset }) => ({
+      data: [
+        {
+          name: `relation${offset ?? 0}`,
+          displayName: 'Relation',
+          category: RelationCategory.Associative,
+        },
+      ],
+      paging: { limit: 15, offset: offset ?? 0, total: 31 },
+    }));
+  });
+
+  it('requests only the selected page of relation types', async () => {
+    render(<GlossaryTermRelationSettingsPage />);
+
+    expect(await screen.findByText('relation0')).toBeInTheDocument();
+    expect(mockGetGlossaryTermRelationTypes).toHaveBeenCalledWith({
+      limit: 15,
+      offset: 0,
+    });
+
+    fireEvent.click(screen.getByTestId('next-page'));
+
+    await waitFor(() =>
+      expect(mockGetGlossaryTermRelationTypes).toHaveBeenLastCalledWith({
+        limit: 15,
+        offset: 15,
+      })
+    );
+
+    expect(await screen.findByText('relation15')).toBeInTheDocument();
+  });
+
+  it('does not allow deleting a system-defined relation type', async () => {
+    mockGetGlossaryTermRelationTypes.mockResolvedValueOnce({
+      data: [
+        {
+          name: 'relatedTo',
+          displayName: 'Related To',
+          category: RelationCategory.Associative,
+          isSystemDefined: true,
+        },
+      ],
+      paging: { limit: 15, offset: 0, total: 1 },
+    });
+
+    render(<GlossaryTermRelationSettingsPage />);
+
+    const deleteButton = await screen.findByTestId('delete-relatedTo-btn');
+
+    expect(deleteButton).toBeDisabled();
+
+    fireEvent.click(deleteButton);
+
+    expect(mockDeleteGlossaryTermRelationType).not.toHaveBeenCalled();
+  });
+
+  it('shows an off-page duplicate error on the name field', async () => {
+    mockCreateGlossaryTermRelationType.mockRejectedValueOnce({
+      response: {
+        status: 409,
+      },
+    });
+
+    render(<GlossaryTermRelationSettingsPage />);
+
+    expect(await screen.findByText('relation0')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('add-relation-type-btn'));
+    fireEvent.change(screen.getByRole('textbox', { name: /label\.name/ }), {
+      target: { value: 'relation30' },
+    });
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /label\.display-name/ }),
+      {
+        target: { value: 'Relation 30' },
+      }
+    );
+    fireEvent.click(screen.getByTestId('save-btn'));
+
+    await waitFor(() =>
+      expect(mockCreateGlossaryTermRelationType).toHaveBeenCalled()
+    );
+
+    expect(
+      await screen.findByText('message.entity-already-exists')
+    ).toBeInTheDocument();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryTermRelationSettings/GlossaryTermRelationSettings.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/GlossaryTermRelationSettings/GlossaryTermRelationSettings.tsx
@@ -19,6 +19,7 @@ import {
   Checkbox,
   Divider,
   Input,
+  PaginationCardWithControls,
   Select,
   SelectItemType,
   SlideoutMenu,
@@ -40,18 +41,24 @@ import {
   RELATION_META,
 } from '../../components/OntologyExplorer/OntologyExplorer.constants';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
-import { GlobalSettingsMenuCategory } from '../../constants/GlobalSettings.constants';
 import {
-  GlossaryTermRelationSettings,
+  PAGE_SIZE_BASE,
+  PAGE_SIZE_LARGE,
+  PAGE_SIZE_MEDIUM,
+} from '../../constants/constants';
+import { GlobalSettingsMenuCategory } from '../../constants/GlobalSettings.constants';
+import { ClientErrors } from '../../enums/Axios.enum';
+import {
   GlossaryTermRelationType,
   RelationCardinality,
   RelationCategory,
 } from '../../generated/configuration/glossaryTermRelationSettings';
 import { useAuth } from '../../hooks/authHooks';
 import {
-  getGlossaryTermRelationSettings,
-  getRelationTypeUsageCounts,
-  updateGlossaryTermRelationSettings,
+  createGlossaryTermRelationType,
+  deleteGlossaryTermRelationType,
+  getGlossaryTermRelationTypes,
+  updateGlossaryTermRelationType,
 } from '../../rest/glossaryAPI';
 import { getSettingPageEntityBreadCrumb } from '../../utils/GlobalSettingsUtils';
 import { deriveCardinality } from '../../utils/Glossary/glossaryTermRelationUtils';
@@ -130,10 +137,12 @@ function GlossaryTermRelationSettingsPage() {
   const { isAdminUser } = useAuth();
   const [loading, setLoading] = useState<boolean>(false);
   const [saving, setSaving] = useState<boolean>(false);
-  const [settings, setSettings] = useState<GlossaryTermRelationSettings | null>(
-    null
-  );
-  const [usageCounts, setUsageCounts] = useState<Record<string, number>>({});
+  const [relationTypes, setRelationTypes] = useState<
+    GlossaryTermRelationType[]
+  >([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_BASE);
+  const [totalRelationTypes, setTotalRelationTypes] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [editingRelation, setEditingRelation] =
     useState<GlossaryTermRelationType | null>(null);
@@ -251,7 +260,7 @@ function GlossaryTermRelationSettingsPage() {
 
   const rdfPredicateUsage = useMemo(() => {
     const usageMap = new Map<string, string[]>();
-    (settings?.relationTypes ?? []).forEach((relationType) => {
+    relationTypes.forEach((relationType) => {
       const predicate = relationType.rdfPredicate?.trim();
       if (!predicate) {
         return;
@@ -261,7 +270,7 @@ function GlossaryTermRelationSettingsPage() {
     });
 
     return usageMap;
-  }, [settings]);
+  }, [relationTypes]);
 
   const rdfPredicateDuplicates = useMemo(() => {
     const predicate = formValues.rdfPredicate?.trim();
@@ -284,6 +293,16 @@ function GlossaryTermRelationSettingsPage() {
       errors.name = t('label.field-required', { field: t('label.name') });
     } else if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(formValues.name)) {
       errors.name = t('message.must-start-with-letter-alphanumeric');
+    } else if (
+      !editingRelation &&
+      relationTypes.some(
+        (relationType) =>
+          relationType.name.toLowerCase() === formValues.name?.toLowerCase()
+      )
+    ) {
+      errors.name = t('message.entity-already-exists', {
+        entity: t('label.relation-type'),
+      });
     }
 
     if (!formValues.displayName) {
@@ -301,17 +320,17 @@ function GlossaryTermRelationSettingsPage() {
     setFormErrors(errors);
 
     return Object.keys(errors).length === 0;
-  }, [formValues, t]);
+  }, [editingRelation, formValues, relationTypes, t]);
 
-  const fetchSettings = useCallback(async () => {
+  const fetchRelationTypes = useCallback(async () => {
     try {
       setLoading(true);
-      const [settingsData, usageData] = await Promise.all([
-        getGlossaryTermRelationSettings(),
-        getRelationTypeUsageCounts(),
-      ]);
-      setSettings(settingsData as GlossaryTermRelationSettings);
-      setUsageCounts(usageData);
+      const response = await getGlossaryTermRelationTypes({
+        limit: pageSize,
+        offset: (currentPage - 1) * pageSize,
+      });
+      setRelationTypes(response.data);
+      setTotalRelationTypes(response.paging.total);
     } catch (error) {
       showErrorToast(
         error as AxiosError,
@@ -322,7 +341,7 @@ function GlossaryTermRelationSettingsPage() {
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [currentPage, pageSize, t]);
 
   const handleAddNew = useCallback(() => {
     setEditingRelation(null);
@@ -342,25 +361,29 @@ function GlossaryTermRelationSettingsPage() {
   }, []);
 
   const handleDelete = useCallback(
-    async (relationName: string) => {
-      if (!settings) {
+    async (relationType: GlossaryTermRelationType) => {
+      if (relationType.isSystemDefined) {
         return;
       }
 
       try {
         setSaving(true);
-        const updatedRelationTypes = (settings.relationTypes ?? []).filter(
-          (r) => r.name !== relationName
-        );
-        await updateGlossaryTermRelationSettings({
-          relationTypes: updatedRelationTypes,
-        });
-        setSettings({ relationTypes: updatedRelationTypes });
+        await deleteGlossaryTermRelationType(relationType.name);
         showSuccessToast(
           t('server.entity-deleted-success', {
             entity: t('label.relation-type'),
           })
         );
+
+        const lastPage = Math.max(
+          Math.ceil((totalRelationTypes - 1) / pageSize),
+          1
+        );
+        if (currentPage > lastPage) {
+          setCurrentPage(lastPage);
+        } else {
+          await fetchRelationTypes();
+        }
       } catch (error) {
         showErrorToast(
           error as AxiosError,
@@ -372,7 +395,7 @@ function GlossaryTermRelationSettingsPage() {
         setSaving(false);
       }
     },
-    [settings, t]
+    [currentPage, fetchRelationTypes, pageSize, t, totalRelationTypes]
   );
 
   const handleModalOk = useCallback(async () => {
@@ -388,40 +411,60 @@ function GlossaryTermRelationSettingsPage() {
         isSystemDefined: false,
       });
 
-      let updatedRelationTypes: GlossaryTermRelationType[];
-
       if (editingRelation) {
-        updatedRelationTypes = (settings?.relationTypes || []).map((r) =>
-          r.name === editingRelation.name ? newRelation : r
-        );
+        await updateGlossaryTermRelationType(newRelation);
       } else {
-        updatedRelationTypes = [
-          ...(settings?.relationTypes || []),
-          newRelation,
-        ];
+        await createGlossaryTermRelationType(newRelation);
       }
 
-      await updateGlossaryTermRelationSettings({
-        relationTypes: updatedRelationTypes,
-      });
-      setSettings({ relationTypes: updatedRelationTypes });
       setIsModalOpen(false);
       showSuccessToast(
         t('server.update-entity-success', {
           entity: t('label.relation-type'),
         })
       );
+
+      const destinationPage = editingRelation
+        ? currentPage
+        : Math.max(Math.ceil((totalRelationTypes + 1) / pageSize), 1);
+      if (destinationPage !== currentPage) {
+        setCurrentPage(destinationPage);
+      } else {
+        await fetchRelationTypes();
+      }
     } catch (error) {
-      showErrorToast(
-        error as AxiosError,
-        t('server.update-entity-error', {
-          entity: t('label.relation-type'),
-        })
-      );
+      const apiError = error as AxiosError;
+      if (
+        !editingRelation &&
+        apiError.response?.status === ClientErrors.CONFLICT
+      ) {
+        setFormErrors((previousErrors) => ({
+          ...previousErrors,
+          name: t('message.entity-already-exists', {
+            entity: t('label.relation-type'),
+          }),
+        }));
+      } else {
+        showErrorToast(
+          apiError,
+          t('server.update-entity-error', {
+            entity: t('label.relation-type'),
+          })
+        );
+      }
     } finally {
       setSaving(false);
     }
-  }, [validateForm, formValues, editingRelation, settings, t]);
+  }, [
+    currentPage,
+    editingRelation,
+    fetchRelationTypes,
+    formValues,
+    pageSize,
+    t,
+    totalRelationTypes,
+    validateForm,
+  ]);
 
   const handleModalCancel = useCallback(() => {
     setIsModalOpen(false);
@@ -450,8 +493,8 @@ function GlossaryTermRelationSettingsPage() {
   );
 
   useEffect(() => {
-    fetchSettings();
-  }, [fetchSettings]);
+    fetchRelationTypes();
+  }, [fetchRelationTypes]);
 
   return (
     <PageLayoutV1 pageTitle={t('label.glossary-term-relation-plural')}>
@@ -489,9 +532,11 @@ function GlossaryTermRelationSettingsPage() {
             </div>
           ) : (
             <TableCard.Root size="sm">
-              <Table data-testid="relation-types-table">
+              <Table
+                aria-label={t('label.glossary-term-relation-plural')}
+                data-testid="relation-types-table">
                 <Table.Header>
-                  <Table.Head id="col-name">
+                  <Table.Head isRowHeader id="col-name">
                     <Typography
                       as="span"
                       className="tw:text-gray-500 tw:whitespace-nowrap"
@@ -573,18 +618,13 @@ function GlossaryTermRelationSettingsPage() {
                     </Typography>
                   </Table.Head>
                 </Table.Header>
-                <Table.Body items={settings?.relationTypes || []}>
+                <Table.Body items={relationTypes}>
                   {(record: GlossaryTermRelationType) => {
-                    const count = usageCounts[record.name] || 0;
-                    const isInUse = count > 0;
                     let deleteTooltip = t('label.delete');
-                    if (!isAdminUser) {
+                    if (record.isSystemDefined) {
+                      deleteTooltip = t('label.system-defined');
+                    } else if (!isAdminUser) {
                       deleteTooltip = t('message.no-permission-for-action');
-                    } else if (isInUse) {
-                      deleteTooltip = t(
-                        'message.cannot-delete-relation-type-in-use',
-                        { count }
-                      );
                     }
 
                     return (
@@ -686,7 +726,7 @@ function GlossaryTermRelationSettingsPage() {
                               }
                               size="sm"
                               tooltip={deleteTooltip}
-                              onClick={() => handleDelete(record.name)}
+                              onClick={() => handleDelete(record)}
                             />
                           </div>
                         </Table.Cell>
@@ -695,6 +735,23 @@ function GlossaryTermRelationSettingsPage() {
                   }}
                 </Table.Body>
               </Table>
+              {totalRelationTypes > PAGE_SIZE_BASE && (
+                <PaginationCardWithControls
+                  page={currentPage}
+                  pageSize={pageSize}
+                  pageSizeOptions={[
+                    PAGE_SIZE_BASE,
+                    PAGE_SIZE_MEDIUM,
+                    PAGE_SIZE_LARGE,
+                  ]}
+                  total={Math.max(Math.ceil(totalRelationTypes / pageSize), 1)}
+                  onPageChange={setCurrentPage}
+                  onPageSizeChange={(newPageSize) => {
+                    setPageSize(newPageSize);
+                    setCurrentPage(1);
+                  }}
+                />
+              )}
             </TableCard.Root>
           )}
         </div>

--- a/openmetadata-ui/src/main/resources/ui/src/rest/glossaryAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/glossaryAPI.ts
@@ -24,6 +24,7 @@ import { AddGlossaryToAssetsRequest } from '../generated/api/addGlossaryToAssets
 import { CreateGlossary } from '../generated/api/data/createGlossary';
 import { CreateGlossaryTerm } from '../generated/api/data/createGlossaryTerm';
 import { MoveGlossaryTermRequest } from '../generated/api/tests/moveGlossaryTermRequest';
+import { GlossaryTermRelationType } from '../generated/configuration/glossaryTermRelationSettings';
 import { EntityReference, Glossary } from '../generated/entity/data/glossary';
 import { GlossaryTerm } from '../generated/entity/data/glossaryTerm';
 import { BulkOperationResult } from '../generated/type/bulkOperationResult';
@@ -511,6 +512,53 @@ export const getGlossaryTermRelationSettings = async () => {
   );
 
   return response.data?.config_value;
+};
+
+const GLOSSARY_TERM_RELATION_TYPES_URL =
+  '/system/settings/glossaryTermRelationSettings/relationTypes';
+
+export const getGlossaryTermRelationTypes = async (
+  params: ListParamsWithOffset
+): Promise<PagingResponse<GlossaryTermRelationType[]>> => {
+  const response = await APIClient.get<
+    PagingResponse<GlossaryTermRelationType[]>
+  >(GLOSSARY_TERM_RELATION_TYPES_URL, { params });
+
+  return response.data;
+};
+
+export const createGlossaryTermRelationType = async (
+  relationType: GlossaryTermRelationType
+): Promise<GlossaryTermRelationType> => {
+  const response = await APIClient.post<GlossaryTermRelationType>(
+    GLOSSARY_TERM_RELATION_TYPES_URL,
+    relationType
+  );
+
+  return response.data;
+};
+
+export const updateGlossaryTermRelationType = async (
+  relationType: GlossaryTermRelationType
+): Promise<GlossaryTermRelationType> => {
+  const response = await APIClient.put<GlossaryTermRelationType>(
+    `${GLOSSARY_TERM_RELATION_TYPES_URL}/${encodeURIComponent(
+      relationType.name
+    )}`,
+    relationType
+  );
+
+  return response.data;
+};
+
+export const deleteGlossaryTermRelationType = async (
+  relationTypeName: string
+): Promise<void> => {
+  await APIClient.delete(
+    `${GLOSSARY_TERM_RELATION_TYPES_URL}/${encodeURIComponent(
+      relationTypeName
+    )}`
+  );
 };
 
 export const updateGlossaryTermRelationSettings = async (settings: unknown) => {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/glossaryRelationTypesAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/glossaryRelationTypesAPI.test.ts
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import APIClient from '.';
+import {
+  GlossaryTermRelationType,
+  RelationCategory,
+} from '../generated/configuration/glossaryTermRelationSettings';
+import {
+  createGlossaryTermRelationType,
+  deleteGlossaryTermRelationType,
+  getGlossaryTermRelationTypes,
+  updateGlossaryTermRelationType,
+} from './glossaryAPI';
+
+jest.mock('.');
+
+const relationType: GlossaryTermRelationType = {
+  name: 'dependsOn',
+  displayName: 'Depends On',
+  category: RelationCategory.Associative,
+};
+
+describe('glossary relation types API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists a page of relation types', async () => {
+    const response = {
+      data: {
+        data: [relationType],
+        paging: { limit: 15, offset: 15, total: 40 },
+      },
+    };
+    (APIClient.get as jest.Mock).mockResolvedValueOnce(response);
+
+    await expect(
+      getGlossaryTermRelationTypes({ limit: 15, offset: 15 })
+    ).resolves.toEqual(response.data);
+    expect(APIClient.get).toHaveBeenCalledWith(
+      '/system/settings/glossaryTermRelationSettings/relationTypes',
+      { params: { limit: 15, offset: 15 } }
+    );
+  });
+
+  it('creates, updates, and deletes one relation type at a time', async () => {
+    (APIClient.post as jest.Mock).mockResolvedValueOnce({
+      data: relationType,
+    });
+    (APIClient.put as jest.Mock).mockResolvedValueOnce({
+      data: relationType,
+    });
+    (APIClient.delete as jest.Mock).mockResolvedValueOnce({});
+
+    await expect(createGlossaryTermRelationType(relationType)).resolves.toEqual(
+      relationType
+    );
+    await expect(updateGlossaryTermRelationType(relationType)).resolves.toEqual(
+      relationType
+    );
+
+    await deleteGlossaryTermRelationType(relationType.name);
+
+    const relationTypeUrl =
+      '/system/settings/glossaryTermRelationSettings/relationTypes';
+
+    expect(APIClient.post).toHaveBeenCalledWith(relationTypeUrl, relationType);
+    expect(APIClient.put).toHaveBeenCalledWith(
+      `${relationTypeUrl}/${relationType.name}`,
+      relationType
+    );
+    expect(APIClient.delete).toHaveBeenCalledWith(
+      `${relationTypeUrl}/${relationType.name}`
+    );
+  });
+});


### PR DESCRIPTION
Manual backport of #30201 to 1.13. Auto cherry-pick failed; conflicts resolved manually.

## Why

Backports #30201 (server-side dedup + pagination for `glossaryTermRelationSettings`) to 1.13.
Volvo + Novartis on 1.13.1 hit a `glossaryTermRelationSettings` bloat (157k entries / 140 unique) via a hand-rolled Python script hitting `PATCH /api/v1/system/settings`, blowing up both the settings-page load and the `/rdf/glossary/graph` SPARQL query. Without this backport, the 1.13 backend has no server-side dedup on PATCH for this settings type and any client can rebloat the row.

## What differs from a straight cherry-pick

- **CollectionDAO.java** — added `getConfigJsonWithKey`, `getGlossaryTermRelationSettingsJson`, `updateSettingsIfCurrent`, `updateGlossaryTermRelationSettingsIfCurrent`. These land on `main` via #29788 which is not on 1.13; the new `patchGlossaryTermRelationSettings` depends on them, so the auto cherry-pick left the code referring to missing symbols.
- **SystemRepository.java** — added `GlossaryTermRelationSettings` + `PreconditionFailedException` imports. Added an early-return in `patchSetting` to route GTR settings through the new `patchGlossaryTermRelationSettings`; kept the legacy generic path unchanged to avoid pulling in the wider `patchSetting`/`updateSetting` refactor from `main`.
- **SystemRepositoryPatchSettingTest.java** — removed 3 tests that exercise `main`'s generic snapshot-CAS path (not backported). Kept the 7 GTR-specific tests + 3 util tests.
- **GlossaryTermRelationSettingsIT.java** — kept 1.13's existing tests. The new IT added on `main` depends on a `SharedResourceLocks` class that does not exist on 1.13; it can be ported separately once the shared harness lands.

## Verification (local)

- `mvn -pl openmetadata-service compile` — SUCCESS
- `mvn -pl openmetadata-service test-compile` — SUCCESS
- `mvn -pl openmetadata-service test -Dtest="GlossaryTermRelationSettingsUtilTest,SystemRepositoryPatchSettingTest"` — **10/10 pass**
- `mvn -pl openmetadata-service package` — SUCCESS
- `mvn -pl openmetadata-service spotless:check` — SUCCESS
- `mvn -pl openmetadata-integration-tests -Dtest="GlossaryTermRelationSettingsIT" test` — **11/11 pass** against local MySQL + Elasticsearch

## Test plan

- [ ] CI green on 1.13
- [ ] Manual: PATCH `glossaryTermRelationSettings` with a duplicate-name JSON-Patch and confirm 409 CONFLICT
- [ ] Manual: paginate the relation-types settings page and confirm no 49MB fetch

Original author: @harshach (`af3a118f56830dc2c443b869cb2549ca7341b576`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds paginated glossary relation-type management. The main changes are:

- New paginated CRUD endpoints for individual relation types.
- Snapshot compare-and-set updates for glossary settings patches.
- Server-side normalization and case-insensitive name deduplication.
- A paginated UI using the new endpoints.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Cross-page validation and concurrent settings updates can persist inconsistent or lost data.

- RDF-predicate validation no longer covers off-page relation types.
- Usage checking can race with relation-type deletion.
- Legacy whole-setting PUT requests can overwrite acknowledged item-level mutations.

GlossaryTermRelationSettings.tsx and SystemResource.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java | Adds raw JSON reads and database-specific compare-and-set updates. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java | Routes glossary patches through validation and snapshot compare-and-set persistence. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java | Adds paginated CRUD endpoints but leaves usage deletion and legacy PUT concurrency gaps. |
| openmetadata-service/src/main/java/org/openmetadata/service/util/GlossaryTermRelationSettingsUtil.java | Centralizes normalization, unique-name checks, and system-defined type protection. |
| openmetadata-ui/src/main/resources/ui/src/pages/GlossaryTermRelationSettings/GlossaryTermRelationSettings.tsx | Moves the table to server pagination but limits RDF-predicate validation to one page. |
| openmetadata-ui/src/main/resources/ui/src/rest/glossaryAPI.ts | Adds typed list, create, update, and delete requests for relation types. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Settings UI
  participant API as SystemResource
  participant Repo as SystemRepository
  participant DB as Settings DB
  UI->>API: GET relationTypes(limit, offset)
  API-->>UI: Page and total count
  UI->>API: POST, PUT, or DELETE relation type
  API->>Repo: Apply JSON Patch
  Repo->>DB: Read settings snapshot
  Repo->>Repo: Normalize and validate
  Repo->>DB: Compare-and-set settings JSON
  alt Snapshot unchanged
    DB-->>Repo: Updated
    Repo-->>UI: Success
  else Snapshot changed
    DB-->>Repo: No rows updated
    Repo-->>UI: 412 Precondition Failed
  end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes 30200: Paginate glossary term rela..."](https://github.com/open-metadata/openmetadata/commit/418354b341ede09719cbd08d81aee1321e78fbac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46573289)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Context used - openmetadata-ui-core-components/CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=41754627-b2bf-474b-8082-f37ef1a07013))
- Context used - CLAUDE.md ([source](https://app.greptile.com/getcollate/github/open-metadata/openmetadata/-/custom-context?memory=52f0d9d9-cad1-4e7d-b070-de181a0aa5e7))

<!-- /greptile_comment -->