### PR TITLE
fix(search): add nested customPropertiesTyped mapping to 5 entity indexes

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java
@@ -126,6 +126,35 @@ class IndexMappingNestedFieldConsistencyTest {
   }
 
   @Test
+  void customPropertiesTypedMustBeNestedWhereExtensionExists() {
+    List<String> violations = new ArrayList<>();
+    for (Map.Entry<String, JsonNode> entry : allMappings.entrySet()) {
+      String entity = entry.getKey();
+      JsonNode properties = getTopLevelProperties(entry.getValue());
+      assertNotNull(
+          properties,
+          "Index mapping for '" + entity + "' has no properties — mapping file may be malformed.");
+      if (properties.has("extension")) {
+        JsonNode typed = properties.get("customPropertiesTyped");
+        boolean nested = typed != null && "nested".equals(typed.path("type").asText());
+        if (!nested) {
+          String detail = typed == null ? "missing" : "\"" + typed.path("type").asText("") + "\"";
+          violations.add(entity + " (customPropertiesTyped=" + detail + ")");
+        }
+      }
+    }
+    assertTrue(
+        violations.isEmpty(),
+        "Every index whose mapping declares a top-level 'extension' field (i.e. it stores "
+            + "custom-property values) must also declare 'customPropertiesTyped' with "
+            + "\"type\": \"nested\". SearchIndex writes customPropertiesTyped into every such doc; "
+            + "if the mapping omits it, OpenSearch dynamic-maps it as a plain object and the nested "
+            + "custom-property search query fails at runtime with '[nested] nested object under "
+            + "path [customPropertiesTyped] is not of nested type'. Violations: "
+            + violations);
+  }
+
+  @Test
   void aiGovernanceProjectionFieldsMustBeMappedExplicitly() {
     List<String> violations = new ArrayList<>();
     for (String entity : List.of("aiApplication", "llmModel", "mcpServer")) {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/chart_index_mapping.json
@@ -79,6 +79,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_index_mapping.json
@@ -79,6 +79,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/glossary_term_index_mapping.json
@@ -79,6 +79,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_server_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/mcp_server_index_mapping.json
@@ -79,6 +79,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "id": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
@@ -79,6 +79,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/chart_index_mapping.json
@@ -84,6 +84,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_index_mapping.json
@@ -84,6 +84,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/glossary_term_index_mapping.json
@@ -84,6 +84,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/mcp_server_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/mcp_server_index_mapping.json
@@ -84,6 +84,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "id": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
@@ -84,6 +84,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/chart_index_mapping.json
@@ -98,6 +98,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_index_mapping.json
@@ -98,6 +98,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/glossary_term_index_mapping.json
@@ -98,6 +98,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/mcp_server_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/mcp_server_index_mapping.json
@@ -98,6 +98,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "id": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
@@ -98,6 +98,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/chart_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/chart_index_mapping.json
@@ -74,6 +74,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_index_mapping.json
@@ -74,6 +74,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_term_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/glossary_term_index_mapping.json
@@ -74,6 +74,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/mcp_server_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/mcp_server_index_mapping.json
@@ -74,6 +74,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "id": {
         "type": "text",
         "fields": {

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
@@ -74,6 +74,48 @@
         "type": "object",
         "enabled": false
       },
+      "customPropertiesTyped": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "keyword"
+          },
+          "propertyType": {
+            "type": "keyword"
+          },
+          "stringValue": {
+            "type": "keyword"
+          },
+          "textValue": {
+            "type": "text",
+            "analyzer": "om_analyzer"
+          },
+          "longValue": {
+            "type": "long"
+          },
+          "doubleValue": {
+            "type": "double"
+          },
+          "start": {
+            "type": "long"
+          },
+          "end": {
+            "type": "long"
+          },
+          "refId": {
+            "type": "keyword"
+          },
+          "refType": {
+            "type": "keyword"
+          },
+          "refName": {
+            "type": "keyword"
+          },
+          "refFqn": {
+            "type": "keyword"
+          }
+        }
+      },
       "changeDescription": {
         "enabled": false
       },


