### PR TITLE
ci: bump postgresql playwright shards from 7 to 32

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -192,7 +192,7 @@ jobs:
           ALL_FILES: ${{ steps.all-changes.outputs.all_changed_files }}
           SPEC_FILES: ${{ steps.changed-specs.outputs.all_changed_files }}
         run: |
-          FULL_MATRIX='{"shardIndex":[1,2,3,4,5,6,7],"shardTotal":[7]}'
+          FULL_MATRIX='{"shardIndex":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32],"shardTotal":[32]}'
           SPEC_MATRIX='{"shardIndex":[1],"shardTotal":[1]}'
 
           ALL_COUNT=$(echo "$ALL_FILES" | wc -w)
@@ -342,13 +342,13 @@ jobs:
               --workers=1
 
           else
-            # Shards 3-7 run common chromium tests equally distributed (5-way sharding)
+            # Shards 3-32 run common chromium tests equally distributed (30-way sharding)
             CHROMIUM_SHARD=$(( ${{ matrix.shardIndex }} - 2 ))
-            echo "🔹 Running common chromium tests on shard ${CHROMIUM_SHARD}/5"
+            echo "🔹 Running common chromium tests on shard ${CHROMIUM_SHARD}/30"
             npx playwright test \
               --project=chromium \
               --grep-invert @dataAssetRules \
-              --shard=${CHROMIUM_SHARD}/5
+              --shard=${CHROMIUM_SHARD}/30
           fi
 
         env:


### PR DESCRIPTION
## What

Bump the PostgreSQL Playwright E2E full matrix from **7** to **32** shards.

- `FULL_MATRIX`: `shardIndex` 1–32, `shardTotal: [32]`
- Chromium split now 30-way (`shard 3–32` → `--shard=${CHROMIUM_SHARD}/30`); shard 1 (DataAssetRules) and shard 2 (search relevance) unchanged

## Why

More parallelism = shorter wall-clock on the PostgreSQL E2E run.

## Scope

Only `.github/workflows/playwright-postgresql-e2e.yml`. Nightly/MySQL workflows untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Increases PostgreSQL Playwright E2E parallelism from 7 to 32 jobs.
- Preserves shards 1 and 2 for DataAssetRules and search relevance tests.
- Expands common Chromium execution from 5 to 30 consistently numbered shards.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The 32 matrix entries map consistently to two special-purpose shards and 30 Chromium shards, and downstream result validation consumes the same expanded matrix.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Expands the full matrix and Chromium shard arithmetic consistently, with no actionable issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: bump postgresql playwright shards fr..."](https://github.com/open-metadata/openmetadata/commit/4ff788be7fc30576e60c23e154fa2ec7afd2dc86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46914813)</sub>

<!-- /greptile_comment -->