### PR TITLE
feat(ui-core): backport PaginationCardWithControls to 1.13

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/pagination/pagination.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/pagination/pagination.tsx
@@ -1,11 +1,19 @@
-import { ArrowLeft, ArrowRight } from '@untitledui/icons';
 import {
   ButtonGroup,
   ButtonGroupItem,
 } from '@/components/base/button-group/button-group';
 import { Button } from '@/components/base/buttons/button';
+import { Select } from '@/components/base/select/select';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { cx } from '@/utils/cx';
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+} from '@untitledui/icons';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { PaginationRootProps } from './pagination-base';
 import { Pagination } from './pagination-base';
 
@@ -40,6 +48,46 @@ const PaginationItem = ({
   );
 };
 
+const compactTextClassName =
+  'tw:text-xs tw:font-normal tw:leading-[18px] tw:text-secondary';
+
+const compactControlClassName =
+  'tw:flex tw:size-6 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg';
+
+const compactPageControlClassName =
+  'tw:flex tw:h-6 tw:min-w-6 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:px-1.5';
+
+const compactIconButtonClassName = cx(
+  compactControlClassName,
+  'tw:cursor-pointer tw:border tw:border-primary tw:bg-primary tw:text-fg-quaternary tw:shadow-xs-skeuomorphic tw:outline-focus-ring tw:transition tw:duration-100 tw:ease-linear',
+  'tw:hover:bg-primary_hover tw:disabled:cursor-not-allowed tw:disabled:text-fg-disabled'
+);
+
+const compactPageItemClassName = ({ isSelected }: { isSelected: boolean }) =>
+  cx(
+    compactPageControlClassName,
+    'tw:cursor-pointer tw:text-xs tw:leading-[18px] tw:outline-focus-ring tw:transition tw:duration-100 tw:ease-linear',
+    isSelected
+      ? 'tw:bg-tertiary tw:font-medium tw:text-primary'
+      : 'tw:bg-transparent tw:font-normal tw:text-quaternary tw:hover:bg-primary_hover tw:hover:text-secondary'
+  );
+
+const compactPageInputClassName = cx(
+  compactPageControlClassName,
+  'tw:min-w-6 tw:border tw:border-primary tw:bg-primary tw:px-0 tw:text-center tw:text-xs tw:font-normal tw:leading-[18px] tw:text-secondary tw:shadow-xs tw:outline-none',
+  'tw:focus-visible:outline-none'
+);
+
+// The Select trigger's border is an outline now (it replaced a ring, which WebKit does not
+// pixel-snap). The old `outline-none!` only suppressed the native focus outline and was
+// harmless; keeping it would erase the border itself. `focus-visible:outline-none!` stays —
+// it reproduces what `[&>button]:focus-visible:outline-none!` used to do (no edge while focused).
+const compactRowsPerPageSelectClassName =
+  'tw:w-[42px] tw:shrink-0 tw:gap-0 tw:[&>button]:h-6 tw:[&>button]:rounded-lg tw:[&>button]:focus-visible:outline-none! tw:[&>button>span]:h-6 tw:[&>button>span]:gap-1 tw:[&>button>span]:px-1 tw:[&>button>span]:py-0 tw:[&>button>span>section]:min-w-0 tw:[&>button>span>section]:gap-0 tw:[&>button>span>section>p]:min-w-4 tw:[&>button>span>section>p]:text-center tw:[&>button>span>section>p]:text-xs tw:[&>button>span>section>p]:leading-[18px] tw:[&>button>span>svg]:size-3';
+
+const compactRowsPerPageItemClassName =
+  'tw:px-0 tw:[&>div]:h-8 tw:[&>div]:px-2 tw:[&>div]:py-0 tw:[&>div]:outline-none! tw:[&[data-focused]>div]:bg-primary_hover tw:[&[data-selected]>div]:bg-primary tw:[&>div>div]:min-w-0 tw:[&>div>div>span]:text-xs tw:[&>div>div>span]:leading-[18px]';
+
 interface MobilePaginationProps {
   /** The current page. */
   page?: number;
@@ -69,7 +117,7 @@ const MobilePagination = ({
         color="secondary"
         iconLeading={ArrowLeft}
         size="sm"
-        onClick={() => onPageChange?.(Math.max(0, page - 1))}
+        onClick={() => onPageChange?.(Math.max(1, page - 1))}
       />
 
       <span className="tw:text-sm tw:text-fg-secondary">
@@ -315,32 +363,28 @@ export const PaginationCardMinimal = ({
           'tw:hidden tw:items-center tw:gap-3 tw:md:flex',
           align === 'center' && 'tw:justify-between'
         )}>
-        <div
-          className={cx(
-            align === 'center' && 'tw:flex tw:flex-1 tw:justify-start'
-          )}>
-          <Button
-            color="secondary"
-            isDisabled={page === 1}
-            size="sm"
-            onClick={() => onPageChange?.(Math.max(0, page - 1))}>
-            Previous
-          </Button>
-        </div>
-
         <span
           className={cx(
             'tw:text-sm tw:font-medium tw:text-fg-secondary',
-            align === 'right' && 'tw:order-first tw:mr-auto',
-            align === 'left' && 'tw:order-last tw:ml-auto'
+            align === 'left' && 'tw:mr-auto',
+            align === 'right' && 'tw:order-last tw:ml-auto'
           )}>
           Page {page} of {total}
         </span>
 
         <div
           className={cx(
+            'tw:flex tw:items-center tw:gap-3',
             align === 'center' && 'tw:flex tw:flex-1 tw:justify-end'
           )}>
+          <Button
+            color="secondary"
+            isDisabled={page === 1}
+            size="sm"
+            onClick={() => onPageChange?.(Math.max(1, page - 1))}>
+            Previous
+          </Button>
+
           <Button
             color="secondary"
             isDisabled={page === total}
@@ -351,6 +395,199 @@ export const PaginationCardMinimal = ({
         </div>
       </nav>
     </div>
+  );
+};
+
+interface PaginationCardWithControlsProps extends PaginationProps {
+  /** The selected rows per page value. */
+  pageSize?: number;
+  /** Available rows per page values. */
+  pageSizeOptions?: number[];
+  /** The function to call when rows per page changes. */
+  onPageSizeChange?: (pageSize: number) => void;
+}
+
+export const PaginationCardWithControls = ({
+  page = 1,
+  total = 10,
+  pageSize = 10,
+  pageSizeOptions = [10, 25, 50],
+  className,
+  onPageChange,
+  onPageSizeChange,
+  ...props
+}: PaginationCardWithControlsProps) => {
+  const totalPages = Math.max(total, 1);
+  const currentPage = Math.min(Math.max(page, 1), totalPages);
+  const [pageInput, setPageInput] = useState(String(currentPage));
+  // Add one character of room so the current input value does not clip.
+  const pageInputWidth = `${Math.max(pageInput.length, 2) + 1}ch`;
+  const pageSizeItems = useMemo(
+    () =>
+      pageSizeOptions.map((option) => ({
+        id: String(option),
+        label: String(option),
+      })),
+    [pageSizeOptions]
+  );
+
+  useEffect(() => {
+    setPageInput(String(currentPage));
+  }, [currentPage]);
+
+  const getValidPage = (nextPage: number) =>
+    Math.min(Math.max(nextPage, 1), totalPages);
+
+  const handlePageChange = (nextPage: number) => {
+    onPageChange?.(getValidPage(nextPage));
+  };
+
+  const handlePageInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { value } = event.target;
+
+    if (value === '') {
+      setPageInput(value);
+
+      return;
+    }
+
+    if (!/^\d+$/.test(value)) {
+      return;
+    }
+
+    const nextPage = Number(value);
+    if (nextPage < 1 || nextPage > totalPages) {
+      return;
+    }
+
+    setPageInput(value);
+  };
+
+  const commitPageInput = () => {
+    if (pageInput === '') {
+      setPageInput(String(currentPage));
+
+      return;
+    }
+
+    const nextPage = getValidPage(Number(pageInput));
+
+    setPageInput(String(nextPage));
+    onPageChange?.(nextPage);
+  };
+
+  const handlePageInputKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      commitPageInput();
+      event.currentTarget.blur();
+    }
+
+    if (event.key === 'Escape') {
+      setPageInput(String(currentPage));
+      event.currentTarget.blur();
+    }
+  };
+
+  return (
+    <Pagination.Root
+      {...props}
+      className={cx(
+        'tw:relative tw:z-[1] tw:m-0 tw:flex tw:w-full tw:rounded-b-xl tw:border-x tw:border-b tw:border-gray-blue-100 tw:bg-primary tw:px-4 tw:py-3 tw:shadow-[0_-1px_4px_0_rgba(0,0,0,0.05)]',
+        className
+      )}
+      page={currentPage}
+      total={totalPages}
+      onPageChange={handlePageChange}>
+      <div className="tw:m-0 tw:flex tw:w-full tw:max-w-full tw:flex-wrap tw:items-center tw:justify-between tw:gap-x-5 tw:gap-y-3">
+        <div className="tw:flex tw:shrink-0 tw:items-center tw:gap-[5px]">
+          <span className={compactTextClassName}>Page</span>
+          <input
+            aria-label="Current page"
+            className={compactPageInputClassName}
+            inputMode="numeric"
+            max={totalPages}
+            min={1}
+            style={{ width: pageInputWidth }}
+            type="text"
+            value={pageInput}
+            onBlur={commitPageInput}
+            onChange={handlePageInputChange}
+            onKeyDown={handlePageInputKeyDown}
+          />
+          <span className={compactTextClassName}>of {totalPages}</span>
+        </div>
+
+        <div className="tw:flex tw:min-w-0 tw:flex-wrap tw:items-center tw:gap-2 tw:px-1">
+          <Pagination.PrevTrigger asChild>
+            <button
+              className={compactIconButtonClassName}
+              data-testid="previous"
+              type="button">
+              <ChevronLeft className="tw:size-3.5" />
+            </button>
+          </Pagination.PrevTrigger>
+
+          <Pagination.Context>
+            {({ pages }) => (
+              <div className="tw:flex tw:min-w-0 tw:flex-wrap tw:items-center tw:gap-1">
+                {pages.map((page, index) =>
+                  page.type === 'page' ? (
+                    <Pagination.Item
+                      className={compactPageItemClassName}
+                      key={index}
+                      {...page}
+                      asChild>
+                      <button type="button">{page.value}</button>
+                    </Pagination.Item>
+                  ) : (
+                    <Pagination.Ellipsis
+                      className="tw:mx-0 tw:flex tw:h-6 tw:w-4 tw:shrink-0 tw:items-center tw:justify-center tw:px-0 tw:text-sm tw:font-medium tw:leading-5 tw:text-quaternary"
+                      key={index}>
+                      &#8230;
+                    </Pagination.Ellipsis>
+                  )
+                )}
+              </div>
+            )}
+          </Pagination.Context>
+
+          <Pagination.NextTrigger asChild>
+            <button
+              className={compactIconButtonClassName}
+              data-testid="next"
+              type="button">
+              <ChevronRight className="tw:size-3.5" />
+            </button>
+          </Pagination.NextTrigger>
+        </div>
+
+        <div className="tw:flex tw:shrink-0 tw:items-center tw:gap-[5px]">
+          <span className={compactTextClassName}>Records</span>
+          <Select
+            aria-label="Records"
+            className={compactRowsPerPageSelectClassName}
+            data-testid="rows-per-page-dropdown"
+            fontSize="xs"
+            items={pageSizeItems}
+            placeholder={String(pageSize)}
+            popoverClassName="tw:min-w-16!"
+            selectedKey={String(pageSize)}
+            size="sm"
+            onSelectionChange={(key) => onPageSizeChange?.(Number(key))}>
+            {(item) => (
+              <Select.Item
+                className={compactRowsPerPageItemClassName}
+                data-testid={`rows-per-page-option-${item.id}`}
+                id={item.id}
+                key={item.id}
+                textValue={item.label}>
+                {item.label}
+              </Select.Item>
+            )}
+          </Select>
+        </div>
+      </div>
+    </Pagination.Root>
   );
 };
 

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Pagination.stories.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/stories/Pagination.stories.tsx
@@ -16,6 +16,7 @@ import {
   PaginationButtonGroup,
   PaginationCardDefault,
   PaginationCardMinimal,
+  PaginationCardWithControls,
   PaginationPageDefault,
   PaginationPageMinimalCenter,
 } from '../components/application/pagination/pagination';
