### PR TITLE
fix(ui): mount BlockEditor slash/mention/hashtag popups inside the ne…

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -21,8 +21,8 @@ import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import {
-  ENTITY_PATH,
   EntityTypeEndpoint,
+  ENTITY_PATH,
 } from '../../support/entity/Entity.interface';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
@@ -3739,7 +3739,10 @@ test.describe('Domain description editor popups', () => {
     page,
   }) => {
     const entityName = table.entityResponseData.name ?? table.entity.name;
-    const displayName = table.entityResponseData.displayName ?? table.entity.displayName;
+    const displayName =
+      table.entityResponseData.displayName ??
+      table.entity.displayName ??
+      entityName;
 
     await sidebarClick(page, SidebarItem.DOMAIN);
     await waitForAllLoadersToDisappear(page);
@@ -3780,5 +3783,4 @@ test.describe('Domain description editor popups', () => {
       await expect(description.locator('a[data-type="hashtag"]')).toBeVisible();
     });
   });
-}
-);
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -21,8 +21,8 @@ import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
 import { DashboardClass } from '../../support/entity/DashboardClass';
 import {
-  EntityTypeEndpoint,
   ENTITY_PATH,
+  EntityTypeEndpoint,
 } from '../../support/entity/Entity.interface';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
@@ -3720,4 +3720,65 @@ test.describe.fixme(
       await expect(inheritedTermCard).toBeVisible({ timeout: 30_000 });
     });
   }
