### PR TITLE
Refactor ontology empty state

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx
@@ -98,6 +98,7 @@ import CertificationTag from '../../common/CertificationTag/CertificationTag';
 import AnnouncementDrawer from '../../common/EntityPageInfos/AnnouncementDrawer/AnnouncementDrawer';
 import ManageButton from '../../common/EntityPageInfos/ManageButton/ManageButton';
 import HeaderBreadcrumb from '../../common/HeaderBreadcrumb/HeaderBreadcrumb.component';
+import { getGlossaryHomeCrumb } from '../../common/HeaderBreadcrumb/HeaderBreadcrumb.utils';
 import { EditIconButton } from '../../common/IconButtons/EditIconButton';
 import TitleBreadcrumbSkeleton from '../../common/Skeleton/BreadCrumb/TitleBreadcrumbSkeleton.component';
 import RetentionPeriod from '../../Database/RetentionPeriod/RetentionPeriod.component';
@@ -689,6 +690,9 @@ export const DataAssetsHeader = ({
                 autoCollapse
                 className="tw:mb-0"
                 items={[
+                  ...(entityType === EntityType.METRIC
+                    ? [getGlossaryHomeCrumb(t)]
+                    : []),
                   ...breadcrumbs.map((link) => ({
                     label: link.name,
                     href:
@@ -699,7 +703,7 @@ export const DataAssetsHeader = ({
                   { label: entityName },
                 ]}
                 showHome={false}
-                size="sm"
+                size="xs"
               />
             </TitleBreadcrumbSkeleton>
           </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricHeaderInfo/MetricHeaderInfo.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricHeaderInfo/MetricHeaderInfo.tsx
@@ -11,15 +11,7 @@
  *  limitations under the License.
  */
 import Icon from '@ant-design/icons/lib/components/Icon';
-import {
-  Button,
-  Divider,
-  List,
-  Popover,
-  Space,
-  Tooltip,
-  Typography,
-} from 'antd';
+import { Button, List, Popover, Space, Tooltip, Typography } from 'antd';
 import classNames from 'classnames';
 import { startCase } from 'lodash';
 import { FC, useMemo, useState } from 'react';
@@ -36,6 +28,7 @@ import {
   MetricGranularity,
   MetricType,
 } from '../../../generated/entity/data/metric';
+import { HeaderDotSeparator } from '../../../utils/DataAssetsHeader.utils';
 import { getSortedOptions } from '../../../utils/MetricEntityUtils/MetricPureUtils';
 import './metric-header-info.less';
 import UnitOfMeasurementInfoItem from './UnitOfMeasurementInfoItem';
@@ -202,7 +195,7 @@ const MetricHeaderInfo: FC<MetricHeaderInfoProps> = ({
 
   return (
     <>
-      <Divider className="self-center vertical-divider" type="vertical" />
+      <HeaderDotSeparator />
       <MetricInfoItem
         hasPermission={hasPermission}
         label={t('label.metric-type')}
@@ -216,7 +209,7 @@ const MetricHeaderInfo: FC<MetricHeaderInfoProps> = ({
         valueKey="metricType"
         onUpdateMetricDetails={onUpdateMetricDetails}
       />
-      <Divider className="self-center vertical-divider" type="vertical" />
+      <HeaderDotSeparator />
 
       <UnitOfMeasurementInfoItem
         hasPermission={hasPermission}
@@ -224,7 +217,7 @@ const MetricHeaderInfo: FC<MetricHeaderInfoProps> = ({
         metricDetails={metricDetails}
         onMetricUpdate={onUpdateMetricDetails}
       />
-      <Divider className="self-center vertical-divider" type="vertical" />
+      <HeaderDotSeparator />
 
       <MetricInfoItem
         hasPermission={hasPermission}

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -341,10 +341,15 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
       }
 
       return (
-        <GraphEmptyState
-          message={t('message.no-glossary-terms-found')}
-          testId="ontology-graph-empty"
-        />
+        <div
+          className="tw:absolute tw:inset-0 tw:z-3 tw:flex tw:items-center tw:justify-center tw:bg-primary"
+          data-testid="ontology-graph-empty">
+          <EmptyPlaceholder
+            description={t('message.no-glossary-terms-found')}
+            icon={<Cube02 className="tw:text-fg-brand-primary" />}
+            title={t('message.ontology-empty-title')}
+          />
+        </div>
       );
     }
 
@@ -452,7 +457,6 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
   // chrome (filter toolbar, mode/search/export bar, zoom controls) has nothing
   // to act on, so it is hidden to match the clean empty layout.
   const showOnboardingEmptyState =
-    scope === 'global' &&
     !loading &&
     graphDataToShow !== null &&
     graphDataToShow.nodes.length === 0 &&
@@ -497,7 +501,7 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
         </Card>
       )}
 
-      <div className="tw:flex tw:min-h-0 tw:flex-1 tw:overflow-hidden">
+      <div className="tw:flex tw:min-h-0 tw:flex-1 tw:overflow-hidden tw:p-px">
         <div
           className={classNames(
             'tw:relative tw:flex tw:min-h-0 tw:min-w-0 tw:flex-1 tw:flex-col tw:overflow-hidden',


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI Refactors:**
    - Refactored `OntologyExplorer` empty state to use `EmptyPlaceholder` with custom description and icon
    - Replaced vertical dividers with `HeaderDotSeparator` in `MetricHeaderInfo`
    - Added glossary home breadcrumb and adjusted size for `DataAssetsHeader` when entity type is metric

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Refactors ontology and metric header presentation.
- Replaces the scoped ontology empty state with the shared `EmptyPlaceholder` presentation.
- Adjusts ontology empty-layout styling and the condition controlling graph chrome.
- Adds a glossary-home crumb to metric headers and uses compact breadcrumb sizing.
- Replaces metric metadata dividers with dot separators.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the eligible follow-up findings.

No blocking failure remains within the scope of this follow-up review.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx | Refactors the scoped empty-state presentation and ontology explorer layout conditions. |
| openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.component.tsx | Adds a glossary-home breadcrumb for metrics and reduces breadcrumb sizing. |
| openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricHeaderInfo/MetricHeaderInfo.tsx | Replaces vertical dividers between metric attributes with shared dot separators. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into govern-spacing"](https://github.com/open-metadata/openmetadata/commit/2b232ebbd0e9f289d79b66f363dee759aadb2d3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46992838)</sub>

<!-- /greptile_comment -->