### PR TITLE
fix(playwright): rename summary check on redundant/skipped runs

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1309,7 +1309,55 @@ jobs:
         run: ./.github/scripts/stop_playwright_fast_environment.sh
 
   playwright-summary:
-    name: ${{ contains(fromJSON('["pull_request","pull_request_target"]'), github.event_name) && github.event.action == 'labeled' && github.event.label.name != 'safe to test' && 'playwright-summary (label ignored)' || 'playwright-summary' }}
+    # Publish the required check name `playwright-summary` ONLY when this
+    # run is going to do real work. Every other case (redundant sibling
+    # event for a same-repo PR / fork PR without safe-to-test / draft /
+    # spurious label event) publishes a differently-named check so branch
+    # protection can distinguish "authoritative for this PR shape" from
+    # "synthetic green / skipped". Without this, GitHub's protection UI
+    # picks the most-recently-completed run of `playwright-summary` — and
+    # the synthetic-green from the redundant event finishes in ~15s while
+    # the real pipeline is still running, making the PR appear mergeable
+    # before tests finish. See run 30097914955 for the failure this
+    # addresses.
+    #
+    # Decision tree (mirrors the gate job):
+    #   merge_group / schedule / workflow_dispatch      → 'playwright-summary'
+    #   same-repo PR + pull_request (not draft, no bad label)
+    #                                                    → 'playwright-summary'
+    #   fork PR + pull_request_target + 'safe to test'
+    #     (not draft, no bad label)                       → 'playwright-summary'
+    #   labeled event with non-'safe to test' label     → 'playwright-summary (label ignored)'
+    #   everything else (redundant events, drafts, fork
+    #     PRs without label)                             → 'playwright-summary (skipped)'
+    name: >-
+      ${{
+        (
+          github.event_name == 'merge_group'
+          || github.event_name == 'workflow_dispatch'
+          || github.event_name == 'schedule'
+          || (
+            github.event_name == 'pull_request'
+            && github.event.pull_request.head.repo.full_name == github.repository
+            && !github.event.pull_request.draft
+            && !(github.event.action == 'labeled' && github.event.label.name != 'safe to test')
+          )
+          || (
+            github.event_name == 'pull_request_target'
+            && github.event.pull_request.head.repo.full_name != github.repository
+            && !github.event.pull_request.draft
+            && contains(github.event.pull_request.labels.*.name, 'safe to test')
+            && !(github.event.action == 'labeled' && github.event.label.name != 'safe to test')
+          )
+        )
+        && 'playwright-summary'
+        || (
+          github.event.action == 'labeled'
+          && github.event.label.name != 'safe to test'
+          && 'playwright-summary (label ignored)'
+          || 'playwright-summary (skipped)'
+        )
+      }}
     if: ${{ always() && !cancelled() }}
     needs:
       [

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1326,7 +1326,12 @@ jobs:
     #   same-repo PR + pull_request (not draft, no bad label)
     #                                                    → 'playwright-summary'
     #   fork PR + pull_request_target + 'safe to test'
-    #     (not draft, no bad label)                       → 'playwright-summary'
+    #     (not draft, not synchronize, no bad label)      → 'playwright-summary'
+    #     synchronize events are rejected here to match the gate — the
+    #     pre-gate step strips the label mid-run but the event payload
+    #     still shows it as present, so we must ignore synchronize
+    #     explicitly to avoid publishing a synthetic green under the
+    #     required check name for unreviewed new commits.
     #   labeled event with non-'safe to test' label     → 'playwright-summary (label ignored)'
     #   everything else (redundant events, drafts, fork
     #     PRs without label)                             → 'playwright-summary (skipped)'
@@ -1346,6 +1351,7 @@ jobs:
             github.event_name == 'pull_request_target'
             && github.event.pull_request.head.repo.full_name != github.repository
             && !github.event.pull_request.draft
+            && github.event.action != 'synchronize'
             && contains(github.event.pull_request.labels.*.name, 'safe to test')
             && !(github.event.action == 'labeled' && github.event.label.name != 'safe to test')
           )


### PR DESCRIPTION
## Summary

Follow-up to #30453 + #30468 that closes a real premature-green hole in required-check gating.

## The bug

