### PR TITLE
fix(playwright): stabilize flaky CI tests for metric search-clear and tag disabled badge

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
@@ -100,6 +100,8 @@ test.describe('Metric List Page - Search', { tag: ['@Discovery'] }, () => {
     const searchInput = page.getByTestId('metric-search').getByRole('textbox');
     await expect(searchInput).toBeVisible();
 
+    const initialCount = await page.getByTestId('metric-name').count();
+
     await test.step('search fires a scoped metric query and narrows the results', async () => {
       // The debounced search must actually reach the API. Regression #29538
       // cancelled this request on the re-render that typing triggered, so the
@@ -136,12 +138,10 @@ test.describe('Metric List Page - Search', { tag: ['@Discovery'] }, () => {
       await clearResponse;
       await waitForAllLoadersToDisappear(page);
 
-      await expect(
-        page.getByTestId('metric-name').filter({ hasText: matchName })
-      ).toBeVisible();
-      await expect(
-        page.getByTestId('metric-name').filter({ hasText: otherName })
-      ).toBeVisible();
+      // The list is paginated — specific names may not be on page 1 after
+      // the full list is restored. Verify restoration by checking the visible
+      // row count on the current page is back to the pre-search count.
+      await expect(page.getByTestId('metric-name')).toHaveCount(initialCount);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts
@@ -100,6 +100,7 @@ test.describe('Metric List Page - Search', { tag: ['@Discovery'] }, () => {
     const searchInput = page.getByTestId('metric-search').getByRole('textbox');
     await expect(searchInput).toBeVisible();
 
+    await expect(page.getByTestId('metric-name').first()).toBeVisible();
     const initialCount = await page.getByTestId('metric-name').count();
 
     await test.step('search fires a scoped metric query and narrows the results', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts
@@ -167,7 +167,14 @@ test('Classification Page', async ({ page }) => {
     await expect(page.getByTestId('add-domain')).not.toBeVisible();
     await expect(page.getByTestId('add-owner')).not.toBeVisible();
 
+    const tagDetailResponseDisable = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/tags') &&
+        response.url().includes(tag.responseData.name) &&
+        response.request().method() === 'GET'
+    );
     await page.getByTestId(tag.responseData.name).click();
+    await tagDetailResponseDisable;
     await waitForAllLoadersToDisappear(page);
 
     await expect(page.getByTestId('disabled')).toBeVisible();
@@ -230,7 +237,14 @@ test('Classification Page', async ({ page }) => {
     await expect(page.getByTestId('add-domain')).toBeVisible();
     await expect(page.getByTestId('add-owner')).toBeVisible();
 
+    const tagDetailResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/tags') &&
+        response.url().includes(tag.responseData.name) &&
+        response.request().method() === 'GET'
+    );
     await page.getByTestId(tag.responseData.name).click();
+    await tagDetailResponse;
     await waitForAllLoadersToDisappear(page);
 
     await expect(page.getByTestId('disabled')).not.toBeVisible();


### PR DESCRIPTION
### Describe your changes:

I worked on stabilizing two flaky Playwright tests that passed locally but failed on CI due to timing races.

**MetricListSearch**: After clearing search, the test checked for specific metric names by visibility — but those metrics could be on a later page of a paginated list. Fix: capture the initial row count before filtering and use `toHaveCount(initialCount)` to verify the list is restored, regardless of which page each item lands on.

**Tags (Classification disabled badge)**: After re-enabling a classification and navigating to its tag detail page, the `disabled` badge assertion (`not.toBeVisible`) fired before the tag page finished fetching its fresh data. Fix: add `page.waitForResponse(...)` targeting `/api/v1/tags` + tag name before clicking into the tag page, so assertions run only after the latest data has rendered.

### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Metric list: clearing the search box restores the full paginated list (verified by row count, not by specific item visibility)
- Classification/Tag: `disabled` badge correctly disappears on the tag detail page after re-enabling the parent classification

#### Unit tests
- [ ] Not applicable (Playwright test fixes only)

#### Backend integration tests
- [ ] Not applicable (no backend API changes).

#### Ingestion integration tests
- [ ] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Modified existing Playwright tests to fix flakiness.
- Files updated: `playwright/e2e/Flow/MetricListSearch.spec.ts`, `playwright/e2e/Pages/Tags.spec.ts`

#### Manual testing performed
Tests verified locally before and after the fix.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Stabilizes two Playwright scenarios:
- Verifies metric-list restoration after clearing search using the initial visible row count.
- Waits for tag-detail GET responses before asserting the classification-disabled badge state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/MetricListSearch.spec.ts | Replaces assertions against potentially paginated metric names with a comparison to the initial visible row count. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Tags.spec.ts | Synchronizes disabled-badge assertions with the corresponding tag-detail GET response. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): wait for metric rows be..."](https://github.com/open-metadata/openmetadata/commit/f30a3ae04bcb3e0ecf3e99611dfa8026cc8b9253) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46647222)</sub>

<!-- /greptile_comment -->