### PR TITLE
fix(security): import jetty-bom for unmanaged jetty modules, bump tools.jackson to 3.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -797,11 +797,13 @@
         <artifactId>bcutil-jdk18on</artifactId>
         <version>1.84</version>
       </dependency>
-      <!-- Force patched tools.jackson 3.x (jsonschema2pojo-core pulls 3.0.2 transitively). -->
+      <!-- Force patched tools.jackson 3.x (jsonschema2pojo-core pulls 3.0.2 transitively).
+           3.1.5 adds CVE-2026-59889. jsonschema2pojo-core is scope=provided so none of this
+           reaches the runtime classpath, but Snyk's Maven scanner walks the provided tree. -->
       <dependency>
         <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>3.1.4</version>
+        <version>3.1.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,25 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- Pin every org.eclipse.jetty:* to one patched line. Declaring individual artifacts
+           with ${jetty.version} only covers the ones named explicitly; the rest arrive
+           transitively from dropwizard-core and stay unmanaged on its older line (e.g.
+           jetty-security, CVE-2026-10050 digest authentication bypass). Imported before
+           anything that pulls dropwizard so the patched line wins. -->
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <!-- Security: Force newer versions to fix vulnerabilities -->
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Two dependency-management fixes for high findings on the Snyk/Inspector reports. Both are cases where an existing pin no longer covers what it was meant to.

---

## 1. jetty — the property bump did not reach transitive modules

#30391 bumped `jetty.version` to 12.1.10 in the root, `openmetadata-service` and `openmetadata-mcp` poms. That moved the jetty artifacts **declared explicitly** with `${jetty.version}` — but nothing else.

Every other jetty module arrives transitively from `dropwizard-core` 5.0.0, is not under `dependencyManagement`, and still resolves to its 12.1.1 line. On `main` (17298a5b6c):

```
$ mvn dependency:tree -Dincludes='org.eclipse.jetty:*' -pl openmetadata-service

org.eclipse.jetty:jetty-server:jar:12.1.10     <- declared, correct
org.eclipse.jetty:jetty-http:jar:12.1.10       <- declared, correct
org.eclipse.jetty:jetty-security:jar:12.1.1    <- unmanaged
org.eclipse.jetty:jetty-util:jar:12.1.1        <- unmanaged
```

`jetty-security` 12.1.1 is the artifact carrying **CVE-2026-10050** (digest authentication bypass via lossy ISO-8859-1 encoding) — the CVE #30394 set out to clear. It is still reported against `openmetadata-service`, `openmetadata-dist`, `openmetadata-mcp` and `openmetadata-k8s-operator`.

`jetty-util` 12.1.1 is also below the 12.1.9 fix line for CVE-2026-8384.

**Fix:** import `jetty-bom` and `jetty-ee10-bom` at `${jetty.version}`, so the whole family is managed from the one property instead of artifact by artifact. Future `jetty.version` bumps then cover transitive modules automatically and cannot silently drift back. Same pattern already used for `netty-bom` in that block.

## 2. tools.jackson — pin is one patch behind

The `tools.jackson:jackson-bom` 3.1.4 pin exists to force `jsonschema2pojo-core` off its transitive 3.0.2 chain. **CVE-2026-59889** (incorrect authorization) was published after that pin, so Snyk now reports `tools.jackson.core:jackson-databind` 3.1.4 against `common`.

`jsonschema2pojo-core` is `scope=provided`, so none of this reaches the runtime classpath — `dependency:tree` on `openmetadata-service` shows no `tools.jackson` at all — but Snyk's Maven scanner walks the provided tree, so the pin has to move. Bumped to 3.1.5.

---

## Verification

`mvn dependency:tree` on this branch:

| Check | Result |
|---|---|
| `org.eclipse.jetty:*` across service / dist / mcp / k8s-operator | all **12.1.10**, no other version present |
| `tools.jackson.core:*` in `common` | **3.1.5**, still `provided` |
| `tools.jackson.core:*` in `openmetadata-service` | absent, as before |
| Build | `BUILD SUCCESS` |

Dependency-only change; no source or config touched.

Follow-up to #30391 / #30394.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates root Maven dependency management to:
- Import the Jetty and Jetty EE10 BOMs at `${jetty.version}`, aligning transitive Jetty modules with the patched version.
- Upgrade the build-time `tools.jackson` BOM from 3.1.4 to 3.1.5.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Adds centralized Jetty BOM management and updates the provided-scope Jackson 3 BOM; no actionable failure was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(security): bump tools.jackson BOM to..."](https://github.com/open-metadata/openmetadata/commit/b7d28b280de60772735fca15671a7aeda5fc4bd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47502512)</sub>

<!-- /greptile_comment -->