### PR TITLE
fix(security): bump netty 4.1.136, jetty 12.1.10, postgresql 42.7.12 [1.12.14]

### DIFF
--- a/openmetadata-mcp/pom.xml
+++ b/openmetadata-mcp/pom.xml
@@ -20,7 +20,7 @@
         <okhttp.version>4.12.0</okhttp.version>
         <awaitility.version>4.2.2</awaitility.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <jetty.version>12.1.7</jetty.version>
+        <jetty.version>12.1.10</jetty.version>
     </properties>
 
     <dependencyManagement>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -29,7 +29,7 @@
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <socket.io-client.version>2.1.1</socket.io-client.version>
     <json-smart.version>2.5.2</json-smart.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <redshift-jdbc.version>2.1.0.30</redshift-jdbc.version>
     <gson.version>2.13.1</gson.version>
     <mysql.connector.version>9.3.0</mysql.connector.version>
-    <postgres.connector.version>42.7.11</postgres.connector.version>
+    <postgres.connector.version>42.7.12</postgres.connector.version>
     <jsonschema2pojo.version>1.3.1</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
     <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
@@ -153,7 +153,7 @@
     <jsonpath.version>2.9.0</jsonpath.version>
     <everit.version>1.14.4</everit.version>
     <json-patch.version>1.13</json-patch.version>
-    <jetty.version>12.1.7</jetty.version>
+    <jetty.version>12.1.10</jetty.version>
     <jakarta-el.version>5.0.0-M1</jakarta-el.version>
     <mcp-sdk.version>1.1.1</mcp-sdk.version>
     <lettuce.version>6.7.1.RELEASE</lettuce.version>
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.1.136.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Backports netty + jetty + postgres to 1.12.14 to clear Inspector findings on the release image. netty 4.1.135 -> 4.1.136.Final, jetty 12.1.7 -> 12.1.10 (root + `openmetadata-service` + `openmetadata-mcp`), postgresql 42.7.11 -> 42.7.12 (CVE-2026-54291). jackson (2.18.9) and logback (1.5.36) already on 1.12.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates security-sensitive dependencies to newer patch releases:
- Aligns Jetty 12.1.10 across the root, service, and MCP Maven configurations.
- Updates the Netty BOM to 4.1.136.Final.
- Updates the PostgreSQL JDBC driver to 42.7.12.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The dependency patch upgrades appear safe to merge, with no concrete changed-code failure identified.

The PR consistently updates the managed Jetty versions across all three affected POMs, while the Netty BOM preserves artifact alignment and the PostgreSQL change remains within the existing patch line; no changed dependency path was found to violate a current build or runtime contract.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates the centrally managed PostgreSQL, Jetty, and Netty versions consistently without introducing a concrete compatibility or resolution defect. |
| openmetadata-service/pom.xml | Aligns the service-specific Jetty override with the new root version; the scanner-reported c3p0 dependency is pre-existing and unaffected. |
| openmetadata-mcp/pom.xml | Aligns the MCP module's Jetty dependencies with the root and service configurations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): bump netty 4.1.136, jetty..."](https://github.com/open-metadata/openmetadata/commit/6bc84886c06975e3a87534c32a6598b5c181b484) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46929150)</sub>

<!-- /greptile_comment -->