### PR TITLE
Skip the ServiceAgentsPauseResume

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts
@@ -95,7 +95,7 @@ const clickAndAwaitToggle = async (page: Page, testId: string) => {
   await toggleResponse;
 };
 
-test.describe('Service Agents pause and resume', () => {
+test.describe.skip('Service Agents pause and resume', () => {
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
 


### PR DESCRIPTION
This pull request makes a small change to the test suite by disabling the "Service Agents pause and resume" test. The test is now skipped and will not run during automated test execution.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables the Service Agents pause/resume Playwright suite.
- Skips both pause and resume transition scenarios.
- Prevents the suite's service and ingestion-pipeline setup from running.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge from a runtime perspective, but the skipped suite should be tied to a documented reason and re-enable plan.

The change affects only test execution, but it removes the sole focused automated checks for both Service Agent pause/resume transitions and leaves no tracking information for restoring them.

openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ServiceAgentsPauseResume.spec.ts | Adds a suite-level skip that removes pause/resume UI coverage without documenting why or when it should be restored. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Skip the ServiceAgentsPauseResume"](https://github.com/open-metadata/openmetadata/commit/92dc8dff2558f6cc883a47ccbf961c72b0dfddeb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46712450)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->