### PR TITLE
fix(security): track libnss3 CVE-2026-16389 in ingestion Docker images

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -46,12 +46,16 @@ RUN apt-get -qq update \
   # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
   # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
   # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-  # wget -> tracked; upstream fix pending, no-op until Debian ships it).
+  # wget -> tracked; upstream fix pending, no-op until Debian ships it,
+  # libnss3/libnss3-tools -> CVE-2026-16389 tracked; bookworm still on
+  #   2:3.87.1-1+deb12u3 (vulnerable), fix only in sid so far, no-op until
+  #   Debian backports it to bookworm-security).
   # --only-upgrade is a no-op for packages not present in the base image.
   && apt-get -qq install -y --only-upgrade \
        libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
        libpam0g libpam-modules libpam-modules-bin libpam-runtime \
        curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+       libnss3 libnss3-tools \
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -53,12 +53,16 @@ RUN dpkg --configure -a \
     # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
     # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
     # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-    # wget -> tracked; upstream fix pending, no-op until Debian ships it).
+    # wget -> tracked; upstream fix pending, no-op until Debian ships it,
+    # libnss3/libnss3-tools -> CVE-2026-16389 tracked; bookworm still on
+    #   2:3.87.1-1+deb12u3 (vulnerable), fix only in sid so far, no-op until
+    #   Debian backports it to bookworm-security).
     # --only-upgrade is a no-op for packages not present in the base image.
     && apt-get -qq install -y --only-upgrade \
          libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
          libpam0g libpam-modules libpam-modules-bin libpam-runtime \
          curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+         libnss3 libnss3-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq


### PR DESCRIPTION
## What

Track `CVE-2026-16389` (NSS integer overflow / incorrect boundary
conditions) in the ingestion and operator Docker images by adding
`libnss3` and `libnss3-tools` to the existing `--only-upgrade` apt list.

## Why

- **`libnss3` is not removable.** It is a transitive dependency of the Java
  runtime — on Debian bookworm, `openjdk-17-jre-headless` hard-depends on
  `libnss3 (>= 2:3.17.1)`. Both images install a JRE (Spark, ANTLR, and
  other Java-backed ingestion paths need it), so NSS is always present.
- **No commit introduced this.** The finding surfaced recently because
  `CVE-2026-16389` was newly published (the fix shipped in Firefox /
  Thunderbird 153) and scanners matched it against the pre-existing
  package — not because of a Dockerfile change.
- Following the established pattern (curl, libcurl*, libmariadb3, wget), we
  add the package to `--only-upgrade` so the Debian security patch is picked
  up automatically on the next rebuild, with no further code change needed.

## Current status

Per the [Debian Security Tracker](https://security-tracker.debian.org/tracker/CVE-2026-16389),
the fix is **not yet backported** to bookworm:

| Suite | Version | Status |
|---|---|---|
| bookworm | `2:3.87.1-1+deb12u2` | vulnerable |
| bookworm-security | `2:3.87.1-1+deb12u3` | vulnerable |
| sid | `2:3.126-1` | fixed |

So this change is a **no-op today** — `--only-upgrade` does nothing until
Debian ships `+deb12u4`. It is a forward-looking fix that requires no
follow-up PR once the patch lands. Scanners will continue to report the CVE
until then, since the vulnerable library genuinely remains installed.

## Changes

- `ingestion/Dockerfile` — add `libnss3 libnss3-tools` + tracking comment
- `ingestion/operators/docker/Dockerfile` — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the ingestion container security-upgrade lists to track the pending Debian fix for CVE-2026-16389.
- Adds `libnss3` and `libnss3-tools` to the production ingestion image’s `apt --only-upgrade` invocation.
- Applies the same NSS tracking change to the production operator image.
- Documents that the upgrade remains a no-op until Debian backports the fix to bookworm-security.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The CI Dockerfiles must be updated before merging so image builds and vulnerability scans validate the same NSS remediation as the production Dockerfiles.

The production images will automatically consume the patched NSS package when Debian publishes it, but CI builds use separate Dockerfiles that omit the new packages and will therefore continue building and scanning the vulnerable configuration.

ingestion/Dockerfile, ingestion/operators/docker/Dockerfile, ingestion/Dockerfile.ci, ingestion/operators/docker/Dockerfile.ci
</details>

<details open><summary><h3>Security Review</h3></summary>

The production Dockerfiles track the pending NSS fix, but their CI counterparts remain unchanged; consequently, CI builds and vulnerability scans will not validate the remediation once the patched Debian package becomes available.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/Dockerfile | Adds NSS packages to the production upgrade list, but the CI Dockerfile used by the Trivy workflow remains inconsistent. |
| ingestion/operators/docker/Dockerfile | Adds the same NSS tracking to the production operator image, while the operator CI build retains the old upgrade list. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): track libnss3 CVE-2026-16..."](https://github.com/open-metadata/openmetadata/commit/e0574962c610a95aaad08c2e19c6c85bfa2bbf22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46637332)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->