### PR TITLE
Fix stale votes/followers served via 304: make ETag content-based

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
@@ -19,6 +19,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.exception.JsonParsingException;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.PreconditionFailedException;
 
 /**
@@ -38,25 +40,45 @@ public class EntityETag {
   private static final String WEAK_PREFIX = "W/";
 
   /**
-   * Generate an ETag for an entity based on its version and last updated timestamp.
-   * Format: "version-updatedAt" wrapped in quotes as per HTTP ETag specification.
+   * Generate a strong ETag for an entity from a hash of its serialized representation.
+   *
+   * <p>An ETag must change whenever the representation the client would receive changes (RFC 7232
+   * §2.3). Hashing only {@code version}+{@code updatedAt} is not enough: relationship-only
+   * mutations — {@code updateVote}, {@code addFollower}/{@code removeFollower},
+   * {@code DataContractRepository.updateLatestResult} — rewrite the response body (e.g. the
+   * {@code votes} block) without bumping either field. A version-based ETag therefore stayed
+   * constant across such a mutation, so a conditional GET was wrongly answered {@code 304 Not
+   * Modified} and the client rendered the stale pre-mutation body (the up/down vote regression).
+   * Hashing the serialized entity ties the ETag to the exact bytes returned.
    *
    * @param entity The entity to generate ETag for
-   * @return ETag string in format "version-updatedAt"
+   * @return quoted strong ETag, or {@code null} if entity is null
    */
   public static String generateETag(EntityInterface entity) {
-    if (entity == null) {
-      return null;
+    String etag = null;
+    if (entity != null) {
+      etag = ETAG_PREFIX + generateHash(fingerprint(entity)) + ETAG_SUFFIX;
     }
+    return etag;
+  }
 
-    // Use version and updatedAt to generate a unique ETag
-    String etagValue = entity.getVersion() + "-" + entity.getUpdatedAt();
-
-    // Generate SHA-256 hash for consistency and to handle special characters
-    String hash = generateHash(etagValue);
-
-    // Return ETag wrapped in quotes as per HTTP specification
-    return ETAG_PREFIX + hash + ETAG_SUFFIX;
+  /**
+   * Content the ETag hashes: the serialized entity. Falls back to {@code version}+{@code updatedAt}
+   * if serialization fails, so a serializer hiccup degrades to the old ETag rather than failing the
+   * response this decorates.
+   */
+  private static String fingerprint(EntityInterface entity) {
+    String result;
+    try {
+      result = JsonUtils.pojoToJson(entity);
+    } catch (JsonParsingException e) {
+      LOG.warn(
+          "ETag falling back to version+updatedAt; entity {} failed to serialize: {}",
+          entity.getId(),
+          e.getMessage());
+      result = entity.getVersion() + "-" + entity.getUpdatedAt();
+    }
+    return result;
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
@@ -66,6 +66,13 @@ public class EntityETag {
    * Content the ETag hashes: the serialized entity. Falls back to {@code version}+{@code updatedAt}
    * if serialization fails, so a serializer hiccup degrades to the old ETag rather than failing the
    * response this decorates.
+   *
+   * <p>Best-effort cache-validation key, not a canonical digest: it relies on the entity serializing
+   * in a stable field/element order across requests. If a map-typed field or a DB-ordered collection
+   * ever serializes differently for otherwise-identical state, the ETag differs and the conditional
+   * GET is answered {@code 200} with the full body instead of {@code 304} — a missed optimization,
+   * never a stale or incorrect body. OpenMetadata map fields (e.g. {@code extension}) deserialize
+   * into order-preserving structures, so this stays stable in practice.
    */
   private static String fingerprint(EntityInterface entity) {
     String result;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java
@@ -18,6 +18,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.util.EntityETag;
 
 class ETagResponseFilterTest {
@@ -69,6 +71,24 @@ class ETagResponseFilterTest {
   }
 
   @Test
+  void staleIfNoneMatchIsNotShortCircuitedAfterVoteChangesBody() {
+    // Regression for the up/down vote P0: a vote repopulates the votes block without bumping
+    // version/updatedAt. The ETag the client cached before voting must no longer match the
+    // post-vote entity, so the conditional GET is answered 200 (fresh body) rather than 304
+    // (stale body). Before the content-based ETag fix this returned 304 and the header stuck.
+    UUID id = UUID.randomUUID();
+    String staleEtag = EntityETag.generateETag(table(id, 1.0, 100L, 0));
+    EntityInterface afterVote = table(id, 1.0, 100L, 1);
+    ContainerResponseContext res = response(OK, afterVote);
+
+    filter.filter(request("GET", staleEtag), res);
+
+    verify(res, never()).setStatus(anyInt());
+    verify(res, never()).setEntity(null);
+    assertEquals(EntityETag.generateETag(afterVote), res.getHeaders().getFirst(HttpHeaders.ETAG));
+  }
+
+  @Test
   void mutationWithMatchingIfNoneMatchIsNotShortCircuited() {
     EntityInterface entity = entity(3.1, 333L);
     String etag = EntityETag.generateETag(entity);
@@ -117,10 +137,19 @@ class ETagResponseFilterTest {
   }
 
   private static EntityInterface entity(double version, long updatedAt) {
-    EntityInterface entity = mock(EntityInterface.class);
-    when(entity.getVersion()).thenReturn(version);
-    when(entity.getUpdatedAt()).thenReturn(updatedAt);
-    when(entity.getId()).thenReturn(UUID.randomUUID());
-    return entity;
+    return new Table()
+        .withId(UUID.randomUUID())
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt);
+  }
+
+  private static EntityInterface table(UUID id, double version, long updatedAt, int upVotes) {
+    return new Table()
+        .withId(id)
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt)
+        .withVotes(new Votes().withUpVotes(upVotes).withDownVotes(0));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
@@ -10,10 +10,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.exception.PreconditionFailedException;
 
@@ -66,6 +69,31 @@ class EntityETagTest {
   }
 
   @Test
+  void etagReflectsRequestedFieldsForPartialFetches() {
+    // The ETag hashes the exact partial representation that is serialized for the requested
+    // `fields`, not a canonical full entity. So `fields=tags` and `fields=owners` on the same
+    // entity are different representations and MUST get different ETags — a `fields=tags` 304 can
+    // never hand back an owners-bearing body. The same selection with unchanged data stays stable
+    // so the conditional GET still short-circuits to 304.
+    UUID id = UUID.randomUUID();
+    EntityInterface tagsOnly =
+        partialTable(id).withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+    EntityInterface ownersOnly =
+        partialTable(id)
+            .withOwners(
+                List.of(
+                    new EntityReference()
+                        .withId(UUID.randomUUID())
+                        .withType("user")
+                        .withName("u1")));
+    EntityInterface tagsOnlyUnchanged =
+        partialTable(id).withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+
+    assertNotEquals(EntityETag.generateETag(tagsOnly), EntityETag.generateETag(ownersOnly));
+    assertEquals(EntityETag.generateETag(tagsOnly), EntityETag.generateETag(tagsOnlyUnchanged));
+  }
+
+  @Test
   void validateETagSupportsExactWildcardWeakAndMultipleMatches() {
     EntityInterface entity = entity(2.5, 98765L);
     String etag = EntityETag.generateETag(entity);
@@ -113,5 +141,9 @@ class EntityETagTest {
         .withVersion(version)
         .withUpdatedAt(updatedAt)
         .withVotes(new Votes().withUpVotes(upVotes).withDownVotes(0));
+  }
+
+  private static Table partialTable(UUID id) {
+    return new Table().withId(id).withName("etag_table").withVersion(1.0).withUpdatedAt(100L);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
@@ -3,17 +3,18 @@ package org.openmetadata.service.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.Response;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.exception.PreconditionFailedException;
 
 class EntityETagTest {
@@ -31,6 +32,37 @@ class EntityETagTest {
     assertEquals("W/\"1.2\"", weak);
     assertNull(EntityETag.generateETag(null));
     assertNull(EntityETag.generateWeakETag(null));
+  }
+
+  @Test
+  void etagIsStableForUnchangedEntity() {
+    EntityInterface entity = entity(1.2, 123456L);
+
+    assertEquals(EntityETag.generateETag(entity), EntityETag.generateETag(entity));
+  }
+
+  @Test
+  void etagChangesWhenVotesChangeWithoutVersionBump() {
+    // The P0 regression: an upvote writes a VOTED relationship and repopulates the entity's
+    // votes block but does NOT bump version/updatedAt. A version-only ETag stayed constant, so
+    // the post-vote conditional GET was answered 304 and the header rendered stale counts.
+    // The ETag must move when the votes block moves, even though version/updatedAt are identical.
+    UUID id = UUID.randomUUID();
+    EntityInterface before = table(id, 1.2, 123456L, 0);
+    EntityInterface after = table(id, 1.2, 123456L, 1);
+
+    assertEquals(before.getVersion(), after.getVersion());
+    assertEquals(before.getUpdatedAt(), after.getUpdatedAt());
+    assertNotEquals(EntityETag.generateETag(before), EntityETag.generateETag(after));
+  }
+
+  @Test
+  void etagChangesWhenVersionChanges() {
+    UUID id = UUID.randomUUID();
+    EntityInterface v1 = table(id, 1.0, 100L, 0);
+    EntityInterface v2 = table(id, 1.1, 200L, 0);
+
+    assertNotEquals(EntityETag.generateETag(v1), EntityETag.generateETag(v2));
   }
 
   @Test
@@ -67,10 +99,19 @@ class EntityETagTest {
   }
 
   private static EntityInterface entity(double version, long updatedAt) {
-    EntityInterface entity = mock(EntityInterface.class);
-    when(entity.getVersion()).thenReturn(version);
-    when(entity.getUpdatedAt()).thenReturn(updatedAt);
-    when(entity.getId()).thenReturn(UUID.randomUUID());
-    return entity;
+    return new Table()
+        .withId(UUID.randomUUID())
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt);
+  }
+
+  private static EntityInterface table(UUID id, double version, long updatedAt, int upVotes) {
+    return new Table()
+        .withId(id)
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt)
+        .withVotes(new Votes().withUpVotes(upVotes).withDownVotes(0));
   }
 }


### PR DESCRIPTION
## Describe your changes

Fixes the P0 where up/down vote buttons appeared unresponsive (data asset header shows stale vote count/status until an "Empty Cache and Hard Reload").

### Root cause
Voting persists a `VOTED` relationship and repopulates the entity's `votes` block, but **does not bump `version`/`updatedAt`** (`EntityRepository.updateVote`). `EntityETag.generateETag` fingerprinted only `version + updatedAt`, so the ETag was **unchanged across the mutation**:

1. Page GETs the asset → interceptor caches `(etag, body)`.
2. User votes → `PUT /{id}/vote` succeeds.
3. UI refetches → sends the old `ETag` in `If-None-Match`.
4. Backend recomputes the same version-based ETag → returns `304 Not Modified`.
5. `etagInterceptor` serves the cached **pre-vote** body → header shows stale votes.

An ETag that doesn't change when the body changes violates RFC 7232. The same class of bug affects `addFollower`/`removeFollower` and `DataContractRepository.updateLatestResult` — all relationship-only mutations that don't touch `version`.

### Fix
`EntityETag.generateETag` now hashes the **serialized entity representation** (`JsonUtils.pojoToJson(entity)`) instead of `version + updatedAt`, so the ETag moves whenever the response body moves. Falls back to `version + updatedAt` if serialization ever throws, so a serializer hiccup degrades gracefully rather than failing the response.

This is a one-method change; the perf model is unchanged (server CPU was never the win — only network bytes + client render were, and both are preserved since a truly-unchanged entity still hashes identically and still 304s).

## Type of change
- [x] Bug fix (P0)

## Tests
`EntityETagTest` and `ETagResponseFilterTest` were rewritten to use **real entities** (not `mock(EntityInterface.class)`) so serialization is exercised for real:

- identical entity state → identical ETag (304 perf preserved)
- votes change with **identical** `version`/`updatedAt` → **different** ETag (the regression)
- `version` change → different ETag
- filter: a stale `If-None-Match` (from before a vote) is **no longer** short-circuited to 304; a current `If-None-Match` still is

Both regression tests were **verified to fail against the old version-only implementation** and pass with the fix. `mvn spotless:check` clean, 14/14 tests green.

### Why the existing E2E vote tests didn't catch this
E2E globally disables the feature via `OM_DISABLE_ETAG_CONDITIONAL_READS` (set in `auth.setup.ts` + fixtures), so the upVote/downVote specs never exercised the 304 path. Authoritative regression coverage is added at the backend layer where it is deterministic.

## Follow-up (separate PR)
Now that the ETag reflects the full body, the E2E `OM_DISABLE_ETAG_CONDITIONAL_READS` opt-out and the interceptor's aggressive cache-clear/`__etagSnapshot` workarounds are redundant and can be removed — but that re-enables conditional reads across the entire Playwright suite and needs a full E2E run to verify, so it's intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates entity ETags to track serialized response content rather than only version metadata.
- Hashes the serialized entity so relationship-only changes invalidate conditional-read caches.
- Falls back to the previous version-and-timestamp fingerprint if serialization fails.
- Adds backend regression coverage for vote changes, partial representations, and conditional GET behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java | Replaces metadata-based strong ETags with hashes of serialized entity content and retains a serialization-failure fallback. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java | Adds filter-level regression coverage proving a relationship-only vote change no longer produces a stale 304 response. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java | Expands ETag tests with real entities, content changes, version changes, and partial response representations. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Entity API
    participant Filter as ETag Response Filter
    Client->>API: GET entity
    API-->>Filter: Serialized entity state
    Filter->>Filter: Hash entity representation
    Filter-->>Client: 200 body + content-based ETag
    Client->>API: Relationship-only mutation
    API-->>Client: Mutation succeeds
    Client->>API: GET entity with old If-None-Match
    API-->>Filter: Updated entity state
    Filter->>Filter: Hash changed representation
    Filter-->>Client: 200 fresh body + new ETag
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: ETag reflects requested fields for..."](https://github.com/open-metadata/openmetadata/commit/2bf0dc4f37997e15fce751d9ce54230b54e54bca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47495461)</sub>

<!-- /greptile_comment -->