### PR TITLE
fix(dq): restore in-place reopen of resolved incidents on the Test Case page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import test, { expect, Page } from '@playwright/test';
+import { TestCaseResolutionStatusTypes } from '../../../../src/generated/tests/testCaseResolutionStatus';
 import { DataQualityDimensions } from '../../../../src/generated/tests/testDefinition';
 import { getCurrentMillis } from '../../../../src/utils/date-time/DateTimeUtils';
 import { DOMAIN_TAGS } from '../../../constant/config';
@@ -23,7 +24,7 @@ import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../../support/tag/ClassificationClass';
 import { TagClass } from '../../../support/tag/TagClass';
 import { UserClass } from '../../../support/user/UserClass';
-import { createNewPage, uuid } from '../../../utils/common';
+import { createNewPage, getApiContext, uuid } from '../../../utils/common';
 import {
   applyDashboardCertificationFilter,
   applyDashboardTagFilter,
@@ -637,17 +638,14 @@ test.describe(
         ).toContainText('New');
       });
 
-      await test.step('Verify no active incident for resolved Uniqueness test case on table4 DQ tab', async () => {
+      await test.step('Verify Resolved incident chip for Uniqueness test case on table4 DQ tab', async () => {
         await visitDataQualityTab(page, table4);
         await expect(
           page.locator(`[data-testid="status-badge-${uniquenessTestCaseName}"]`)
         ).toContainText('Failed');
         await expect(
-          page
-            .getByRole('row', { name: uniquenessTestCaseName })
-            .getByRole('gridcell', { exact: true, name: '--' })
-            .last()
-        ).toHaveText('--');
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Resolved');
       });
 
       await test.step('Filter by Certification and verify Uniqueness widget shows 1 Failed test case', async () => {
@@ -671,6 +669,93 @@ test.describe(
           failed: '1',
           aborted: '0',
         });
+      });
+    });
+
+    // Regression for #30455: a resolved incident must stay visible with its
+    // edit affordance so it can be reopened in place, continuing the SAME
+    // incident (stateId) instead of forking a new one.
+    test('Reopen resolved incident in place from the Test Case page', async ({
+      page,
+    }) => {
+      let resolvedStateId = '';
+
+      await test.step('Open the resolved test case from the DQ tab', async () => {
+        await visitDataQualityTab(page, table4);
+        await page
+          .getByTestId(uniquenessTestCaseName)
+          .getByText(uniquenessTestCaseName)
+          .click();
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await test.step('Test Case page shows the resolved incident with its edit affordance', async () => {
+        const { apiContext } = await getApiContext(page);
+        const fetchLatestIncident = () =>
+          apiContext
+            .get(
+              `/api/v1/dataQuality/testCases/testCaseIncidentStatus?latest=true` +
+                `&startTs=0&endTs=${getCurrentMillis()}` +
+                `&testCaseFQN=${uniquenessTestCaseFqn}`
+            )
+            .then((res) => res.json());
+
+        let latest = await fetchLatestIncident();
+        // A failed earlier attempt may have left the incident reopened;
+        // restore the resolved precondition so retries stay deterministic.
+        if (
+          latest.data?.[0]?.testCaseResolutionStatusType !==
+          TestCaseResolutionStatusTypes.Resolved
+        ) {
+          await apiContext.post(
+            '/api/v1/dataQuality/testCases/testCaseIncidentStatus',
+            {
+              data: {
+                testCaseReference: uniquenessTestCaseFqn,
+                testCaseResolutionStatusType:
+                  TestCaseResolutionStatusTypes.Resolved,
+              },
+            }
+          );
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+          latest = await fetchLatestIncident();
+        }
+        resolvedStateId = latest.data?.[0]?.stateId ?? '';
+
+        expect(resolvedStateId).not.toBe('');
+
+        await expect(
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Resolved');
+        await expect(
+          page.locator('[data-testid="edit-resolution-icon"]')
+        ).toBeVisible();
+      });
+
+      await test.step('Reopen the incident as Acknowledged from the header', async () => {
+        await page.click('[data-testid="edit-resolution-icon"]');
+        await page.click('[data-testid="test-case-resolution-status-type"]');
+        await page.click('[title="Ack"]');
+
+        const reopenResponse = page.waitForResponse(
+          (response) =>
+            response
+              .url()
+              .includes('/dataQuality/testCases/testCaseIncidentStatus') &&
+            response.request().method() === 'POST'
+        );
+        await page.click('#update-status-button');
+        const reopened = await (await reopenResponse).json();
+
+        expect(reopened.stateId).toBe(resolvedStateId);
+        expect(reopened.testCaseResolutionStatusType).toBe(
+          TestCaseResolutionStatusTypes.ACK
+        );
+
+        await expect(
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Ack');
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -53,7 +53,10 @@ test(
      * selects the new test case, sets a weekly schedule, deploys, and verifies success modal.
      */
     await test.step('Create a new pipeline', async () => {
-      await page.getByTestId('profiler').getByText('Data Observability').click();
+      await page
+        .getByTestId('profiler')
+        .getByText('Data Observability')
+        .click();
       await page
         .getByRole('tab', {
           name: 'Table Profile',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -53,7 +53,7 @@ test(
      * selects the new test case, sets a weekly schedule, deploys, and verifies success modal.
      */
     await test.step('Create a new pipeline', async () => {
-      await page.getByText('Data Observability').click();
+      await page.getByTestId('profiler').getByText('Data Observability').click();
       await page
         .getByRole('tab', {
           name: 'Table Profile',
@@ -257,7 +257,7 @@ test(
       testCaseNames
     );
     await table.visitEntityPage(page, table.entity.displayName);
-    await page.getByText('Data Observability').click();
+    await page.getByTestId('profiler').getByText('Data Observability').click();
     await page.getByRole('tab', { name: 'Data Quality' }).click();
 
     const ingestionPipelinesListResponse =

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -189,7 +189,7 @@ export const visitCreateTestCasePanelFromEntityPage = async (
       table.entityResponseData?.['fullyQualifiedName'] ?? ''
     )}/tableProfile/latest?includeColumnProfile=false`
   );
-  await page.getByText('Data Observability').click();
+  await page.getByTestId('profiler').getByText('Data Observability').click();
   await profileResponse;
   await page.getByRole('tab', { name: 'Table Profile' }).click();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
@@ -228,6 +228,30 @@ describe('useTestCaseIncidentHeader', () => {
     expect(result.current.testCaseStatusData).toBeUndefined();
   });
 
+  it('should clear stale incident state when moving to a test case without an incident', async () => {
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentId: '123',
+    };
+
+    const { result, rerender } = renderIncidentHeaderHook();
+
+    await waitFor(() =>
+      expect(result.current.testCaseStatusData).toEqual(
+        MOCK_TEST_CASE_INCIDENT.data[0]
+      )
+    );
+
+    mockUseTestCaseStore.testCase = { ...MOCK_TEST_CASE_DATA };
+    rerender();
+
+    await waitFor(() =>
+      expect(result.current.testCaseStatusData).toBeUndefined()
+    );
+
+    expect(result.current.incidentTask).toBeNull();
+  });
+
   it('should expose the owner version diff only on the version page', async () => {
     const { result: liveResult } = renderIncidentHeaderHook();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
@@ -12,7 +12,11 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
-import { Severities } from '../../../../generated/tests/testCaseResolutionStatus';
+import {
+  Severities,
+  TestCaseResolutionStatus,
+  TestCaseResolutionStatusTypes,
+} from '../../../../generated/tests/testCaseResolutionStatus';
 import {
   MOCK_TASK_DATA,
   MOCK_TEST_CASE_DATA,
@@ -100,7 +104,10 @@ jest.mock('react-router-dom', () => ({
 
 const mockUseTestCaseStore = {
   testCase: { ...MOCK_TEST_CASE_DATA, incidentId: '123' } as
-    | (typeof MOCK_TEST_CASE_DATA & { incidentId?: string })
+    | (typeof MOCK_TEST_CASE_DATA & {
+        incidentId?: string;
+        incidentStatus?: TestCaseResolutionStatus;
+      })
     | undefined,
   testCasePermission: mockEntityPermissions,
   setTestCase: jest.fn(),
@@ -173,6 +180,44 @@ describe('useTestCaseIncidentHeader', () => {
 
   it('should skip incident fetches when there is no incident id', async () => {
     mockUseTestCaseStore.testCase = { ...MOCK_TEST_CASE_DATA };
+
+    const { result } = renderIncidentHeaderHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getIncidentTaskByStateId).not.toHaveBeenCalled();
+    expect(getListTestCaseIncidentByStateId).not.toHaveBeenCalled();
+    expect(result.current.testCaseStatusData).toBeUndefined();
+  });
+
+  it('should render the resolved inline status when there is no incident id', async () => {
+    const resolvedInlineStatus = {
+      ...MOCK_TEST_CASE_INCIDENT.data[0],
+      testCaseResolutionStatusType: TestCaseResolutionStatusTypes.Resolved,
+    } as unknown as TestCaseResolutionStatus;
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentStatus: resolvedInlineStatus,
+    };
+
+    const { result } = renderIncidentHeaderHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getListTestCaseIncidentByStateId).not.toHaveBeenCalled();
+    expect(getIncidentTaskByStateId).toHaveBeenCalledWith(
+      resolvedInlineStatus.stateId
+    );
+    expect(result.current.testCaseStatusData).toEqual(resolvedInlineStatus);
+    expect(result.current.incidentTask).toEqual(MOCK_TASK_DATA[1]);
+  });
+
+  it('should ignore a non-resolved inline status when there is no incident id', async () => {
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentStatus: MOCK_TEST_CASE_INCIDENT
+        .data[0] as unknown as TestCaseResolutionStatus,
+    };
 
     const { result } = renderIncidentHeaderHook();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
@@ -248,16 +248,31 @@ export const useTestCaseIncidentHeader = ({
   }, [testCaseResolutionStatus, incidentStateId, fetchTaskCount]);
 
   useEffect(() => {
+    const inlineStatus = testCaseData?.incidentStatus as
+      | TestCaseResolutionStatus
+      | undefined;
+    const resolvedStatus =
+      inlineStatus?.testCaseResolutionStatusType ===
+      TestCaseResolutionStatusTypes.Resolved
+        ? inlineStatus
+        : undefined;
+
     if (testCaseData?.incidentId) {
       setIsLoading(true);
       Promise.allSettled([
         fetchTestCaseResolution(testCaseData.incidentId),
         fetchIncidentTask(testCaseData.incidentId),
       ]).finally(() => setIsLoading(false));
+    } else if (resolvedStatus?.stateId) {
+      setIsLoading(true);
+      setTestCaseStatusData(resolvedStatus);
+      fetchIncidentTask(resolvedStatus.stateId).finally(() =>
+        setIsLoading(false)
+      );
     } else {
       setIsLoading(false);
     }
-  }, [testCaseData?.incidentId]);
+  }, [testCaseData?.incidentId, testCaseData?.incidentStatus]);
 
   const handleDomainUpdate = async (
     selectedDomain: EntityReference | EntityReference[]

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
@@ -215,18 +215,17 @@ export const useTestCaseIncidentHeader = ({
     try {
       const { data } = await getListTestCaseIncidentByStateId(id);
 
-      setTestCaseStatusData(first(data));
+      return first(data);
     } catch {
-      setTestCaseStatusData(undefined);
+      return undefined;
     }
   };
 
   const fetchIncidentTask = async (stateId: string) => {
     try {
-      const task = await getIncidentTaskByStateId(stateId);
-      setIncidentTask(task);
+      return await getIncidentTaskByStateId(stateId);
     } catch {
-      setIncidentTask(null);
+      return null;
     }
   };
 
@@ -248,30 +247,50 @@ export const useTestCaseIncidentHeader = ({
   }, [testCaseResolutionStatus, incidentStateId, fetchTaskCount]);
 
   useEffect(() => {
-    const inlineStatus = testCaseData?.incidentStatus as
-      | TestCaseResolutionStatus
-      | undefined;
+    const inlineStatus = testCaseData?.incidentStatus;
     const resolvedStatus =
       inlineStatus?.testCaseResolutionStatusType ===
       TestCaseResolutionStatusTypes.Resolved
         ? inlineStatus
         : undefined;
+    const incidentId = testCaseData?.incidentId;
+    const stateId = incidentId ?? resolvedStatus?.stateId;
 
-    if (testCaseData?.incidentId) {
-      setIsLoading(true);
-      Promise.allSettled([
-        fetchTestCaseResolution(testCaseData.incidentId),
-        fetchIncidentTask(testCaseData.incidentId),
-      ]).finally(() => setIsLoading(false));
-    } else if (resolvedStatus?.stateId) {
-      setIsLoading(true);
-      setTestCaseStatusData(resolvedStatus);
-      fetchIncidentTask(resolvedStatus.stateId).finally(() =>
-        setIsLoading(false)
-      );
-    } else {
+    if (!stateId) {
+      setTestCaseStatusData(undefined);
+      setIncidentTask(null);
       setIsLoading(false);
+
+      return;
     }
+
+    // Guard against a stale response landing after the test case changed:
+    // both fetches below resolve asynchronously, so the cleanup flips `active`
+    // and the late writer is dropped instead of showing the prior incident.
+    let active = true;
+    setIsLoading(true);
+
+    Promise.all([
+      incidentId
+        ? fetchTestCaseResolution(incidentId)
+        : Promise.resolve(resolvedStatus),
+      fetchIncidentTask(stateId),
+    ])
+      .then(([status, task]) => {
+        if (active) {
+          setTestCaseStatusData(status);
+          setIncidentTask(task);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
   }, [testCaseData?.incidentId, testCaseData?.incidentStatus]);
 
   const handleDomainUpdate = async (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
@@ -80,6 +80,7 @@ describe('TestCaseClassBase', () => {
       'testDefinition',
       'owners',
       'incidentId',
+      'incidentStatus',
       'tags',
       'dataProducts',
       'domains',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
@@ -155,6 +155,7 @@ class TestCaseClassBase {
       TabSpecificField.TEST_DEFINITION,
       TabSpecificField.OWNERS,
       TabSpecificField.INCIDENT_ID,
+      TabSpecificField.INCIDENT_STATUS,
       TabSpecificField.TAGS,
       TabSpecificField.DATA_PRODUCTS,
       TabSpecificField.DOMAINS,


### PR DESCRIPTION
Fixes #30455

## Problem

After #30182, a resolved DQ incident renders as "No Incident" on the Test Case page. That also removed the status edit control, so a resolved incident can no longer be reopened (Resolved -> Ack) in place -- the recovery path a user needs after resolving by mistake (#30168). Reopen was only possible from the global Incident Manager list.

## Fix

The Test Case page now requests and reads the inlined `incidentStatus` field (added in #30157) and, when there is no ongoing `incidentId`, renders the resolved incident with its edit affordance so it can be reopened in place. Reopen continues the same incident (same `stateId`). `incidentId` semantics are unchanged, so auto-close and the Resolved-Incidents KPI are unaffected. The DQ dashboard tab already renders this via #30157.

## Tests

- Unit: the header hook renders the resolved inline status (and ignores a non-resolved one) when there is no `incidentId`.
- E2E: the resolved incident shows its chip on the DQ tab, and reopening it from the Test Case page continues the same `stateId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores resolved-incident visibility and reopening on the Test Case page.
- Requests the inline `incidentStatus` field and displays it when no active `incidentId` exists.
- Coordinates incident-status and task loading with cleanup guards that prevent stale asynchronous writes during navigation.
- Adds unit and end-to-end coverage for resolved incident display, state cleanup, and reopening with the existing `stateId`.
- Tightens Data Observability selectors in related Playwright flows.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with both previously reported stale incident-state failures addressed.

No blocking failure remains.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts | Adds resolved inline-status handling and addresses both previously reported stale-state paths through explicit clearing and effect cleanup. |
| openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts | Requests `incidentStatus` alongside the existing incident fields for Test Case detail rendering. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx | Covers resolved inline status, rejection of non-resolved inline status, and state clearing during navigation. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts | Verifies resolved-incident visibility and reopening while preserving the original incident state identifier. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(test): wrap Data Observability locat..."](https://github.com/open-metadata/openmetadata/commit/bab0083908768ad833a24e2349d3b0ba4f033a36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46962085)</sub>

<!-- /greptile_comment -->