### PR TITLE
feat(ui): compact padding variant for PageLayoutV1 in AI mode

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -21,7 +21,14 @@ import {
 } from '@openmetadata/ui-core-components';
 import { Globe01, SearchLg } from '@untitledui/icons';
 import { debounce, isEmpty } from 'lodash';
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  FC,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as FolderEmptyIcon } from '../../assets/svg/folder-empty.svg';
 import { NO_DATA, ROUTES } from '../../constants/constants';
@@ -29,7 +36,6 @@ import { LEARNING_PAGE_IDS } from '../../constants/Learning.constants';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
 import { ERROR_PLACEHOLDER_TYPE } from '../../enums/common.enum';
 import { DataProduct } from '../../generated/entity/domains/dataProduct';
-import { withPageLayout } from '../../hoc/withPageLayout';
 import { useIsAiMode } from '../../hooks/useAppMode';
 import { useMarketplaceStore } from '../../hooks/useMarketplaceStore';
 import { getEntityName } from '../../utils/EntityNameUtils';
@@ -57,6 +63,7 @@ import HeaderBreadcrumb from '../common/HeaderBreadcrumb/HeaderBreadcrumb.compon
 import { OwnerLabel } from '../common/OwnerLabel/OwnerLabel.component';
 import TagBadgeList from '../common/TagBadgeList/TagBadgeList.component';
 import ViewToggle, { ViewMode } from '../common/ViewToggle/ViewToggle';
+import PageLayoutV1 from '../PageLayoutV1/PageLayoutV1';
 import { DataProductListPageProps } from './DataProductListPage.interface';
 import { useDataProductCreateDrawer } from './hooks/useDataProductCreateDrawer';
 import { useDataProductListingData } from './hooks/useDataProductListingData';
@@ -403,6 +410,18 @@ const DataProductListPage = ({
   );
 };
 
+const DataProductListPageWithLayout: FC<DataProductListPageProps> = (props) => {
+  const isAiMode = useIsAiMode();
+
+  return (
+    <PageLayoutV1
+      pageTitle={props.pageTitle}
+      variant={isAiMode ? 'compact' : 'default'}>
+      <DataProductListPage {...props} />
+    </PageLayoutV1>
+  );
+};
+
 export { DataProductListPage };
 
-export default withPageLayout(DataProductListPage);
+export default DataProductListPageWithLayout;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
@@ -19,14 +19,13 @@ import {
 } from '@openmetadata/ui-core-components';
 import { SearchLg } from '@untitledui/icons';
 import { debounce, isEmpty } from 'lodash';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as FolderEmptyIcon } from '../../assets/svg/folder-empty.svg';
 import { ROUTES } from '../../constants/constants';
 import { LEARNING_PAGE_IDS } from '../../constants/Learning.constants';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
 import { ERROR_PLACEHOLDER_TYPE } from '../../enums/common.enum';
-import { withPageLayout } from '../../hoc/withPageLayout';
 import { useIsAiMode } from '../../hooks/useAppMode';
 import { useMarketplaceStore } from '../../hooks/useMarketplaceStore';
 import { useDelete } from '../common/atoms/actions/useDelete';
@@ -42,6 +41,7 @@ import EntityListingTable from '../common/EntityListingTable/EntityListingTable.
 import ErrorPlaceHolder from '../common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import HeaderBreadcrumb from '../common/HeaderBreadcrumb/HeaderBreadcrumb.component';
 import ViewToggle, { ViewMode } from '../common/ViewToggle/ViewToggle';
+import PageLayoutV1 from '../PageLayoutV1/PageLayoutV1';
 import DomainTreeView from './components/DomainTreeView';
 import { DomainListPageProps } from './DomainListPage.interface';
 import { useDomainCreateDrawer } from './hooks/useDomainCreateDrawer';
@@ -332,6 +332,18 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
   );
 };
 
+const DomainListPageWithLayout: FC<DomainListPageProps> = (props) => {
+  const isAiMode = useIsAiMode();
+
+  return (
+    <PageLayoutV1
+      pageTitle={props.pageTitle}
+      variant={isAiMode ? 'compact' : 'default'}>
+      <DomainListPage {...props} />
+    </PageLayoutV1>
+  );
+};
+
 export { DomainListPage };
 
-export default withPageLayout(DomainListPage);
+export default DomainListPageWithLayout;

--- a/openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.test.tsx
@@ -125,6 +125,32 @@ describe('PageLayoutV1', () => {
     expect(pageLayout).not.toHaveStyle({ height: 'calc(100vh - 64px)' });
   });
 
