### PR TITLE
fix(test): add authenticateAdminPage function for GlossaryTermRelationSettings tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
@@ -66,7 +66,7 @@ export const createAdminApiContext = async (): Promise<{
 
     if (!loginResponse.ok()) {
       throw new Error(
-        `Admin authentication failed (${loginResponse.status()}): ${await loginResponse.text()}`
+        `Admin authentication failed (${loginResponse.status()}): ${await loginResponse.text()}`,
       );
     }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts
@@ -10,10 +10,26 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, Browser, request } from '@playwright/test';
+import { APIRequestContext, Browser, Page, request } from '@playwright/test';
 import { AdminClass } from '../support/user/AdminClass';
 import { DEFAULT_ADMIN_USER } from '../constant/user';
 import { getAuthContext, getToken, redirectToHomePage } from './common';
+
+export const authenticateAdminPage = async (page: Page) => {
+  await page.goto('/');
+  await page.waitForURL((url) => {
+    return (
+      url.pathname.includes('/my-data') || url.pathname.includes('/signin')
+    );
+  });
+
+  if (page.url().includes('/signin')) {
+    const admin = new AdminClass();
+    await admin.login(page);
+  }
+
+  await redirectToHomePage(page);
+};
 
 export const performAdminLogin = async (browser: Browser) => {
   const admin = new AdminClass();


### PR DESCRIPTION
## Summary
- Add the missing `authenticateAdminPage` function to `playwright/utils/admin.ts`
- This function was required by GlossaryTermRelationSettings.spec.ts tests but was missing in the 1.13 branch
- Fixes 6 failing Playwright tests in GlossaryTermRelationSettings.spec.ts

## Changes
- Added `authenticateAdminPage` export to `openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts`
- Added `Page` import from `@playwright/test`
- Function handles admin authentication for Playwright tests

## Testing
- The function is only used by GlossaryTermRelationSettings.spec.ts
- No other files are affected by this change
- No existing exports or imports are modified

## Related
- Fixes tests that were failing in the automated upgrade tests workflow
- Complements the GlossaryTermRelationSettings.spec.ts tests added in #30372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Playwright helper that authenticates an admin page before glossary term relation settings tests.
- Imports the Playwright `Page` type.
- Navigates to the application, conditionally performs admin login, and redirects to the home page.
- Applies a formatting-only trailing comma to an existing error constructor.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/admin.ts | Adds the missing admin-page authentication helper used by the glossary relation settings Playwright tests. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style(test): fix prettier formatting in ..."](https://github.com/open-metadata/openmetadata/commit/31668603f37fdf7b037338085a4ba8e5122a305b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46926831)</sub>

<!-- /greptile_comment -->