### PR TITLE
Bulk remove logical testCase

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java
@@ -1130,6 +1130,49 @@ public class TestCaseResourceIT extends BaseEntityIT<TestCase, CreateTestCase> {
   }
 
   @Test
+  void test_deleteTestCasesFromLogicalTestSuite(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns);
+
+    TestCase testCase1 =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("bulk_del_1"))
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    TestCase testCase2 =
+        TestCaseBuilder.create(client)
+            .name(ns.prefix("bulk_del_2"))
+            .forTable(table)
+            .testDefinition("tableColumnCountToEqual")
+            .parameter("columnCount", "2")
+            .create();
+
+    CreateTestSuite suiteReq = new CreateTestSuite();
+    suiteReq.setName(ns.prefix("logical_bulk_del"));
+    TestSuite logicalSuite = client.testSuites().create(suiteReq);
+
+    addTestCasesToLogicalTestSuite(
+        client, logicalSuite.getId(), List.of(testCase1.getId(), testCase2.getId()));
+
+    TestSuite updatedSuite = client.testSuites().get(logicalSuite.getId().toString(), "tests");
+    assertNotNull(updatedSuite.getTests());
+    assertEquals(2, updatedSuite.getTests().size());
+
+    client
+        .testCases()
+        .deleteFromLogicalTestSuite(
+            logicalSuite.getId(), List.of(testCase1.getId(), testCase2.getId()));
+
+    TestSuite suiteAfterDel = client.testSuites().get(logicalSuite.getId().toString(), "tests");
+    assertTrue(
+        suiteAfterDel.getTests() == null || suiteAfterDel.getTests().isEmpty(),
+        "Logical suite should have no test cases after bulk deletion");
+  }
+
+  @Test
   void test_concurrentLogicalSuiteAddsPreserveEverySearchMembership(TestNamespace ns)
       throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tests/TestCaseService.java
+++ b/openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tests/TestCaseService.java
@@ -121,6 +121,22 @@ public class TestCaseService extends EntityServiceBase<TestCase> {
         Void.class);
   }
 
+  /**
+   * Delete test cases from a logical test suite in bulk.
+   *
+   * @param testSuiteId The logical test suite ID
+   * @param testCaseIds The list of test case IDs to remove
+   * @return The updated test suite
+   */
+  public org.openmetadata.schema.tests.TestSuite deleteFromLogicalTestSuite(
+      UUID testSuiteId, List<UUID> testCaseIds) throws OpenMetadataException {
+    return httpClient.execute(
+        HttpMethod.POST,
+        basePath + "/logicalTestCases/" + testSuiteId + "/delete",
+        testCaseIds,
+        org.openmetadata.schema.tests.TestSuite.class);
+  }
+
   // ===================================================================
   // FAILED ROWS SAMPLE OPERATIONS
   // ===================================================================

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -1320,6 +1320,33 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     return new RestUtil.DeleteResponse<>(testCase, ENTITY_DELETED);
   }
 
