### PR TITLE
fix(security): bump netty-bom 4.1.136.Final and jetty 12.1.10 [1.13]

### DIFF
--- a/openmetadata-mcp/pom.xml
+++ b/openmetadata-mcp/pom.xml
@@ -17,7 +17,7 @@
     
     <properties>
         <assertj-core.version>3.27.7</assertj-core.version>
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.10</jetty.version>
     </properties>
 
     <dependencyManagement>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -25,7 +25,7 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>
     <json-smart.version>2.5.2</json-smart.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <jsonpath.version>2.9.0</jsonpath.version>
     <everit.version>1.14.4</everit.version>
     <json-patch.version>1.13</json-patch.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <jakarta-el.version>5.0.0-M1</jakarta-el.version>
     <mcp-sdk.version>1.1.1</mcp-sdk.version>
     <lettuce.version>6.7.1.RELEASE</lettuce.version>
@@ -701,7 +701,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fixes #30394

Backports the netty + jetty bumps from #30391 to 1.13. jetty.version is set in root, `openmetadata-service` and `openmetadata-mcp` (all three shadow-independent). Clears CVE-2026-55831/55833/56745, GHSA-558v-64gr-wgg4 (netty) and CVE-2026-10051, GHSA-2fvj-hgj9-j2gr (jetty). postgres/jackson/logback/calcite already on 1.13 via #30396.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the project’s security-sensitive networking dependencies.
- Raises Jetty from 12.1.7 to 12.1.10 consistently in the root, service, and MCP Maven scopes.
- Raises the root Netty BOM from 4.1.135.Final to 4.1.136.Final.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the dependency versions are updated consistently across all relevant Maven scopes.

The root, service, and MCP Jetty declarations now agree on 12.1.10, the Netty BOM is centrally updated to 4.1.136.Final, and no remaining conflicting or stale version declaration was found.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates the reactor-wide Jetty property and Netty BOM to the intended patched versions without introducing competing version declarations. |
| openmetadata-service/pom.xml | Keeps the service-level Jetty override aligned with the root version at 12.1.10. |
| openmetadata-mcp/pom.xml | Keeps the MCP module’s independent Jetty property aligned with the service and distribution classpath at 12.1.10. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump netty-bom 4.1.136.Fi..."](https://github.com/open-metadata/openmetadata/commit/35ec277b0d3feb143b09885fc68feaf64a8655d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46929109)</sub>

<!-- /greptile_comment -->