@@ -31,6 +32,8 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+const TOTAL_ITEMS = 100;
 
 export const PageDefault: Story = {
   render: () => {
@@ -102,6 +105,26 @@ export const ButtonGroup: StoryObj = {
     return (
       <div style={{ width: 600 }}>
         <PaginationButtonGroup page={page} total={10} onPageChange={setPage} />
+      </div>
+    );
+  },
+};
+
+export const CardWithControls: StoryObj = {
+  render: () => {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const totalPages = Math.max(Math.ceil(TOTAL_ITEMS / pageSize), 1);
+
+    return (
+      <div style={{ width: 632 }}>
+        <PaginationCardWithControls
+          page={page}
+          pageSize={pageSize}
+          total={totalPages}
+          onPageChange={setPage}
+          onPageSizeChange={setPageSize}
+        />
       </div>
     );
   },


### PR DESCRIPTION
## Summary

Backport of core component changes from #29624 to the `1.13` release branch.

- Adds `PaginationCardWithControls` component to `openmetadata-ui-core-components`
- Compact pagination bar with: page input field, prev/next chevron buttons, page numbers, and rows-per-page dropdown
- Adds `CardWithControls` story to `Pagination.stories.tsx`

## Changes

- `openmetadata-ui-core-components/.../pagination/pagination.tsx` — new `PaginationCardWithControls` export + supporting compact class name constants; adds `Select`, `ChevronLeft`, `ChevronRight`, React hook imports
- `openmetadata-ui-core-components/.../stories/Pagination.stories.tsx` — new `CardWithControls` story

## Test plan

- [ ] Storybook renders `CardWithControls` story correctly
- [ ] Page input accepts valid numbers, rejects out-of-range, commits on Enter/blur
- [ ] Rows-per-page dropdown updates `pageSize` and recalculates `total`
- [ ] Prev/Next chevron buttons navigate correctly and are disabled at boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a compact controlled pagination component to UI Core.
- Provides page entry, previous/next navigation, numbered pages, and a rows-per-page selector.
- Adds a Storybook story demonstrating controlled page and page-size state.
- Corrects previous-page clamping in the existing mobile and minimal pagination variants.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR should not merge until pressing Escape reliably cancels the page edit rather than navigating.

The Escape branch resets state and immediately triggers the blur commit handler, which reads the previously rendered input value and calls onPageChange with the discarded edit.

openmetadata-ui-core-components/src/main/resources/ui/src/components/application/pagination/pagination.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/pagination/pagination.tsx | Adds the compact pagination implementation, but Escape can commit the page edit it is intended to discard. |
| openmetadata-ui-core-components/src/main/resources/ui/src/stories/Pagination.stories.tsx | Adds a controlled Storybook example for the new pagination component. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(ui-core): backport PaginationCardWi..."](https://github.com/open-metadata/openmetadata/commit/7466e700bf243b698bf684b8e887d1eb91d257e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46590379)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->