### PR TITLE
fix(ui): restore owner icon in TagsForm chips on edit

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
@@ -96,7 +96,11 @@ const mapOwnerToSelectItem = (ref: EntityReference): TagFormSelectItem => {
     icon: isTeam ? (
       <Avatar placeholderIcon={Users01} size="xs" />
     ) : (
-      <Avatar initials={character} size="xs" style={{ color, backgroundColor }} />
+      <Avatar
+        initials={character}
+        size="xs"
+        style={{ color, backgroundColor }}
+      />
     ),
     value: ref,
   };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx
@@ -84,11 +84,29 @@ const mapEntityReferenceToSelectItem = (
   value: ref,
 });
 
+const mapOwnerToSelectItem = (ref: EntityReference): TagFormSelectItem => {
+  const displayName = getEntityName(ref);
+  const isTeam = ref.type === EntityType.TEAM;
+  const { color, backgroundColor, character } = getRandomColor(displayName);
+
+  return {
+    id: ref.id,
+    label: displayName,
+    supportingText: ref.fullyQualifiedName ?? ref.type,
+    icon: isTeam ? (
+      <Avatar placeholderIcon={Users01} size="xs" />
+    ) : (
+      <Avatar initials={character} size="xs" style={{ color, backgroundColor }} />
+    ),
+    value: ref,
+  };
+};
+
 const convertToTagFormValues = (
   entity: Classification | Tag
 ): Partial<TagFormValues> => ({
   ...entity,
-  owners: (entity.owners ?? []).map(mapEntityReferenceToSelectItem),
+  owners: (entity.owners ?? []).map(mapOwnerToSelectItem),
   domains: (entity.domains ?? []).map(mapEntityReferenceToSelectItem),
 });
 


### PR DESCRIPTION
### Describe your changes:


https://github.com/user-attachments/assets/d3dd1dd0-02fd-473b-a3c7-838d5a6460f6



I worked on fixing a bug in the TagsForm where owner chips were missing their avatar icon when the edit form was opened. When selecting an owner from the dropdown (create mode), the chip correctly shows an icon because dropdown options include an `icon` property. But when re-opening the form in edit mode, owners are converted from `EntityReference` via `mapEntityReferenceToSelectItem` which did not set `icon`, so the `Autocomplete` chip renderer had nothing to show.

Added `mapOwnerToSelectItem` which generates an avatar icon (team placeholder or user initials via `getRandomColor`) matching the pattern already used in `fetchUserTeamOptions`. Updated `convertToTagFormValues` to use it for owners while keeping `mapEntityReferenceToSelectItem` for domains.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Owner chip in TagsForm shows avatar icon when form is opened in edit mode (was showing name-only before)
- Owner chip continues to show avatar icon when freshly selecting an owner in create/edit mode

#### Unit tests
- [ ] I added unit tests for the new/changed logic.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.

#### Manual testing performed
1. Open Tags page, open edit form for a tag/classification that has an owner set.
2. Verified the owner chip now shows avatar icon alongside the owner name.
3. Verified selecting a new owner in create mode still shows the icon correctly.

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI.
-->

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores avatar icons for persisted owner chips in the TagsForm edit flow.
- Adds owner-specific conversion from entity references to form select items.
- Renders team placeholders and user-initial avatars while leaving domain conversion unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.tsx | Adds avatar metadata when converting persisted owners into TagsForm select items. |

</details>

<sub>Reviews (2): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/18f8d707fa53f29d5a3052ebc9cca166f829dd82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46953006)</sub>

<!-- /greptile_comment -->