### PR TITLE
fix(security): align 1.13 jackson, logback, postgres and calcite pins with main [1.13]

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -26,8 +26,8 @@
     <socket.io-client.version>2.1.1</socket.io-client.version>
     <json-smart.version>2.5.2</json-smart.version>
     <jetty.version>12.1.7</jetty.version>
-    <logback-core.version>1.5.25</logback-core.version>
-    <logback-classic.version>1.5.25</logback-classic.version>
+    <logback-core.version>1.5.36</logback-core.version>
+    <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>
     <kubernetes-client.version>24.0.0</kubernetes-client.version>
   </properties>
@@ -1016,7 +1016,7 @@
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-core</artifactId>
-      <version>1.36.0</version>
+      <version>1.42.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-lang</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <mockito.version>5.14.2</mockito.version>
     <!-- Upgrading slf4j causes dropwizard issues -->
     <slf4j.version>2.0.4</slf4j.version>
-    <jackson.version>2.18.8</jackson.version>
+    <jackson.version>2.18.9</jackson.version>
     <!-- Single source for the AWS SDK v2 BOM version, consumed by the root BOM
          import below and by openmetadata-service's BOM import. -->
     <awssdk.version>2.41.30</awssdk.version>
@@ -100,7 +100,7 @@
     <redshift-jdbc.version>2.1.0.30</redshift-jdbc.version>
     <gson.version>2.13.1</gson.version>
     <mysql.connector.version>9.3.0</mysql.connector.version>
-    <postgres.connector.version>42.7.11</postgres.connector.version>
+    <postgres.connector.version>42.7.12</postgres.connector.version>
     <jsonschema2pojo.version>1.3.1</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
     <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
@@ -157,8 +157,8 @@
     <slack.version>1.29.2</slack.version>
     <spotless.version>2.41.1</spotless.version>
     <picocli.version>4.7.6</picocli.version>
-    <logback-core.version>1.5.25</logback-core.version>
-    <logback-classic.version>1.5.25</logback-classic.version>
+    <logback-core.version>1.5.36</logback-core.version>
+    <logback-classic.version>1.5.36</logback-classic.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <everit.version>1.14.4</everit.version>
     <json-patch.version>1.13</json-patch.version>


### PR DESCRIPTION
Fixes #30397

Brings the 1.13 branch to parity with `main` on the dependency pins behind the remaining Inspector Medium/Low findings on the `collate/server` 1.13 image.

| Pin | 1.13 before | after (= main) | Clears |
|---|---|---|---|
| `jackson.version` | 2.18.8 | 2.18.9 | CVE-2026-54515, CVE-2026-59889, GHSA-mhm7-754m-9p8w (shaded into elasticsearch-deps / opensearch-deps) |
| `postgres.connector.version` | 42.7.11 | 42.7.12 | CVE-2026-54291 |
| `logback-core/classic.version` (root + service) | 1.5.25 | 1.5.36 | CVE-2026-10532 |
| `calcite-core` | 1.36.0 | 1.42.0 | CVE-2026-46718 |

All four are already on `main` (via #30051, which was merged without the `To release` label and so never reached 1.13). Every value here is set to **exactly** main's current value, never above it, so `main` stays ahead of the release branch and nothing needs forward-porting.

This is a hand-written parity change rather than a cherry-pick of `83599aed64`: that commit conflicts in `openmetadata-sdk/pom.xml` and `openmetadata-integration-tests/pom.xml` (it edits main-only dependency blocks that do not exist on 1.13) and would drag in ~8 unrelated bumps.

`mvn -pl openmetadata-service -am package` passes, including 39/39 `sql2sparql` tests, which are the only code touching Calcite.

Should merge after #30391 is cherry-picked to 1.13; that cherry-pick touches `jetty.version` on the line directly above the logback properties in `openmetadata-service/pom.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns release-branch dependency pins with main.
- Upgrades Jackson from 2.18.8 to 2.18.9 and PostgreSQL JDBC from 42.7.11 to 42.7.12.
- Upgrades Logback Core and Classic from 1.5.25 to 1.5.36 in both root and service properties.
- Upgrades Calcite Core from 1.36.0 to 1.42.0 for the SQL-to-SPARQL implementation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no changed-code-triggered correctness or security failures identified.

The updated dependency properties continue to govern their intended runtime artifacts, and the Calcite upgrade affects a focused SQL-to-SPARQL path with existing compile-time and unit-test coverage.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates centrally managed Jackson, PostgreSQL JDBC, and Logback versions; consumers continue to resolve through existing dependency management. |
| openmetadata-service/pom.xml | Updates service-local Logback pins and Calcite Core while preserving the existing dependency structure and exclusions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): align 1.13 jackson, logba..."](https://github.com/open-metadata/openmetadata/commit/e76ad32172c4cd22377ba4cab87dee0abd621059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46642948)</sub>

<!-- /greptile_comment -->


<!-- revalidate -->
