### PR TITLE
Fixes #29429: perf(ingestion): bulk-fetch Vertica column comments, dr…

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -35,8 +35,8 @@ from metadata.ingestion.source.database.column_type_parser import create_sqlalch
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
 from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.source.database.vertica.queries import (
+    VERTICA_COLUMN_COMMENTS,
     VERTICA_GET_COLUMNS,
-    VERTICA_GET_PRIMARY_KEYS,
     VERTICA_LIST_DATABASES,
     VERTICA_SCHEMA_COMMENTS,
     VERTICA_TABLE_COMMENTS,
@@ -46,7 +46,9 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.sqlalchemy_utils import (
+    get_all_column_comments,
     get_all_table_comments,
+    get_column_comment_wrapper,
     get_schema_descriptions,
     get_table_comment_wrapper,
 )
@@ -76,7 +78,13 @@ ischema_names.update(
 @reflection.cache
 def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: disable=too-many-locals,unused-argument
     """
-    Method to handle column details
+    Method to handle column details.
+
+    Column comments are resolved from an in-memory cache populated by a single
+    bulk query (see `get_all_column_comments`), instead of joining
+    `v_catalog.comments` per table. The internal primary-key lookup was removed:
+    its result was never consumed downstream (primary keys are read via
+    `get_pk_constraint`), so it was a redundant catalog query per table.
     """
     if schema is not None:
         schema_condition = f"lower(table_schema) = '{schema.lower()}'"
@@ -87,17 +95,20 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: dis
         dedent(VERTICA_GET_COLUMNS.format(table=table_name.lower(), schema_condition=schema_condition))
     )
 
-    spk = sql.text(dedent(VERTICA_GET_PRIMARY_KEYS.format(table=table_name.lower(), schema_condition=schema_condition)))
-
-    pk_columns = [x[0] for x in connection.execute(spk)]
     columns = {}
     for row in connection.execute(sql_query):
         name = row.column_name
         dtype = row.data_type.lower()
-        primary_key = name in pk_columns
         default = row.column_default
         nullable = row.is_nullable
-        comment = row.comment
+        comment = get_column_comment_wrapper(
+            self,
+            connection,
+            query=VERTICA_COLUMN_COMMENTS,
+            table_name=table_name,
+            column_name=name,
+            schema=schema,
+        )
 
         column_info = self._get_column_info(  # pylint: disable=protected-access
             name,
@@ -107,7 +118,6 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: dis
             schema,
             comment,
         )
-        column_info.update({"primary_key": primary_key})
         if columns.get(name) is None or comment:
             columns[name] = column_info
     return columns.values()
@@ -253,7 +263,13 @@ VerticaDialect.get_columns = get_columns
 VerticaDialect._get_column_info = _get_column_info  # pylint: disable=protected-access
 VerticaDialect.get_view_definition = get_view_definition
 VerticaDialect.get_all_table_comments = get_all_table_comments
+VerticaDialect.get_all_column_comments = get_all_column_comments
 VerticaDialect.get_table_comment = get_table_comment
+
+# The reflection queries used during ingestion embed their literal values into the
+# statement text, so enabling SQLAlchemy's compiled-statement cache is safe and
+# avoids recompiling every statement (matching the MSSQL dialect behaviour).
+VerticaDialect.supports_statement_cache = True
 
 
 class VerticaSource(CommonDbSourceService, MultiDBSource):

--- a/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
@@ -14,56 +14,47 @@ SQL Queries used during ingestion
 
 import textwrap
 
-# Column comments in Vertica can only happen on Projections
-#   https://forum.vertica.com/discussion/238945/vertica-try-to-create-comment
-# And Vertica projections follow this naming:
-#   https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/AdministratorsGuide/Projections/WorkingWithProjections.htm
-# So to fetch column comments we need to concat the table_name + projection infix + column name.
-# Example: querying `v_catalog.comments` we find an object_name for a column in the table vendor_dimension as
-# `vendor_dimension_super.vendor_name`. Note how this is the `_super` projection.
-# Then, our join looks for the match in `vendor_dimension_super.vendor_name`.
-# In case there are more than one projections available for a table then we pick up
-# comments from any one projection available for table
-# Note: This might not suit for all column scenarios, but currently we did not find a better way to join
-# v_catalog.comments with v_catalog.columns.
+# Column metadata is read from v_catalog.columns / v_catalog.view_columns only.
+# Column comments used to be resolved here with a per-table
+# `LEFT JOIN v_catalog.comments`, which cost 1-13s per table and dominated the
+# ingestion time (see issue #29429). They are now fetched in a single bulk query
+# (`VERTICA_COLUMN_COMMENTS`) and looked up from an in-memory cache, mirroring how
+# table comments are handled by `get_all_table_comments`.
 VERTICA_GET_COLUMNS = textwrap.dedent(
     """
-        select
+        SELECT
           column_name,
           data_type,
           column_default,
-          is_nullable,
-          comment 
-        from 
-          v_catalog.columns col
-          LEFT JOIN v_catalog.comments cm
-          ON col.table_schema = cm.object_schema
-          AND col.table_name = cm.object_name
-          AND col.column_name = cm.child_object
-          AND cm.object_type = 'COLUMN'
-        WHERE 
-          lower(table_name) = '{table}'
+          is_nullable
+        FROM v_catalog.columns
+        WHERE lower(table_name) = '{table}'
           AND {schema_condition}
         UNION ALL
         SELECT
           column_name,
           data_type,
           '' AS column_default,
-          true AS is_nullable,
-          ''  AS comment
+          true AS is_nullable
         FROM v_catalog.view_columns
         WHERE lower(table_name) = '{table}'
-        AND {schema_condition}
-    """  # noqa: W291
+          AND {schema_condition}
+    """
 )
 
-VERTICA_GET_PRIMARY_KEYS = textwrap.dedent(
+# Bulk-fetch every column comment in one shot. `v_catalog.comments` only holds a
+# row per object that actually has a comment, so the result set is bounded by the
+# number of commented columns (sparse) rather than the total column count.
+# For a COLUMN row: object_schema = schema, object_name = table, child_object = column.
+VERTICA_COLUMN_COMMENTS = textwrap.dedent(
     """
-        SELECT column_name
-        FROM v_catalog.primary_keys
-        WHERE lower(table_name) = '{table}'
-        AND constraint_type = 'p'
-        AND {schema_condition}
+    SELECT
+      object_schema AS schema,
+      object_name   AS table_name,
+      child_object  AS column_name,
+      comment       AS column_comment
+    FROM v_catalog.comments
+    WHERE object_type = 'COLUMN'
     """
 )
 

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -55,6 +55,12 @@ def get_all_column_comments(self, connection, query):
     row), so bulk-loading them once and caching by (schema, table, column) avoids a
     per-table catalog join while keeping the memory footprint bounded by the number
     of commented columns.
+
+    Keys are lower-cased on both storage and lookup: the bulk query returns the
+    catalog-original case from ``v_catalog.comments`` while the reflection wrapper
+    is called with the un-normalized ``schema``/``table_name`` arguments, so
+    mixed-case identifiers would otherwise miss the cache and silently drop
+    comments that actually exist.
     """
     self.all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
     self.current_db: str = connection.engine.url.database
@@ -62,14 +68,23 @@ def get_all_column_comments(self, connection, query):
     for row in result:
         row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
         self.all_column_comments[
-            (row_dict["schema"], row_dict["table_name"], row_dict["column_name"])
+            (
+                (row_dict["schema"] or "").lower(),
+                (row_dict["table_name"] or "").lower(),
+                (row_dict["column_name"] or "").lower(),
+            )
         ] = row_dict["column_comment"]
 
 
 def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
     if not hasattr(self, "all_column_comments") or self.current_db != connection.engine.url.database:
         self.get_all_column_comments(connection, query)
-    return self.all_column_comments.get((schema, table_name, column_name))
+    key = (
+        (schema or "").lower(),
+        (table_name or "").lower(),
+        (column_name or "").lower(),
+    )
+    return self.all_column_comments.get(key)
 
 
 @reflection.cache

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -47,6 +47,32 @@ def get_table_comment_wrapper(self, connection, query, table_name, schema=None):
 
 
 @reflection.cache
+def get_all_column_comments(self, connection, query):
+    """
+    Method to fetch comments of all columns in a single query.
+
+    Column comments live in a sparse catalog table (only commented columns have a
+    row), so bulk-loading them once and caching by (schema, table, column) avoids a
+    per-table catalog join while keeping the memory footprint bounded by the number
+    of commented columns.
+    """
+    self.all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
+    self.current_db: str = connection.engine.url.database
+    result = connection.execute(text(query) if isinstance(query, str) else query)
+    for row in result:
+        row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
+        self.all_column_comments[
+            (row_dict["schema"], row_dict["table_name"], row_dict["column_name"])
+        ] = row_dict["column_comment"]
+
+
+def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
+    if not hasattr(self, "all_column_comments") or self.current_db != connection.engine.url.database:
+        self.get_all_column_comments(connection, query)
+    return self.all_column_comments.get((schema, table_name, column_name))
+
+
+@reflection.cache
 def get_all_table_owners(self, connection, query, schema_name, **kw):  # pylint: disable=unused-argument
     """
     Method to fetch owners of all available tables

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -143,6 +143,22 @@ def test_bulk_comment_query_runs_once_across_tables():
     assert _comment_query_count(connection) == 1
 
 
+def test_comment_lookup_is_case_insensitive():
+    # v_catalog.comments returns catalog-original case, while get_columns is
+    # reflected with mixed-case schema/table arguments. Keys are normalized to
+    # lowercase on both sides so the comment is not silently dropped.
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("MyCol")]},
+        comment_rows=[_comment_row("public", "t1", "mycol", "case-folded comment")],
+    )
+
+    columns = list(dialect.get_columns(connection, "T1", schema="Public"))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["MyCol"] == "case-folded comment"
+
+
 def test_get_columns_query_does_not_join_comments():
     dialect = _new_dialect()
     connection = _make_connection(

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -1,0 +1,198 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for the Vertica connector metadata reflection (issue #29429).
+
+These cover the column-comment bulk-caching that replaces the old per-table
+``LEFT JOIN v_catalog.comments`` (the dominant ingestion cost), verifying that:
+
+* column comments are resolved from a single bulk query instead of a per-table
+  join,
+* the bulk comment query runs only once and is reused across tables,
+* ``VERTICA_GET_COLUMNS`` no longer joins ``v_catalog.comments``,
+* the cache is invalidated when the database changes, and
+* ``VerticaDialect`` enables SQLAlchemy statement caching.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# The dialect lives in the optional ``vertica`` plugin; skip cleanly when absent.
+pytest.importorskip("sqlalchemy_vertica")
+
+from sqlalchemy_vertica.base import VerticaDialect  # noqa: E402
+
+# Importing the module applies the OpenMetadata monkeypatches onto VerticaDialect
+# (get_columns, get_all_column_comments, supports_statement_cache, ...).
+import metadata.ingestion.source.database.vertica.metadata  # noqa: E402,F401
+from metadata.ingestion.source.database.vertica.queries import (  # noqa: E402
+    VERTICA_COLUMN_COMMENTS,
+)
+from metadata.utils.sqlalchemy_utils import (  # noqa: E402
+    get_all_column_comments,
+    get_column_comment_wrapper,
+)
+
+
+def _column_row(name, data_type="varchar", default=None, nullable=True):
+    """Row shape returned by VERTICA_GET_COLUMNS (attribute access)."""
+    return SimpleNamespace(
+        column_name=name,
+        data_type=data_type,
+        column_default=default,
+        is_nullable=nullable,
+    )
+
+
+def _comment_row(schema, table, column, comment):
+    """Row shape returned by VERTICA_COLUMN_COMMENTS (``._mapping`` access)."""
+    return SimpleNamespace(
+        _mapping={
+            "schema": schema,
+            "table_name": table,
+            "column_name": column,
+            "column_comment": comment,
+        }
+    )
+
+
+def _make_connection(columns_by_table, comment_rows, database="testdb"):
+    """
+    Build a mock connection that routes queries by their SQL text:
+    the comment bulk query -> comment_rows, the per-table columns query ->
+    the rows registered for that table name.
+    """
+    connection = MagicMock()
+    connection.engine.url.database = database
+
+    def _execute(query, *_args, **_kwargs):
+        text = str(query)
+        if "v_catalog.comments" in text:
+            return iter(list(comment_rows))
+        for table, rows in columns_by_table.items():
+            if f"'{table}'" in text:
+                return iter(list(rows))
+        return iter([])
+
+    connection.execute.side_effect = _execute
+    return connection
+
+
+def _new_dialect():
+    # Bypass __init__ side effects; class attributes (ischema_names and the
+    # monkeypatched methods) are all we need for reflection.
+    return object.__new__(VerticaDialect)
+
+
+def _comment_query_count(connection):
+    return sum(
+        1
+        for call in connection.execute.call_args_list
+        if "v_catalog.comments" in str(call.args[0])
+    )
+
+
+def test_get_columns_resolves_comments_from_bulk_cache():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1"), _column_row("c2")]},
+        comment_rows=[_comment_row("public", "t1", "c1", "c1 comment")],
+    )
+
+    columns = list(dialect.get_columns(connection, "t1", schema="public"))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["c1"] == "c1 comment"
+    # A column without a comment resolves to None, not an empty-string artifact
+    # from the old outer join.
+    assert comment_by_name["c2"] is None
+    # Two columns, but the (slow) comment catalog is queried only once.
+    assert _comment_query_count(connection) == 1
+
+
+def test_bulk_comment_query_runs_once_across_tables():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={
+            "t1": [_column_row("c1")],
+            "t2": [_column_row("cx")],
+        },
+        comment_rows=[
+            _comment_row("public", "t1", "c1", "c1 comment"),
+            _comment_row("public", "t2", "cx", "cx comment"),
+        ],
+    )
+
+    t1 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t1", schema="public")}
+    t2 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t2", schema="public")}
+
+    assert t1["c1"] == "c1 comment"
+    assert t2["cx"] == "cx comment"
+    # The whole point of the fix: the second table reuses the cache, so the
+    # comment catalog is still queried only once in total.
+    assert _comment_query_count(connection) == 1
+
+
+def test_get_columns_query_does_not_join_comments():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1")]},
+        comment_rows=[],
+    )
+
+    list(dialect.get_columns(connection, "t1", schema="public"))
+
+    columns_queries = [
+        str(call.args[0])
+        for call in connection.execute.call_args_list
+        if "v_catalog.columns" in str(call.args[0])
+    ]
+    assert columns_queries, "expected a v_catalog.columns query"
+    for query in columns_queries:
+        assert "v_catalog.comments" not in query
+        assert "comment" not in query.lower()
+
+
+def test_column_comment_cache_is_invalidated_on_db_switch():
+    dialect = SimpleNamespace()
+    # Bind the bulk loader so the wrapper can call self.get_all_column_comments.
+    dialect.get_all_column_comments = get_all_column_comments.__get__(dialect)
+
+    conn_a = MagicMock()
+    conn_a.engine.url.database = "db_a"
+    conn_a.execute.return_value = iter([_comment_row("public", "t", "c", "from A")])
+
+    first = get_column_comment_wrapper(
+        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    second = get_column_comment_wrapper(
+        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    assert first == second == "from A"
+    # Same DB -> cache reused, loaded only once.
+    assert conn_a.execute.call_count == 1
+
+    conn_b = MagicMock()
+    conn_b.engine.url.database = "db_b"
+    conn_b.execute.return_value = iter([_comment_row("public", "t", "c", "from B")])
+
+    switched = get_column_comment_wrapper(
+        dialect, conn_b, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    # Different DB -> cache invalidated and reloaded from the new connection.
+    assert switched == "from B"
+    assert conn_b.execute.call_count == 1
+
+
+def test_vertica_dialect_enables_statement_cache():
+    assert VerticaDialect.supports_statement_cache is True


### PR DESCRIPTION
### Describe your changes:

Fixes #29429

I reworked how the Vertica connector fetches column comments because it made
metadata ingestion ~5x slower than comparable sources: ~11h for ~2,000
tables/views on Vertica vs ~2h for ~10,000 tables on MSSQL with an almost
identical ingestion config.

**Root cause.** `get_columns` resolved column comments with a per-table
`LEFT JOIN` on `v_catalog.comments`, which cost 1–13s *per table* and dominated
the run. Vertica's own documentation flags this system table as inherently
expensive to query:

> "Queries on this table can be slow because it fetches data at query time from
> other catalog tables."
> — [V_CATALOG.COMMENTS, Vertica 26.2.x docs](https://docs.vertica.com/26.2.x/en/sql-reference/system-tables/v-catalog-schema/comments/)

`v_catalog.*` tables are derived from the in-memory catalog at query time and
have no projections/indexes, so a per-table join against `comments` re-runs that
expensive derivation on every one of the ~2,000 tables. `v_catalog.columns` (the
column list itself) has no such "slow" note, so it is *not* the bottleneck — the
repeated `comments` join is.

**Fix.** Stop touching the slow `comments` table per table. Fetch every column
comment once (bounded by the number of *commented* columns, which is sparse) and
look it up from an in-memory cache — the same pattern already used for table
comments via `get_all_table_comments`:

1. **Bulk column comments (main win).** New `VERTICA_COLUMN_COMMENTS` query plus
   `get_all_column_comments` / `get_column_comment_wrapper` in `sqlalchemy_utils`.
   `VERTICA_GET_COLUMNS` now reads `v_catalog.columns` alone (no join). The match
   keys `(schema, table, column)` are unchanged, so results are identical.
2. **Remove a redundant per-table catalog query.** `get_columns` ran
   `VERTICA_GET_PRIMARY_KEYS` on every table to set a `primary_key` flag that is
   never consumed downstream (primary keys are read via `get_pk_constraint`).
   Removed the query and the flag.
3. **Enable statement caching.** `VerticaDialect` did not set
   `supports_statement_cache`, so SQLAlchemy recompiled every statement (MSSQL
   sets it). The reflection queries embed their literal values into the statement
   text, so enabling it is safe.

**Why bulk (and not per-schema).** The cost of `v_catalog.comments` is per-query
(the derivation), not per-row, so touching it **once per database** is the
minimum. A per-schema variant would multiply that expensive derivation by the
number of schemas, and — because the SQLAlchemy dialect is shared across the
worker threads that process schemas in parallel — a single-slot per-schema cache
would also thrash and race. Whole-DB bulk is loaded once, shared safely across
threads, and mirrors the existing table-comment cache.

**Memory.** The cache holds only columns that actually have a comment
(`v_catalog.comments` stores a row per commented object). Realistic databases
land in the tens of MB; even 5,000 tables × 100 fully-commented columns is
~150–250 MB. Only extreme scale (tens of thousands of tables, densely commented)
would warrant a per-thread/per-schema scope, which can be added later if needed.

**Note on the issue framing.** The issue listed "primary keys queried twice" as
one inefficiency. With `sqlalchemy-vertica` (>=0.0.5) the base `get_pk_constraint`
is an empty stub (no catalog I/O), so there was no double PK read — the real
waste was the discarded PK query inside `get_columns`, which this PR removes.

I also dropped the outdated comment on `VERTICA_GET_COLUMNS`: it described
matching column comments against projection names (e.g.
`vendor_dimension_super.vendor_name`), but the query already joins on
`child_object = column name`, which is the documented behaviour for
`v_catalog.comments` on current Vertica (`object_name` = table, `child_object`
= column).

#
### Type of change:
- [x] Improvement

#
### High-level design:

Only the Vertica dialect and one shared SQLAlchemy util are touched (3 source
files + 1 test file):

- `ingestion/.../vertica/queries.py` — drop the `LEFT JOIN v_catalog.comments`
  from `VERTICA_GET_COLUMNS`; add `VERTICA_COLUMN_COMMENTS`; remove the now-unused
  `VERTICA_GET_PRIMARY_KEYS`.
- `ingestion/.../utils/sqlalchemy_utils.py` — add `get_all_column_comments` /
  `get_column_comment_wrapper`, mirroring the existing `get_all_table_comments`
  cache pattern (keyed by `(schema, table, column)`, invalidated on DB switch).
- `ingestion/.../vertica/metadata.py` — `get_columns` looks comments up from the
  cache and no longer runs the per-table PK query; register
  `get_all_column_comments`; set `VerticaDialect.supports_statement_cache = True`.

Alternatives considered: (a) per-schema scoping — rejected, it multiplies the
expensive `comments` derivation and is unsafe with the thread-shared dialect;
(b) keep the per-table join but make it cheap like MSSQL — not possible, MSSQL's
`sys.*` catalog is indexed while Vertica's `v_catalog.*` is derived per query.

Backward compatibility: ingested metadata is unchanged; only the fetch strategy
and timing change.

#
### Tests:

#### Use cases covered
- Vertica metadata ingestion extracts the same column/table/view metadata and
  column comments as before, with the per-table `v_catalog.comments` join
  collapsed to a single bulk fetch per database.

#### Unit tests
- [x] Added `ingestion/tests/unit/source/database/vertica/test_metadata.py`
  (mock-based, no live Vertica required):
  - `test_get_columns_resolves_comments_from_bulk_cache` — comments resolve for
    commented columns and are `None` otherwise; the comment catalog is queried
    only once for a multi-column table.
  - `test_bulk_comment_query_runs_once_across_tables` — the bulk comment query
    runs once in total and is reused across tables (the core of the fix).
  - `test_get_columns_query_does_not_join_comments` — the columns query no longer
    references `v_catalog.comments`.
  - `test_column_comment_cache_is_invalidated_on_db_switch` — cache reloads when
    the database changes.
  - `test_vertica_dialect_enables_statement_cache` — `supports_statement_cache`
    is enabled.

#### Ingestion integration tests
- [ ] Not applicable — no new API surface; existing Vertica CLI e2e
  (`ingestion/tests/cli_e2e/database/vertica`) still applies.

#### Manual testing performed
- Pending: before/after ingestion timing on a real Vertica 26.0.0.2 instance
  will be added. The change is behaviour-preserving (identical metadata output)
  and covered by the unit tests above.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #29429` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: N/A.
- [ ] For UI changes: N/A.
- [x] I have added tests (unit) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces Vertica’s per-table comment join with a database-wide bulk lookup.
- Adds bulk loading and normalized lookup of column comments.
- Removes the redundant primary-key query from column reflection.
- Enables SQLAlchemy statement caching for the Vertica dialect.
- Adds mock-based tests for comment resolution, cache reuse, database switching, and query shape.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR is not yet safe to merge because concurrent schema reflection can silently omit existing Vertica column comments.

The cache marks itself initialized before the bulk query has populated its shared dictionary, allowing another schema worker to read incomplete state; the previously reported unrestricted cache also remains.

**Files Needing Attention:** ingestion/src/metadata/utils/sqlalchemy_utils.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/utils/sqlalchemy_utils.py | Adds the bulk column-comment cache, but exposes partially initialized state to concurrent reflection workers. |
| ingestion/src/metadata/ingestion/source/database/vertica/metadata.py | Switches Vertica column reflection to cached comments, removes the redundant primary-key lookup, and enables statement caching. |
| ingestion/src/metadata/ingestion/source/database/vertica/queries.py | Separates column metadata retrieval from a new database-wide column-comment query. |
| ingestion/tests/unit/source/database/vertica/test_metadata.py | Covers sequential cache behavior and query changes but does not exercise concurrent initialization. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Schema worker A
  participant B as Schema worker B
  participant D as Shared Vertica dialect
  participant V as Vertica catalog
  A->>D: Lookup first column comment
  D->>D: Publish empty cache and current_db
  D->>V: Execute bulk comments query
  B->>D: Lookup another column comment
  D-->>B: Cache miss from incomplete dictionary
  V-->>D: Comment rows
  D->>D: Populate cache
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Fixes #29429: fix(ingestion): normalize ..."](https://github.com/open-metadata/openmetadata/commit/9da018b29c2ccfacb7c3821d7f942bce53970ae4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47378216)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->