### PR TITLE
fix(mcp): use full OIDC round-trip for MCP OAuth to avoid id_token issuer mismatch

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/provider/UserSSOOAuthProvider.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/provider/UserSSOOAuthProvider.java
@@ -348,6 +348,26 @@ public class UserSSOOAuthProvider implements OAuthAuthorizationServerProvider {
           authRequestId,
           currentResponse.get() != null && currentResponse.get().isCommitted());
 
+      // For the MCP flow, handleLogin() ran the full authorization-code round-trip and exposed
+      // the state/nonce/PKCE-verifier it sent to the OIDC provider as request attributes. Persist
+      // them against this pending request so the returning /callback?state=... can be matched back
+      // (isMcpState -> findByPac4jState) and its pac4j session restored for the token exchange.
+      String mcpOidcState =
+          (String) wrappedRequest.getAttribute(AuthenticationCodeFlowHandler.MCP_OIDC_STATE);
+      if (mcpOidcState != null) {
+        String mcpOidcNonce =
+            (String) wrappedRequest.getAttribute(AuthenticationCodeFlowHandler.MCP_OIDC_NONCE);
+        String mcpOidcCodeVerifier =
+            (String)
+                wrappedRequest.getAttribute(AuthenticationCodeFlowHandler.MCP_OIDC_CODE_VERIFIER);
+        pendingAuthRepository.updatePac4jSession(
+            authRequestId, mcpOidcState, mcpOidcNonce, mcpOidcCodeVerifier);
+        LOG.info(
+            "Linked OIDC round-trip state to MCP pending request {} for provider callback",
+            authRequestId);
+        return CompletableFuture.completedFuture("SSO_REDIRECT_INITIATED");
+      }
+
       // After handleLogin(), pac4j has stored its state in the session
       // Extract pac4j session attributes and store in database
       // Note: pac4j stores State and CodeVerifier as objects, not strings

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -128,6 +128,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   public static final String SESSION_REDIRECT_URI = "sessionRedirectUri";
   public static final String SESSION_SSO_CALLBACK_URL = "googleCallbackUrl";
 
+  // For the MCP OAuth flow, handleLogin() exposes the state/nonce/PKCE-verifier it generated for
+  // the provider round-trip as request attributes so UserSSOOAuthProvider can persist them against
+  // the MCP pending request (updatePac4jSession). Without this link the returning
+  // /callback?state=... cannot be matched back to the pending MCP request.
+  public static final String MCP_OIDC_STATE = "mcpOidcState";
+  public static final String MCP_OIDC_NONCE = "mcpOidcNonce";
+  public static final String MCP_OIDC_CODE_VERIFIER = "mcpOidcCodeVerifier";
+
   private static volatile AuthenticationCodeFlowHandler latestInstance;
 
   private OidcClient client;
@@ -353,7 +361,9 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       // 2. Web login flow: any other redirect URI
       String redirectUri;
       String expectedMcpCallback = serverUrl + "/mcp/callback";
