### PR TITLE
fix(e2e): skip Ontology Explorer — RDF graph data loading describe block

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts
@@ -212,7 +212,7 @@ test.describe.skip('Ontology Explorer — RDF exports (Turtle and RDF/XML)', () 
   });
 });
 
-test.describe('Ontology Explorer — RDF graph data loading', () => {
+test.describe.skip('Ontology Explorer — RDF graph data loading', () => {
   test('term Relations Graph requests /rdf/glossary/graph scoped to the selected term (glossaryTermId) when RDF is enabled', async ({
     browser,
   }) => {


### PR DESCRIPTION
## Summary

- Skips the `'Ontology Explorer — RDF graph data loading'` describe block in `OntologyExplorerRdf.spec.ts` by changing `test.describe` → `test.describe.skip`

## Context

The first describe block in the same file (`'Ontology Explorer — RDF exports (Turtle and RDF/XML)'`) is already marked `.skip`. This PR aligns the second block to the same state while the tests are being stabilised.

## Test plan

- [ ] The `OntologyExplorerRdf.spec.ts` file now has both describe blocks marked `.skip` — no tests in it will run in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR disables the remaining RDF graph data-loading Playwright suite.
- Changes the second `OntologyExplorerRdf.spec.ts` describe block to `test.describe.skip`.
- Leaves both describe blocks in the file skipped.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only applies the explicitly intended skip to the RDF graph data-loading test suite.

The changed line has no production runtime effect, and the affected tests were already absent from the dedicated RDF CI project because that project selects tagged tests while this suite is untagged.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerRdf.spec.ts | Marks the RDF graph data-loading test suite as skipped, matching the already-skipped RDF export suite; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(e2e): skip Ontology Explorer RDF gra..."](https://github.com/open-metadata/openmetadata/commit/8f376a0e7ede7923a778ec7c72cbccc5c40b246b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46916183)</sub>

<!-- /greptile_comment -->