### PR TITLE
fix(playwright): run trusted fork updates

### DIFF
--- a/.github/workflows/playwright-mysql-e2e.yml
+++ b/.github/workflows/playwright-mysql-e2e.yml
@@ -46,6 +46,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
     environment: test
     permissions:
+      checks: read
       contents: read
       pull-requests: read
     env:
@@ -71,7 +72,7 @@ jobs:
           swap-storage: true
           docker-images: false
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.7.0
+        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
         if: ${{ github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -107,7 +107,7 @@ jobs:
         if: |
           github.event_name == 'pull_request_target' &&
           github.event.pull_request.head.repo.full_name != github.repository
-        uses: lewagon/wait-on-check-action@v1.7.0
+        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: Team Label
@@ -125,8 +125,8 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          labels=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}" \
-            --jq '[.labels[].name]')
+          labels=$(gh api "/repos/${REPO}/pulls/${PR_NUMBER}" \
+            --jq '[.labels[].name] | @json')
           echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
       - name: Compute gate decision
@@ -290,7 +290,7 @@ jobs:
       BUILD_TOOLCHAIN: ${{ needs.cache-keys.outputs.toolchain }}
     steps:
       - name: Wait for the labeler
-        uses: lewagon/wait-on-check-action@v1.7.0
+        uses: lewagon/wait-on-check-action@9312864dfbc9fd208e9c0417843430751c042800 # v1.7.0
         if: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -92,36 +92,42 @@ jobs:
   #                                                the "safe to test" label
   gate:
     runs-on: ubuntu-latest
-    # write on pull-requests is only needed for the auto-strip-label step
-    # below (fork sync). All other jobs keep the workflow-level read scope.
     permissions:
+      checks: read
       contents: read
-      pull-requests: write
+      pull-requests: read
     outputs:
       should_run: ${{ steps.gate.outputs.should_run }}
     steps:
-      # SECURITY: "safe to test" persists on the PR after it's applied.
-      # If we accept it on later `synchronize` events, a fork author can
-      # push malicious commits AFTER a maintainer vouched for the earlier
-      # head, and those unreviewed commits execute with base-repo secrets.
-      # Strip the label whenever the fork syncs so it only ever vouches
-      # for the SHA the maintainer actually saw. Re-labelling is required
-      # before the next fork push can run CI.
-      - name: Invalidate safe-to-test on fork sync
+      # Team Label atomically removes stale fork approval on synchronize and
+      # re-adds it only for allowlisted authors. Wait for that reconciliation
+      # instead of relying on another labeled event: GITHUB_TOKEN label writes
+      # intentionally do not trigger a new workflow run.
+      - name: Wait for fork label reconciliation
         if: |
           github.event_name == 'pull_request_target' &&
-          github.event.action == 'synchronize' &&
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          contains(github.event.pull_request.labels.*.name, 'safe to test')
+          github.event.pull_request.head.repo.full_name != github.repository
+        uses: lewagon/wait-on-check-action@v1.7.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: Team Label
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+
+      - name: Read reconciled fork labels
+        id: fork-labels
+        if: |
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.head.repo.full_name != github.repository
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          echo "::warning::Fork sync detected; removing 'safe to test' label (re-apply after reviewing the new commits)."
-          gh api -X DELETE "/repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test" \
-            || echo "Label already absent"
+          labels=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}" \
+            --jq '[.labels[].name]')
+          echo "labels=$labels" >> "$GITHUB_OUTPUT"
 
       - name: Compute gate decision
         id: gate
