### PR TITLE
fix(playwright): green playwright-summary when gate skips the pipeline

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1545,19 +1545,31 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
-      # Short-circuit when gate said "don't run" — every upstream job is
-      # legitimately `skipped` in that case (redundant pull_request_target
-      # for a same-repo PR, or fork PR without safe-to-test), and the
-      # renderer below counts each skipped upstream as a "CI/reporting
-      # failure" and fails the whole check. That's what turned run 30090391086
-      # red on PR #30454 despite the pipeline correctly opting out.
-      # The authoritative playwright-summary check for such PRs comes from
-      # the OTHER event's run — this job needs to exit success so branch
-      # protection isn't blocked by the redundant event's synthetic red.
-      - name: Report gate-skipped run as green
-        if: ${{ needs.gate.outputs.should_run != 'true' }}
+      # If gate itself didn't produce a valid decision (crash, cancelled,
+      # unknown), FAIL loudly rather than silently reporting green below.
+      # Without this guard, the "should_run != 'true'" branch (or any
+      # negative match) would treat an unset gate output the same as an
+      # explicit skip decision — hiding the gate failure and letting a
+      # required check pass on an invalid pipeline state.
+      # (Per @greptile-apps P1 review on this PR.)
+      - name: Guard against missing gate decision
+        if: ${{ needs.gate.result != 'success' }}
         run: |
-          echo "Gate returned should_run=false for event=${{ github.event_name }}."
+          echo "::error::gate did not succeed (result=${{ needs.gate.result }}, should_run=${{ needs.gate.outputs.should_run }}). Refusing synthetic green — this playwright-summary must not report success without a valid gate decision."
+          exit 1
+
+      # Short-circuit when gate explicitly decided should_run=false —
+      # every upstream job is legitimately `skipped` in that case
+      # (redundant pull_request_target for a same-repo PR, or fork PR
+      # without safe-to-test), and the renderer below counts each
+      # skipped upstream as a "CI/reporting failure" and fails the whole
+      # check. That's what turned run 30090391086 red on PR #30454 despite
+      # the pipeline correctly opting out. Match on the exact "false"
+      # string (not != 'true') so unset outputs never fall through here.
+      - name: Report gate-skipped run as green
+        if: ${{ needs.gate.outputs.should_run == 'false' }}
+        run: |
+          echo "Gate decided should_run=false for event=${{ github.event_name }}."
           echo "This run is intentionally skipped; the authoritative playwright-summary comes from the sibling event's run."
           echo "Exiting 0 so this check does not block branch protection."
 

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1313,6 +1313,7 @@ jobs:
     if: ${{ always() && !cancelled() }}
     needs:
       [
+        gate,
         check-changes,
         cache-keys,
         build,
@@ -1544,8 +1545,24 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      # Short-circuit when gate said "don't run" — every upstream job is
+      # legitimately `skipped` in that case (redundant pull_request_target
+      # for a same-repo PR, or fork PR without safe-to-test), and the
+      # renderer below counts each skipped upstream as a "CI/reporting
+      # failure" and fails the whole check. That's what turned run 30090391086
+      # red on PR #30454 despite the pipeline correctly opting out.
+      # The authoritative playwright-summary check for such PRs comes from
+      # the OTHER event's run — this job needs to exit success so branch
+      # protection isn't blocked by the redundant event's synthetic red.
+      - name: Report gate-skipped run as green
+        if: ${{ needs.gate.outputs.should_run != 'true' }}
+        run: |
+          echo "Gate returned should_run=false for event=${{ github.event_name }}."
+          echo "This run is intentionally skipped; the authoritative playwright-summary comes from the sibling event's run."
+          echo "Exiting 0 so this check does not block branch protection."
+
       - name: Render consolidated job summary and gate on results
-        if: always()
+        if: ${{ always() && needs.gate.outputs.should_run == 'true' }}
         uses: actions/github-script@v8
         env:
           CHECK_CHANGES_RESULT: ${{ needs.check-changes.result }}


### PR DESCRIPTION
## Summary

Regression from #30453 that surfaced on PR #30454 ([run 30090391086](https://github.com/open-metadata/OpenMetadata/actions/runs/30090391086/job/89472165978)):

- \`pull_request_target\` fires on a same-repo PR
- \`gate\` correctly returns \`should_run=false\` (redundant — \`pull_request\` already handles it)
- Every upstream job is legitimately \`skipped\`
- **But** \`playwright-summary\` runs the render step unconditionally (\`if: always()\`)
- \`render_playwright_summary.cjs\` counts each skipped upstream as a \"CI/reporting failure\" and calls \`core.setFailed()\`
- The required \`playwright-summary\` check goes 🔴 with \`0 Playwright test failure(s); 9 CI/reporting failure(s)\`
- Branch protection blocks the PR, even though the sibling \`pull_request\` run passed

## Fix

Three-line change on the \`playwright-summary\` job:

1. Add \`gate\` to its \`needs:\` list (so it can read \`needs.gate.outputs.should_run\`)
2. Gate the render step on \`should_run == 'true'\` — skips when gate said skip
3. Add a tiny \"Report gate-skipped run as green\" step with the opposite condition that echoes success — keeps the job's conclusion at ✅ so branch protection sees green regardless of which event fired

## Behaviour matrix after this fix

| Event | gate | render | job conclusion |
|---|---|---|---|
| merge_group / workflow_dispatch / schedule | true | run | real result |
| same-repo PR + pull_request | true | run | real result |
| same-repo PR + pull_request_target | false | skipped | ✅ green (this fix) |
| fork PR + pull_request_target + label | true | run | real result |
| fork PR + pull_request_target, no label | false | skipped | ✅ green (this fix) |
| fork PR + pull_request | false | skipped | ✅ green (this fix) |
| any draft PR | false | skipped | ✅ green (this fix) |

## Diff scope

\`\`\`
 .github/workflows/playwright-postgresql-e2e.yml | 19 ++++++++++++++++++-
 1 file changed, 18 insertions(+), 1 deletion(-)
\`\`\`

Pure workflow change. No script edits, no test edits, no logic changes to the render pathway.

## Test plan

- [ ] Same-repo PR (this one): \`pull_request\` triggers, gate returns \`true\`, everything runs normally including render. \`pull_request_target\` triggers, gate returns \`false\`, render skips, \"Report gate-skipped run as green\" runs, job ✅.
- [ ] Fork PR without \`safe to test\`: both events fire, both gate to false, both skip render, both jobs ✅.
- [ ] Merge queue: gate=true, everything runs, render fires normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds explicit handling for every Playwright gate outcome.
- Fails the summary job when the gate does not complete successfully.
- Reports an explicit `should_run=false` decision as a successful intentional skip.
- Runs the consolidated summary renderer only for an explicit `should_run=true` decision.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | The summary job now distinguishes gate failures, explicit skips, and executable test runs without leaving the previously reported missing-output path green. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  G[Gate job completes] --> R{Gate result is success?}
  R -- No --> F[Fail summary job]
  R -- Yes --> D{should_run decision}
  D -- true --> P[Render consolidated Playwright summary]
  D -- false --> S[Report intentional skip as green]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile P1: fail if gate itself..."](https://github.com/open-metadata/openmetadata/commit/497d7d0b004bc65da94b7112aaa886d63ec3868c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46973818)</sub>

<!-- /greptile_comment -->