### PR TITLE
feat(mcp): add get_user_context tool

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpUserContextIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpUserContextIT.java
@@ -191,7 +191,9 @@ public class McpUserContextIT extends McpTestBase {
 
     assertThat(payload.has("warnings")).isTrue();
     assertThat(payload.get("warnings").get(0).asText()).contains("MISSING_TIERS");
-    assertThat(payload.get("owned").get("totalCount").asInt()).isGreaterThan(0);
+    // Only the warnings contract is asserted here: owned counts depend on index latency and are
+    // covered by the Awaitility-guarded tests above, so this test stays stable in isolation.
+    assertThat(payload.has("owned")).isTrue();
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpUserContextIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpUserContextIT.java
@@ -1,0 +1,218 @@
+package org.openmetadata.it.tests.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.services.CreateDatabaseService;
+import org.openmetadata.schema.api.services.DatabaseConnection;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.services.connections.database.MysqlConnection;
+import org.openmetadata.schema.services.connections.database.common.basicAuth;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EntityReference;
+
+/**
+ * Outcome-level coverage for the {@code get_user_context} MCP tool: identity projection from the
+ * authenticated caller, the nested owners / flat followers search paths against a live index, the
+ * governance gap filters, and the unrecognized-filter warning contract.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@Execution(ExecutionMode.SAME_THREAD)
+public class McpUserContextIT extends McpTestBase {
+
+  private static final String TOOL_NAME = "get_user_context";
+  private static final Duration INDEX_WAIT = Duration.ofSeconds(60);
+
+  private static User adminUser;
+  private static Table ownedTable;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    initAuth();
+    adminUser = get("users/loggedInUser", User.class);
+    ownedTable = createOwnedTableWithoutDescription();
+  }
+
+  private static Table createOwnedTableWithoutDescription() throws Exception {
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+    DatabaseConnection connection =
+        new DatabaseConnection()
+            .withConfig(
+                new MysqlConnection()
+                    .withHostPort("localhost:3306")
+                    .withUsername("test")
+                    .withAuthType(new basicAuth().withPassword("test")));
+    DatabaseService service =
+        post(
+            "services/databaseServices",
+            new CreateDatabaseService()
+                .withName("mcp_user_ctx_service_" + suffix)
+                .withServiceType(CreateDatabaseService.DatabaseServiceType.Mysql)
+                .withConnection(connection),
+            DatabaseService.class);
+    Database database =
+        post(
+            "databases",
+            new CreateDatabase()
+                .withName("mcp_user_ctx_db_" + suffix)
+                .withService(service.getFullyQualifiedName()),
+            Database.class);
+    DatabaseSchema schema =
+        post(
+            "databaseSchemas",
+            new CreateDatabaseSchema()
+                .withName("mcp_user_ctx_schema")
+                .withDatabase(database.getFullyQualifiedName()),
+            DatabaseSchema.class);
+    EntityReference adminRef =
+        new EntityReference()
+            .withId(adminUser.getId())
+            .withType("user")
+            .withName(adminUser.getName());
+    return post(
+        "tables",
+        new CreateTable()
+            .withName("mcp_user_ctx_table_" + suffix)
+            .withDatabaseSchema(schema.getFullyQualifiedName())
+            .withOwners(List.of(adminRef))
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))),
+        Table.class);
+  }
+
+  private JsonNode callUserContext(Map<String, Object> arguments) throws Exception {
+    JsonNode response = executeMcpRequest(McpTestUtils.createToolCallRequest(TOOL_NAME, arguments));
+    assertThat(response.has("result")).isTrue();
+    return toolPayload(response.get("result"));
+  }
+
+  private JsonNode toolPayload(JsonNode result) throws Exception {
+    JsonNode payload;
+    if (result.has("structuredContent")) {
+      payload = result.get("structuredContent");
+    } else {
+      payload = OBJECT_MAPPER.readTree(result.get("content").get(0).get("text").asText());
+    }
+    return payload;
+  }
+
+  private static List<String> fqns(JsonNode entityArray) {
+    List<String> result = new ArrayList<>();
+    if (entityArray != null && entityArray.isArray()) {
+      entityArray.forEach(node -> result.add(node.path("fqn").asText()));
+    }
+    return result;
+  }
+
+  @Test
+  @Order(1)
+  void identityReflectsAuthenticatedCaller() throws Exception {
+    JsonNode payload =
+        callUserContext(Map.of("includeOwnedSummary", false, "includeFollowedSummary", false));
+
+    JsonNode user = payload.get("user");
+    assertThat(user.get("name").asText()).isEqualTo(adminUser.getName());
+    assertThat(user.get("id").asText()).isEqualTo(adminUser.getId().toString());
+    assertThat(user.get("isAdmin").asBoolean()).isTrue();
+    assertThat(payload.has("owned")).isFalse();
+    assertThat(payload.has("followed")).isFalse();
+    assertThat(payload.get("roles").isArray()).isTrue();
+    assertThat(payload.get("teams").isArray()).isTrue();
+  }
+
+  @Test
+  @Order(2)
+  void ownedSummaryFindsOwnedTableViaNestedOwnersQuery() {
+    Awaitility.await("owned table should appear in the user context owned summary")
+        .atMost(INDEX_WAIT)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              JsonNode payload =
+                  callUserContext(Map.of("includeFollowedSummary", false, "ownedLimit", 50));
+              JsonNode owned = payload.get("owned");
+              assertThat(owned.get("totalCount").asInt()).isGreaterThan(0);
+              assertThat(owned.has("byTypeComplete")).isTrue();
+              assertThat(fqns(owned.get("recent"))).contains(ownedTable.getFullyQualifiedName());
+            });
+  }
+
+  @Test
+  @Order(3)
+  void gapFilterReturnsOwnedTableMissingDescription() {
+    Awaitility.await("description-less owned table should match MISSING_DESCRIPTION")
+        .atMost(INDEX_WAIT)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              JsonNode payload =
+                  callUserContext(
+                      Map.of(
+                          "includeFollowedSummary",
+                          false,
+                          "ownedLimit",
+                          50,
+                          "ownedFilter",
+                          "MISSING_DESCRIPTION"));
+              JsonNode owned = payload.get("owned");
+              assertThat(fqns(owned.get("recent"))).contains(ownedTable.getFullyQualifiedName());
+              assertThat(payload.has("warnings")).isFalse();
+            });
+  }
+
+  @Test
+  @Order(4)
+  void unrecognizedOwnedFilterSurfacesWarningInsteadOfSilentDefault() throws Exception {
+    Map<String, Object> arguments = new HashMap<>();
+    arguments.put("includeFollowedSummary", false);
+    arguments.put("ownedFilter", "MISSING_TIERS");
+    JsonNode payload = callUserContext(arguments);
+
+    assertThat(payload.has("warnings")).isTrue();
+    assertThat(payload.get("warnings").get(0).asText()).contains("MISSING_TIERS");
+    assertThat(payload.get("owned").get("totalCount").asInt()).isGreaterThan(0);
+  }
+
+  @Test
+  @Order(5)
+  void followedSummaryFindsFollowedTableViaFollowersQuery() throws Exception {
+    put(
+        "tables/" + ownedTable.getId() + "/followers",
+        adminUser.getId().toString(),
+        JsonNode.class);
+
+    Awaitility.await("followed table should appear in the user context followed summary")
+        .atMost(INDEX_WAIT)
+        .pollInterval(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              JsonNode payload =
+                  callUserContext(Map.of("includeOwnedSummary", false, "followedLimit", 50));
+              JsonNode followed = payload.get("followed");
+              assertThat(followed.get("totalCount").asInt()).isGreaterThan(0);
+              assertThat(fqns(followed.get("entities")))
+                  .contains(ownedTable.getFullyQualifiedName());
+            });
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/DefaultToolContext.java
@@ -91,6 +91,9 @@ public class DefaultToolContext {
         case "get_persona_context":
           result = new GetPersonaContextTool().execute(authorizer, securityContext, params);
           break;
+        case "get_user_context":
+          result = new GetUserContextTool().execute(authorizer, securityContext, params);
+          break;
         case "find_context":
           result = new FindContextTool().execute(authorizer, securityContext, params);
           break;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetUserContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetUserContextTool.java
@@ -1,0 +1,200 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.mcp.tools;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.service.security.DefaultAuthorizer.getSubjectContext;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.security.auth.CatalogSecurityContext;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * Returns the authenticated caller's platform context: identity, teams, roles (direct and
+ * team-inherited), domains, persona, and lightweight summaries of owned and followed entities. The
+ * user is resolved only from the request's {@link SubjectContext} (JWT / impersonation header) —
+ * the tool takes no user-identifying parameter, so it can never read another user's context.
+ */
+@Slf4j
+public class GetUserContextTool implements McpTool {
+  private static final int DEFAULT_LIMIT = 20;
+  private static final int MAX_LIMIT = 100;
+
+  /** Narrows the owned-entity scan to assets worth surfacing (e.g. governance gaps). */
+  public enum OwnedFilter {
+    NONE,
+    MISSING_DESCRIPTION,
+    MISSING_TIER,
+    ANY_GAP;
+
+    static OwnedFilter fromValue(String value) {
+      OwnedFilter parsed = NONE;
+      if (value != null) {
+        try {
+          parsed = valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ignored) {
+          parsed = NONE;
+        }
+      }
+      return parsed;
+    }
+  }
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
+      throws IOException {
+    SubjectContext subject = getSubjectContext(securityContext);
+    User user = subject.user();
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("user", identity(user));
+    result.put("teams", namedRefs(user.getTeams()));
+    result.put("roles", namedRefs(user.getRoles()));
+    result.put("inheritedRoles", namedRefs(SubjectContext.getRolesForTeams(user.getTeams())));
+    result.put("domains", domainRefs(user.getDomains()));
+    putIfPresent(result, "persona", personaRef(subject.getActivePersona()));
+    attachSummaries(result, subject, user, params);
+    return result;
+  }
+
+  @Override
+  public Map<String, Object> execute(
+      Authorizer authorizer,
+      Limits limits,
+      CatalogSecurityContext securityContext,
+      Map<String, Object> params) {
+    throw new UnsupportedOperationException(
+        "GetUserContextTool does not require limit validation.");
+  }
+
+  private void attachSummaries(
+      Map<String, Object> result, SubjectContext subject, User user, Map<String, Object> params)
+      throws IOException {
+    if (boolParam(params, "includeOwnedSummary", true)) {
+      result.put(
+          "owned",
+          UserContextSearch.ownedSummary(
+              subject,
+              ownerIds(user),
+              intParam(params, "ownedLimit"),
+              OwnedFilter.fromValue(stringParam(params, "ownedFilter"))));
+    }
+    if (boolParam(params, "includeFollowedSummary", true)) {
+      result.put(
+          "followed",
+          UserContextSearch.followedSummary(
+              subject, user.getId().toString(), intParam(params, "followedLimit")));
+    }
+  }
+
+  private static List<String> ownerIds(User user) {
+    List<String> ids = new ArrayList<>();
+    ids.add(user.getId().toString());
+    for (EntityReference team : listOrEmpty(user.getTeams())) {
+      ids.add(team.getId().toString());
+    }
+    return ids;
+  }
+
+  static Map<String, Object> identity(User user) {
+    Map<String, Object> identity = new LinkedHashMap<>();
+    identity.put("id", user.getId().toString());
+    identity.put("name", user.getName());
+    putIfPresent(identity, "displayName", user.getDisplayName());
+    putIfPresent(identity, "email", user.getEmail());
+    identity.put("isAdmin", Boolean.TRUE.equals(user.getIsAdmin()));
+    identity.put("isBot", Boolean.TRUE.equals(user.getIsBot()));
+    return identity;
+  }
+
+  static List<Map<String, Object>> namedRefs(List<EntityReference> refs) {
+    List<Map<String, Object>> named = new ArrayList<>();
+    for (EntityReference ref : listOrEmpty(refs)) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("id", ref.getId() == null ? null : ref.getId().toString());
+      entry.put("name", ref.getName());
+      putIfPresent(entry, "displayName", ref.getDisplayName());
+      named.add(entry);
+    }
+    return named;
+  }
+
+  static List<Map<String, Object>> domainRefs(List<EntityReference> refs) {
+    List<Map<String, Object>> domains = new ArrayList<>();
+    for (EntityReference ref : listOrEmpty(refs)) {
+      Map<String, Object> entry = new LinkedHashMap<>();
+      entry.put("name", ref.getName());
+      entry.put(
+          "fqn", ref.getFullyQualifiedName() == null ? ref.getName() : ref.getFullyQualifiedName());
+      domains.add(entry);
+    }
+    return domains;
+  }
+
+  static Map<String, Object> personaRef(EntityReference persona) {
+    Map<String, Object> ref = null;
+    if (persona != null) {
+      ref = new LinkedHashMap<>();
+      ref.put("name", persona.getName());
+      putIfPresent(ref, "displayName", persona.getDisplayName());
+    }
+    return ref;
+  }
+
+  private static void putIfPresent(Map<String, Object> target, String key, Object value) {
+    if (value != null) {
+      target.put(key, value);
+    }
+  }
+
+  private static String stringParam(Map<String, Object> params, String key) {
+    Object value = params.get(key);
+    return value == null ? null : String.valueOf(value);
+  }
+
+  private static boolean boolParam(Map<String, Object> params, String key, boolean defaultValue) {
+    Object value = params.get(key);
+    boolean parsed = defaultValue;
+    if (value instanceof Boolean bool) {
+      parsed = bool;
+    } else if (value != null) {
+      parsed = Boolean.parseBoolean(String.valueOf(value));
+    }
+    return parsed;
+  }
+
+  private static int intParam(Map<String, Object> params, String key) {
+    Object value = params.get(key);
+    int parsed = DEFAULT_LIMIT;
+    if (value instanceof Number number) {
+      parsed = number.intValue();
+    } else if (value != null) {
+      try {
+        parsed = Integer.parseInt(String.valueOf(value));
+      } catch (NumberFormatException ignored) {
+        parsed = DEFAULT_LIMIT;
+      }
+    }
+    return Math.min(Math.max(parsed, 1), MAX_LIMIT);
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetUserContextTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetUserContextTool.java
@@ -66,14 +66,18 @@ public class GetUserContextTool implements McpTool {
       throws IOException {
     SubjectContext subject = getSubjectContext(securityContext);
     User user = subject.user();
+    List<String> warnings = new ArrayList<>();
     Map<String, Object> result = new LinkedHashMap<>();
     result.put("user", identity(user));
     result.put("teams", namedRefs(user.getTeams()));
     result.put("roles", namedRefs(user.getRoles()));
-    result.put("inheritedRoles", namedRefs(SubjectContext.getRolesForTeams(user.getTeams())));
+    result.put("inheritedRoles", namedRefs(user.getInheritedRoles()));
     result.put("domains", domainRefs(user.getDomains()));
     putIfPresent(result, "persona", personaRef(subject.getActivePersona()));
-    attachSummaries(result, subject, user, params);
+    attachSummaries(result, subject, user, params, warnings);
+    if (!warnings.isEmpty()) {
+      result.put("warnings", warnings);
+    }
     return result;
   }
 
@@ -88,7 +92,11 @@ public class GetUserContextTool implements McpTool {
   }
 
   private void attachSummaries(
-      Map<String, Object> result, SubjectContext subject, User user, Map<String, Object> params)
+      Map<String, Object> result,
+      SubjectContext subject,
+      User user,
+      Map<String, Object> params,
+      List<String> warnings)
       throws IOException {
     if (boolParam(params, "includeOwnedSummary", true)) {
       result.put(
@@ -97,7 +105,7 @@ public class GetUserContextTool implements McpTool {
               subject,
               ownerIds(user),
               intParam(params, "ownedLimit"),
-              OwnedFilter.fromValue(stringParam(params, "ownedFilter"))));
+              resolveOwnedFilter(params, warnings)));
     }
     if (boolParam(params, "includeFollowedSummary", true)) {
       result.put(
@@ -105,6 +113,28 @@ public class GetUserContextTool implements McpTool {
           UserContextSearch.followedSummary(
               subject, user.getId().toString(), intParam(params, "followedLimit")));
     }
+  }
+
+  /**
+   * Parses {@code ownedFilter}, but unlike a silent default it records a warning when a non-blank
+   * value is unrecognized — otherwise "MISSING_TIERS" would quietly fall back to NONE and the tool
+   * would return every owned entity as if it were the gap subset, with no signal to the caller.
+   */
+  static OwnedFilter resolveOwnedFilter(Map<String, Object> params, List<String> warnings) {
+    String raw = stringParam(params, "ownedFilter");
+    OwnedFilter filter = OwnedFilter.fromValue(raw);
+    if (raw != null
+        && !raw.isBlank()
+        && filter == OwnedFilter.NONE
+        && !"NONE".equalsIgnoreCase(raw.trim())) {
+      warnings.add(
+          "Unrecognized ownedFilter '"
+              + raw
+              + "'; returned all owned entities without gap filtering. Valid values: NONE, "
+              + "MISSING_DESCRIPTION, MISSING_TIER, ANY_GAP.");
+      LOG.debug("Unrecognized ownedFilter '{}'; defaulting to NONE", raw);
+    }
+    return filter;
   }
 
   private static List<String> ownerIds(User user) {
@@ -172,13 +202,23 @@ public class GetUserContextTool implements McpTool {
     return value == null ? null : String.valueOf(value);
   }
 
-  private static boolean boolParam(Map<String, Object> params, String key, boolean defaultValue) {
+  /**
+   * Reads a boolean param, failing safe to {@code defaultValue} on any non-boolean input. Using
+   * {@link Boolean#parseBoolean} here would coerce truthy-looking strings ("yes", "1") to
+   * {@code false} and silently drop an entire summary section the caller asked for.
+   */
+  static boolean boolParam(Map<String, Object> params, String key, boolean defaultValue) {
     Object value = params.get(key);
     boolean parsed = defaultValue;
     if (value instanceof Boolean bool) {
       parsed = bool;
     } else if (value != null) {
-      parsed = Boolean.parseBoolean(String.valueOf(value));
+      String text = String.valueOf(value).trim();
+      if ("true".equalsIgnoreCase(text)) {
+        parsed = true;
+      } else if ("false".equalsIgnoreCase(text)) {
+        parsed = false;
+      }
     }
     return parsed;
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
@@ -74,9 +74,13 @@ final class UserContextSearch {
       must.addAll(gapClauses(filter));
       Map<String, Object> raw = runSearch(query(must), ALL_INDEX, limit, subjectContext);
       List<Map<String, Object>> recent = parseHits(raw);
+      int total = parseTotal(raw);
       summary = new LinkedHashMap<>();
-      summary.put("totalCount", parseTotal(raw));
+      summary.put("totalCount", total);
       summary.put("byType", tallyByType(recent));
+      // byType is tallied over the returned page only; when the page is truncated it does not cover
+      // every owned entity. The flag lets the LLM avoid presenting a partial breakdown as complete.
+      summary.put("byTypeComplete", recent.size() == total);
       summary.put("recent", recent);
     }
     return summary;
@@ -133,7 +137,11 @@ final class UserContextSearch {
     } else {
       result = JsonUtils.convertValue(entity, Map.class);
     }
-    return result == null ? Map.of() : result;
+    if (result == null) {
+      LOG.warn("Search response body did not deserialize to a map; treating as empty result");
+      result = Map.of();
+    }
+    return result;
   }
 
   private static String query(List<ObjectNode> mustClauses) {
@@ -154,6 +162,10 @@ final class UserContextSearch {
     ObjectNode nested = mapper.createObjectNode();
     nested.put("path", path);
     nested.set("query", flatTerms(field, values));
+    // The `all` alias spans indices with no `owners` mapping (user, team, tag, ...); without
+    // ignore_unmapped the engine throws "failed to find nested object under path [owners]" (400).
+    // Matches the canonical OSS clause in SearchListFilter / QueryFilterBuilder.
+    nested.put("ignore_unmapped", true);
     ObjectNode wrapper = mapper.createObjectNode();
     wrapper.set("nested", nested);
     return wrapper;
@@ -253,6 +265,10 @@ final class UserContextSearch {
           summaries.add(summary);
         }
       }
+    } else if (!raw.isEmpty()) {
+      // A non-empty body without the expected hits structure means the response contract drifted,
+      // not that the user owns/follows nothing. Log so it is not silently reported as empty.
+      LOG.warn("Search response missing expected 'hits' structure; keys present: {}", raw.keySet());
     }
     return summaries;
   }
@@ -271,6 +287,8 @@ final class UserContextSearch {
         summary.put("name", string(source.getOrDefault("name", fqn)));
         putIfPresent(summary, "displayName", source.get("displayName"));
         putIfPresent(summary, UPDATED_AT, source.get(UPDATED_AT));
+      } else {
+        LOG.debug("Dropping search hit missing entityType/fullyQualifiedName: {}", source.keySet());
       }
     }
     return summary;

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
@@ -1,0 +1,312 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.mcp.tools;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.search.SearchRequest;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.security.policyevaluator.SubjectContext;
+
+/**
+ * In-process owned/followed entity search backing {@link GetUserContextTool}. Runs against the
+ * search repository ({@link org.openmetadata.service.search.SearchRepository}) with the caller's
+ * {@link SubjectContext}, so RBAC and domain scoping are enforced by the engine — no HTTP hop and no
+ * client-supplied identity.
+ */
+@Slf4j
+final class UserContextSearch {
+  static final String ALL_INDEX = "all";
+  private static final String UPDATED_AT = "updatedAt";
+  private static final String MATCH_ALL = "*";
+  private static final int MAX_LIMIT = 100;
+
+  /**
+   * Data-asset entity types where a "missing description / tier" gap is meaningful. Excludes
+   * testCase, ingestionPipeline, query, and other bookkeeping entities a user may own but that
+   * aren't useful governance-gap results.
+   */
+  private static final List<String> GAP_ENTITY_TYPES =
+      List.of(
+          "table",
+          "dashboard",
+          "topic",
+          "mlmodel",
+          "container",
+          "apiEndpoint",
+          "searchIndex",
+          "databaseSchema",
+          "database",
+          "pipeline",
+          "glossaryTerm");
+
+  private UserContextSearch() {}
+
+  static Map<String, Object> ownedSummary(
+      SubjectContext subjectContext,
+      List<String> ownerIds,
+      int limit,
+      GetUserContextTool.OwnedFilter filter)
+      throws IOException {
+    Map<String, Object> summary = emptySummary();
+    if (!ownerIds.isEmpty()) {
+      ObjectNode ownersClause = nestedTerms("owners", "owners.id", ownerIds);
+      List<ObjectNode> must = new ArrayList<>(List.of(ownersClause));
+      must.addAll(gapClauses(filter));
+      Map<String, Object> raw = runSearch(query(must), ALL_INDEX, limit, subjectContext);
+      List<Map<String, Object>> recent = parseHits(raw);
+      summary = new LinkedHashMap<>();
+      summary.put("totalCount", parseTotal(raw));
+      summary.put("byType", tallyByType(recent));
+      summary.put("recent", recent);
+    }
+    return summary;
+  }
+
+  static Map<String, Object> followedSummary(
+      SubjectContext subjectContext, String userId, int limit) throws IOException {
+    ObjectNode followersClause = flatTerms("followers", List.of(userId));
+    Map<String, Object> raw =
+        runSearch(query(List.of(followersClause)), ALL_INDEX, limit, subjectContext);
+    List<Map<String, Object>> entities = parseHits(raw);
+    Map<String, Object> summary = new LinkedHashMap<>();
+    summary.put("totalCount", parseTotal(raw));
+    summary.put("entities", entities);
+    return summary;
+  }
+
+  private static Map<String, Object> emptySummary() {
+    Map<String, Object> summary = new LinkedHashMap<>();
+    summary.put("totalCount", 0);
+    summary.put("byType", Map.of());
+    summary.put("recent", List.of());
+    return summary;
+  }
+
+  private static Map<String, Object> runSearch(
+      String queryFilter, String index, int limit, SubjectContext subjectContext)
+      throws IOException {
+    // Use search() (not searchWithDirectQuery): it honors sortFieldParam / sortOrder /
+    // trackTotalHits, which the direct-query path silently ignores. queryFilter narrows a match-all
+    // base to the owned/followed set — the same wiring the REST /search/query endpoint uses.
+    SearchRequest request =
+        new SearchRequest()
+            .withQuery(MATCH_ALL)
+            .withIndex(Entity.getSearchRepository().getIndexOrAliasName(index))
+            .withQueryFilter(queryFilter)
+            .withSize(Math.min(Math.max(limit, 1), MAX_LIMIT))
+            .withFrom(0)
+            .withFetchSource(true)
+            .withTrackTotalHits(true)
+            .withSortFieldParam(UPDATED_AT)
+            .withSortOrder("desc")
+            .withDeleted(false);
+    Response response = Entity.getSearchRepository().search(request, subjectContext);
+    return toMap(response);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> toMap(Response response) {
+    Object entity = response.getEntity();
+    Map<String, Object> result;
+    if (entity instanceof String responseStr) {
+      result = JsonUtils.convertValue(JsonUtils.readTree(responseStr), Map.class);
+    } else {
+      result = JsonUtils.convertValue(entity, Map.class);
+    }
+    return result == null ? Map.of() : result;
+  }
+
+  private static String query(List<ObjectNode> mustClauses) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ArrayNode must = mapper.createArrayNode();
+    mustClauses.forEach(must::add);
+    ObjectNode bool = mapper.createObjectNode();
+    bool.set("must", must);
+    ObjectNode boolWrapper = mapper.createObjectNode();
+    boolWrapper.set("bool", bool);
+    ObjectNode root = mapper.createObjectNode();
+    root.set("query", boolWrapper);
+    return root.toString();
+  }
+
+  private static ObjectNode nestedTerms(String path, String field, List<String> values) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ObjectNode nested = mapper.createObjectNode();
+    nested.put("path", path);
+    nested.set("query", flatTerms(field, values));
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("nested", nested);
+    return wrapper;
+  }
+
+  private static ObjectNode flatTerms(String field, List<String> values) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ArrayNode array = mapper.createArrayNode();
+    values.forEach(array::add);
+    ObjectNode terms = mapper.createObjectNode();
+    terms.set(field, array);
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("terms", terms);
+    return wrapper;
+  }
+
+  private static List<ObjectNode> gapClauses(GetUserContextTool.OwnedFilter filter) {
+    List<ObjectNode> clauses = new ArrayList<>();
+    if (filter != GetUserContextTool.OwnedFilter.NONE) {
+      clauses.add(termsClause("entityType", GAP_ENTITY_TYPES));
+      clauses.addAll(gapConditionClauses(filter));
+    }
+    return clauses;
+  }
+
+  private static List<ObjectNode> gapConditionClauses(GetUserContextTool.OwnedFilter filter) {
+    return switch (filter) {
+      case MISSING_DESCRIPTION -> List.of(missingDescription());
+      case MISSING_TIER -> List.of(missingTier());
+      case ANY_GAP -> List.of(anyGap());
+      case NONE -> List.of();
+    };
+  }
+
+  private static ObjectNode missingDescription() {
+    return mustNot(term("descriptionStatus", "COMPLETE"));
+  }
+
+  private static ObjectNode missingTier() {
+    return mustNot(existsField("tier.tagFQN"));
+  }
+
+  private static ObjectNode anyGap() {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ArrayNode should = mapper.createArrayNode();
+    should.add(missingDescription());
+    should.add(missingTier());
+    ObjectNode bool = mapper.createObjectNode();
+    bool.set("should", should);
+    bool.put("minimum_should_match", 1);
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("bool", bool);
+    return wrapper;
+  }
+
+  private static ObjectNode mustNot(ObjectNode clause) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ArrayNode mustNot = mapper.createArrayNode();
+    mustNot.add(clause);
+    ObjectNode bool = mapper.createObjectNode();
+    bool.set("must_not", mustNot);
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("bool", bool);
+    return wrapper;
+  }
+
+  private static ObjectNode term(String field, String value) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ObjectNode term = mapper.createObjectNode();
+    term.put(field, value);
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("term", term);
+    return wrapper;
+  }
+
+  private static ObjectNode termsClause(String field, List<String> values) {
+    return flatTerms(field, values);
+  }
+
+  private static ObjectNode existsField(String field) {
+    ObjectMapper mapper = JsonUtils.getObjectMapper();
+    ObjectNode exists = mapper.createObjectNode();
+    exists.put("field", field);
+    ObjectNode wrapper = mapper.createObjectNode();
+    wrapper.set("exists", exists);
+    return wrapper;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<Map<String, Object>> parseHits(Map<String, Object> raw) {
+    List<Map<String, Object>> summaries = new ArrayList<>();
+    Object hits = raw.get("hits");
+    if (hits instanceof Map<?, ?> hitsMap && hitsMap.get("hits") instanceof List<?> hitList) {
+      for (Object hit : hitList) {
+        Map<String, Object> summary = summarizeHit(hit);
+        if (summary != null) {
+          summaries.add(summary);
+        }
+      }
+    }
+    return summaries;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> summarizeHit(Object hit) {
+    Map<String, Object> summary = null;
+    if (hit instanceof Map<?, ?> hitMap && hitMap.get("_source") instanceof Map<?, ?> sourceRaw) {
+      Map<String, Object> source = (Map<String, Object>) sourceRaw;
+      String fqn = string(source.get("fullyQualifiedName"));
+      String type = string(source.get("entityType"));
+      if (fqn != null && type != null) {
+        summary = new LinkedHashMap<>();
+        summary.put("type", type);
+        summary.put("fqn", fqn);
+        summary.put("name", string(source.getOrDefault("name", fqn)));
+        putIfPresent(summary, "displayName", source.get("displayName"));
+        putIfPresent(summary, UPDATED_AT, source.get(UPDATED_AT));
+      }
+    }
+    return summary;
+  }
+
+  private static void putIfPresent(Map<String, Object> target, String key, Object value) {
+    if (value != null) {
+      target.put(key, value);
+    }
+  }
+
+  private static int parseTotal(Map<String, Object> raw) {
+    int total = 0;
+    if (raw.get("hits") instanceof Map<?, ?> hitsMap) {
+      Object totalNode = hitsMap.get("total");
+      if (totalNode instanceof Map<?, ?> totalMap && totalMap.get("value") instanceof Number n) {
+        total = n.intValue();
+      } else if (totalNode instanceof Number n) {
+        total = n.intValue();
+      }
+    }
+    return total;
+  }
+
+  private static Map<String, Integer> tallyByType(List<Map<String, Object>> summaries) {
+    Map<String, Integer> counts = new LinkedHashMap<>();
+    for (Map<String, Object> summary : summaries) {
+      String type = string(summary.get("type"));
+      if (type != null) {
+        counts.merge(type, 1, Integer::sum);
+      }
+    }
+    return counts;
+  }
+
+  private static String string(Object value) {
+    return value == null ? null : String.valueOf(value);
+  }
+}

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java
@@ -80,7 +80,9 @@ final class UserContextSearch {
       summary.put("byType", tallyByType(recent));
       // byType is tallied over the returned page only; when the page is truncated it does not cover
       // every owned entity. The flag lets the LLM avoid presenting a partial breakdown as complete.
-      summary.put("byTypeComplete", recent.size() == total);
+      // Compare the raw hit count (not recent.size()) so hits dropped by summarizeHit for missing
+      // fields don't make a fully-covered page report as incomplete.
+      summary.put("byTypeComplete", rawHitCount(raw) == total);
       summary.put("recent", recent);
     }
     return summary;
@@ -298,6 +300,15 @@ final class UserContextSearch {
     if (value != null) {
       target.put(key, value);
     }
+  }
+
+  private static int rawHitCount(Map<String, Object> raw) {
+    int count = 0;
+    Object hits = raw.get("hits");
+    if (hits instanceof Map<?, ?> hitsMap && hitsMap.get("hits") instanceof List<?> hitList) {
+      count = hitList.size();
+    }
+    return count;
   }
 
   private static int parseTotal(Map<String, Object> raw) {

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -386,6 +386,57 @@
       }
     },
     {
+      "name": "get_user_context",
+      "title": "Get User Context",
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "openWorldHint": false
+      },
+      "description": "Get context about the CURRENT authenticated user: identity (id, name, displayName, email, isAdmin, isBot), team memberships, roles (direct and team-inherited), domains, active persona, and lightweight summaries of owned and followed entities. Use this to answer identity questions such as 'what is my role?', 'which teams am I on?', 'what do I own?', or 'what do I follow?' before asking the user for their email. The user is resolved from the authenticated request; there is no user parameter and the tool cannot read another user's context.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "includeOwnedSummary": {
+            "type": "boolean",
+            "description": "Include a summary of entities owned by the user and their teams. Defaults to true.",
+            "default": true
+          },
+          "includeFollowedSummary": {
+            "type": "boolean",
+            "description": "Include a summary of entities the user follows. Defaults to true.",
+            "default": true
+          },
+          "ownedLimit": {
+            "type": "integer",
+            "description": "Max owned entities to return in the recent list (1-100). Defaults to 20.",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "followedLimit": {
+            "type": "integer",
+            "description": "Max followed entities to return (1-100). Defaults to 20.",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "ownedFilter": {
+            "type": "string",
+            "description": "Narrow owned entities to ones worth surfacing: NONE (default, all owned), MISSING_DESCRIPTION (description not complete), MISSING_TIER (no tier assigned), ANY_GAP (missing description or tier). Gap filters apply to data-asset entity types only. Results are sorted by updatedAt descending.",
+            "enum": [
+              "NONE",
+              "MISSING_DESCRIPTION",
+              "MISSING_TIER",
+              "ANY_GAP"
+            ],
+            "default": "NONE"
+          }
+        },
+        "required": []
+      }
+    },
+    {
       "name": "find_context",
       "title": "Find Context",
       "annotations": {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetUserContextToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetUserContextToolTest.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.mcp.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.type.EntityReference;
+
+class GetUserContextToolTest {
+
+  @Test
+  void ownedFilterParsesCaseInsensitivelyAndDefaultsToNone() {
+    assertEquals(
+        GetUserContextTool.OwnedFilter.ANY_GAP,
+        GetUserContextTool.OwnedFilter.fromValue("any_gap"));
+    assertEquals(
+        GetUserContextTool.OwnedFilter.MISSING_TIER,
+        GetUserContextTool.OwnedFilter.fromValue("  Missing_Tier "));
+    assertEquals(
+        GetUserContextTool.OwnedFilter.NONE, GetUserContextTool.OwnedFilter.fromValue(null));
+    assertEquals(
+        GetUserContextTool.OwnedFilter.NONE,
+        GetUserContextTool.OwnedFilter.fromValue("not_a_filter"));
+  }
+
+  @Test
+  void identityProjectsScalarFieldsAndFlags() {
+    UUID id = UUID.randomUUID();
+    User user =
+        new User()
+            .withId(id)
+            .withName("jdoe")
+            .withDisplayName("Jane Doe")
+            .withEmail("jane@example.com")
+            .withIsAdmin(true);
+
+    Map<String, Object> identity = GetUserContextTool.identity(user);
+
+    assertEquals(id.toString(), identity.get("id"));
+    assertEquals("jdoe", identity.get("name"));
+    assertEquals("Jane Doe", identity.get("displayName"));
+    assertEquals("jane@example.com", identity.get("email"));
+    assertEquals(Boolean.TRUE, identity.get("isAdmin"));
+    assertEquals(Boolean.FALSE, identity.get("isBot"));
+  }
+
+  @Test
+  void identityOmitsNullOptionalFields() {
+    Map<String, Object> identity =
+        GetUserContextTool.identity(new User().withId(UUID.randomUUID()).withName("bot"));
+
+    assertFalse(identity.containsKey("displayName"));
+    assertFalse(identity.containsKey("email"));
+    assertEquals(Boolean.FALSE, identity.get("isAdmin"));
+  }
+
+  @Test
+  void namedRefsMapIdNameDisplayName() {
+    UUID id = UUID.randomUUID();
+    EntityReference ref =
+        new EntityReference().withId(id).withName("Data Team").withDisplayName("Data");
+
+    List<Map<String, Object>> refs = GetUserContextTool.namedRefs(List.of(ref));
+
+    assertEquals(1, refs.size());
+    assertEquals(id.toString(), refs.getFirst().get("id"));
+    assertEquals("Data Team", refs.getFirst().get("name"));
+    assertEquals("Data", refs.getFirst().get("displayName"));
+  }
+
+  @Test
+  void namedRefsHandlesNullList() {
+    assertTrue(GetUserContextTool.namedRefs(null).isEmpty());
+  }
+
+  @Test
+  void domainRefsFallBackToNameWhenFqnMissing() {
+    EntityReference withFqn =
+        new EntityReference().withName("marketing").withFullyQualifiedName("org.marketing");
+    EntityReference withoutFqn = new EntityReference().withName("sales");
+
+    List<Map<String, Object>> refs = GetUserContextTool.domainRefs(List.of(withFqn, withoutFqn));
+
+    assertEquals("org.marketing", refs.get(0).get("fqn"));
+    assertEquals("sales", refs.get(1).get("fqn"));
+  }
+
+  @Test
+  void personaRefReturnsNullWhenAbsent() {
+    assertNull(GetUserContextTool.personaRef(null));
+  }
+
+  @Test
+  void personaRefProjectsNameAndDisplayName() {
+    Map<String, Object> ref =
+        GetUserContextTool.personaRef(
+            new EntityReference().withName("analyst").withDisplayName("Data Analyst"));
+
+    assertEquals("analyst", ref.get("name"));
+    assertEquals("Data Analyst", ref.get("displayName"));
+  }
+}

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetUserContextToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/GetUserContextToolTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -116,5 +117,39 @@ class GetUserContextToolTest {
 
     assertEquals("analyst", ref.get("name"));
     assertEquals("Data Analyst", ref.get("displayName"));
+  }
+
+  @Test
+  void boolParamFailsSafeOnNonBooleanInput() {
+    assertTrue(GetUserContextTool.boolParam(Map.of("k", "yes"), "k", true));
+    assertTrue(GetUserContextTool.boolParam(Map.of("k", 1), "k", true));
+    assertFalse(GetUserContextTool.boolParam(Map.of("k", "false"), "k", true));
+    assertTrue(GetUserContextTool.boolParam(Map.of("k", "true"), "k", false));
+    assertTrue(GetUserContextTool.boolParam(Map.of(), "k", true));
+  }
+
+  @Test
+  void resolveOwnedFilterWarnsOnUnrecognizedNonBlankValue() {
+    List<String> warnings = new ArrayList<>();
+    GetUserContextTool.OwnedFilter filter =
+        GetUserContextTool.resolveOwnedFilter(Map.of("ownedFilter", "MISSING_TIERS"), warnings);
+
+    assertEquals(GetUserContextTool.OwnedFilter.NONE, filter);
+    assertEquals(1, warnings.size());
+    assertTrue(warnings.getFirst().contains("MISSING_TIERS"));
+  }
+
+  @Test
+  void resolveOwnedFilterDoesNotWarnOnValidOrAbsentValue() {
+    List<String> warnings = new ArrayList<>();
+
+    assertEquals(
+        GetUserContextTool.OwnedFilter.ANY_GAP,
+        GetUserContextTool.resolveOwnedFilter(Map.of("ownedFilter", "any_gap"), warnings));
+    assertEquals(
+        GetUserContextTool.OwnedFilter.NONE,
+        GetUserContextTool.resolveOwnedFilter(Map.of(), warnings));
+
+    assertTrue(warnings.isEmpty());
   }
 }


### PR DESCRIPTION
## Summary
- New MCP tool `get_user_context`: identity (id, name, displayName, email, isAdmin, isBot), teams, direct + team-inherited roles, domains, active persona of the authenticated caller
- Owned entity summary (totalCount, byType, recent) with governance gap filters: NONE, MISSING_DESCRIPTION, MISSING_TIER, ANY_GAP
- Followed entity summary
- No user parameter: identity resolved from JWT only; search runs with caller's SubjectContext so RBAC/domain scoping apply
- Invalid `ownedFilter` values surface a `warnings` entry instead of silently returning unfiltered results
- 11 unit tests; live-validated end to end via MCP `tools/call`

Fixes: https://github.com/open-metadata/OpenMetadata/issues/30341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds an authenticated MCP user-context tool.
- Projects caller identity, teams, roles, domains, and active persona.
- Queries owned and followed entities with optional governance-gap filters.
- Registers the tool schema and dispatch path.
- Adds unit and live-index integration coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GetUserContextTool.java | Resolves the authenticated user and assembles identity, membership, persona, ownership, and follower context. |
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/UserContextSearch.java | Implements SubjectContext-aware owned and followed searches plus governance-gap filtering and result projection. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/mcp/McpUserContextIT.java | Adds live-index outcome coverage for identity, ownership, following, filtering, and warning responses. |
| openmetadata-mcp/src/main/resources/json/data/mcp/tools.json | Declares the get_user_context MCP tool and its optional summary and filter parameters. |

</details>

<sub>Reviews (3): Last reviewed commit: ["bot feedback: make invalid-filter IT ind..."](https://github.com/open-metadata/openmetadata/commit/c53f9b6afcddb2181cd6a9277d2a3801616302a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46619841)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [OpenMetadata MCP Server](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-mcp.md)

<!-- /greptile_comment -->