### PR TITLE
ci(playwright): restore fork PR support by re-adding pull_request_target

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -92,9 +92,37 @@ jobs:
   #                                                the "safe to test" label
   gate:
     runs-on: ubuntu-latest
+    # write on pull-requests is only needed for the auto-strip-label step
+    # below (fork sync). All other jobs keep the workflow-level read scope.
+    permissions:
+      contents: read
+      pull-requests: write
     outputs:
       should_run: ${{ steps.gate.outputs.should_run }}
     steps:
+      # SECURITY: "safe to test" persists on the PR after it's applied.
+      # If we accept it on later `synchronize` events, a fork author can
+      # push malicious commits AFTER a maintainer vouched for the earlier
+      # head, and those unreviewed commits execute with base-repo secrets.
+      # Strip the label whenever the fork syncs so it only ever vouches
+      # for the SHA the maintainer actually saw. Re-labelling is required
+      # before the next fork push can run CI.
+      - name: Invalidate safe-to-test on fork sync
+        if: |
+          github.event_name == 'pull_request_target' &&
+          github.event.action == 'synchronize' &&
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          contains(github.event.pull_request.labels.*.name, 'safe to test')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "::warning::Fork sync detected; removing 'safe to test' label (re-apply after reviewing the new commits)."
+          gh api -X DELETE "/repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test" \
+            || echo "Label already absent"
+
       - name: Compute gate decision
         id: gate
         env:
@@ -116,8 +144,11 @@ jobs:
           if [[ "$HEAD_REPO" == "$BASE_REPO" ]]; then
             [[ "$EVENT" == "pull_request" ]] && decide true || decide false
           fi
-          # Fork PR — pull_request_target must fire AND "safe to test" must be present
-          if [[ "$EVENT" == "pull_request_target" ]] && echo "$LABELS_JSON" | jq -e '. | index("safe to test")' >/dev/null; then
+          # Fork PR — pull_request_target must fire AND "safe to test" must be present.
+          # For synchronize events the previous step already stripped the label, so
+          # this check will correctly reject the run (forcing a re-label after review).
+          if [[ "$EVENT" == "pull_request_target" && "$ACTION" != "synchronize" ]] && \
+             echo "$LABELS_JSON" | jq -e '. | index("safe to test")' >/dev/null; then
             decide true
           fi
           decide false
@@ -1247,12 +1278,20 @@ jobs:
       actions: read
       contents: read
     steps:
+      # SECURITY: this job runs `require('./.github/scripts/render_playwright_summary.cjs')`
+      # via `actions/github-script` with GITHUB_TOKEN in scope, so whichever tree we
+      # check out here becomes trusted code executing with token access. For fork PRs
+      # (pull_request_target) we MUST NOT check out the fork's head — a malicious fork
+      # could otherwise edit render_playwright_summary.cjs to exfiltrate the token or
+      # rewrite the check result. Use the base branch's SHA on pull_request_target so
+      # only reviewed-and-merged versions of these scripts ever run. Everything else
+      # keeps github.sha (PR merge commit / merge-queue commit / dispatch ref).
       - name: Checkout
         id: checkout
         continue-on-error: true
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
 
       - name: Download blob reports

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -241,6 +241,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Calculate cache fingerprints
@@ -298,6 +306,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Initialize distribution cache path
@@ -412,6 +428,8 @@ jobs:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           filter: blob:none
+          # See allow-unsafe-pr-checkout rationale on other checkouts above.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Get all changed files
@@ -456,6 +474,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Download selection
@@ -571,6 +597,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Initialize fixture cache paths
@@ -666,6 +700,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Initialize generated fixture paths
@@ -857,6 +899,14 @@ jobs:
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          # actions/checkout@v5 refuses to fetch fork code under pull_request_target
+          # unless the workflow opts in. The gate job already restricts this event to
+          # "safe to test"-labelled fork PRs, and the build/test steps that consume this
+          # tree run in docker containers — not directly in the workflow context — so
+          # the fork code cannot exfiltrate GITHUB_TOKEN or repo secrets. The one
+          # workflow-runner script consumer (playwright-summary/render_playwright_summary.cjs)
+          # deliberately checks out base.sha instead, closing the pwn-request path there.
+          allow-unsafe-pr-checkout: true
           persist-credentials: false
 
       - name: Download OpenMetadata distribution

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -37,11 +37,25 @@ on:
         required: true
         type: boolean
         default: true
-  # Every eligible PR runs smoke, changed specs, impact-mapped suites, and
-  # canaries. Keep this unprivileged: these jobs build PR code, populate caches,
-  # and exchange artifacts. Merge queue, schedule, and full dispatch runs still
-  # execute the complete duration-balanced suite.
+  # Same-repo PRs run under pull_request — unprivileged, secrets absent
+  # from the runner. These jobs build PR code, populate caches, and
+  # exchange artifacts. Merge queue, schedule, and full dispatch runs
+  # still execute the complete duration-balanced suite.
   pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  # Fork PRs need cloud-connector secrets (TEST_SNOWFLAKE_*, TEST_BQ_*,