### PR DESCRIPTION
### Describe your changes:

Fixes # <!-- No GitHub issue was filed — internal merge-queue AUT failure reported in Slack. Please link an issue number here if one is opened. -->

`SearchIndex` writes a `customPropertiesTyped` object into every entity's search document, but the **chart, glossary, glossaryTerm, mcpServer and metric** index mappings never declared the field, so OpenSearch dynamic-maps it as a plain `object`. The nested custom-property search query then fails at runtime with `[nested] nested object under path [customPropertiesTyped] is not of nested type` (HTTP 500) — the `CustomProperties` chart E2E failure that was blocking the merge queue. I added the `customPropertiesTyped` nested block (identical to `table`/`dashboard`) to those 5 mappings across `en/jp/ru/zh`, plus a consistency test asserting that any index declaring a top-level `extension` field must also declare `customPropertiesTyped` as nested, so this cannot regress one entity at a time. Existing indices for these 5 entities must be **reindexed** after this ships — the dynamically-mapped `object` type is sticky until the index is recreated.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — index-mapping fix plus a guard test.

#
### Tests:

#### Use cases covered
- Setting a custom property on a chart (and glossary / glossaryTerm / metric / mcpServer) and searching it no longer 500s.

#### Unit tests
- [x] Added `IndexMappingNestedFieldConsistencyTest#customPropertiesTypedMustBeNestedWhereExtensionExists` — fails pre-fix (lists the 5 offending entities), passes post-fix. Full class run locally: `Tests run: 6, Failures: 0, Errors: 0`.

#### Backend integration tests
- [x] Not applicable — Elasticsearch index-mapping resource change, no new/changed API endpoint.

#### Ingestion integration tests
- [x] Not applicable.

#### Playwright (UI) tests
- [x] Not applicable — the pre-existing `CustomProperties` chart E2E is the scenario this fixes.

#### Manual testing performed
- Verified the invariant holds across every index mapping in all 4 languages; all 20 patched files are valid JSON with `customPropertiesTyped` as `type: nested`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For JSON Schema changes: no migration script needed — these are Elasticsearch index-mapping templates applied on reindex; existing indices for the 5 entities must be reindexed to pick up the nested field.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds nested custom-property mappings and regression coverage for affected search indexes.
- Declares `customPropertiesTyped` as a nested field for chart, glossary, glossary-term, MCP-server, and metric indexes across English, Japanese, Russian, and Chinese mappings.
- Adds a consistency test requiring mappings with a top-level `extension` field to define `customPropertiesTyped` as nested.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/java/org/openmetadata/service/search/IndexMappingNestedFieldConsistencyTest.java | Adds a mapping consistency assertion; current MCP-server mappings are loaded for all four languages and satisfy the `extension`-based guard, resolving the prior concern. |
| openmetadata-spec/src/main/resources/elasticsearch/en/chart_index_mapping.json | Adds the complete nested custom-property mapping to the English chart index. |
| openmetadata-spec/src/main/resources/elasticsearch/en/glossary_index_mapping.json | Adds the complete nested custom-property mapping to the English glossary index. |
| openmetadata-spec/src/main/resources/elasticsearch/en/glossary_term_index_mapping.json | Adds the complete nested custom-property mapping to the English glossary-term index. |
| openmetadata-spec/src/main/resources/elasticsearch/en/mcp_server_index_mapping.json | Adds the complete nested custom-property mapping to the English MCP-server index, with equivalent changes in the other language mappings. |
| openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json | Adds the complete nested custom-property mapping to the English metric index. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into slack-issue-rca"](https://github.com/open-metadata/openmetadata/commit/0be5e9a6572258f9a8c731f638ab4b3be8a073fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47512844)</sub>

<!-- /greptile_comment -->