Same-repo PRs fire **both** \`pull_request\` and \`pull_request_target\` on every push. #30453's gate correctly routes them:

- \`pull_request\` → gate=true, real pipeline runs
- \`pull_request_target\` → gate=false, #30468's summary short-circuit reports a synthetic green

So far so good. **But** both runs' \`playwright-summary\` jobs publish check runs with the **same name** — \`playwright-summary\` — which is exactly the required check on main's branch protection. GitHub's protection UI picks the **most-recently-completed** run of a given check name, and the synthetic-green run finishes in **~15 seconds** while the real pipeline is still compiling. Result: the PR appears mergeable before any test executes.

## Evidence

[Run 30097914955, job 89496479495](https://github.com/open-metadata/OpenMetadata/actions/runs/30097914955/job/89496479495?pr=30388):

- Event: \`pull_request_target\`
- Branch: \`fix/persona-localization\` (same-repo PR)
- gate result: success, \`should_run=false\`
- Every real summary step skipped
- \`Report gate-skipped run as green\` ran and job succeeded
- Check named \`playwright-summary\` published green — satisfying branch protection prematurely

## The fix

Publish the required check name \`playwright-summary\` **only when this run is going to do real work**. Every other case publishes a differently-named check that branch protection ignores.

## Decision tree (mirrors the gate)

| Trigger | Check name |
|---|---|
| \`merge_group\` / \`schedule\` / \`workflow_dispatch\` | \`playwright-summary\` |
| Same-repo PR + \`pull_request\` (not draft, no bad label) | \`playwright-summary\` |
| Fork PR + \`pull_request_target\` + \`safe to test\` (not draft, no bad label) | \`playwright-summary\` |
| Labeled event with a non-\`safe to test\` label | \`playwright-summary (label ignored)\` |
| Everything else (redundant sibling events, drafts, fork PRs without label) | \`playwright-summary (skipped)\` |

## Behaviour after this fix

| PR shape | pull_request run | pull_request_target run | Required check |
|---|---|---|---|
| Same-repo PR | \`playwright-summary\` (real) | \`... (skipped)\` | 🟡 held until real run finishes |
| Fork PR + \`safe to test\` label | \`... (skipped)\` | \`playwright-summary\` (real) | 🟡 held until real run finishes |
| Fork PR without label | \`... (skipped)\` | \`... (skipped)\` | 🔴 expected → blocks merge |
| Draft PR | \`... (skipped)\` | \`... (skipped)\` | 🔴 expected → blocks merge |

Fork-PR-without-label and draft-PR cases correctly stay at \"expected\" so the required check blocks the PR until the maintainer applies the label (or the author marks it ready for review). Matches the pre-#30310 UX that \`playwright-required-checks-stub.yml\` used to provide.

## Diff scope

\`\`\`
.github/workflows/playwright-postgresql-e2e.yml | 50 ++++++++++++++++++++++++-
1 file changed, 49 insertions(+), 1 deletion(-)
\`\`\`

Pure name-expression change on \`playwright-summary\`. The gate logic, the summary job's steps, and \`render_playwright_summary.cjs\` are all untouched. No new secrets, permissions, or dependencies.

## Test plan

- [ ] This PR (same-repo): \`pull_request\` publishes \`playwright-summary\` real result, \`pull_request_target\` publishes \`playwright-summary (skipped)\`. Branch protection should hold on the real one.
- [ ] Merge queue: publishes \`playwright-summary\` real result. Unchanged.
- [ ] A fork PR without \`safe to test\`: no \`playwright-summary\` check appears → required check stays \"expected\" → merge blocked. Correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Playwright summary check naming logic to prevent skipped fork synchronization runs from satisfying the required check.
- Excludes `pull_request_target` synchronization events from the authoritative `playwright-summary` name.
- Publishes skipped and ignored runs under distinct check names while preserving the required name for runs that execute the real pipeline.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains in the updated required-check naming logic.

</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | The updated name expression now mirrors the gate's synchronization exclusion and completes the fix described in the previous review thread. |

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile P1: reject synchronize ..."](https://github.com/open-metadata/openmetadata/commit/c0f5a4d3f6514b2f427cc32b1c46a7c094860bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47013189)</sub>

<!-- /greptile_comment -->