### PR TITLE
Replaced old empty placeholder with core component

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx
@@ -543,7 +543,10 @@ const ClassificationDetails = forwardRef(
                       loading={isLoading}
                       pagination={false}
                       rowKey="id"
-                      scroll={{ x: true, y: 'calc(100vh - 460px)' }}
+                      scroll={{
+                        x: true,
+                        y: 'calc(100vh - 380px - var(--ant-navbar-height))',
+                      }}
                       size="small"
                     />
                   )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/classification-details.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/classification-details.less
@@ -37,15 +37,52 @@
     flex: 1 1 auto;
     min-height: 0;
     padding: 16px;
-    // Only the antd table body scrolls (via scroll.y); the card body itself does
-    // not, so there is no double scrollbar and the pagination row stays visible
-    // below the scrolling tag rows. (Do NOT flex the antd table Row here — that
-    // collapses the table's internal layout.)
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    > [data-testid='description-container'] {
+      flex: 0 0 auto;
+    }
 
     .table-container {
       position: relative;
       z-index: 0;
+      flex: 1 1 auto;
+      min-height: 0;
+      flex-direction: column;
+      flex-wrap: nowrap;
+      > .ant-col {
+        flex: 0 0 auto;
+        max-width: 100%;
+      }
+
+      > .ant-col:has(.ant-table-wrapper) {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .ant-table-wrapper,
+      .ant-spin-nested-loading,
+      .ant-spin-container,
+      .ant-table,
+      .ant-table-container {
+        flex: 1 1 auto;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .ant-table-header {
+        flex: 0 0 auto;
+      }
+
+      .ant-table-body {
+        flex: 1 1 auto;
+        min-height: 0;
+        max-height: none !important;
+      }
     }
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -46,7 +46,6 @@ import { ReactComponent as AddPlaceHolderIcon } from '../../../../assets/svg/ic-
 import { ReactComponent as IconDropdown } from '../../../../assets/svg/menu.svg';
 import { ASSET_MENU_KEYS } from '../../../../constants/Assets.constants';
 import { ES_UPDATE_DELAY } from '../../../../constants/constants';
-import { ERROR_PLACEHOLDER_TYPE } from '../../../../enums/common.enum';
 import { EntityType, TabSpecificField } from '../../../../enums/entity.enum';
 import { SearchIndex } from '../../../../enums/search.enum';
 import { Tag } from '../../../../generated/entity/classification/tag';
@@ -92,7 +91,7 @@ import {
 } from '../../../../utils/StringUtils';
 import { getTagAssetsQueryFilter } from '../../../../utils/TagsPureUtils';
 import { showErrorToast } from '../../../../utils/ToastUtils';
-import ErrorPlaceHolder from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolder';
+import CreatePlaceholder from '../../../common/EmptyPlaceholder/CreatePlaceholder';
 import ErrorPlaceHolderNew from '../../../common/ErrorWithPlaceholder/ErrorPlaceHolderNew';
 import { ManageButtonItemLabel } from '../../../common/ManageButtonContentItem/ManageButtonContentItem.component';
 import NextPrevious from '../../../common/NextPrevious/NextPrevious';
@@ -723,17 +722,26 @@ const AssetsTabs = forwardRef(
         );
       } else {
         return (
-          <ErrorPlaceHolder
-            buttonId="data-assets-add-button"
-            buttonTitle={t('label.add-entity', { entity: t('label.asset') })}
-            className="border-none"
-            heading={t('message.no-data-message', {
+          <CreatePlaceholder
+            actions={
+              permissions.Create
+                ? [
+                    {
+                      key: 'add-asset',
+                      id: 'data-assets-add-button',
+                      label: t('label.add-entity', {
+                        entity: t('label.asset'),
+                      }),
+                      color: 'primary',
+                      onPress: onAddAsset,
+                    },
+                  ]
+                : undefined
+            }
+            description={t('message.no-data-message', {
               entity: t('label.data-asset-lowercase-plural'),
             })}
             icon={<FolderEmptyIcon />}
-            permission={permissions.Create}
-            type={ERROR_PLACEHOLDER_TYPE.CORE_CREATE}
-            onClick={onAddAsset}
           />
         );
       }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -843,7 +843,7 @@ const AssetsTabs = forwardRef(
             />
           </div>
         ) : (
-          <div className="h-full">{assetErrorPlaceHolder}</div>
+          <div className="h-full tw:relative">{assetErrorPlaceHolder}</div>
         ),
       [
         type,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx
@@ -843,7 +843,9 @@ const AssetsTabs = forwardRef(
             />
           </div>
         ) : (
-          <div className="h-full tw:relative">{assetErrorPlaceHolder}</div>
+          <div className="h-full tw:relative tw:min-h-90">
+            {assetErrorPlaceHolder}
+          </div>
         ),
       [
         type,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/glossaryV1.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/glossaryV1.less
@@ -289,7 +289,7 @@
 
 .glossary-terms-empty-container {
   flex: 1 1 auto;
-  min-height: 300px;
+  min-height: calc(100vh - @om-navbar-height - 200px);
   overflow: auto;
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/glossaryV1.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/glossaryV1.less
@@ -243,6 +243,11 @@
     overflow-y: auto;
   }
 
+  .ant-tabs-tabpane:has(.glossary-terms-empty-container) {
+    display: flex;
+    flex-direction: column;
+  }
+
   .activity-feed-tab {
     height: 100%;
 
@@ -289,7 +294,7 @@
 
 .glossary-terms-empty-container {
   flex: 1 1 auto;
-  min-height: calc(100vh - @om-navbar-height - 200px);
+  min-height: 360px;
   overflow: auto;
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -503,27 +503,12 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
 
       <div
         className={classNames(
-          'tw:flex tw:min-h-0 tw:flex-1 tw:overflow-hidden',
-          // 1px inset clears the container's overflow clip so the panel border
-          // isn't shaved. When the toolbar is shown (global), drop the TOP inset
-          // so the graph connects flush to the toolbar's bottom border; the
-          // standalone graph (glossary/term) keeps the inset on all sides.
+          'tw:flex tw:min-h-0 tw:flex-1',
           scope === 'global' && !showOnboardingEmptyState
             ? 'tw:px-px tw:pb-px'
-            : 'tw:px-px tw:pb-px tw:pt-0.5'
+            : 'tw:p-px'
         )}>
-        <div
-          className={classNames(
-            // `tw:isolate` forces a stacking/compositing context so WebKit
-            // clips the absolutely-positioned dotted backdrop + graph to this
-            // element's `border-radius` — without it the corners spill square.
-            'tw:relative tw:isolate tw:flex tw:min-h-0 tw:min-w-0 tw:flex-1 tw:flex-col tw:overflow-hidden',
-            !showOnboardingEmptyState &&
-              'tw:border tw:border-utility-gray-blue-100',
-            scope === 'global' && !showOnboardingEmptyState
-              ? 'tw:rounded-b-lg tw:rounded-t-none tw:border-t-0'
-              : 'tw:rounded-lg'
-          )}>
+        <div className="tw:relative tw:flex tw:min-h-0 tw:min-w-0 tw:flex-1 tw:flex-col">
           {!showOnboardingEmptyState && (
             <>
               <Card
@@ -600,7 +585,11 @@ const OntologyExplorer: React.FC<OntologyExplorerProps> = ({
           <div
             className={classNames(
               ONTOLOGY_GRAPH_BACKDROP_CLASS,
-              'tw:overflow-hidden'
+              'tw:overflow-hidden',
+              !showOnboardingEmptyState &&
+                (scope === 'global'
+                  ? 'tw:rounded-b-lg tw:rounded-t-none tw:border tw:border-t-0 tw:border-utility-gray-blue-100'
+                  : 'tw:rounded-lg tw:border tw:border-utility-gray-blue-100')
             )}>
             {renderGraphContent()}
           </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx
@@ -85,7 +85,7 @@ function OntologyOnboardingEmptyState() {
 
   return (
     <div
-      className="tw:absolute tw:inset-0 tw:z-3 tw:bg-primary"
+      className="tw:absolute tw:inset-0 tw:z-3 tw:overflow-hidden tw:rounded-lg tw:bg-primary"
       data-testid="ontology-graph-onboarding">
       <EmptyPlaceholder
         description={t('message.ontology-empty-description')}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.test.tsx
@@ -50,6 +50,10 @@ jest.mock('../ErrorWithPlaceholder/ErrorPlaceHolder', () => {
   return jest.fn().mockReturnValue(<div>ErrorPlaceHolder.component</div>);
 });
 
+jest.mock('../EmptyPlaceholder/CreatePlaceholder', () => {
+  return jest.fn().mockReturnValue(<div>CreatePlaceholder.component</div>);
+});
+
 jest.mock('../../common/Loader/Loader', () => {
   return jest.fn().mockReturnValue(<div data-testid="loader">Loader</div>);
 });
@@ -177,7 +181,7 @@ describe('Test CustomProperty Table Component', () => {
       );
     });
     const noDataPlaceHolder = await screen.findByText(
-      'ErrorPlaceHolder.component'
+      'CreatePlaceholder.component'
     );
 
     expect(noDataPlaceHolder).toBeInTheDocument();
@@ -208,7 +212,7 @@ describe('Test CustomProperty Table Component', () => {
     await waitForElementToBeRemoved(() => screen.getByText('Skeleton.loader'));
 
     const noDataPlaceHolder = await screen.findByText(
-      'ErrorPlaceHolder.component'
+      'CreatePlaceholder.component'
     );
 
     expect(noDataPlaceHolder).toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -226,6 +226,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
     !isRenderedInRightPanel
   ) {
     return (
+      <div className="h-full tw:relative">
         <CreatePlaceholder
           description={
             <Transi18next
@@ -246,6 +247,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
           }
           icon={<CustomPropertyEmpty />}
         />
+      </div>
     );
   }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -43,6 +43,7 @@ import { Transi18next } from '../../../utils/i18next/LocalUtil';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
+import CreatePlaceholder from '../EmptyPlaceholder/CreatePlaceholder';
 import ErrorPlaceHolder from '../ErrorWithPlaceholder/ErrorPlaceHolder';
 import WidgetCard from '../WidgetCard/WidgetCard';
 import './custom-property-table.less';
@@ -225,29 +226,26 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
     !isRenderedInRightPanel
   ) {
     return (
-      <div className="h-full flex-center border-default border-radius-sm tw:overflow-hidden">
-        <ErrorPlaceHolder
-          className="border-none"
-          contentMaxWidthClass="tw:max-w-96"
+        <CreatePlaceholder
+          description={
+            <Transi18next
+              i18nKey="message.no-custom-properties-entity"
+              renderElement={
+                <a
+                  href={CUSTOM_PROPERTIES_DOCS}
+                  rel="noreferrer"
+                  target="_blank"
+                  title="Custom properties documentation"
+                />
+              }
+              values={{
+                docs: t('label.doc-plural-lowercase'),
+                entity: startCase(entityType),
+              }}
+            />
+          }
           icon={<CustomPropertyEmpty />}
-          type={ERROR_PLACEHOLDER_TYPE.CORE_CREATE}>
-          <Transi18next
-            i18nKey="message.no-custom-properties-entity"
-            renderElement={
-              <a
-                href={CUSTOM_PROPERTIES_DOCS}
-                rel="noreferrer"
-                target="_blank"
-                title="Custom properties documentation"
-              />
-            }
-            values={{
-              docs: t('label.doc-plural-lowercase'),
-              entity: startCase(entityType),
-            }}
-          />
-        </ErrorPlaceHolder>
-      </div>
+        />
     );
   }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx
@@ -226,7 +226,7 @@ export const CustomPropertyTable = <T extends ExtentionEntitiesKeys>({
     !isRenderedInRightPanel
   ) {
     return (
-      <div className="h-full tw:relative">
+      <div className="h-full tw:relative tw:min-h-90">
         <CreatePlaceholder
           description={
             <Transi18next

--- a/openmetadata-ui/src/main/resources/ui/src/styles/components/tabs.less
+++ b/openmetadata-ui/src/main/resources/ui/src/styles/components/tabs.less
@@ -104,6 +104,9 @@
   .ant-tabs.tabs-new {
     .ant-tabs-tabpane {
       background-color: @grey-9;
+      &:has([data-testid='ontology-explorer']) {
+        background-color: transparent;
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Replaced old empty placeholder with core component and make classification table responsive in AI mode


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI components:**
    - Replaced `ErrorPlaceHolder` with `CreatePlaceholder` in `CustomPropertyTable` and `AssetsTabs` components
    - Updated `OntologyExplorer`, `ClassificationDetails`, and `glossaryV1` styles for improved layout and backdrop rendering

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Replaces legacy empty-state placeholders with the core placeholder component and adjusts related ontology, classification, glossary, and tab layouts.
- Adds positioned, minimum-height hosts for the new absolutely positioned placeholders.
- Revises ontology graph borders, clipping, rounding, and tab-pane background styling.
- Changes classification table flex sizing and viewport-relative scroll height.
- Updates glossary empty-state sizing and associated tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because three previously reported layouts still rely on `:has()` despite explicitly targeting Firefox 91.

Unsupported selectors continue to remove the ontology background override, break the classification table’s flex and scrolling constraints, and prevent the glossary empty state from filling its tab on supported older browsers.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/styles/components/tabs.less, openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/classification-details.less, openmetadata-ui/src/main/resources/ui/src/components/Glossary/glossaryV1.less
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.tsx | Replaces the legacy custom-property empty state with CreatePlaceholder and supplies its required positioned host. |
| openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/AssetsTabs.component.tsx | Replaces the asset empty state with CreatePlaceholder, preserving permission-gated creation actions and adding a positioned host. |
| openmetadata-ui/src/main/resources/ui/src/components/OntologyExplorer/OntologyExplorer.tsx | Moves graph border and rounding styles onto the backdrop and updates onboarding clipping. |
| openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.tsx | Adjusts the classification table’s vertical scroll calculation to account for navbar height. |
| openmetadata-ui/src/main/resources/ui/src/components/common/CustomPropertyTable/CustomPropertyTable.test.tsx | Updates empty-state assertions to use the mocked CreatePlaceholder component. |

</details>

<sub>Reviews (6): Last reviewed commit: ["test(ui): update CustomPropertyTable tes..."](https://github.com/open-metadata/openmetadata/commit/23db6de679e902a4ac04b886bb8103253aef1008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47330277)</sub>

<!-- /greptile_comment -->