### PR TITLE
Fixes #29429: perf(ingestion): bulk-fetch Vertica column comments, drop redundant per-table catalog reads

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -35,8 +35,8 @@ from metadata.ingestion.source.database.column_type_parser import create_sqlalch
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
 from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.source.database.vertica.queries import (
+    VERTICA_COLUMN_COMMENTS,
     VERTICA_GET_COLUMNS,
-    VERTICA_GET_PRIMARY_KEYS,
     VERTICA_LIST_DATABASES,
     VERTICA_SCHEMA_COMMENTS,
     VERTICA_TABLE_COMMENTS,
@@ -46,7 +46,9 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.sqlalchemy_utils import (
+    get_all_column_comments,
     get_all_table_comments,
+    get_column_comment_wrapper,
     get_schema_descriptions,
     get_table_comment_wrapper,
 )
@@ -76,7 +78,13 @@ ischema_names.update(
 @reflection.cache
 def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: disable=too-many-locals,unused-argument
     """
-    Method to handle column details
+    Method to handle column details.
+
+    Column comments are resolved from an in-memory cache populated by a single
+    bulk query (see `get_all_column_comments`), instead of joining
+    `v_catalog.comments` per table. The internal primary-key lookup was removed:
+    its result was never consumed downstream (primary keys are read via
+    `get_pk_constraint`), so it was a redundant catalog query per table.
     """
     if schema is not None:
         schema_condition = f"lower(table_schema) = '{schema.lower()}'"
@@ -87,17 +95,20 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: dis
         dedent(VERTICA_GET_COLUMNS.format(table=table_name.lower(), schema_condition=schema_condition))
     )
 
-    spk = sql.text(dedent(VERTICA_GET_PRIMARY_KEYS.format(table=table_name.lower(), schema_condition=schema_condition)))
-
-    pk_columns = [x[0] for x in connection.execute(spk)]
     columns = {}
     for row in connection.execute(sql_query):
         name = row.column_name
         dtype = row.data_type.lower()
-        primary_key = name in pk_columns
         default = row.column_default
         nullable = row.is_nullable
-        comment = row.comment
+        comment = get_column_comment_wrapper(
+            self,
+            connection,
+            query=VERTICA_COLUMN_COMMENTS,
+            table_name=table_name,
+            column_name=name,
+            schema=schema,
+        )
 
         column_info = self._get_column_info(  # pylint: disable=protected-access
             name,
@@ -107,7 +118,6 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: dis
             schema,
             comment,
         )
-        column_info.update({"primary_key": primary_key})
         if columns.get(name) is None or comment:
             columns[name] = column_info
     return columns.values()
@@ -253,7 +263,13 @@ VerticaDialect.get_columns = get_columns
 VerticaDialect._get_column_info = _get_column_info  # pylint: disable=protected-access
 VerticaDialect.get_view_definition = get_view_definition
 VerticaDialect.get_all_table_comments = get_all_table_comments
+VerticaDialect.get_all_column_comments = get_all_column_comments
 VerticaDialect.get_table_comment = get_table_comment
+
+# The reflection queries used during ingestion embed their literal values into the
+# statement text, so enabling SQLAlchemy's compiled-statement cache is safe and
+# avoids recompiling every statement (matching the MSSQL dialect behaviour).
+VerticaDialect.supports_statement_cache = True
 
 
 class VerticaSource(CommonDbSourceService, MultiDBSource):

--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -101,13 +101,17 @@ def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: dis
         dtype = row.data_type.lower()
         default = row.column_default
         nullable = row.is_nullable
+        # Key the comment lookup by the row's own schema rather than the reflection
+        # argument: when get_columns is called with schema=None the query spans all
+        # schemas, so only the per-row table_schema aligns with the cache key (the
+        # old per-table join matched schema-to-schema, and this preserves that).
         comment = get_column_comment_wrapper(
             self,
             connection,
             query=VERTICA_COLUMN_COMMENTS,
             table_name=table_name,
             column_name=name,
-            schema=schema,
+            schema=row.table_schema,
         )
 
         column_info = self._get_column_info(  # pylint: disable=protected-access

--- a/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/metadata.py
@@ -35,9 +35,10 @@ from metadata.ingestion.source.database.column_type_parser import create_sqlalch
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
 from metadata.ingestion.source.database.multi_db_source import MultiDBSource
 from metadata.ingestion.source.database.vertica.queries import (
-    VERTICA_COLUMN_COMMENTS,
     VERTICA_GET_COLUMNS,
+    VERTICA_GET_COLUMNS_WITH_COMMENTS,
     VERTICA_LIST_DATABASES,
+    VERTICA_SCHEMA_COLUMN_COMMENTS,
     VERTICA_SCHEMA_COMMENTS,
     VERTICA_TABLE_COMMENTS,
     VERTICA_VIEW_DEFINITION,
@@ -46,9 +47,8 @@ from metadata.utils import fqn
 from metadata.utils.filters import filter_by_database
 from metadata.utils.logger import ingestion_logger
 from metadata.utils.sqlalchemy_utils import (
-    get_all_column_comments,
     get_all_table_comments,
-    get_column_comment_wrapper,
+    get_schema_column_comments,
     get_schema_descriptions,
     get_table_comment_wrapper,
 )
@@ -76,43 +76,52 @@ ischema_names.update(
 
 
 @reflection.cache
-def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: disable=too-many-locals,unused-argument
+def get_columns(self, connection, table_name, schema=None, **kw):  # pylint: disable=too-many-locals
     """
     Method to handle column details.
 
-    Column comments are resolved from an in-memory cache populated by a single
-    bulk query (see `get_all_column_comments`), instead of joining
-    `v_catalog.comments` per table. The internal primary-key lookup was removed:
-    its result was never consumed downstream (primary keys are read via
-    `get_pk_constraint`), so it was a redundant catalog query per table.
+    Column comments are resolved from a schema-scoped in-memory cache (see
+    `get_schema_column_comments`) instead of joining `v_catalog.comments` per
+    table, which is the dominant ingestion cost (issue #29429). When that cache is
+    unavailable -- no schema to scope to, no info_cache to hold it, or a schema
+    above `MAX_SCHEMA_COMMENTS` -- we fall back to the original per-table join, so
+    every comment is still resolved.
+
+    The internal primary-key lookup was removed: its result was never consumed
+    downstream (primary keys are read via `get_pk_constraint`), so it was a
+    redundant catalog query per table.
     """
     if schema is not None:
         schema_condition = f"lower(table_schema) = '{schema.lower()}'"
     else:
         schema_condition = "1"
 
-    sql_query = sql.text(
-        dedent(VERTICA_GET_COLUMNS.format(table=table_name.lower(), schema_condition=schema_condition))
-    )
+    info_cache = kw.get("info_cache")
+    comments = None
+    if schema is not None and info_cache is not None:
+        comments = get_schema_column_comments(
+            self,
+            connection,
+            query=VERTICA_SCHEMA_COLUMN_COMMENTS,
+            schema=schema,
+            info_cache=info_cache,
+        )
 
+    use_join_fallback = comments is None
+    query = VERTICA_GET_COLUMNS_WITH_COMMENTS if use_join_fallback else VERTICA_GET_COLUMNS
+    sql_query = sql.text(dedent(query.format(table=table_name.lower(), schema_condition=schema_condition)))
+
+    table_key = table_name.lower()
     columns = {}
     for row in connection.execute(sql_query):
         name = row.column_name
         dtype = row.data_type.lower()
         default = row.column_default
         nullable = row.is_nullable
-        # Key the comment lookup by the row's own schema rather than the reflection
-        # argument: when get_columns is called with schema=None the query spans all
-        # schemas, so only the per-row table_schema aligns with the cache key (the
-        # old per-table join matched schema-to-schema, and this preserves that).
-        comment = get_column_comment_wrapper(
-            self,
-            connection,
-            query=VERTICA_COLUMN_COMMENTS,
-            table_name=table_name,
-            column_name=name,
-            schema=row.table_schema,
-        )
+        if use_join_fallback:
+            comment = row.comment
+        else:
+            comment = comments.get((table_key, (name or "").lower()))
 
         column_info = self._get_column_info(  # pylint: disable=protected-access
             name,
@@ -267,7 +276,6 @@ VerticaDialect.get_columns = get_columns
 VerticaDialect._get_column_info = _get_column_info  # pylint: disable=protected-access
 VerticaDialect.get_view_definition = get_view_definition
 VerticaDialect.get_all_table_comments = get_all_table_comments
-VerticaDialect.get_all_column_comments = get_all_column_comments
 VerticaDialect.get_table_comment = get_table_comment
 
 # The reflection queries used during ingestion embed their literal values into the

--- a/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
@@ -14,56 +14,47 @@ SQL Queries used during ingestion
 
 import textwrap
 
-# Column comments in Vertica can only happen on Projections
-#   https://forum.vertica.com/discussion/238945/vertica-try-to-create-comment
-# And Vertica projections follow this naming:
-#   https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/AdministratorsGuide/Projections/WorkingWithProjections.htm
-# So to fetch column comments we need to concat the table_name + projection infix + column name.
-# Example: querying `v_catalog.comments` we find an object_name for a column in the table vendor_dimension as
-# `vendor_dimension_super.vendor_name`. Note how this is the `_super` projection.
-# Then, our join looks for the match in `vendor_dimension_super.vendor_name`.
-# In case there are more than one projections available for a table then we pick up
-# comments from any one projection available for table
-# Note: This might not suit for all column scenarios, but currently we did not find a better way to join
-# v_catalog.comments with v_catalog.columns.
+# Column metadata is read from v_catalog.columns / v_catalog.view_columns only.
+# Column comments used to be resolved here with a per-table
+# `LEFT JOIN v_catalog.comments`, which cost 1-13s per table and dominated the
+# ingestion time (see issue #29429). They are now fetched in a single bulk query
+# (`VERTICA_COLUMN_COMMENTS`) and looked up from an in-memory cache, mirroring how
+# table comments are handled by `get_all_table_comments`.
 VERTICA_GET_COLUMNS = textwrap.dedent(
     """
-        select
+        SELECT
           column_name,
           data_type,
           column_default,
-          is_nullable,
-          comment 
-        from 
-          v_catalog.columns col
-          LEFT JOIN v_catalog.comments cm
-          ON col.table_schema = cm.object_schema
-          AND col.table_name = cm.object_name
-          AND col.column_name = cm.child_object
-          AND cm.object_type = 'COLUMN'
-        WHERE 
-          lower(table_name) = '{table}'
+          is_nullable
+        FROM v_catalog.columns
+        WHERE lower(table_name) = '{table}'
           AND {schema_condition}
         UNION ALL
         SELECT
           column_name,
           data_type,
           '' AS column_default,
-          true AS is_nullable,
-          ''  AS comment
+          true AS is_nullable
         FROM v_catalog.view_columns
         WHERE lower(table_name) = '{table}'
-        AND {schema_condition}
-    """  # noqa: W291
+          AND {schema_condition}
+    """
 )
 
-VERTICA_GET_PRIMARY_KEYS = textwrap.dedent(
+# Bulk-fetch every column comment in one shot. `v_catalog.comments` only holds a
+# row per object that actually has a comment, so the result set is bounded by the
+# number of commented columns (sparse) rather than the total column count.
+# For a COLUMN row: object_schema = schema, object_name = table, child_object = column.
+VERTICA_COLUMN_COMMENTS = textwrap.dedent(
     """
-        SELECT column_name
-        FROM v_catalog.primary_keys
-        WHERE lower(table_name) = '{table}'
-        AND constraint_type = 'p'
-        AND {schema_condition}
+    SELECT
+      object_schema AS schema,
+      object_name   AS table_name,
+      child_object  AS column_name,
+      comment       AS column_comment
+    FROM v_catalog.comments
+    WHERE object_type = 'COLUMN'
     """
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
@@ -26,7 +26,8 @@ VERTICA_GET_COLUMNS = textwrap.dedent(
           column_name,
           data_type,
           column_default,
-          is_nullable
+          is_nullable,
+          table_schema
         FROM v_catalog.columns
         WHERE lower(table_name) = '{table}'
           AND {schema_condition}
@@ -35,7 +36,8 @@ VERTICA_GET_COLUMNS = textwrap.dedent(
           column_name,
           data_type,
           '' AS column_default,
-          true AS is_nullable
+          true AS is_nullable,
+          table_schema
         FROM v_catalog.view_columns
         WHERE lower(table_name) = '{table}'
           AND {schema_condition}

--- a/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/vertica/queries.py
@@ -14,20 +14,19 @@ SQL Queries used during ingestion
 
 import textwrap
 
-# Column metadata is read from v_catalog.columns / v_catalog.view_columns only.
-# Column comments used to be resolved here with a per-table
+# Fast path: column metadata is read from v_catalog.columns / v_catalog.view_columns
+# only. Column comments used to be resolved here with a per-table
 # `LEFT JOIN v_catalog.comments`, which cost 1-13s per table and dominated the
-# ingestion time (see issue #29429). They are now fetched in a single bulk query
-# (`VERTICA_COLUMN_COMMENTS`) and looked up from an in-memory cache, mirroring how
-# table comments are handled by `get_all_table_comments`.
+# ingestion time (see issue #29429). They are now bulk-fetched per schema
+# (`VERTICA_SCHEMA_COLUMN_COMMENTS`) and looked up from an in-memory cache,
+# mirroring how table comments are handled by `get_all_table_comments`.
 VERTICA_GET_COLUMNS = textwrap.dedent(
     """
         SELECT
           column_name,
           data_type,
           column_default,
-          is_nullable,
-          table_schema
+          is_nullable
         FROM v_catalog.columns
         WHERE lower(table_name) = '{table}'
           AND {schema_condition}
@@ -36,27 +35,65 @@ VERTICA_GET_COLUMNS = textwrap.dedent(
           column_name,
           data_type,
           '' AS column_default,
-          true AS is_nullable,
-          table_schema
+          true AS is_nullable
         FROM v_catalog.view_columns
         WHERE lower(table_name) = '{table}'
           AND {schema_condition}
     """
 )
 
-# Bulk-fetch every column comment in one shot. `v_catalog.comments` only holds a
-# row per object that actually has a comment, so the result set is bounded by the
-# number of commented columns (sparse) rather than the total column count.
+# Fallback path: the original per-table join, still used when the schema-scoped
+# comment cache is unavailable -- either the schema holds more than
+# MAX_SCHEMA_COMMENTS comments (bulk-caching it would be unbounded memory), or
+# reflection was invoked without a schema so there is no schema to scope to.
+# Slower, but it always resolves every comment.
+VERTICA_GET_COLUMNS_WITH_COMMENTS = textwrap.dedent(
+    """
+        SELECT
+          column_name,
+          data_type,
+          column_default,
+          is_nullable,
+          comment
+        FROM
+          v_catalog.columns col
+          LEFT JOIN v_catalog.comments cm
+            ON col.table_schema = cm.object_schema
+            AND col.table_name = cm.object_name
+            AND col.column_name = cm.child_object
+            AND cm.object_type = 'COLUMN'
+        WHERE lower(table_name) = '{table}'
+          AND {schema_condition}
+        UNION ALL
+        SELECT
+          column_name,
+          data_type,
+          '' AS column_default,
+          true AS is_nullable,
+          '' AS comment
+        FROM v_catalog.view_columns
+        WHERE lower(table_name) = '{table}'
+          AND {schema_condition}
+    """
+)
+
+# Bulk-fetch the column comments of a single schema. `v_catalog.comments` only
+# holds a row per object that actually has a comment, so the result set is bounded
+# by the number of commented columns (sparse) rather than the total column count.
 # For a COLUMN row: object_schema = schema, object_name = table, child_object = column.
-VERTICA_COLUMN_COMMENTS = textwrap.dedent(
+#
+# Filtering and limiting happen in the database so an oversized schema never
+# materialises client-side.
+VERTICA_SCHEMA_COLUMN_COMMENTS = textwrap.dedent(
     """
     SELECT
-      object_schema AS schema,
       object_name   AS table_name,
       child_object  AS column_name,
       comment       AS column_comment
     FROM v_catalog.comments
     WHERE object_type = 'COLUMN'
+      AND LOWER(object_schema) = LOWER(:schema)
+    LIMIT :limit
     """
 )
 

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -55,6 +55,12 @@ def get_all_column_comments(self, connection, query):
     row), so bulk-loading them once and caching by (schema, table, column) avoids a
     per-table catalog join while keeping the memory footprint bounded by the number
     of commented columns.
+
+    Keys are lower-cased on both storage and lookup: the bulk query returns the
+    catalog-original case from ``v_catalog.comments`` while the reflection wrapper
+    is called with the un-normalized ``schema``/``table_name`` arguments, so
+    mixed-case identifiers would otherwise miss the cache and silently drop
+    comments that actually exist.
     """
     self.all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
     self.current_db: str = connection.engine.url.database
@@ -62,14 +68,23 @@ def get_all_column_comments(self, connection, query):
     for row in result:
         row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
         self.all_column_comments[
-            (row_dict["schema"], row_dict["table_name"], row_dict["column_name"])
+            (
+                (row_dict["schema"] or "").lower(),
+                (row_dict["table_name"] or "").lower(),
+                (row_dict["column_name"] or "").lower(),
+            )
         ] = row_dict["column_comment"]
 
 
 def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
     if not hasattr(self, "all_column_comments") or self.current_db != connection.engine.url.database:
         self.get_all_column_comments(connection, query)
-    return self.all_column_comments.get((schema, table_name, column_name))
+    key = (
+        (schema or "").lower(),
+        (table_name or "").lower(),
+        (column_name or "").lower(),
+    )
+    return self.all_column_comments.get(key)
 
 
 @reflection.cache

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -66,6 +66,15 @@ def get_all_column_comments(self, connection, query):
     per-table catalog join while keeping the memory footprint bounded by the number
     of commented columns.
 
+    Scope and bound: this is a complete per-database lookup table, not a
+    demand-filled cache -- ``get_columns`` runs for every table and must be able to
+    resolve any commented column, so the whole result set stays resident for that
+    database's reflection. It is bounded by lifetime rather than by eviction: the
+    dict is rebuilt and replaced wholesale when the database changes (see the
+    ``current_db`` check in ``get_column_comment_wrapper``), so nothing accumulates
+    across databases. Size eviction is deliberately not used, as dropping an entry
+    would silently omit a column comment that exists in the catalog.
+
     Keys are lower-cased on both storage and lookup: the bulk query returns the
     catalog-original case from ``v_catalog.comments`` while the reflection wrapper
     is called with the un-normalized ``schema``/``table_name`` arguments, so

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -47,6 +47,32 @@ def get_table_comment_wrapper(self, connection, query, table_name, schema=None):
 
 
 @reflection.cache
+def get_all_column_comments(self, connection, query):
+    """
+    Method to fetch comments of all columns in a single query.
+
+    Column comments live in a sparse catalog table (only commented columns have a
+    row), so bulk-loading them once and caching by (schema, table, column) avoids a
+    per-table catalog join while keeping the memory footprint bounded by the number
+    of commented columns.
+    """
+    self.all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
+    self.current_db: str = connection.engine.url.database
+    result = connection.execute(text(query) if isinstance(query, str) else query)
+    for row in result:
+        row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
+        self.all_column_comments[
+            (row_dict["schema"], row_dict["table_name"], row_dict["column_name"])
+        ] = row_dict["column_comment"]
+
+
+def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
+    if not hasattr(self, "all_column_comments") or self.current_db != connection.engine.url.database:
+        self.get_all_column_comments(connection, query)
+    return self.all_column_comments.get((schema, table_name, column_name))
+
+
+@reflection.cache
 def get_all_table_owners(self, connection, query, schema_name, **kw):  # pylint: disable=unused-argument
     """
     Method to fetch owners of all available tables

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -61,30 +61,44 @@ def get_all_column_comments(self, connection, query):
     is called with the un-normalized ``schema``/``table_name`` arguments, so
     mixed-case identifiers would otherwise miss the cache and silently drop
     comments that actually exist.
+
+    The dialect is shared across the worker threads that reflect schemas in
+    parallel, so the fully-built dict is published in a single assignment: a
+    concurrent reader sees either the previous cache or the complete new one,
+    never a half-populated dict. ``current_db`` is assigned last so the wrapper's
+    freshness check only passes once the data is in place.
     """
-    self.all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
-    self.current_db: str = connection.engine.url.database
+    all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
+    current_db = connection.engine.url.database
     result = connection.execute(text(query) if isinstance(query, str) else query)
     for row in result:
         row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
-        self.all_column_comments[
+        all_column_comments[
             (
                 (row_dict["schema"] or "").lower(),
                 (row_dict["table_name"] or "").lower(),
                 (row_dict["column_name"] or "").lower(),
             )
         ] = row_dict["column_comment"]
+    # Atomic publish (see docstring): data first, freshness flag last.
+    self.all_column_comments = all_column_comments
+    self.current_db = current_db
 
 
 def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
-    if not hasattr(self, "all_column_comments") or self.current_db != connection.engine.url.database:
+    # Snapshot the shared attributes once. getattr avoids racing with the atomic
+    # publish above (all_column_comments is assigned before current_db, so a reader
+    # in that window harmlessly sees an unset current_db and rebuilds).
+    cache = getattr(self, "all_column_comments", None)
+    if cache is None or getattr(self, "current_db", None) != connection.engine.url.database:
         self.get_all_column_comments(connection, query)
+        cache = self.all_column_comments
     key = (
         (schema or "").lower(),
         (table_name or "").lower(),
         (column_name or "").lower(),
     )
-    return self.all_column_comments.get(key)
+    return cache.get(key)
 
 
 @reflection.cache

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -14,6 +14,7 @@
 Module for sqlalchemy dialect utils
 """
 
+import threading
 import traceback
 from typing import Dict, Optional, Tuple  # noqa: UP035
 
@@ -25,6 +26,15 @@ from sqlalchemy.schema import CreateTable, MetaData
 from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
+
+# Serializes the first (expensive) bulk load of the column-comment cache. The
+# dialect is shared across the worker threads that reflect schemas in parallel, so
+# without this several threads would each run the costly VERTICA_COLUMN_COMMENTS
+# query before any of them publishes the result. A single module-level lock is
+# enough: it is only taken on the rare first load / database switch (steady-state
+# lookups never touch it), so gating it across dialect instances is negligible and
+# avoids the race of lazily creating a per-instance lock.
+_column_comment_load_lock = threading.Lock()
 
 
 @reflection.cache
@@ -87,12 +97,19 @@ def get_all_column_comments(self, connection, query):
 
 def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
     # Snapshot the shared attributes once. getattr avoids racing with the atomic
-    # publish above (all_column_comments is assigned before current_db, so a reader
-    # in that window harmlessly sees an unset current_db and rebuilds).
+    # publish in get_all_column_comments (all_column_comments is assigned before
+    # current_db, so a reader in that window harmlessly sees an unset current_db).
+    database = connection.engine.url.database
     cache = getattr(self, "all_column_comments", None)
-    if cache is None or getattr(self, "current_db", None) != connection.engine.url.database:
-        self.get_all_column_comments(connection, query)
-        cache = self.all_column_comments
+    if cache is None or getattr(self, "current_db", None) != database:
+        # Double-checked locking: only the first racing thread runs the expensive
+        # bulk query; the rest wait, then re-check and reuse the published cache.
+        # Steady-state lookups skip the lock entirely (fast path above).
+        with _column_comment_load_lock:
+            cache = getattr(self, "all_column_comments", None)
+            if cache is None or getattr(self, "current_db", None) != database:
+                self.get_all_column_comments(connection, query)
+            cache = self.all_column_comments
     key = (
         (schema or "").lower(),
         (table_name or "").lower(),

--- a/ingestion/src/metadata/utils/sqlalchemy_utils.py
+++ b/ingestion/src/metadata/utils/sqlalchemy_utils.py
@@ -14,7 +14,6 @@
 Module for sqlalchemy dialect utils
 """
 
-import threading
 import traceback
 from typing import Dict, Optional, Tuple  # noqa: UP035
 
@@ -27,14 +26,14 @@ from metadata.utils.logger import ingestion_logger
 
 logger = ingestion_logger()
 
-# Serializes the first (expensive) bulk load of the column-comment cache. The
-# dialect is shared across the worker threads that reflect schemas in parallel, so
-# without this several threads would each run the costly VERTICA_COLUMN_COMMENTS
-# query before any of them publishes the result. A single module-level lock is
-# enough: it is only taken on the rare first load / database switch (steady-state
-# lookups never touch it), so gating it across dialect instances is negligible and
-# avoids the race of lazily creating a per-instance lock.
-_column_comment_load_lock = threading.Lock()
+# Upper bound on how many column comments are cached for a single schema. Schemas
+# above it fall back to the per-table comments join, so no comment is ever lost --
+# only the optimisation is skipped.
+MAX_SCHEMA_COMMENTS = 1_000
+
+# Slot in the Inspector's info_cache holding (schema, comments) for the one schema
+# a worker is currently reflecting.
+SCHEMA_COLUMN_COMMENTS_CACHE_KEY = "_om_schema_column_comments"
 
 
 @reflection.cache
@@ -56,75 +55,77 @@ def get_table_comment_wrapper(self, connection, query, table_name, schema=None):
     return {"text": self.all_table_comments.get((table_name, schema))}
 
 
-@reflection.cache
-def get_all_column_comments(self, connection, query):
+def get_schema_column_comments(  # pylint: disable=unused-argument
+    self,
+    connection,
+    query,
+    schema,
+    info_cache,
+    max_comments: int = MAX_SCHEMA_COMMENTS,
+):
     """
-    Method to fetch comments of all columns in a single query.
+    Bulk-fetch the column comments of a single schema, cached per reflection worker.
 
     Column comments live in a sparse catalog table (only commented columns have a
-    row), so bulk-loading them once and caching by (schema, table, column) avoids a
-    per-table catalog join while keeping the memory footprint bounded by the number
-    of commented columns.
+    row), so fetching a schema's comments once and looking them up in memory avoids
+    the per-table catalog join that dominates ingestion time (issue #29429).
 
-    Scope and bound: this is a complete per-database lookup table, not a
-    demand-filled cache -- ``get_columns`` runs for every table and must be able to
-    resolve any commented column, so the whole result set stays resident for that
-    database's reflection. It is bounded by lifetime rather than by eviction: the
-    dict is rebuilt and replaced wholesale when the database changes (see the
-    ``current_db`` check in ``get_column_comment_wrapper``), so nothing accumulates
-    across databases. Size eviction is deliberately not used, as dropping an entry
-    would silently omit a column comment that exists in the catalog.
+    Scope and bound. The cache holds exactly one schema -- the one the worker is
+    currently reflecting -- and is replaced when the worker moves on, so schemas do
+    not accumulate. The size is bounded explicitly: the query asks for at most
+    ``max_comments + 1`` rows, and if the schema exceeds the limit the partial
+    result is discarded and ``None`` is returned so the caller falls back to the
+    per-table comments join. No comment is ever dropped -- only the optimisation is
+    skipped, which is why size-based eviction is not used here.
 
-    Keys are lower-cased on both storage and lookup: the bulk query returns the
-    catalog-original case from ``v_catalog.comments`` while the reflection wrapper
-    is called with the un-normalized ``schema``/``table_name`` arguments, so
-    mixed-case identifiers would otherwise miss the cache and silently drop
-    comments that actually exist.
+    The cache lives in the ``Inspector.info_cache`` rather than on the dialect
+    because the dialect is shared across the worker threads that reflect schemas in
+    parallel, while each worker has its own ``info_cache``. That keeps workers
+    independent: no shared state, no lock, and no cross-worker thrashing when two
+    workers reflect different schemas at the same time.
 
-    The dialect is shared across the worker threads that reflect schemas in
-    parallel, so the fully-built dict is published in a single assignment: a
-    concurrent reader sees either the previous cache or the complete new one,
-    never a half-populated dict. ``current_db`` is assigned last so the wrapper's
-    freshness check only passes once the data is in place.
+    Keys are lower-cased on both storage and lookup: the query returns the
+    catalog-original case from ``v_catalog.comments`` while reflection passes the
+    un-normalized ``schema``/``table_name``, so mixed-case identifiers would
+    otherwise miss the cache and silently drop comments that actually exist.
+
+    :return: ``{(table_name, column_name): comment}`` for the schema, or ``None``
+        when the caller should use the per-table comments join instead.
     """
-    all_column_comments: Dict[Tuple[str, str, str], str] = {}  # noqa: UP006
-    current_db = connection.engine.url.database
-    result = connection.execute(text(query) if isinstance(query, str) else query)
-    for row in result:
-        row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
-        all_column_comments[
-            (
-                (row_dict["schema"] or "").lower(),
+    schema_key = (schema or "").lower()
+    cached_schema, cached_comments = info_cache.get(SCHEMA_COLUMN_COMMENTS_CACHE_KEY, (None, None))
+    if cached_schema == schema_key:
+        return cached_comments
+
+    # max_comments + 1 is a sentinel: reading one row beyond the limit is what tells
+    # us the schema is oversized, without materialising all of it.
+    rows = list(
+        connection.execute(
+            text(query) if isinstance(query, str) else query,
+            {"schema": schema, "limit": max_comments + 1},
+        )
+    )
+
+    comments: Optional[Dict[Tuple[str, str], str]] = None  # noqa: UP006, UP045
+    if len(rows) <= max_comments:
+        comments = {}
+        for row in rows:
+            row_dict = {k.lower(): v for k, v in dict(row._mapping).items()}
+            key = (
                 (row_dict["table_name"] or "").lower(),
                 (row_dict["column_name"] or "").lower(),
             )
-        ] = row_dict["column_comment"]
-    # Atomic publish (see docstring): data first, freshness flag last.
-    self.all_column_comments = all_column_comments
-    self.current_db = current_db
+            comments[key] = row_dict["column_comment"]
+    else:
+        logger.debug(
+            f"Schema {schema} has more than {max_comments} column comments; "
+            "falling back to the per-table comments join for it."
+        )
 
-
-def get_column_comment_wrapper(self, connection, query, table_name, column_name, schema=None):
-    # Snapshot the shared attributes once. getattr avoids racing with the atomic
-    # publish in get_all_column_comments (all_column_comments is assigned before
-    # current_db, so a reader in that window harmlessly sees an unset current_db).
-    database = connection.engine.url.database
-    cache = getattr(self, "all_column_comments", None)
-    if cache is None or getattr(self, "current_db", None) != database:
-        # Double-checked locking: only the first racing thread runs the expensive
-        # bulk query; the rest wait, then re-check and reuse the published cache.
-        # Steady-state lookups skip the lock entirely (fast path above).
-        with _column_comment_load_lock:
-            cache = getattr(self, "all_column_comments", None)
-            if cache is None or getattr(self, "current_db", None) != database:
-                self.get_all_column_comments(connection, query)
-            cache = self.all_column_comments
-    key = (
-        (schema or "").lower(),
-        (table_name or "").lower(),
-        (column_name or "").lower(),
-    )
-    return cache.get(key)
+    # Replace the previous schema instead of accumulating schemas. The oversized
+    # verdict is cached too, so the probe runs once per schema rather than per table.
+    info_cache[SCHEMA_COLUMN_COMMENTS_CACHE_KEY] = (schema_key, comments)
+    return comments
 
 
 @reflection.cache

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -22,6 +22,8 @@ These cover the column-comment bulk-caching that replaces the old per-table
 * ``VerticaDialect`` enables SQLAlchemy statement caching.
 """
 
+import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -201,6 +203,52 @@ def test_bulk_population_is_atomic():
     assert observed == [None]
     assert dialect.all_column_comments[("public", "t1", "c1")] == "c1 comment"
     assert dialect.all_column_comments[("public", "t1", "c2")] == "c2 comment"
+
+
+def test_first_load_runs_bulk_query_once_under_concurrency():
+    # The dialect is shared across worker threads reflecting schemas in parallel.
+    # On the first load they all see an empty cache; double-checked locking must
+    # ensure only one thread runs the expensive bulk query while the rest wait and
+    # reuse the published result.
+    dialect = _new_dialect()
+    comment_query_calls = []
+    start = threading.Barrier(5)
+
+    def _execute(query, *_args, **_kwargs):
+        if "v_catalog.comments" in str(query):
+            comment_query_calls.append(1)
+            time.sleep(0.05)  # widen the load window so all threads race the load
+            return iter([_comment_row("public", "t1", "c1", "c1 comment")])
+        return iter([])
+
+    connection = MagicMock()
+    connection.engine.url.database = "db"
+    connection.execute.side_effect = _execute
+
+    results = []
+
+    def worker():
+        start.wait()
+        results.append(
+            get_column_comment_wrapper(
+                dialect,
+                connection,
+                VERTICA_COLUMN_COMMENTS,
+                table_name="t1",
+                column_name="c1",
+                schema="public",
+            )
+        )
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert all(result == "c1 comment" for result in results)
+    # Five racing threads, but the costly comment catalog is queried exactly once.
+    assert len(comment_query_calls) == 1
 
 
 def test_get_columns_query_does_not_join_comments():

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -143,6 +143,22 @@ def test_bulk_comment_query_runs_once_across_tables():
     assert _comment_query_count(connection) == 1
 
 
+def test_comment_lookup_is_case_insensitive():
+    # v_catalog.comments returns catalog-original case, while get_columns is
+    # reflected with mixed-case schema/table arguments. Keys are normalized to
+    # lowercase on both sides so the comment is not silently dropped.
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("MyCol")]},
+        comment_rows=[_comment_row("public", "t1", "mycol", "case-folded comment")],
+    )
+
+    columns = list(dialect.get_columns(connection, "T1", schema="Public"))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["MyCol"] == "case-folded comment"
+
+
 def test_get_columns_query_does_not_join_comments():
     dialect = _new_dialect()
     connection = _make_connection(

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -1,0 +1,198 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Unit tests for the Vertica connector metadata reflection (issue #29429).
+
+These cover the column-comment bulk-caching that replaces the old per-table
+``LEFT JOIN v_catalog.comments`` (the dominant ingestion cost), verifying that:
+
+* column comments are resolved from a single bulk query instead of a per-table
+  join,
+* the bulk comment query runs only once and is reused across tables,
+* ``VERTICA_GET_COLUMNS`` no longer joins ``v_catalog.comments``,
+* the cache is invalidated when the database changes, and
+* ``VerticaDialect`` enables SQLAlchemy statement caching.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+# The dialect lives in the optional ``vertica`` plugin; skip cleanly when absent.
+pytest.importorskip("sqlalchemy_vertica")
+
+from sqlalchemy_vertica.base import VerticaDialect  # noqa: E402
+
+# Importing the module applies the OpenMetadata monkeypatches onto VerticaDialect
+# (get_columns, get_all_column_comments, supports_statement_cache, ...).
+import metadata.ingestion.source.database.vertica.metadata  # noqa: E402,F401
+from metadata.ingestion.source.database.vertica.queries import (  # noqa: E402
+    VERTICA_COLUMN_COMMENTS,
+)
+from metadata.utils.sqlalchemy_utils import (  # noqa: E402
+    get_all_column_comments,
+    get_column_comment_wrapper,
+)
+
+
+def _column_row(name, data_type="varchar", default=None, nullable=True):
+    """Row shape returned by VERTICA_GET_COLUMNS (attribute access)."""
+    return SimpleNamespace(
+        column_name=name,
+        data_type=data_type,
+        column_default=default,
+        is_nullable=nullable,
+    )
+
+
+def _comment_row(schema, table, column, comment):
+    """Row shape returned by VERTICA_COLUMN_COMMENTS (``._mapping`` access)."""
+    return SimpleNamespace(
+        _mapping={
+            "schema": schema,
+            "table_name": table,
+            "column_name": column,
+            "column_comment": comment,
+        }
+    )
+
+
+def _make_connection(columns_by_table, comment_rows, database="testdb"):
+    """
+    Build a mock connection that routes queries by their SQL text:
+    the comment bulk query -> comment_rows, the per-table columns query ->
+    the rows registered for that table name.
+    """
+    connection = MagicMock()
+    connection.engine.url.database = database
+
+    def _execute(query, *_args, **_kwargs):
+        text = str(query)
+        if "v_catalog.comments" in text:
+            return iter(list(comment_rows))
+        for table, rows in columns_by_table.items():
+            if f"'{table}'" in text:
+                return iter(list(rows))
+        return iter([])
+
+    connection.execute.side_effect = _execute
+    return connection
+
+
+def _new_dialect():
+    # Bypass __init__ side effects; class attributes (ischema_names and the
+    # monkeypatched methods) are all we need for reflection.
+    return object.__new__(VerticaDialect)
+
+
+def _comment_query_count(connection):
+    return sum(
+        1
+        for call in connection.execute.call_args_list
+        if "v_catalog.comments" in str(call.args[0])
+    )
+
+
+def test_get_columns_resolves_comments_from_bulk_cache():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1"), _column_row("c2")]},
+        comment_rows=[_comment_row("public", "t1", "c1", "c1 comment")],
+    )
+
+    columns = list(dialect.get_columns(connection, "t1", schema="public"))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["c1"] == "c1 comment"
+    # A column without a comment resolves to None, not an empty-string artifact
+    # from the old outer join.
+    assert comment_by_name["c2"] is None
+    # Two columns, but the (slow) comment catalog is queried only once.
+    assert _comment_query_count(connection) == 1
+
+
+def test_bulk_comment_query_runs_once_across_tables():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={
+            "t1": [_column_row("c1")],
+            "t2": [_column_row("cx")],
+        },
+        comment_rows=[
+            _comment_row("public", "t1", "c1", "c1 comment"),
+            _comment_row("public", "t2", "cx", "cx comment"),
+        ],
+    )
+
+    t1 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t1", schema="public")}
+    t2 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t2", schema="public")}
+
+    assert t1["c1"] == "c1 comment"
+    assert t2["cx"] == "cx comment"
+    # The whole point of the fix: the second table reuses the cache, so the
+    # comment catalog is still queried only once in total.
+    assert _comment_query_count(connection) == 1
+
+
+def test_get_columns_query_does_not_join_comments():
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1")]},
+        comment_rows=[],
+    )
+
+    list(dialect.get_columns(connection, "t1", schema="public"))
+
+    columns_queries = [
+        str(call.args[0])
+        for call in connection.execute.call_args_list
+        if "v_catalog.columns" in str(call.args[0])
+    ]
+    assert columns_queries, "expected a v_catalog.columns query"
+    for query in columns_queries:
+        assert "v_catalog.comments" not in query
+        assert "comment" not in query.lower()
+
+
+def test_column_comment_cache_is_invalidated_on_db_switch():
+    dialect = SimpleNamespace()
+    # Bind the bulk loader so the wrapper can call self.get_all_column_comments.
+    dialect.get_all_column_comments = get_all_column_comments.__get__(dialect)
+
+    conn_a = MagicMock()
+    conn_a.engine.url.database = "db_a"
+    conn_a.execute.return_value = iter([_comment_row("public", "t", "c", "from A")])
+
+    first = get_column_comment_wrapper(
+        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    second = get_column_comment_wrapper(
+        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    assert first == second == "from A"
+    # Same DB -> cache reused, loaded only once.
+    assert conn_a.execute.call_count == 1
+
+    conn_b = MagicMock()
+    conn_b.engine.url.database = "db_b"
+    conn_b.execute.return_value = iter([_comment_row("public", "t", "c", "from B")])
+
+    switched = get_column_comment_wrapper(
+        dialect, conn_b, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
+    )
+    # Different DB -> cache invalidated and reloaded from the new connection.
+    assert switched == "from B"
+    assert conn_b.execute.call_count == 1
+
+
+def test_vertica_dialect_enables_statement_cache():
+    assert VerticaDialect.supports_statement_cache is True

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -44,13 +44,14 @@ from metadata.utils.sqlalchemy_utils import (  # noqa: E402
 )
 
 
-def _column_row(name, data_type="varchar", default=None, nullable=True):
+def _column_row(name, data_type="varchar", default=None, nullable=True, schema="public"):
     """Row shape returned by VERTICA_GET_COLUMNS (attribute access)."""
     return SimpleNamespace(
         column_name=name,
         data_type=data_type,
         column_default=default,
         is_nullable=nullable,
+        table_schema=schema,
     )
 
 
@@ -149,7 +150,7 @@ def test_comment_lookup_is_case_insensitive():
     # lowercase on both sides so the comment is not silently dropped.
     dialect = _new_dialect()
     connection = _make_connection(
-        columns_by_table={"t1": [_column_row("MyCol")]},
+        columns_by_table={"t1": [_column_row("MyCol", schema="Public")]},
         comment_rows=[_comment_row("public", "t1", "mycol", "case-folded comment")],
     )
 
@@ -157,6 +158,49 @@ def test_comment_lookup_is_case_insensitive():
     comment_by_name = {c["name"]: c["comment"] for c in columns}
 
     assert comment_by_name["MyCol"] == "case-folded comment"
+
+
+def test_get_columns_resolves_comments_when_schema_is_none():
+    # When reflected with schema=None, VERTICA_GET_COLUMNS spans every schema, so
+    # the comment key must be taken from each row's own table_schema rather than
+    # the (missing) argument, otherwise comments are silently dropped.
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1", schema="realschema")]},
+        comment_rows=[_comment_row("realschema", "t1", "c1", "the comment")],
+    )
+
+    columns = list(dialect.get_columns(connection, "t1", schema=None))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["c1"] == "the comment"
+
+
+def test_bulk_population_is_atomic():
+    # The dialect is shared across the worker threads that reflect schemas in
+    # parallel, so the cache must be published in a single assignment: a reader
+    # must never observe a half-built dict. We assert the dialect does not expose
+    # the new dict until every row has been consumed.
+    dialect = _new_dialect()
+    observed = []
+
+    def rows():
+        # Produced lazily as the loop iterates. At this point the cache must still
+        # be built in a local variable, not yet assigned onto the dialect.
+        observed.append(getattr(dialect, "all_column_comments", None))
+        yield _comment_row("public", "t1", "c1", "c1 comment")
+        yield _comment_row("public", "t1", "c2", "c2 comment")
+
+    connection = MagicMock()
+    connection.engine.url.database = "db"
+    connection.execute.return_value = rows()
+
+    get_all_column_comments(dialect, connection, VERTICA_COLUMN_COMMENTS)
+
+    # Nothing was published while rows were still being read (atomic publish).
+    assert observed == [None]
+    assert dialect.all_column_comments[("public", "t1", "c1")] == "c1 comment"
+    assert dialect.all_column_comments[("public", "t1", "c2")] == "c2 comment"
 
 
 def test_get_columns_query_does_not_join_comments():

--- a/ingestion/tests/unit/source/database/vertica/test_metadata.py
+++ b/ingestion/tests/unit/source/database/vertica/test_metadata.py
@@ -11,19 +11,20 @@
 """
 Unit tests for the Vertica connector metadata reflection (issue #29429).
 
-These cover the column-comment bulk-caching that replaces the old per-table
-``LEFT JOIN v_catalog.comments`` (the dominant ingestion cost), verifying that:
+These cover the schema-scoped column-comment cache that replaces the old
+per-table ``LEFT JOIN v_catalog.comments`` (the dominant ingestion cost),
+verifying that:
 
-* column comments are resolved from a single bulk query instead of a per-table
-  join,
-* the bulk comment query runs only once and is reused across tables,
-* ``VERTICA_GET_COLUMNS`` no longer joins ``v_catalog.comments``,
-* the cache is invalidated when the database changes, and
+* a normal schema costs exactly one bulk comment query, reused across tables,
+* the previous schema is released when a worker moves to another schema,
+* a schema above ``MAX_SCHEMA_COMMENTS`` falls back to the per-table join
+  without losing any comment,
+* concurrent workers stay independent through their own ``info_cache``,
+* ``VERTICA_GET_COLUMNS`` no longer joins ``v_catalog.comments``, and
 * ``VerticaDialect`` enables SQLAlchemy statement caching.
 """
 
 import threading
-import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -32,36 +33,36 @@ import pytest
 # The dialect lives in the optional ``vertica`` plugin; skip cleanly when absent.
 pytest.importorskip("sqlalchemy_vertica")
 
-from sqlalchemy_vertica.base import VerticaDialect  # noqa: E402
+from sqlalchemy_vertica.base import VerticaDialect
 
 # Importing the module applies the OpenMetadata monkeypatches onto VerticaDialect
-# (get_columns, get_all_column_comments, supports_statement_cache, ...).
-import metadata.ingestion.source.database.vertica.metadata  # noqa: E402,F401
-from metadata.ingestion.source.database.vertica.queries import (  # noqa: E402
-    VERTICA_COLUMN_COMMENTS,
+# (get_columns, supports_statement_cache, ...).
+import metadata.ingestion.source.database.vertica.metadata  # noqa: F401
+from metadata.ingestion.source.database.vertica.queries import (
+    VERTICA_SCHEMA_COLUMN_COMMENTS,
 )
-from metadata.utils.sqlalchemy_utils import (  # noqa: E402
-    get_all_column_comments,
-    get_column_comment_wrapper,
+from metadata.utils.sqlalchemy_utils import (
+    MAX_SCHEMA_COMMENTS,
+    SCHEMA_COLUMN_COMMENTS_CACHE_KEY,
+    get_schema_column_comments,
 )
 
 
-def _column_row(name, data_type="varchar", default=None, nullable=True, schema="public"):
-    """Row shape returned by VERTICA_GET_COLUMNS (attribute access)."""
+def _column_row(name, data_type="varchar", default=None, nullable=True, comment=None):
+    """Row shape returned by the VERTICA_GET_COLUMNS family (attribute access)."""
     return SimpleNamespace(
         column_name=name,
         data_type=data_type,
         column_default=default,
         is_nullable=nullable,
-        table_schema=schema,
+        comment=comment,
     )
 
 
-def _comment_row(schema, table, column, comment):
-    """Row shape returned by VERTICA_COLUMN_COMMENTS (``._mapping`` access)."""
+def _comment_row(table, column, comment):
+    """Row shape returned by VERTICA_SCHEMA_COLUMN_COMMENTS (``._mapping`` access)."""
     return SimpleNamespace(
         _mapping={
-            "schema": schema,
             "table_name": table,
             "column_name": column,
             "column_comment": comment,
@@ -69,21 +70,28 @@ def _comment_row(schema, table, column, comment):
     )
 
 
-def _make_connection(columns_by_table, comment_rows, database="testdb"):
+def _is_comment_query(statement):
+    # The bulk comment query is the only one selecting ``column_comment``; the
+    # per-table fallback also touches v_catalog.comments, so match on the alias.
+    return "column_comment" in str(statement)
+
+
+def _make_connection(columns_by_table, comments_by_schema, database="testdb"):
     """
-    Build a mock connection that routes queries by their SQL text:
-    the comment bulk query -> comment_rows, the per-table columns query ->
-    the rows registered for that table name.
+    Mock connection routing by SQL text: the bulk comment query resolves against
+    ``comments_by_schema`` using the bound ``:schema``, and the per-table columns
+    query resolves against the rows registered for that table name.
     """
     connection = MagicMock()
     connection.engine.url.database = database
 
-    def _execute(query, *_args, **_kwargs):
-        text = str(query)
-        if "v_catalog.comments" in text:
-            return iter(list(comment_rows))
+    def _execute(query, params=None, *_args, **_kwargs):
+        statement = str(query)
+        if _is_comment_query(statement):
+            schema = (params or {}).get("schema")
+            return iter(list(comments_by_schema.get(schema, [])))
         for table, rows in columns_by_table.items():
-            if f"'{table}'" in text:
+            if f"'{table}'" in statement:
                 return iter(list(rows))
         return iter([])
 
@@ -98,21 +106,21 @@ def _new_dialect():
 
 
 def _comment_query_count(connection):
-    return sum(
-        1
-        for call in connection.execute.call_args_list
-        if "v_catalog.comments" in str(call.args[0])
-    )
+    return sum(1 for call in connection.execute.call_args_list if _is_comment_query(call.args[0]))
 
 
-def test_get_columns_resolves_comments_from_bulk_cache():
+def _executed_columns_queries(connection):
+    return [str(call.args[0]) for call in connection.execute.call_args_list if "v_catalog.columns" in str(call.args[0])]
+
+
+def test_get_columns_resolves_comments_from_schema_cache():
     dialect = _new_dialect()
     connection = _make_connection(
         columns_by_table={"t1": [_column_row("c1"), _column_row("c2")]},
-        comment_rows=[_comment_row("public", "t1", "c1", "c1 comment")],
+        comments_by_schema={"public": [_comment_row("t1", "c1", "c1 comment")]},
     )
 
-    columns = list(dialect.get_columns(connection, "t1", schema="public"))
+    columns = list(dialect.get_columns(connection, "t1", schema="public", info_cache={}))
     comment_by_name = {c["name"]: c["comment"] for c in columns}
 
     assert comment_by_name["c1"] == "c1 comment"
@@ -123,27 +131,116 @@ def test_get_columns_resolves_comments_from_bulk_cache():
     assert _comment_query_count(connection) == 1
 
 
-def test_bulk_comment_query_runs_once_across_tables():
+def test_one_bulk_comment_query_per_schema():
     dialect = _new_dialect()
+    info_cache = {}
     connection = _make_connection(
-        columns_by_table={
-            "t1": [_column_row("c1")],
-            "t2": [_column_row("cx")],
+        columns_by_table={"t1": [_column_row("c1")], "t2": [_column_row("cx")]},
+        comments_by_schema={
+            "public": [
+                _comment_row("t1", "c1", "c1 comment"),
+                _comment_row("t2", "cx", "cx comment"),
+            ]
         },
-        comment_rows=[
-            _comment_row("public", "t1", "c1", "c1 comment"),
-            _comment_row("public", "t2", "cx", "cx comment"),
-        ],
     )
 
-    t1 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t1", schema="public")}
-    t2 = {c["name"]: c["comment"] for c in dialect.get_columns(connection, "t2", schema="public")}
+    t1 = {
+        c["name"]: c["comment"] for c in dialect.get_columns(connection, "t1", schema="public", info_cache=info_cache)
+    }
+    t2 = {
+        c["name"]: c["comment"] for c in dialect.get_columns(connection, "t2", schema="public", info_cache=info_cache)
+    }
 
     assert t1["c1"] == "c1 comment"
     assert t2["cx"] == "cx comment"
     # The whole point of the fix: the second table reuses the cache, so the
-    # comment catalog is still queried only once in total.
+    # comment catalog is queried exactly once for the schema.
     assert _comment_query_count(connection) == 1
+
+
+def test_previous_schema_is_released_when_worker_changes_schema():
+    dialect = _new_dialect()
+    info_cache = {}
+    connection = _make_connection(
+        columns_by_table={},
+        comments_by_schema={
+            "schema_a": [_comment_row("t", "c", "from A")],
+            "schema_b": [_comment_row("t", "c", "from B")],
+        },
+    )
+
+    first = get_schema_column_comments(dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, "schema_a", info_cache)
+    assert first == {("t", "c"): "from A"}
+    assert _comment_query_count(connection) == 1
+
+    # Same schema again -> served from the cache, no extra query.
+    get_schema_column_comments(dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, "schema_a", info_cache)
+    assert _comment_query_count(connection) == 1
+
+    # Moving to another schema replaces the entry rather than accumulating.
+    second = get_schema_column_comments(dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, "schema_b", info_cache)
+    assert second == {("t", "c"): "from B"}
+    # Exactly one slot is kept, so schema_a's comments are no longer resident.
+    assert info_cache[SCHEMA_COLUMN_COMMENTS_CACHE_KEY] == ("schema_b", {("t", "c"): "from B"})
+
+
+def test_oversized_schema_returns_none_and_caches_the_verdict():
+    dialect = _new_dialect()
+    info_cache = {}
+    connection = _make_connection(
+        columns_by_table={},
+        comments_by_schema={"big": [_comment_row("t", f"c{i}", f"comment {i}") for i in range(3)]},
+    )
+
+    result = get_schema_column_comments(
+        dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, "big", info_cache, max_comments=2
+    )
+
+    # Over the limit -> the partial result is discarded so memory stays bounded.
+    assert result is None
+    assert info_cache[SCHEMA_COLUMN_COMMENTS_CACHE_KEY] == ("big", None)
+
+    # The verdict is cached, so the probe runs once per schema, not once per table.
+    repeated = get_schema_column_comments(
+        dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, "big", info_cache, max_comments=2
+    )
+    assert repeated is None
+    assert _comment_query_count(connection) == 1
+
+
+def test_oversized_schema_falls_back_to_per_table_join_without_losing_comments():
+    dialect = _new_dialect()
+    oversized = [_comment_row(f"t{i}", "c", f"comment {i}") for i in range(MAX_SCHEMA_COMMENTS + 1)]
+    connection = _make_connection(
+        # The fallback resolves the comment from the join itself, not from the cache.
+        columns_by_table={"t1": [_column_row("c1", comment="joined comment")]},
+        comments_by_schema={"public": oversized},
+    )
+
+    columns = list(dialect.get_columns(connection, "t1", schema="public", info_cache={}))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    # No comment is lost: only the optimisation is skipped for this schema.
+    assert comment_by_name["c1"] == "joined comment"
+    columns_queries = _executed_columns_queries(connection)
+    assert columns_queries, "expected a v_catalog.columns query"
+    assert all("v_catalog.comments" in query for query in columns_queries)
+
+
+def test_get_columns_without_schema_uses_the_join_fallback():
+    # Reflected with schema=None there is no schema to scope the cache to, so the
+    # per-table join resolves the comments instead of silently dropping them.
+    dialect = _new_dialect()
+    connection = _make_connection(
+        columns_by_table={"t1": [_column_row("c1", comment="the comment")]},
+        comments_by_schema={},
+    )
+
+    columns = list(dialect.get_columns(connection, "t1", schema=None, info_cache={}))
+    comment_by_name = {c["name"]: c["comment"] for c in columns}
+
+    assert comment_by_name["c1"] == "the comment"
+    assert _comment_query_count(connection) == 0
 
 
 def test_comment_lookup_is_case_insensitive():
@@ -152,154 +249,70 @@ def test_comment_lookup_is_case_insensitive():
     # lowercase on both sides so the comment is not silently dropped.
     dialect = _new_dialect()
     connection = _make_connection(
-        columns_by_table={"t1": [_column_row("MyCol", schema="Public")]},
-        comment_rows=[_comment_row("public", "t1", "mycol", "case-folded comment")],
+        columns_by_table={"t1": [_column_row("MyCol")]},
+        comments_by_schema={"Public": [_comment_row("T1", "MYCOL", "case-folded comment")]},
     )
 
-    columns = list(dialect.get_columns(connection, "T1", schema="Public"))
+    columns = list(dialect.get_columns(connection, "T1", schema="Public", info_cache={}))
     comment_by_name = {c["name"]: c["comment"] for c in columns}
 
     assert comment_by_name["MyCol"] == "case-folded comment"
 
 
-def test_get_columns_resolves_comments_when_schema_is_none():
-    # When reflected with schema=None, VERTICA_GET_COLUMNS spans every schema, so
-    # the comment key must be taken from each row's own table_schema rather than
-    # the (missing) argument, otherwise comments are silently dropped.
+def test_concurrent_workers_use_separate_info_caches():
+    # The dialect is shared across the worker threads that reflect schemas in
+    # parallel, but each worker owns its info_cache. No shared state, no lock, and
+    # no cross-worker thrashing: each worker loads its own schema exactly once.
     dialect = _new_dialect()
+    schemas = ["schema_a", "schema_b", "schema_c", "schema_d"]
     connection = _make_connection(
-        columns_by_table={"t1": [_column_row("c1", schema="realschema")]},
-        comment_rows=[_comment_row("realschema", "t1", "c1", "the comment")],
+        columns_by_table={},
+        comments_by_schema={schema: [_comment_row("t", "c", f"from {schema}")] for schema in schemas},
     )
 
-    columns = list(dialect.get_columns(connection, "t1", schema=None))
-    comment_by_name = {c["name"]: c["comment"] for c in columns}
+    start = threading.Barrier(len(schemas))
+    lock = threading.Lock()
+    results = {}
 
-    assert comment_by_name["c1"] == "the comment"
-
-
-def test_bulk_population_is_atomic():
-    # The dialect is shared across the worker threads that reflect schemas in
-    # parallel, so the cache must be published in a single assignment: a reader
-    # must never observe a half-built dict. We assert the dialect does not expose
-    # the new dict until every row has been consumed.
-    dialect = _new_dialect()
-    observed = []
-
-    def rows():
-        # Produced lazily as the loop iterates. At this point the cache must still
-        # be built in a local variable, not yet assigned onto the dialect.
-        observed.append(getattr(dialect, "all_column_comments", None))
-        yield _comment_row("public", "t1", "c1", "c1 comment")
-        yield _comment_row("public", "t1", "c2", "c2 comment")
-
-    connection = MagicMock()
-    connection.engine.url.database = "db"
-    connection.execute.return_value = rows()
-
-    get_all_column_comments(dialect, connection, VERTICA_COLUMN_COMMENTS)
-
-    # Nothing was published while rows were still being read (atomic publish).
-    assert observed == [None]
-    assert dialect.all_column_comments[("public", "t1", "c1")] == "c1 comment"
-    assert dialect.all_column_comments[("public", "t1", "c2")] == "c2 comment"
-
-
-def test_first_load_runs_bulk_query_once_under_concurrency():
-    # The dialect is shared across worker threads reflecting schemas in parallel.
-    # On the first load they all see an empty cache; double-checked locking must
-    # ensure only one thread runs the expensive bulk query while the rest wait and
-    # reuse the published result.
-    dialect = _new_dialect()
-    comment_query_calls = []
-    start = threading.Barrier(5)
-
-    def _execute(query, *_args, **_kwargs):
-        if "v_catalog.comments" in str(query):
-            comment_query_calls.append(1)
-            time.sleep(0.05)  # widen the load window so all threads race the load
-            return iter([_comment_row("public", "t1", "c1", "c1 comment")])
-        return iter([])
-
-    connection = MagicMock()
-    connection.engine.url.database = "db"
-    connection.execute.side_effect = _execute
-
-    results = []
-
-    def worker():
+    def worker(schema):
+        info_cache = {}
         start.wait()
-        results.append(
-            get_column_comment_wrapper(
-                dialect,
-                connection,
-                VERTICA_COLUMN_COMMENTS,
-                table_name="t1",
-                column_name="c1",
-                schema="public",
+        # Two lookups per worker: the second must be served from that worker's own
+        # cache, so every worker still costs exactly one bulk query.
+        for _ in range(2):
+            comments = get_schema_column_comments(
+                dialect, connection, VERTICA_SCHEMA_COLUMN_COMMENTS, schema, info_cache
             )
-        )
+            with lock:
+                results[schema] = comments
 
-    threads = [threading.Thread(target=worker) for _ in range(5)]
+    threads = [threading.Thread(target=worker, args=(schema,)) for schema in schemas]
     for thread in threads:
         thread.start()
     for thread in threads:
         thread.join()
 
-    assert all(result == "c1 comment" for result in results)
-    # Five racing threads, but the costly comment catalog is queried exactly once.
-    assert len(comment_query_calls) == 1
+    # Every worker resolved its own schema, unaffected by the others.
+    for schema in schemas:
+        assert results[schema] == {("t", "c"): f"from {schema}"}
+    # One bulk query per worker, not one per lookup.
+    assert _comment_query_count(connection) == len(schemas)
 
 
-def test_get_columns_query_does_not_join_comments():
+def test_fast_path_query_does_not_join_comments():
     dialect = _new_dialect()
     connection = _make_connection(
         columns_by_table={"t1": [_column_row("c1")]},
-        comment_rows=[],
+        comments_by_schema={"public": []},
     )
 
-    list(dialect.get_columns(connection, "t1", schema="public"))
+    list(dialect.get_columns(connection, "t1", schema="public", info_cache={}))
 
-    columns_queries = [
-        str(call.args[0])
-        for call in connection.execute.call_args_list
-        if "v_catalog.columns" in str(call.args[0])
-    ]
+    columns_queries = _executed_columns_queries(connection)
     assert columns_queries, "expected a v_catalog.columns query"
     for query in columns_queries:
         assert "v_catalog.comments" not in query
         assert "comment" not in query.lower()
-
-
-def test_column_comment_cache_is_invalidated_on_db_switch():
-    dialect = SimpleNamespace()
-    # Bind the bulk loader so the wrapper can call self.get_all_column_comments.
-    dialect.get_all_column_comments = get_all_column_comments.__get__(dialect)
-
-    conn_a = MagicMock()
-    conn_a.engine.url.database = "db_a"
-    conn_a.execute.return_value = iter([_comment_row("public", "t", "c", "from A")])
-
-    first = get_column_comment_wrapper(
-        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
-    )
-    second = get_column_comment_wrapper(
-        dialect, conn_a, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
-    )
-    assert first == second == "from A"
-    # Same DB -> cache reused, loaded only once.
-    assert conn_a.execute.call_count == 1
-
-    conn_b = MagicMock()
-    conn_b.engine.url.database = "db_b"
-    conn_b.execute.return_value = iter([_comment_row("public", "t", "c", "from B")])
-
-    switched = get_column_comment_wrapper(
-        dialect, conn_b, VERTICA_COLUMN_COMMENTS, table_name="t", column_name="c", schema="public"
-    )
-    # Different DB -> cache invalidated and reloaded from the new connection.
-    assert switched == "from B"
-    assert conn_b.execute.call_count == 1
 
 
 def test_vertica_dialect_enables_statement_cache():


### PR DESCRIPTION
### Describe your changes:

Fixes #29429

> **Updated 2026-09-08 after review.** The cache was originally whole-database;
> it is now scoped to a single schema and explicitly bounded, per @IceS2's
> review below. This description has been updated to match the current branch —
> see the review thread for the original design and the discussion.

Reworks how the Vertica connector fetches column comments, which made metadata
ingestion ~5x slower than comparable sources (~11h for ~2,000 tables/views on
Vertica vs ~2h for ~10,000 tables on MSSQL with an almost identical config).

**Root cause.** `get_columns` resolved column comments with a per-table
`LEFT JOIN` on `v_catalog.comments`. Vertica's docs flag this system table as
inherently expensive:

> "Queries on this table can be slow because it fetches data at query time from
> other catalog tables."
> — [V_CATALOG.COMMENTS, Vertica 26.2.x docs](https://docs.vertica.com/26.2.x/en/sql-reference/system-tables/v-catalog-schema/comments/)

`v_catalog.*` tables are derived from the catalog at query time with no
projections/indexes, so joining `comments` per table re-runs that derivation on
every table.

**This cost is independent of how many columns actually have comments.** The
`LEFT JOIN` forces a full derivation of `v_catalog.comments` even for a table
whose columns have no comments at all, so the penalty applies to the whole
catalog, not just commented tables.

**Fix.** Stop touching the slow `comments` table per table. Fetch a schema's
column comments in one bulk query and look them up from a bounded in-memory
cache:

1. **Bulk column comments per schema (main win).** New
   `VERTICA_SCHEMA_COLUMN_COMMENTS` query plus `get_schema_column_comments` in
   `sqlalchemy_utils`. `VERTICA_GET_COLUMNS` now reads `v_catalog.columns` alone
   (no join). Match keys `(table, column)` within the schema are unchanged, so
   results are identical. Keys are lower-cased on both storage and lookup so
   mixed-case identifiers don't silently drop comments.
2. **Remove a redundant per-table catalog query.** `get_columns` ran a primary-key
   query per table to set a `primary_key` flag that is never consumed downstream
   (primary keys are read via `get_pk_constraint`). Removed the query and the flag.
3. **Enable statement caching.** `VerticaDialect` did not set
   `supports_statement_cache`, so SQLAlchemy recompiled every statement (MSSQL sets
   it). The reflection queries embed their literal values into the statement text,
   so enabling it is safe. This also silences the SAWarning about missing
   statement-cache support.

**Scope and bound of the cache.** The cache holds exactly one schema — the one
the worker is currently reflecting — and is replaced when the worker moves on, so
schemas do not accumulate. The size is bounded explicitly: the query asks for at
most `MAX_SCHEMA_COMMENTS + 1` rows, and if the schema exceeds the limit the
partial result is discarded and that schema falls back to the original per-table
comments join. No comment is ever lost — only the optimisation is skipped, which
is why size-based eviction is not used. The oversized verdict is cached too, so
the probe runs once per schema rather than once per table.

The cache lives in `Inspector.info_cache` rather than on the dialect, because the
dialect is shared across the worker threads that reflect schemas in parallel
while each worker has its own `info_cache`. That keeps workers independent: no
shared state, no lock, and no cross-worker thrashing when two workers reflect
different schemas at the same time.

Reflection invoked with `schema=None` has no schema to scope the cache to and
also takes the join fallback, so comments are still resolved there.

**Measured on a real Vertica 26.0.0.2 instance** (identifiers omitted):

| | Before (per-table `LEFT JOIN comments`) | After (columns-only) |
|---|---|---|
| `get_columns` for one table | **~20–23 s / table** | **~0.3 s / table** |

The old query took ~20–23 s per table regardless of whether that table's columns
had comments. The new path issues one bulk comment fetch per schema, then a
sub-second columns-only query per table. That is O(schemas) instead of O(tables),
which is where the win comes from.

**Memory.** Bounded by construction: at most `MAX_SCHEMA_COMMENTS` entries for a
single schema, per worker; anything larger degrades to the previous per-table
behaviour rather than growing. Measured with `tracemalloc` on a dict of the same
shape (non-interned strings, Japanese comments, no customer data), entries cost
~310 B, most of it Python object overhead rather than the comment text:

| Bound | Per worker |
|---:|---:|
| 1,000 | ~0.3 MB |
| 20,000 | ~6.5 MB |
| 50,000 | ~15.6 MB |

`threads` defaults to 1, so the per-worker figure is also the effective peak.
The value of `MAX_SCHEMA_COMMENTS` is still under discussion in the review thread.

**Note on the issue framing.** The issue listed "primary keys queried twice" as
an inefficiency. With `sqlalchemy-vertica` (>=0.0.5) the base `get_pk_constraint`
is an empty stub (no catalog I/O), so there was no double PK read — the real waste
was the discarded PK query inside `get_columns`, which this PR removes.

Also dropped the outdated comment on `VERTICA_GET_COLUMNS` describing a
projection-name match; the query already matched on `child_object = column name`,
the documented behaviour for `v_catalog.comments`.

**Out of scope (candidate follow-ups).** Profiling the same instance showed two
other `v_catalog`-derived costs unrelated to column comments: the schema-comments
query (`object_type='SCHEMA'`, once per database) and a per-table
unique/constraint lookup. Left for a separate PR to keep this change focused.

#
### Type of change:
- [x] Improvement

#
### High-level design:

Only the Vertica dialect and one shared SQLAlchemy util are touched:

- `ingestion/.../vertica/queries.py` — drop the `LEFT JOIN v_catalog.comments`
  from `VERTICA_GET_COLUMNS`; keep the original joined query as
  `VERTICA_GET_COLUMNS_WITH_COMMENTS` for the fallback path; add
  `VERTICA_SCHEMA_COLUMN_COMMENTS`, which filters and limits in the database;
  remove the unused `VERTICA_GET_PRIMARY_KEYS`.
- `ingestion/.../utils/sqlalchemy_utils.py` — add `get_schema_column_comments`,
  a single-schema cache kept in the worker's `Inspector.info_cache`, bounded by
  `MAX_SCHEMA_COMMENTS` and returning `None` to signal the fallback.
- `ingestion/.../vertica/metadata.py` — `get_columns` looks comments up from that
  cache, falls back to the joined query when the cache is unavailable, and no
  longer runs the per-table PK query; set
  `VerticaDialect.supports_statement_cache = True`.

Alternatives considered: (a) a whole-database cache — rejected, unbounded memory;
(b) an LRU with size-based eviction — rejected, evicting an entry would silently
drop a comment that exists, whereas the fallback preserves correctness;
(c) keeping the per-table join but making it cheap like MSSQL — not possible,
MSSQL's `sys.*` catalog is indexed while Vertica's `v_catalog.*` is derived per
query.

Backward compatibility: ingested metadata is unchanged; only the fetch strategy
and timing change.

#
### Tests:

#### Unit tests
- [x] `ingestion/tests/unit/source/database/vertica/test_metadata.py` (mock-based,
  no live Vertica required):
  - `test_get_columns_resolves_comments_from_schema_cache`
  - `test_one_bulk_comment_query_per_schema` — the bulk query runs once per schema
    and is reused across tables (core of the fix)
  - `test_previous_schema_is_released_when_worker_changes_schema` — a single slot
    is kept, so schemas do not accumulate
  - `test_oversized_schema_returns_none_and_caches_the_verdict`
  - `test_oversized_schema_falls_back_to_per_table_join_without_losing_comments`
  - `test_get_columns_without_schema_uses_the_join_fallback`
  - `test_comment_lookup_is_case_insensitive` — mixed-case identifiers resolve
  - `test_concurrent_workers_use_separate_info_caches` — four threads synchronised
    with a `threading.Barrier`, no sleeps and no global lock
  - `test_fast_path_query_does_not_join_comments`
  - `test_vertica_dialect_enables_statement_cache`

#### Manual / integration
- Behaviour-preserving (identical metadata output); the before/after timings above
  were captured on a real Vertica 26.0.0.2 instance.
- The new `VERTICA_SCHEMA_COLUMN_COMMENTS` query was executed against that same
  instance to confirm it is valid as written and that `LIMIT` with a bound
  parameter is accepted.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #29429`.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: N/A.
- [ ] For UI changes: N/A.
- [x] I have added tests (unit) and listed them above.
