### PR TITLE
fix(ui): warn instead of throw on silent token renewal failures

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -619,6 +619,17 @@ export const AuthProvider = ({
                   config: error.config,
                 });
 
+                // Reject every queued 401'd request with the given error and
+                // clear the queue. Called on any path where the refresh does
+                // not yield a new token (null-return or thrown error) so the
+                // callers don't hang waiting for a retry that will never come.
+                const rejectPending = (rejectionError: unknown) => {
+                  pendingRequests.forEach(({ reject }) =>
+                    reject(rejectionError)
+                  );
+                  pendingRequests = [];
+                };
+
                 // Refresh the token and retry the requests in the queue
                 tokenService.current
                   .refreshToken()
@@ -633,13 +644,13 @@ export const AuthProvider = ({
                       // Clear the queue after retrying
                       pendingRequests = [];
                     } else {
+                      rejectPending(error);
                       resetUserDetails(true);
                     }
                   })
-                  .catch((error) => {
+                  .catch((refreshError) => {
+                    rejectPending(refreshError);
                     resetUserDetails(true);
-
-                    return Promise.reject(error);
                   });
               });
             }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts
@@ -161,18 +161,26 @@ describe('TokenService', () => {
       expect(localStorage.getItem('refreshInProgress')).toBeNull();
     });
 
-    it('should handle errors during refresh', async () => {
+    it('should log a warning and resolve to null on renewal failure', async () => {
       (getOidcToken as jest.Mock).mockResolvedValue('token');
       (extractDetailsFromToken as jest.Mock).mockReturnValue({
         isExpired: true,
       });
       tokenService.updateRenewToken(mockRenewToken);
       mockRenewToken.mockRejectedValue(new Error('Refresh failed'));
+      const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
 
-      await expect(tokenService.refreshToken()).rejects.toThrow(
+      const result = await tokenService.refreshToken();
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
         'Failed to refresh token: Refresh failed'
       );
       expect(localStorage.getItem('refreshInProgress')).toBeNull();
+
+      warnSpy.mockRestore();
     });
   });
 
@@ -204,13 +212,21 @@ describe('TokenService', () => {
       expect(result).toBeNull();
     });
 
-    it('should throw other errors', async () => {
+    it('should log a warning and return null for other errors', async () => {
       tokenService.updateRenewToken(mockRenewToken);
       mockRenewToken.mockRejectedValue(new Error('Network error'));
+      const warnSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(() => undefined);
 
-      await expect(tokenService.fetchNewToken()).rejects.toThrow(
+      const result = await tokenService.fetchNewToken();
+
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
         'Failed to refresh token: Network error'
       );
+
+      warnSpy.mockRestore();
     });
 
     it('should clear refreshInProgress on success', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts
@@ -131,12 +131,16 @@ class TokenService {
       try {
         response = await this.renewToken();
       } catch (error) {
-        // Silent Frame window timeout error since it doesn't affect refresh token process
-        if ((error as AxiosError).message === 'Frame window timed out') {
-          return null;
-        }
+        // Token renewal failures are usually caused by the user's session/browser
+        // environment (e.g. popups blocked, frame window timeout, silent auth
+        // interrupted). They don't require a thrown error — log for diagnostics
+        // and return null so callers fall back to their normal auth flow.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Failed to refresh token: ${(error as AxiosError | Error).message}`
+        );
 
-        throw new Error(`Failed to refresh token: ${(error as Error).message}`);
+        return null;
       } finally {
         this.clearRefreshInProgress();
       }


### PR DESCRIPTION
### Describe your changes:

I stopped surfacing silent-token-renewal failures as thrown errors in the UI. `TokenService.fetchNewToken` now logs a `console.warn` and returns `null` for any renewal error (popup blocked / \`popup_window_error\`, frame window timeout, silent auth interrupted, network, …) because these are user-session/browser-environment issues that don't need a red uncaught error. The 401 axios interceptor's null-refresh branch now also rejects the queued `pendingRequests` (via a shared \`rejectPending\` helper) and calls \`resetUserDetails(true)\` — matching the pre-existing catch branch — so session cleanup still runs on every failed refresh and queued requests can't dangle. Two unit tests in `TokenServiceUtil.test.ts` were updated to assert the new warn+null behavior; all 15 pass.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Use cases covered
- Silent token renewal that fails with `popup_window_error` (popups blocked) or any other renewal error no longer throws — the 401 interceptor still logs the user out via `resetUserDetails(true)` and pending 401'd requests are rejected instead of hanging.
- Existing `Frame window timed out` silent path continues to work (now goes through the same code path as every other renewal failure).

#### Unit tests
- Updated: `openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts` — 15/15 pass.

#### Manual testing performed
- `yarn test --testPathPattern='AuthProvider|TokenServiceUtil'` → 80/80 pass.
- UI checkstyle sequence (organize-imports → eslint --fix → prettier) run on the three touched files, clean.

#
### UI screen recording / screenshots:

Not applicable — no visible UI change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added / updated unit tests for the changed logic.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates silent token-renewal failure handling and request cleanup.
- Converts renewal exceptions into warning logs and `null` results.
- Rejects all queued 401 requests and resets session state when refresh fails.
- Updates token-service tests for the warning-and-null contract.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified in the changed token-renewal and queued-request cleanup paths.

Existing callers either handle null renewal results through logout and queue rejection or intentionally discard the refresh result, while the updated interceptor settles every queued request on failure.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Failed refresh paths now reject every queued request before resetting the user session, without leaving callers pending. |
| openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts | Token-renewal exceptions are consistently logged and converted to null while refresh state remains cleared in the finally block. |
| openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts | Tests now verify that renewal failures warn, resolve to null, and clear refresh state. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): don&#39;t throw on silent token ren..."](https://github.com/open-metadata/openmetadata/commit/e813acf62c16b69642571dc74bfb910228ccdb68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46577052)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)

<!-- /greptile_comment -->