+);
+
+test.describe('Domain description editor popups', () => {
+  const table = new TableClass();
+
+  test.beforeAll('Setup pre-requests', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await table.create(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach('Visit home page', async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('slash, mention, and hashtag popups are usable inside the Add Domain drawer', async ({
+    page,
+  }) => {
+    const entityName = table.entityResponseData.name ?? table.entity.name;
+    const displayName = table.entityResponseData.displayName ?? table.entity.displayName;
+
+    await sidebarClick(page, SidebarItem.DOMAIN);
+    await waitForAllLoadersToDisappear(page);
+
+    await page.getByTestId('add-domain').click();
+    await page.getByTestId('add-domain-form').waitFor();
+
+    const description = page.locator(descriptionBox);
+    await description.click();
+
+    await test.step('Slash command inserts an image block', async () => {
+      await description.pressSequentially('/image');
+      await page.locator('#editor-command-Image').click();
+
+      await expect(
+        description.locator('[data-testid="add-image-container"]')
+      ).toBeVisible();
+    });
+
+    await test.step('Mention popup inserts a user mention', async () => {
+      await description.pressSequentially(' @admin');
+      await page
+        .locator('.mention-item')
+        .filter({ hasText: 'admin' })
+        .first()
+        .click();
+
+      await expect(description.locator('a[data-type="mention"]')).toBeVisible();
+    });
+
+    await test.step('Hashtag popup inserts an entity link', async () => {
+      const searchResponse = page.waitForResponse('/api/v1/search/query?**');
+      await description.pressSequentially(` #${entityName}`);
+      await searchResponse;
+
+      await page.getByTestId(`hash-mention-${displayName}`).click();
+
+      await expect(description.locator('a[data-type="hashtag"]')).toBeVisible();
+    });
+  });
+}
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx
@@ -17,6 +17,7 @@ import tippy, { Instance, Props } from 'tippy.js';
 import { EditorSlotsProps, EditorSlotsRef } from './BlockEditor.interface';
 import BlockMenu from './BlockMenu/BlockMenu';
 import BubbleMenu from './BubbleMenu/BubbleMenu';
+import { getDialogContainer } from './Extensions/getDialogContainer';
 import LinkModal, { LinkData } from './LinkModal/LinkModal';
 import LinkPopup from './LinkPopup/LinkPopup';
 import TableMenu from './TableMenu/TableMenu';
@@ -77,18 +78,8 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
       handleLinkToggle();
     };
 
-    // Mount the link modal and popup inside the editor's nearest focus-trapping
-    // dialog (e.g. React Aria's SlideoutMenu) so it does not steal focus or
-    // swallow their clicks. antd modals/drawers don't trap focus from a
-    // body-portalled modal, and their transforms would misposition it, so fall
-    // back to document.body for those (and when not inside a dialog at all).
-    const getDialogContainer = (): HTMLElement => {
-      const dialog = editor?.view.dom.closest('[role="dialog"]');
-
-      return dialog && !dialog.closest('.ant-modal, .ant-drawer')
-        ? (dialog as HTMLElement)
-        : document.body;
-    };
+    const getContainer = (): HTMLElement =>
+      editor ? getDialogContainer(editor.view) : document.body;
 
     const handleUnlink = () => {
       if (isNil(editor)) {
@@ -152,7 +143,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
 
         popup = tippy('body', {
           getReferenceClientRect: () => target.getBoundingClientRect(),
-          appendTo: () => getDialogContainer(),
+          appendTo: getContainer,
           content: component.element,
           showOnCreate: true,
           interactive: true,
@@ -190,7 +181,7 @@ const EditorSlots = forwardRef<EditorSlotsRef, EditorSlotsProps>(
         {isLinkModalOpen && (
           <LinkModal
             data={{ href: editor?.getAttributes('link').href }}
-            getContainer={getDialogContainer}
+            getContainer={getContainer}
             isOpen={isLinkModalOpen}
             onCancel={handleLinkCancel}
             onSave={(values) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/getDialogContainer.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/getDialogContainer.ts
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2023 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { EditorView } from '@tiptap/pm/view';
+
+/**
+ * Mount editor popups (tippy content) inside the editor's nearest
+ * focus-trapping dialog (e.g. React Aria's SlideoutMenu) so it does not get
+ * marked inert or swallow their clicks. antd modals/drawers don't trap focus
+ * from a body-portalled popup, and their transforms would misposition it, so
+ * fall back to document.body for those (and when not inside a dialog at all).
+ */
+export const getDialogContainer = (view: EditorView): HTMLElement => {
+  const dialog = view.dom.closest('[role="dialog"]');
+
+  return dialog && !dialog.closest('.ant-modal, .ant-drawer')
+    ? (dialog as HTMLElement)
+    : document.body;
+};

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/hashtagSuggestion.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/hashtagSuggestion.ts
@@ -20,6 +20,7 @@ import { searchQuery } from '../../../../rest/searchAPI';
 import { buildMentionLink } from '../../../../utils/FeedUtilsPure';
 import searchClassBase from '../../../../utils/SearchClassBase';
 import { ExtensionRef } from '../../BlockEditor.interface';
+import { getDialogContainer } from '../getDialogContainer';
 import HashList from './HashList';
 
 export const hashtagSuggestion = () => ({
@@ -74,7 +75,7 @@ export const hashtagSuggestion = () => ({
         popup = tippy('body', {
           getReferenceClientRect:
             props.clientRect as Props['getReferenceClientRect'],
-          appendTo: () => document.body,
+          appendTo: () => getDialogContainer(props.editor.view),
           content: component.element,
           showOnCreate: true,
           interactive: true,

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/mention/mentionSuggestions.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/mention/mentionSuggestions.ts
@@ -21,6 +21,7 @@ import {
 import { getUserAndTeamSearch } from '../../../../rest/miscAPI';
 import { buildMentionLink } from '../../../../utils/FeedUtilsPure';
 import { ExtensionRef } from '../../BlockEditor.interface';
+import { getDialogContainer } from '../getDialogContainer';
 import MentionList from './MentionList';
 
 export const mentionSuggestion = () => ({
@@ -60,7 +61,7 @@ export const mentionSuggestion = () => ({
         popup = tippy('body', {
           getReferenceClientRect:
             props.clientRect as Props['getReferenceClientRect'],
-          appendTo: () => document.body,
+          appendTo: () => getDialogContainer(props.editor.view),
           content: component.element,
           showOnCreate: true,
           interactive: true,

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/slash-command/renderItems.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/slash-command/renderItems.ts
@@ -14,6 +14,7 @@ import { ReactRenderer } from '@tiptap/react';
 import { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion';
 import { isEmpty } from 'lodash';
 import tippy, { Instance, Props } from 'tippy.js';
+import { getDialogContainer } from '../getDialogContainer';
 import { SlashCommandList, SlashCommandRef } from './SlashCommandList';
 
 const renderItems = () => {
@@ -41,7 +42,7 @@ const renderItems = () => {
       popup = tippy('body', {
         getReferenceClientRect:
           props.clientRect as Props['getReferenceClientRect'],
-        appendTo: () => document.body,
+        appendTo: () => getDialogContainer(props.editor.view),
         content: component.element,
         showOnCreate: true,
         interactive: true,


### PR DESCRIPTION
…arest dialog to fix Drawer click-through

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Mounts BlockEditor slash-command, mention, hashtag, link, and modal popups in the nearest compatible dialog container.
- Adds a shared dialog-container resolver with Ant Design modal and drawer fallback behavior.
- Adds Playwright coverage for editor popups in the Add Domain drawer.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no new blocking failures eligible for this follow-up review.

No blocking failure remains in the accepted follow-up comment set.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/getDialogContainer.ts | Adds shared logic for selecting a popup container based on the editor's nearest compatible dialog. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/EditorSlots.tsx | Reuses the shared container resolver for link popups and the link modal. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/hashtag/hashtagSuggestion.ts | Mounts hashtag suggestions within the resolved dialog container. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/mention/mentionSuggestions.ts | Mounts mention suggestions within the resolved dialog container. |
| openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/slash-command/renderItems.ts | Mounts slash-command suggestions within the resolved dialog container. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts | Adds end-to-end coverage for slash, mention, and hashtag interactions in the Add Domain drawer. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/61b531d801edd1790101ffc77e38fc60714e5a94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46598791)</sub>

<!-- /greptile_comment -->