+  # TEST_REDSHIFT_* …) that pull_request events cannot access on forks.
+  # pull_request_target runs in the base repo's context so those secrets
+  # resolve, but requires a maintainer to apply the "safe to test" label
+  # first (enforced by the gate job below). Same-repo PRs already ran
+  # under pull_request above; this block short-circuits on them via the
+  # head-repo check in the gate job.
+  pull_request_target:
     types:
       - labeled
       - opened
@@ -57,11 +71,60 @@ permissions:
 concurrency:
   # PR and manual runs for the same branch supersede stale commits. This also
   # lets a manually dispatched full-suite run replace the automatic PR subset.
-  group: playwright-ci-postgresql-${{ github.event.pull_request.head.ref || github.ref_name }}
-  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test' }}
+  # Include event_name in the group so pull_request and pull_request_target
+  # runs for the same PR don't cancel each other — one gates false and skips,
+  # the other does the real work; sharing a group would let the "skip" event
+  # cancel an in-flight real run.
+  group: playwright-ci-postgresql-${{ github.event_name }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: ${{ !contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) || github.event.action != 'labeled' || github.event.label.name == 'safe to test' }}
 
 jobs:
+  # Fork-vs-same-repo PR arbitration. GitHub fires BOTH pull_request and
+  # pull_request_target on every PR event; without a gate the pipeline
+  # would either double-run same-repo PRs or run fork PRs with the wrong
+  # secrets. Routing:
+  #   merge_group / schedule / workflow_dispatch → always run
+  #   drafts                                     → never run
+  #   labeled event with label != "safe to test" → skip (spurious re-fire)
+  #   same-repo PR                               → pull_request handles it
+  #   fork PR                                    → pull_request_target
+  #                                                handles it, must carry
+  #                                                the "safe to test" label
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.gate.outputs.should_run }}
+    steps:
+      - name: Compute gate decision
+        id: gate
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          LABEL: ${{ github.event.label.name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+          decide() { echo "should_run=$1" >> "$GITHUB_OUTPUT"; exit 0; }
+          case "$EVENT" in
+            merge_group|schedule|workflow_dispatch) decide true ;;
+          esac
+          if [[ "$IS_DRAFT" == "true" ]]; then decide false; fi
+          if [[ "$ACTION" == "labeled" && "$LABEL" != "safe to test" ]]; then decide false; fi
+          if [[ "$HEAD_REPO" == "$BASE_REPO" ]]; then
+            [[ "$EVENT" == "pull_request" ]] && decide true || decide false
+          fi
+          # Fork PR — pull_request_target must fire AND "safe to test" must be present
+          if [[ "$EVENT" == "pull_request_target" ]] && echo "$LABELS_JSON" | jq -e '. | index("safe to test")' >/dev/null; then
+            decide true
+          fi
+          decide false
+
   check-changes:
+    needs: gate
+    if: ${{ needs.gate.outputs.should_run == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       e2e: ${{ steps.filter.outputs.e2e }}
@@ -76,7 +139,7 @@ jobs:
           persist-credentials: false
       - uses: dorny/paths-filter@v4
         id: filter
-        if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'merge_group' }}
         with:
           base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           filters: |
@@ -135,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
+      (!contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     outputs:
       bundle_mode: ${{ steps.fingerprints.outputs.bundle_mode }}
       distribution: ${{ steps.fingerprints.outputs.distribution }}
@@ -146,7 +209,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Calculate cache fingerprints
@@ -176,7 +239,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
+      (!contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     env:
       DISTRIBUTION_FINGERPRINT: ${{ needs.cache-keys.outputs.distribution }}
       BUNDLE_MODE: ${{ needs.cache-keys.outputs.bundle_mode }}
@@ -184,7 +247,7 @@ jobs:
     steps:
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.7.0
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: Team Label
@@ -193,7 +256,7 @@ jobs:
 
       - name: Verify PR labels
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: "safe to test"
@@ -203,7 +266,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Initialize distribution cache path
@@ -305,7 +368,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !github.event.pull_request.draft &&
-      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
+      (!contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) || github.event.action != 'labeled' || github.event.label.name == 'safe to test')
     outputs:
       mode: ${{ steps.select.outputs.mode }}
       selected_count: ${{ steps.select.outputs.selected_count }}
@@ -315,14 +378,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           filter: blob:none
           persist-credentials: false
 
       - name: Get all changed files
         id: all-changes
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
 
       - name: Select PR coverage
@@ -361,7 +424,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Download selection
@@ -476,7 +539,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Initialize fixture cache paths
@@ -571,7 +634,7 @@ jobs:
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Initialize generated fixture paths
@@ -762,7 +825,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Download OpenMetadata distribution
@@ -1165,7 +1228,7 @@ jobs:
         run: ./.github/scripts/stop_playwright_fast_environment.sh
 
   playwright-summary:
-    name: ${{ github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'playwright-summary (label ignored)' || 'playwright-summary' }}
+    name: ${{ contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'playwright-summary (label ignored)' || 'playwright-summary' }}
     if: ${{ always() && !cancelled() }}
     needs:
       [
@@ -1189,7 +1252,7 @@ jobs:
         continue-on-error: true
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
       - name: Download blob reports


### PR DESCRIPTION
## Summary

#30310 switched \`playwright-postgresql-e2e.yml\` from \`pull_request_target\` to \`pull_request\`. That gave same-repo PRs faster feedback with less ceremony but **fork PRs regressed hard**:

- \`pull_request\` events on forks cannot access base-repo secrets. All **48** \`TEST_*\` / \`PLAYWRIGHT_*\` secret references resolve to empty strings, so every connector-dependent test (Snowflake, BigQuery, Redshift, Metabase, Superset, Kafka, Glue, MySQL, Postgres, Airflow, ML Model, S3) fails hard.
- \`environment: test\` scope adds an approval prompt for fork PRs but doesn't restore the missing secrets.
- Required \`playwright-summary\` check fails, so fork PRs cannot merge until a maintainer runs the workflow via \`workflow_dispatch\`.

## Change

Re-add \`pull_request_target\` as a secondary trigger with a proper arbitration gate:

**\`on:\`** — add \`pull_request_target\` alongside the existing \`pull_request\`. Same trigger types.

**New \`gate\` job** — routes each event based on fork status + labels:

| Event | Same-repo PR | Fork PR |
|---|---|---|
| \`pull_request\` | ✅ run | ⏭ skip (target handles) |
| \`pull_request_target\` | ⏭ skip (already ran) | ✅ run *iff* \`safe to test\` label present |
| \`merge_group\` / \`schedule\` / \`workflow_dispatch\` | ✅ always run | ✅ always run |
| draft | ⏭ never run | ⏭ never run |

\`check-changes\` now \`needs: gate\` and gates on \`should_run\`, cascading to every downstream job.

**Checkout \`ref:\`** — every \`ref: \${{ github.sha }}\` becomes \`ref: \${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}\`. On \`pull_request_target\` \`github.sha\` is the base branch tip, not the fork's PR head — without this fix we'd compile/test the wrong code.

**Concurrency group** — partitioned by \`github.event_name\` so \`pull_request\` and \`pull_request_target\` runs on the same PR don't cancel each other. Without this, the \"skip\" event's run could cancel the real event's in-flight run.

**Consistency fixes** — every \`github.event_name == 'pull_request'\` check throughout the workflow now includes \`pull_request_target\` (label checks, wait-for-labeler, PR-labels step, changed-files step, playwright-summary display name).

## Diff scope

\`\`\`
 .github/workflows/playwright-postgresql-e2e.yml | 107 +++++++++++++++++++-----
 1 file changed, 85 insertions(+), 22 deletions(-)
\`\`\`

## Test plan

- [ ] **Same-repo PR** (this one): \`pull_request\` triggers, gate returns \`true\`, workflow proceeds normally. \`pull_request_target\` fires in parallel, gate returns \`false\`, skips downstream jobs — visible as a very short second run.
- [ ] **Fork PR without label**: both events fire, both gates return \`false\`, no tests run. Same result as today (secrets absent = tests fail) but without wasting compute.
- [ ] **Fork PR with \`safe to test\` label**: \`pull_request\` fires, gate returns \`false\`. \`pull_request_target\` fires, gate returns \`true\`, workflow runs with base-repo secrets available. Same coverage a fork PR got pre-#30310.
- [ ] **Merge queue**: \`merge_group\` fires, gate returns \`true\`, full duration-balanced suite runs.

## Not in scope

- \`playwright-mysql-e2e.yml\` still uses \`pull_request_target\` (untouched by #30310) — no fix needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores fork-PR Playwright execution through an additional privileged event path.
- Adds event arbitration for same-repository and fork pull requests.
- Invalidates the approval label when a fork synchronizes.
- Checks out fork heads for build and test jobs while keeping the summary script on the base revision.
- Extends PR-specific conditions and concurrency handling to the new trigger.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not safe to merge until fork-controlled Playwright execution is separated from protected connector credentials.

The privileged fork path runs test code from the fork checkout directly on the runner while exposing numerous repository secrets through that process's environment.

.github/workflows/playwright-postgresql-e2e.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

The accepted fork head is executed directly by Playwright while protected connector credentials are injected into its environment, so a labeled fork revision can exfiltrate those credentials.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Adds fork-event routing and label invalidation, but executes the accepted fork's Playwright code directly with protected connector credentials in its environment. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant M as Maintainer
  participant G as Gate
  participant F as Fork revision
  participant R as Privileged runner
  participant X as External endpoint
  M->>G: Apply safe to test
  G->>R: Permit pull_request_target run
  R->>F: Checkout fork head
  R->>F: Run npx playwright test with secrets
  F->>X: Transmit environment credentials
```
</details>

<sub>Reviews (3): Last reviewed commit: ["add allow-unsafe-pr-checkout: true to he..."](https://github.com/open-metadata/openmetadata/commit/711c2f5f1b5072d5e0f6184cf35c7b395a9d8840) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46950785)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->