### PR TITLE
Fixes 30486: Map SchemaSearch to the Playwright ingestion lane

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -112,7 +112,14 @@
         "openmetadata-ui/src/main/resources/ui/src/pages/Explore/**",
         "openmetadata-service/src/main/java/org/openmetadata/service/search/**"
       ],
-      "projects": ["chromium", "Basic", "search-nightly", "Reindex", "GlobalSettings"],
+      "projects": [
+        "chromium",
+        "Basic",
+        "Ingestion",
+        "search-nightly",
+        "Reindex",
+        "GlobalSettings"
+      ],
       "specs": [
         "playwright/e2e/Pages/Explore*.spec.ts",
         "playwright/e2e/Features/*Search*.spec.ts",

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -611,6 +611,41 @@ def test_targeted_selection_combines_changed_specs_impacts_and_unmapped_canaries
     assert selection["directChangedSpecs"] == ["playwright/e2e/Pages/Entity.spec.ts"]
 
 
+def test_explore_changes_schedule_schema_search_in_ingestion(tmp_path, monkeypatch):
+    selector = load_script("select_playwright_tests")
+    changed = tmp_path / "changed.txt"
+    output = tmp_path / "selection.json"
+    changed.write_text(
+        "openmetadata-ui/src/main/resources/ui/src/components/Explore/Explore.tsx\n"
+    )
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "select_playwright_tests.py",
+            "--event-name",
+            "pull_request_target",
+            "--changed-files",
+            str(changed),
+            "--impact-map",
+            str(Path(".github/playwright/impact-map.json")),
+            "--output",
+            str(output),
+        ],
+    )
+
+    selector.main()
+
+    selection = json.loads(output.read_text())
+    schema_search = next(
+        entry
+        for entry in selection["selectors"]
+        if entry["spec"] == "playwright/e2e/Features/SchemaSearch.spec.ts"
+    )
+    assert "Ingestion" in schema_search["projects"]
+
+
 def test_targeted_selection_does_not_schedule_deleted_specs(tmp_path, monkeypatch):
     selector = load_script("select_playwright_tests")
     existing_spec = tmp_path / selector.UI_ROOT / "playwright/e2e/Smoke.spec.ts"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30486

Adds the `Ingestion` project to the Explore impact mapping so the ingestion-tagged `SchemaSearch.spec.ts` selector has a runnable lane instead of aborting targeted Playwright planning. Adds a regression test that runs PR selection for an Explore source change and verifies `SchemaSearch.spec.ts` is scheduled under `Ingestion`.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Explore source changes produce a valid targeted Playwright plan for `SchemaSearch.spec.ts`.

#### Unit tests

- [x] Added coverage in `.github/scripts/tests/test_playwright_ci_planning.py`.
- `uv run --with pytest pytest .github/scripts/tests/test_playwright_ci_planning.py` — 54 passed.

#### Backend integration tests

- [x] Not applicable; no backend API changes.

#### Ingestion integration tests

- [x] Not applicable; no ingestion implementation changes.

#### Playwright (UI) tests

- [x] Not applicable; this changes CI planning only.

#### Manual testing performed

- Reproduced the failing selector/project mismatch from PR #30484 and verified the updated selection includes the `Ingestion` project.

#
### UI screen recording / screenshots:

Not applicable; no UI changes.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario being fixed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates Playwright CI planning for Explore changes.
- Adds the `Ingestion` project to the Explore impact mapping.
- Adds regression coverage confirming `SchemaSearch.spec.ts` is selected for the ingestion lane.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The updated impact mapping makes the ingestion-tagged SchemaSearch test reachable in targeted planning, while downstream Playwright discovery filters project-incompatible tests; the regression test covers the intended selection.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/playwright/impact-map.json | Adds the existing Ingestion project to the Explore mapping so ingestion-tagged search tests have a compatible targeted lane. |
| .github/scripts/tests/test_playwright_ci_planning.py | Adds focused regression coverage for selecting SchemaSearch under Ingestion after an Explore source change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): map schema search to in..."](https://github.com/open-metadata/openmetadata/commit/5642e7b693a44d8d98ed24f96fbe0023db470165) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47185464)</sub>

<!-- /greptile_comment -->