@@ -131,7 +137,7 @@ jobs:
           LABEL: ${{ github.event.label.name }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPO: ${{ github.repository }}
-          LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          LABELS_JSON: ${{ steps.fork-labels.outputs.labels || toJSON(github.event.pull_request.labels.*.name) }}
           IS_DRAFT: ${{ github.event.pull_request.draft }}
         run: |
           set -euo pipefail
@@ -142,12 +148,11 @@ jobs:
           if [[ "$IS_DRAFT" == "true" ]]; then decide false; fi
           if [[ "$ACTION" == "labeled" && "$LABEL" != "safe to test" ]]; then decide false; fi
           if [[ "$HEAD_REPO" == "$BASE_REPO" ]]; then
-            [[ "$EVENT" == "pull_request" ]] && decide true || decide false
+            if [[ "$EVENT" == "pull_request" ]]; then decide true; else decide false; fi
           fi
-          # Fork PR — pull_request_target must fire AND "safe to test" must be present.
-          # For synchronize events the previous step already stripped the label, so
-          # this check will correctly reject the run (forcing a re-label after review).
-          if [[ "$EVENT" == "pull_request_target" && "$ACTION" != "synchronize" ]] && \
+          # Fork PR — pull_request_target must fire and the reconciled labels
+          # for the current head SHA must include "safe to test".
+          if [[ "$EVENT" == "pull_request_target" ]] && \
              echo "$LABELS_JSON" | jq -e '. | index("safe to test")' >/dev/null; then
             decide true
           fi
@@ -1334,51 +1339,21 @@ jobs:
 
   playwright-summary:
     # Publish the required check name `playwright-summary` ONLY when this
-    # run is going to do real work. Every other case (redundant sibling
-    # event for a same-repo PR / fork PR without safe-to-test / draft /
-    # spurious label event) publishes a differently-named check so branch
-    # protection can distinguish "authoritative for this PR shape" from
-    # "synthetic green / skipped". Without this, GitHub's protection UI
-    # picks the most-recently-completed run of `playwright-summary` — and
-    # the synthetic-green from the redundant event finishes in ~15s while
-    # the real pipeline is still running, making the PR appear mergeable
-    # before tests finish. See run 30097914955 for the failure this
-    # addresses.
+    # gate authorizes the run. Every explicit gate skip publishes a
+    # differently-named check so a redundant sibling event cannot satisfy
+    # branch protection before the real pipeline finishes. Gate failures keep
+    # the required name and fail in the guard step below.
     #
-    # Decision tree (mirrors the gate job):
-    #   merge_group / schedule / workflow_dispatch      → 'playwright-summary'
-    #   same-repo PR + pull_request (not draft, no bad label)
-    #                                                    → 'playwright-summary'
-    #   fork PR + pull_request_target + 'safe to test'
-    #     (not draft, not synchronize, no bad label)      → 'playwright-summary'
-    #     synchronize events are rejected here to match the gate — the
-    #     pre-gate step strips the label mid-run but the event payload
-    #     still shows it as present, so we must ignore synchronize
-    #     explicitly to avoid publishing a synthetic green under the
-    #     required check name for unreviewed new commits.
+    # Decision tree:
+    #   gate succeeds with should_run=true              → 'playwright-summary'
+    #   gate fails                                      → 'playwright-summary'
     #   labeled event with non-'safe to test' label     → 'playwright-summary (label ignored)'
-    #   everything else (redundant events, drafts, fork
-    #     PRs without label)                             → 'playwright-summary (skipped)'
+    #   gate succeeds with should_run=false              → 'playwright-summary (skipped)'
     name: >-
       ${{
         (
-          github.event_name == 'merge_group'
-          || github.event_name == 'workflow_dispatch'
-          || github.event_name == 'schedule'
-          || (
-            github.event_name == 'pull_request'
-            && github.event.pull_request.head.repo.full_name == github.repository
-            && !github.event.pull_request.draft
-            && !(github.event.action == 'labeled' && github.event.label.name != 'safe to test')
-          )
-          || (
-            github.event_name == 'pull_request_target'
-            && github.event.pull_request.head.repo.full_name != github.repository
-            && !github.event.pull_request.draft
-            && github.event.action != 'synchronize'
-            && contains(github.event.pull_request.labels.*.name, 'safe to test')
-            && !(github.event.action == 'labeled' && github.event.label.name != 'safe to test')
-          )
+          needs.gate.result != 'success'
+          || needs.gate.outputs.should_run == 'true'
         )
         && 'playwright-summary'
         || (

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -12,6 +12,23 @@ jobs:
     runs-on: ubuntu-latest
     name: Team Label
     steps:
+      # Keep fork approval scoped to the current head SHA. This must run in
+      # the same job as the trusted-author labeler so synchronize events first
+      # invalidate an earlier approval and then revalidate allowlisted authors.
+      - name: Invalidate safe-to-test on fork sync
+        if: |
+          github.event.action == 'synchronize' &&
+          github.event.pull_request.head.repo.full_name != github.repository &&
+          contains(github.event.pull_request.labels.*.name, 'safe to test')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api -X DELETE \
+            "/repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test"
+
       - uses: JulienKode/team-labeler-action@v3.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/team-labeler.yml
+++ b/.github/workflows/team-labeler.yml
@@ -26,8 +26,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh api -X DELETE \
-            "/repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test"
+          if ! response=$(gh api --silent -X DELETE \
+            "/repos/${REPO}/issues/${PR_NUMBER}/labels/safe%20to%20test" 2>&1); then
+            if [[ "$response" != *"HTTP 404"* ]]; then
+              echo "$response" >&2
+              exit 1
+            fi
+            echo "safe to test label already absent"
+          fi
 
       - uses: JulienKode/team-labeler-action@v3.0.0
         with:


### PR DESCRIPTION
### What changed

- Move fork `safe to test` invalidation into the Team Label job so invalidation and trusted-author revalidation are ordered.
- Make the PostgreSQL + OpenSearch Playwright gate wait for Team Label and read the live PR labels.
- Keep MySQL + Elasticsearch on the same reconciled-label contract and pin its wait action for safe re-enablement.
- Use the gate result as the source of truth for the required `playwright-summary` check name.

### Root cause

The PostgreSQL Playwright gate removed `safe to test` and skipped every fork `synchronize` event. Team Label then restored the label for allowlisted authors with `GITHUB_TOKEN`, but GitHub intentionally does not launch another workflow for that bot-generated `labeled` event. As a result, trusted fork updates never reached Playwright.

This keeps approval SHA-scoped for untrusted forks while automatically revalidating authors listed under `safe to test` in `.github/teams.yml` on the existing `synchronize` event.

The MySQL + Elasticsearch workflow already waits for Team Label and verifies the live label, but it is currently disabled at the GitHub workflow level. After this fix merges, it will be re-enabled before #30484 is updated so both database/search variants exercise the corrected path.

### Validation

- `actionlint` on all three changed workflows, excluding the workflows' pre-existing `allow-unsafe-pr-checkout` metadata warnings
- trusted/untrusted fork and same-repo gate scenario matrix
- idempotent label-invalidation scenarios for success, 404, and non-404 failure
- `uv run --with pytest python -m pytest -q .github/scripts/tests/test_playwright_ci_planning.py .github/scripts/tests/test_playwright_pr_comment.py` — 59 passed
- `git diff --check`

After merge, PR #30484 will be updated from `main` to exercise both PostgreSQL + OpenSearch and MySQL + Elasticsearch.

This urgent CI regression fix uses the maintainer `skip-pr-checks` bypass because it does not have a product issue.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR hardens trusted-fork Playwright workflow coordination.
- Moves fork approval invalidation into the Team Label job and handles an already-absent label.
- Makes the PostgreSQL gate wait for reconciliation and evaluate live pull-request labels.
- Derives the required Playwright summary check name from the gate result.
- Pins the changed wait-on-check action references to a full commit SHA.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain within the eligible follow-up scope.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/team-labeler.yml | Moves fork approval invalidation before trusted-author relabeling and safely tolerates concurrent removal of the label. |
| .github/workflows/playwright-postgresql-e2e.yml | Waits for Team Label reconciliation, reads live fork labels, and uses the gate result to select the authoritative summary check. |
| .github/workflows/playwright-mysql-e2e.yml | Adds the check-read permission and pins the Team Label wait action to a full commit SHA. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Sync as Fork synchronize event
  participant Label as Team Label job
  participant API as GitHub API
  participant Gate as PostgreSQL gate
  participant Tests as Playwright jobs
  Sync->>Label: Start reconciliation for current head SHA
  Label->>API: Remove stale safe-to-test label
  Label->>Label: Revalidate allowlisted author
  Label->>API: Restore label when trusted
  Gate->>Label: Wait for Team Label check
  Gate->>API: Read live pull-request labels
  Gate->>Gate: Compute should_run
  alt should_run is true
    Gate->>Tests: Authorize Playwright execution
  else should_run is false
    Gate->>Tests: Publish skipped summary name
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): harden fork label recon..."](https://github.com/open-metadata/openmetadata/commit/de09211272d84d9a7ea9a9ede4c661c939f9a719) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47127227)</sub>

<!-- /greptile_comment -->