-      if (requestedRedirectUri != null && requestedRedirectUri.equals(expectedMcpCallback)) {
+      boolean isMcpFlow =
+          requestedRedirectUri != null && requestedRedirectUri.equals(expectedMcpCallback);
+      if (isMcpFlow) {
         redirectUri = requestedRedirectUri;
         LOG.debug(
             "MCP OAuth flow detected - using registered callback URL, final redirect: {}",
@@ -362,21 +372,33 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         redirectUri = requireRedirectUri(requestedRedirectUri);
       }
 
-      Optional<UserSession> activeSession = sessionService.getActiveSession(req, resp);
-      if (activeSession.isPresent()) {
-        User user = getSessionUser(activeSession.get());
-        if (user != null) {
-          JWTAuthMechanism jwtAuthMechanism = generateJwtToken(user, activeSession.get());
-          sendRedirectWithToken(resp, redirectUri, user, jwtAuthMechanism.getJWTToken());
-          return;
+      // The active-session shortcut mints an OpenMetadata-internal JWT (issuer = deployment
+      // authority) and returns it directly. That is fine for web login, but the MCP callback
+      // validates the id_token against the external OIDC provider's issuer/JWKS and rejects an
+      // OpenMetadata-issued token as an issuer mismatch. For MCP, always run the full
+      // authorization-code round-trip so the id_token comes from the provider itself.
+      if (!isMcpFlow) {
+        Optional<UserSession> activeSession = sessionService.getActiveSession(req, resp);
+        if (activeSession.isPresent()) {
+          User user = getSessionUser(activeSession.get());
+          if (user != null) {
+            JWTAuthMechanism jwtAuthMechanism = generateJwtToken(user, activeSession.get());
+            sendRedirectWithToken(resp, redirectUri, user, jwtAuthMechanism.getJWTToken());
+            return;
+          }
+          sessionService.revokeSession(req, resp);
         }
-        sessionService.revokeSession(req, resp);
       }
 
       Map<String, String> params = buildLoginParams();
       params.put(OidcConfiguration.REDIRECT_URI, client.getCallbackUrl());
 
       PendingLoginContext pendingLoginContext = addStateAndNonceParameters(params);
+      if (isMcpFlow) {
+        req.setAttribute(MCP_OIDC_STATE, pendingLoginContext.state());
+        req.setAttribute(MCP_OIDC_NONCE, pendingLoginContext.nonce());
+        req.setAttribute(MCP_OIDC_CODE_VERIFIER, pendingLoginContext.pkceVerifier());
+      }
       sessionService.createPendingSession(
           req,
           resp,


### PR DESCRIPTION
Fixes #30445

### Problem
MCP OAuth (e.g. ChatGPT connector) fails on instances with OIDC SSO. `POST /mcp/callback` returns 500:
```
ID token issuer mismatch. Expected 'https://accounts.google.com' but got '<deployment-authority>'.
```
### Fix
- `AuthenticationCodeFlowHandler`: skip the active-session shortcut for MCP flows so the id_token always comes from the external OIDC provider; expose the round-trip `state`/`nonce`/PKCE-verifier as request attributes.
- `UserSSOOAuthProvider`: link those to the MCP pending request via `updatePac4jSession`, so the returning `/callback?state=...` resolves and a provider-issued id_token is validated.

Web login path is untouched (guarded behind `!isMcpFlow`).

### Not covered here
Live ChatGPT↔SSO end-to-end round-trip — needs verification on a deployed instance.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR repairs MCP authentication for OIDC deployments by:
- forcing MCP authorization through the external provider’s complete authorization-code flow instead of reusing an OpenMetadata session token;
- carrying the generated state, nonce, and PKCE verifier into the MCP pending authorization record for callback restoration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no blocking failure identified in the follow-up scope.

No blocking failure remains.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/java/org/openmetadata/mcp/server/auth/provider/UserSSOOAuthProvider.java | Persists the provider-generated OIDC state, nonce, and PKCE verifier against the pending MCP authorization before returning from redirect initiation. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java | Detects MCP login requests, bypasses internal active-session token reuse, and exposes the external OIDC round-trip parameters to the MCP bridge. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client as MCP Client
  participant MCP as UserSSOOAuthProvider
  participant OIDC as AuthenticationCodeFlowHandler
  participant IdP as External OIDC Provider
  participant Repo as MCP Pending Auth Repository
  Client->>MCP: Start authorization
  MCP->>OIDC: handleLogin(MCP callback URI)
  OIDC->>OIDC: Generate state, nonce, and PKCE verifier
  OIDC-->>MCP: Expose values as request attributes
  MCP->>Repo: Link OIDC values to pending MCP request
  OIDC-->>IdP: Redirect to provider authorization
  IdP-->>OIDC: "/callback?state=..."
  OIDC->>Repo: Resolve pending request by provider state
  OIDC-->>Client: Complete MCP authorization
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(mcp): use full OIDC round-trip for M..."](https://github.com/open-metadata/openmetadata/commit/0292b11efd98293d49adee75dc0c37bf79fc13d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46932525)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata MCP Server](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-mcp.md)
- Knowledge Base — [Auth and Security: Authentication, Authorization, Secrets, and SCIM](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-auth-security.md)

<!-- /greptile_comment -->