### PR TITLE
ci(playwright): free ~30GB disk before prepare-playwright-fixture docker save

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -695,6 +695,30 @@ jobs:
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit == 'true' && (needs.plan-playwright.outputs.requires_airflow != 'true' || needs.restore-playwright-fixture.outputs.ingestion_cache_hit == 'true') }}
         run: echo "The golden fixture and optional ingestion image were restored while the distribution was prepared."
 
+      # Reclaim ~30 GB of runner disk (dotnet, android, haskell, swap) BEFORE
+      # any docker work runs. `create_playwright_fixture.sh` does a
+      # `docker image save <ingestion>` after packing the fixture tar, which
+      # streams multi-GB blobs through /var/lib/docker/tmp/. On a fresh
+      # ubuntu-latest that partition has ~14 GB free after all the OM images
+      # (server, ingestion, postgres, opensearch, airflow) and their seeded
+      # volumes are loaded — not enough headroom for the docker export tmp,
+      # so the save fails with:
+      #   Error response from daemon: write /var/lib/docker/tmp/...: no space left on device
+      # (See failure on https://github.com/open-metadata/OpenMetadata/actions/runs/30097915650)
+      # docker-images:false is deliberate — the OM images are exactly what
+      # this job needs to snapshot, so we can't prune them here.
+      - name: Free Disk Space (Ubuntu)
+        if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: true
+          docker-images: false
+
       - name: Checkout
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

The \`prepare-playwright-fixture\` job intermittently fails on the \`Prepare seeded environment\` step with:

\`\`\`
Created Playwright fixture at /home/runner/work/_temp/playwright-fixture-cache/playwright-fixture.tar.zst (52M)
Error response from daemon: write /var/lib/docker/tmp/docker-export-3337596201/blobs/sha256/...: no space left on device
/*stdin*\            :  (     0 B =>     13 B, /home/runner/work/_temp/playwright-ingestion-cache/playwright-ingestion-image.tar.zst)
Error: Process completed with exit code 1.
\`\`\`

Seen on [PR #30388 run 30097915650](https://github.com/open-metadata/OpenMetadata/actions/runs/30097915650/job/89499366025).

## Root cause

The failure sits in \`.github/scripts/create_playwright_fixture.sh\`:

\`\`\`bash
line 127: sudo tar --numeric-owner --zstd -C "$stage_dir" -cf "$output_path" .        # succeeds (52 MB)
line 134: docker image save "$ingestion_image" | zstd -T0 -3 -f -o "$ingestion_output_path"  # fails
\`\`\`

\`docker image save\` streams multi-GB blobs through \`/var/lib/docker/tmp/\` before piping to stdout. By this point the runner's docker root already holds:

- Every OM image: \`openmetadata-server\`, \`openmetadata-ingestion\`, \`postgres\`, \`opensearch\`, \`airflow\`
- Their seeded volumes (postgres data + opensearch data)
- Maven build output (\`openmetadata-dist/target\`)
- The 52 MB fixture tar we just wrote

On a stock \`ubuntu-latest\` runner (~14 GB free after image downloads and setup), there is no headroom left for the export tmp. Hence \`no space left on device\` on the very first blob write, and the resulting \`ingestion-image.tar.zst\` is a 13-byte zst of the empty stream.

## What #30310 changed

The pre-#30310 workflow ran \`jlumbroso/free-disk-space\` on **every shard job** to reclaim ~30 GB (dotnet, android, haskell, swap). That step was dropped from \`prepare-playwright-fixture\` during the rewrite — even though this is the job doing the heaviest docker export.

## Change

Add the same \`Free Disk Space (Ubuntu)\` step at the top of \`prepare-playwright-fixture\`, gated on the cache-miss condition (no point freeing disk if we're just going to reuse the fixture cache):

\`\`\`yaml
- name: Free Disk Space (Ubuntu)
  if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
  uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
  with:
    tool-cache: false
    android: true
    dotnet: true
    haskell: true
    large-packages: false
    swap-storage: true
    docker-images: false   # deliberate — those images are what we're snapshotting
\`\`\`

Placed **between** \`Reuse cached Playwright assets\` and \`Checkout\` so it fires only on the fixture-rebuild path.

## Cost / benefit

| | Before | After |
|---|---|---|
| Cache-hit run | ~30 s (skip everything) | unchanged |
| Cache-miss run | 15-20 min, sometimes crashes on docker save | 16-21 min, robust |

**Cost**: ~1 min added to cache-miss runs.
**Benefit**: eliminates the intermittent docker-export OOM failure that blocks affected PRs and forces a re-run.

## Follow-up worth considering (not in scope)

A targeted \`docker container prune\` / \`docker builder prune\` between the fixture-tar line and the docker-save line inside \`create_playwright_fixture.sh\` would give similar headroom in ~5 seconds without needing the workflow-level free-disk-space step. Kept out of this PR to minimise blast radius and reviewer surface; can be revisited if the 1-min cost of the free-disk step is worth optimising.

## Test plan

- [ ] Rerun a previously-failed PR against this workflow, confirm \`prepare-playwright-fixture\` completes past the docker-save step.
- [ ] Multi-run stability: no space-related failures over ~10 consecutive PR runs.
- [ ] Cache-hit paths unaffected (step condition explicitly excludes them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a cache-miss-only, commit-pinned disk cleanup step to the Playwright PostgreSQL fixture preparation job, preserving Docker images and the runner tool cache while reclaiming space from unused SDKs and swap.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The new action is commit-pinned, runs only when fixture work is required, preserves the tool cache and Docker images needed by later steps, and removes SDKs that the job does not use.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | The cleanup condition correctly matches fixture preparation paths, and its configuration is consistent with comparable repository workflows without disrupting required tools or Docker images. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): free ~30GB disk before p..."](https://github.com/open-metadata/openmetadata/commit/e8eb2eb7d78f1c5f2dbdf0791f4884dde0b20529) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47007450)</sub>

<!-- /greptile_comment -->