+  public RestUtil.DeleteResponse<TestSuite> deleteTestCasesFromLogicalTestSuite(
+      TestSuite testSuite, List<UUID> testCaseIds) {
+    AtomicReference<LogicalSuiteRelationshipChange> relationshipChange =
+        new AtomicReference<>(LogicalSuiteRelationshipChange.empty());
+    flushInOneTransaction(
+        () ->
+            relationshipChange.set(
+                deleteTestCasesFromLogicalTestSuiteFlush(testSuite.getId(), testCaseIds)));
+
+    postLogicalSuiteRelationshipUpdate(relationshipChange.get());
+    updateLogicalTestSuite(relationshipChange.get());
+    return new RestUtil.DeleteResponse<>(testSuite, ENTITY_DELETED);
+  }
+
+  private LogicalSuiteRelationshipChange deleteTestCasesFromLogicalTestSuiteFlush(
+      UUID testSuiteId, List<UUID> testCaseIds) {
+    List<EntityReference> testCaseReferences = new ArrayList<>();
+    for (UUID id : testCaseIds) {
+      TestCase tc = Entity.getEntity(Entity.TEST_CASE, id, null, null);
+      if (tc != null) {
+        testCaseReferences.add(tc.getEntityReference());
+      }
+      deleteRelationship(testSuiteId, TEST_SUITE, id, TEST_CASE, Relationship.CONTAINS);
+    }
+    return prepareLogicalSuiteRelationshipChange(testSuiteId, testCaseReferences);
+  }
+
   private List<TestCase> getLogicalSuiteUpdatedTestCase(List<EntityReference> testCaseReferences) {
     List<TestCase> testCases = Entity.getEntities(testCaseReferences, "*", Include.ALL);
     testCases.forEach(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java
@@ -1005,6 +1005,69 @@ public class TestCaseResource extends EntityResource<TestCase, TestCaseRepositor
     return response.toResponse();
   }
 
+  @POST
+  @Path("/logicalTestCases/{testSuiteId}/delete")
+  @Operation(
+      operationId = "deleteTestCasesFromLogicalTestSuite",
+      summary = "Delete test cases from a logical test suite",
+      description = "Delete test cases from a logical test suite.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "Successfully deleted test cases from the logical test suite.",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = TestSuite.class)))
+      })
+  public Response deleteTestCasesFromLogicalTestSuite(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @PathParam("testSuiteId") UUID testSuiteId,
+      List<UUID> testCaseIds) {
+
+    TestSuite testSuite =
+        Entity.getEntity(
+            Entity.TEST_SUITE,
+            testSuiteId,
+            "domains,owners",
+            null,
+            false);
+
+    if (testCaseIds == null || testCaseIds.isEmpty()) {
+      return new RestUtil.DeleteResponse<>(testSuite, ENTITY_NO_CHANGE).toResponse();
+    }
+
+    int existingTestCaseCount = repository.getTestCaseCount(testCaseIds);
+    if (existingTestCaseCount != testCaseIds.size()) {
+      throw new IllegalArgumentException(
+          "You are trying to remove one or more test cases that do not exist.");
+    }
+
+    ResourceContextInterface testSuiteRC =
+        TestCaseResourceContext.builder().entity(testSuite).build();
+    OperationContext testSuiteEditAllOpContext =
+        new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_ALL);
+    OperationContext testSuiteEditTestsOpContext =
+        new OperationContext(Entity.TEST_SUITE, MetadataOperation.EDIT_TESTS);
+
+    OperationContext testCaseDeleteOpContext =
+        new OperationContext(Entity.TEST_CASE, MetadataOperation.DELETE);
+
+    List<AuthRequest> requests = new ArrayList<>();
+    requests.add(new AuthRequest(testSuiteEditAllOpContext, testSuiteRC));
+    requests.add(new AuthRequest(testSuiteEditTestsOpContext, testSuiteRC));
+    for (UUID id : testCaseIds) {
+      requests.add(
+          new AuthRequest(testCaseDeleteOpContext, TestCaseResourceContext.builder().id(id).build()));
+    }
+    authorizer.authorizeRequests(securityContext, requests, AuthorizationLogic.ANY);
+
+    DeleteResponse<TestSuite> response =
+        repository.deleteTestCasesFromLogicalTestSuite(testSuite, testCaseIds);
+    return response.toResponse();
+  }
+
   @PUT
   @Path("/restore")
   @Operation(


### PR DESCRIPTION
Fixes #30423 
@TeddyCr @
### Description:
- Adds support for bulk removal of test cases from a logical test suite.
- The endpoint accepts a list of test case IDs and removes their associations with the specified logical test suite.

## Changes

- Added bulk removal support for test cases from a logical test suite.
- Added validation for test case IDs before performing the removal.
- Handles empty requests and invalid/nonexistent test case IDs appropriately.
- Ensures a request containing an invalid test case does not partially remove valid test cases.

## Testing

Tested the endpoint manually against a local OpenMetadata instance.

### 1. Bulk removal of multiple test cases

Removed multiple test cases from a logical test suite in a single request.

**Before:** The logical test suite contained 3 test cases.

<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/9d52e57a-a8ae-4d9f-bd18-ec4ce820ce58" />
<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/7c632ba7-a993-4f42-962c-795c0c4e8e3e" />



**Bulk removal:** Removed 2 test cases using the bulk removal endpoint.

<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/36e98dbc-6dc5-4c6a-9cb3-c376ce694b11" />


**After:** Only the test case that was not included in the request remained in the suite.

<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/12137e21-8f98-4153-aada-2fae61c87601" />


### 2. Edge cases

Verified the following validation behavior:

- A nonexistent test case ID returns `400 Bad Request`. 
<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/e01ab9df-91d7-465e-a995-85e6d4c24f4f" />

- An empty list is accepted as a no-op and returns `200 OK`.
<img width="1096" height="1043" alt="image" src="https://github.com/user-attachments/assets/65b46334-5d2b-41c2-b2c5-0ec3fb561f9f" />

## Result

Bulk removal works as expected, including validation and atomic behavior for invalid requests.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a bulk logical-test-suite membership removal API.
- Adds a POST resource that validates test-case IDs, authorizes the request, and delegates removal to the repository.
- Deletes requested relationships transactionally and updates logical-suite-derived entity state.
- Exposes the endpoint through the Java SDK.
- Adds an integration test for successful removal of two test cases.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The authorization bypass must be fixed before merging because permission on one requested test case can authorize removal of every test case in the batch.

The endpoint submits suite-level and per-item permissions under one ANY check, but the repository mutates all requested relationships after only one authorization request succeeds.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java; openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tests/TestCaseService.java
</details>

<details open><summary><h3>Security Review</h3></summary>

The bulk authorization gate can be satisfied by permission on only one requested test case, after which all requested associations are removed. **How this was verified:** AuthorizationLogic.ANY stops at the first permitted request, while the repository iterates over and deletes every supplied test-case relationship.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResource.java | Adds validation and authorization for the bulk endpoint, but ANY authorization permits one authorized item to authorize removal of the whole batch. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Adds transactional bulk relationship removal followed by the existing logical-suite update flow. |
| openmetadata-sdk/src/main/java/org/openmetadata/sdk/services/tests/TestCaseService.java | Adds the SDK call for bulk removal, with a minor violation of the repository's Java import convention. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TestCaseResourceIT.java | Covers successful removal of two logical-suite memberships but does not exercise authorization boundaries. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Resource as TestCaseResource
  participant Auth as Authorizer
  participant Repo as TestCaseRepository
  participant DB
  participant Index as Search/RDF updates
  Client->>Resource: POST suite ID + test-case IDs
  Resource->>Resource: Validate IDs exist
  Resource->>Auth: Suite and per-test-case requests
  Auth-->>Resource: Authorization result
  Resource->>Repo: Remove all requested memberships
  Repo->>DB: Delete CONTAINS relationships transactionally
  Repo->>Index: Publish updated test cases and suite
  Repo-->>Client: "DeleteResponse<TestSuite>"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Bulk remove logical testCase"](https://github.com/open-metadata/openmetadata/commit/efef2f75bb105845f0f316223f6b01ce5d2e605c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47403180)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))
- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [OpenMetadata SDK and Java Clients](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-sdk-clients.md)
</details>

<!-- /greptile_comment -->