### PR TITLE
fix(ui): center-align Domain & Data Product header icon with the name

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -819,7 +819,7 @@ const DataProductsDetailsPage = ({
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
           <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-start tw:justify-between">
-            <div className="entity-header-title-top tw:max-w-full tw:lg:max-w-[60%]">
+            <div className="tw:max-w-full tw:lg:max-w-[60%]">
               <EntityHeader
                 badge={statusBadge}
                 breadcrumb={[]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -958,7 +958,7 @@ const DomainDetails = ({
           className="entity-header tw:mx-5 tw:gap-y-3"
           justify="between"
           wrap="wrap">
-          <div className="entity-header-title-top tw:max-w-full tw:lg:max-w-[60%]">
+          <div className="tw:max-w-full tw:lg:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}
               displayNameClassName="entity-header-title-wrap"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
@@ -37,13 +37,6 @@
   word-break: break-word;
 }
 
-// When the title wraps onto multiple lines, top-align the icon and the name
-// container with the first line instead of centering them against the full
-// (tall) title block. `!important` overrides antd's `.ant-row-middle`.
-.entity-header-title-top .entity-header-title {
-  align-items: flex-start !important;
-}
-
 .ant-btn.entity-follow-button {
   border-radius: 16px;
   background-color: @primary-button-background;


### PR DESCRIPTION
## What

Restores vertical **center** alignment of the entity icon against the name on the **Domain** and **Data Product** details headers, so the icon is centered on the full title block again — consistent with every other entity header in the app.

A recent change (part of #30335) added an `entity-header-title-top` override that pinned the icon to the **top** (first line) of the name. When a Domain or Data Product has a long, multi-line name the icon floated up beside the first line instead of centering, looking off-balance. This drops the class from both pages and removes the now-unused LESS rule, letting antd's default `.ant-row-middle` (center) apply for both short and wrapped names.

## Changes

- `DataProductsDetailsPage.component.tsx` — remove `entity-header-title-top` from the title wrapper
- `DomainDetails.component.tsx` — remove `entity-header-title-top` from the title wrapper
- `entity-header-title.less` — remove the `.entity-header-title-top .entity-header-title { align-items: flex-start !important; }` rule

## Before / After

### Domain

| Before (icon top-aligned) | After (icon centered) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/center-align-domain-dp-header/before-domain.png" width="440" /> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/center-align-domain-dp-header/after-domain.png" width="440" /> |

### Data Product

| Before (icon top-aligned) | After (icon centered) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/center-align-domain-dp-header/before-dataproduct.png" width="440" /> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/center-align-domain-dp-header/after-dataproduct.png" width="440" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores centered icon alignment for Domain and Data Product title blocks.
- Removes the `entity-header-title-top` modifier from both detail-page title wrappers.
- Removes the now-unused LESS override that forced title-row contents to align at the top.
- Preserves wrapped title behavior while allowing `EntityHeaderTitle`’s default centered alignment to apply.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it consistently removes the two modifier usages and their sole associated style override.

The underlying entity title row explicitly uses centered alignment, and no remaining consumer references the deleted top-alignment class.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx | Removes the top-alignment modifier so Data Product icons use the entity header’s default centered alignment. |
| openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx | Removes the top-alignment modifier so Domain icons use the entity header’s default centered alignment. |
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less | Removes the unused scoped rule that overrode the Ant Design row’s centered alignment. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): center-align Domain &amp; Data Prod..."](https://github.com/open-metadata/openmetadata/commit/8aac61a078d0aeac65e1af7b32b5507dbe61f28b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46576092)</sub>

<!-- /greptile_comment -->