+  it('Should apply the default 20px padding class when no variant is provided', () => {
+    const { getByTestId } = render(
+      <PageLayoutV1 pageTitle="Test Page">Center content</PageLayoutV1>
+    );
+
+    const pageLayout = getByTestId('page-layout-v1');
+
+    expect(pageLayout).toHaveClass('p-x-box');
+    expect(pageLayout).not.toHaveClass('tw:p-2');
+    expect(pageLayout).toHaveAttribute('data-variant', 'default');
+  });
+
+  it('Should apply the compact 8px padding class when variant is compact', () => {
+    const { getByTestId } = render(
+      <PageLayoutV1 pageTitle="Test Page" variant="compact">
+        Center content
+      </PageLayoutV1>
+    );
+
+    const pageLayout = getByTestId('page-layout-v1');
+
+    expect(pageLayout).toHaveClass('tw:p-2');
+    expect(pageLayout).not.toHaveClass('p-x-box');
+    expect(pageLayout).toHaveAttribute('data-variant', 'compact');
+  });
+
   it('Should merge custom pageContainerStyle with fullHeight styles', () => {
     const centerText = 'Center content';
     const { getByTestId } = render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.tsx
@@ -26,6 +26,8 @@ import { FULLSCREEN_QUERY_PARAM_KEY } from '../../constants/constants';
 import DocumentTitle from '../common/DocumentTitle/DocumentTitle';
 import './../../styles/layout/page-layout.less';
 
+export type PageLayoutVariant = 'default' | 'compact';
+
 interface PageLayoutProp extends HTMLAttributes<HTMLDivElement> {
   leftPanel?: ReactNode;
   rightPanel?: ReactNode;
@@ -36,6 +38,7 @@ interface PageLayoutProp extends HTMLAttributes<HTMLDivElement> {
   rightPanelWidth?: number;
   leftPanelWidth?: number;
   fullHeight?: boolean;
+  variant?: PageLayoutVariant;
 }
 
 export const pageContainerStyles: CSSProperties = {
@@ -100,8 +103,11 @@ const PageLayoutV1: FC<PageLayoutProp> = ({
   mainContainerClassName = '',
   pageContainerStyle = {},
   fullHeight = false,
+  variant = 'default',
 }: PageLayoutProp) => {
   const location = useLocation();
+
+  const paddingClassName = variant === 'compact' ? 'tw:p-2' : 'p-x-box';
 
   const contentWidth = useMemo(() => {
     if (leftPanel && rightPanel) {
@@ -137,8 +143,9 @@ const PageLayoutV1: FC<PageLayoutProp> = ({
     <Fragment>
       <DocumentTitle title={pageTitle} />
       <Row
-        className={classNames('p-x-box', className)}
+        className={classNames(paddingClassName, className)}
         data-testid="page-layout-v1"
+        data-variant={variant}
         style={{ ...pageContainerStyles, ...finalPageContainerStyle }}
         wrap={false}>
         {leftPanel && (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnBulkOperations.component.tsx
@@ -31,7 +31,9 @@ const ColumnBulkOperations = () => {
   ];
 
   return (
-    <PageLayoutV1 pageTitle={t('label.column-bulk-operations')}>
+    <PageLayoutV1
+      pageTitle={t('label.column-bulk-operations')}
+      variant={isAiMode ? 'compact' : 'default'}>
       <div>
         {isAiMode ? (
           <HeaderShell

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -144,7 +144,7 @@ const DataMarketplacePage = ({
       <div className="tw:mb-8">
         {renderPageHeader ? (
           <div className={gridWrapperClassName} dir="ltr">
-            <div className="p-x-box tw:pt-4">{renderPageHeader()}</div>
+            <div className="tw:p-2">{renderPageHeader()}</div>
           </div>
         ) : (
           <div

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -760,7 +760,9 @@ const MetricListPage = () => {
   );
 
   return (
-    <PageLayoutV1 pageTitle={t('label.metric-plural')}>
+    <PageLayoutV1
+      pageTitle={t('label.metric-plural')}
+      variant={isAiMode ? 'compact' : 'default'}>
       <div className="p-b-md m-t-xs metric-list-page-stack">
         <div>
           {isAiMode ? (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.tsx
@@ -113,7 +113,9 @@ const OntologyExplorerPage: React.FC = () => {
   );
 
   return (
-    <PageLayoutV1 pageTitle={t('label.ontology-explorer')}>
+    <PageLayoutV1
+      pageTitle={t('label.ontology-explorer')}
+      variant={isAiMode ? 'compact' : 'default'}>
       <Box direction="col" gap={3}>
         {isAiMode ? (
           <HeaderShell

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.tsx
@@ -880,7 +880,9 @@ const TagPage = () => {
     ) : null;
 
   return (
-    <PageLayoutV1 pageTitle={tagItem.name}>
+    <PageLayoutV1
+      pageTitle={tagItem.name}
+      variant={isAiMode ? 'compact' : 'default'}>
       <Row gutter={[0, 12]}>
         <Col span={24}>
           {showAiHeader ? (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
@@ -305,10 +305,13 @@ const WorkflowsPage = () => {
       fullHeight
       className="workflow-page"
       mainContainerClassName="workflow-page-layout"
-      pageContainerStyle={{ paddingLeft: 0, paddingRight: 0 }}
+      pageContainerStyle={isAiMode ? {} : { paddingLeft: 0, paddingRight: 0 }}
       pageTitle={t('label.workflow-plural')}
       variant={isAiMode ? 'compact' : 'default'}>
-      <div className="tw:flex tw:flex-col tw:flex-1 tw:min-h-0 tw:overflow-hidden tw:mx-6 tw:my-4">
+      <div
+        className={`tw:flex tw:flex-col tw:flex-1 tw:min-h-0 tw:overflow-hidden tw:my-4${
+          isAiMode ? '' : ' tw:mx-6'
+        }`}>
         {isAiMode ? (
           <HeaderShell
             actions={createWorkflowButton}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
@@ -306,7 +306,8 @@ const WorkflowsPage = () => {
       className="workflow-page"
       mainContainerClassName="workflow-page-layout"
       pageContainerStyle={{ paddingLeft: 0, paddingRight: 0 }}
-      pageTitle={t('label.workflow-plural')}>
+      pageTitle={t('label.workflow-plural')}
+      variant={isAiMode ? 'compact' : 'default'}>
       <div className="tw:flex tw:flex-col tw:flex-1 tw:min-h-0 tw:overflow-hidden tw:mx-6 tw:my-4">
         {isAiMode ? (
           <HeaderShell


### PR DESCRIPTION
## What

`PageLayoutV1` gains a `variant?: 'default' | 'compact'` prop. In **compact** mode it swaps the 20px horizontal `p-x-box` for `tw:p-2` (8px on all four sides), matching the 2.0 AI‑mode design, and now emits a `data-variant` attribute so downstream layout overrides can defer to it when compact padding is applied.

## Why

The 2.0 AI‑mode design specifies 8px padding on all sides. `PageLayoutV1` previously hard‑coded `p-x-box` (20px horizontal, no vertical), leaving AI‑mode list pages over‑padded.

## Changes

- **`PageLayoutV1`** — new `variant` prop (`compact` → `tw:p-2`) and a `data-variant` attribute.
- AI‑mode pages pass `variant={isAiMode ? 'compact' : 'default'}`: Ontology Explorer, Tag, Metric list, Workflows, Column Bulk Operations, and the Domain / Data Product listings (wired via small in‑file layout wrappers so the generic `withPageLayout` HOC stays hook‑free).
- **Data Marketplace** — AI‑mode header padding reduced (`p-x-box tw:pt-4` → `tw:p-2`).
- **Workflows** — the page set inline `paddingLeft/paddingRight: 0` plus `tw:mx-6` margins, which overrode `tw:p-2`; in AI mode those are dropped so it gets a true 8px gutter (default mode unchanged).
- Unit tests for `variant` + `data-variant`.

## Before / After (AI mode)

### Data Marketplace header
| Before (20px sides / 16px top) | After (8px) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/marketplace-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/marketplace-after.png" width="440"> |

### Domains
| Before (20px) | After (8px) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/domain-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/domain-after.png" width="440"> |

### Data Products
| Before (20px) | After (8px) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/dataProduct-before.png" width="440"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pagelayoutv2-ai-padding/dataProduct-after.png" width="440"> |

## Testing

- `yarn test PageLayoutV1` → 10/10
- `tsc --noEmit` clean; UI checkstyle (organize-imports + eslint + prettier) clean
- Verified in a local Collate build (AI mode) across all listed pages.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

PageLayoutV1 now supports compact padding for AI-mode pages.
- Adds a compact variant and `data-variant` attribute with unit coverage.
- Enables compact layouts across the listed AI-mode pages and adjusts the Data Marketplace header.
- Reworks the Workflows page spacing so layout padding can apply in AI mode.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs a spacing correction before merging because the AI Workflows page still renders a 24px vertical gutter instead of the compact layout's intended 8px.

The compact parent padding and the workflow wrapper's unconditional vertical margin accumulate on the AI-mode route, so the previous spacing fix remains incomplete.

openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.tsx | Adds the default and compact padding variants and exposes the selected variant as a data attribute. |
| openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/WorkflowsPage/WorkflowsPage.tsx | Removes the conflicting AI-mode horizontal overrides, but the retained vertical margin still defeats uniform compact spacing. |
| openmetadata-ui/src/main/resources/ui/src/components/PageLayoutV1/PageLayoutV1.test.tsx | Covers the padding class and data attribute for both layout variants. |
| openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx | Replaces the generic layout HOC with an app-mode-aware PageLayoutV1 wrapper. |
| openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx | Replaces the generic layout HOC with an app-mode-aware PageLayoutV1 wrapper. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): give WorkflowsPage a true 8px g..."](https://github.com/open-metadata/openmetadata/commit/9dacd5e38485ec6b53796e809aca00cb8090ebbd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46648236)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->