### PR TITLE
Fix stale votes/followers served via 304: make ETag content-based (cherry-pick #30497)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
@@ -19,6 +19,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.exception.JsonParsingException;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.exception.PreconditionFailedException;
 
 /**
@@ -38,25 +40,52 @@ public class EntityETag {
   private static final String WEAK_PREFIX = "W/";
 
   /**
-   * Generate an ETag for an entity based on its version and last updated timestamp.
-   * Format: "version-updatedAt" wrapped in quotes as per HTTP ETag specification.
+   * Generate a strong ETag for an entity from a hash of its serialized representation.
+   *
+   * <p>An ETag must change whenever the representation the client would receive changes (RFC 7232
+   * §2.3). Hashing only {@code version}+{@code updatedAt} is not enough: relationship-only
+   * mutations — {@code updateVote}, {@code addFollower}/{@code removeFollower},
+   * {@code DataContractRepository.updateLatestResult} — rewrite the response body (e.g. the
+   * {@code votes} block) without bumping either field. A version-based ETag therefore stayed
+   * constant across such a mutation, so a conditional GET was wrongly answered {@code 304 Not
+   * Modified} and the client rendered the stale pre-mutation body (the up/down vote regression).
+   * Hashing the serialized entity ties the ETag to the exact bytes returned.
    *
    * @param entity The entity to generate ETag for
-   * @return ETag string in format "version-updatedAt"
+   * @return quoted strong ETag, or {@code null} if entity is null
    */
   public static String generateETag(EntityInterface entity) {
-    if (entity == null) {
-      return null;
+    String etag = null;
+    if (entity != null) {
+      etag = ETAG_PREFIX + generateHash(fingerprint(entity)) + ETAG_SUFFIX;
     }
+    return etag;
+  }
 
-    // Use version and updatedAt to generate a unique ETag
-    String etagValue = entity.getVersion() + "-" + entity.getUpdatedAt();
-
-    // Generate SHA-256 hash for consistency and to handle special characters
-    String hash = generateHash(etagValue);
-
-    // Return ETag wrapped in quotes as per HTTP specification
-    return ETAG_PREFIX + hash + ETAG_SUFFIX;
+  /**
+   * Content the ETag hashes: the serialized entity. Falls back to {@code version}+{@code updatedAt}
+   * if serialization fails, so a serializer hiccup degrades to the old ETag rather than failing the
+   * response this decorates.
+   *
+   * <p>Best-effort cache-validation key, not a canonical digest: it relies on the entity serializing
+   * in a stable field/element order across requests. If a map-typed field or a DB-ordered collection
+   * ever serializes differently for otherwise-identical state, the ETag differs and the conditional
+   * GET is answered {@code 200} with the full body instead of {@code 304} — a missed optimization,
+   * never a stale or incorrect body. OpenMetadata map fields (e.g. {@code extension}) deserialize
+   * into order-preserving structures, so this stays stable in practice.
+   */
+  private static String fingerprint(EntityInterface entity) {
+    String result;
+    try {
+      result = JsonUtils.pojoToJson(entity);
+    } catch (JsonParsingException e) {
+      LOG.warn(
+          "ETag falling back to version+updatedAt; entity {} failed to serialize: {}",
+          entity.getId(),
+          e.getMessage());
+      result = entity.getVersion() + "-" + entity.getUpdatedAt();
+    }
+    return result;
   }
 
   /**

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java
@@ -18,6 +18,8 @@ import jakarta.ws.rs.core.Response;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.util.EntityETag;
 
 class ETagResponseFilterTest {
@@ -69,6 +71,24 @@ class ETagResponseFilterTest {
   }
 
   @Test
+  void staleIfNoneMatchIsNotShortCircuitedAfterVoteChangesBody() {
+    // Regression for the up/down vote P0: a vote repopulates the votes block without bumping
+    // version/updatedAt. The ETag the client cached before voting must no longer match the
+    // post-vote entity, so the conditional GET is answered 200 (fresh body) rather than 304
+    // (stale body). Before the content-based ETag fix this returned 304 and the header stuck.
+    UUID id = UUID.randomUUID();
+    String staleEtag = EntityETag.generateETag(table(id, 1.0, 100L, 0));
+    EntityInterface afterVote = table(id, 1.0, 100L, 1);
+    ContainerResponseContext res = response(OK, afterVote);
+
+    filter.filter(request("GET", staleEtag), res);
+
+    verify(res, never()).setStatus(anyInt());
+    verify(res, never()).setEntity(null);
+    assertEquals(EntityETag.generateETag(afterVote), res.getHeaders().getFirst(HttpHeaders.ETAG));
+  }
+
+  @Test
   void mutationWithMatchingIfNoneMatchIsNotShortCircuited() {
     EntityInterface entity = entity(3.1, 333L);
     String etag = EntityETag.generateETag(entity);
@@ -117,10 +137,19 @@ class ETagResponseFilterTest {
   }
 
   private static EntityInterface entity(double version, long updatedAt) {
-    EntityInterface entity = mock(EntityInterface.class);
-    when(entity.getVersion()).thenReturn(version);
-    when(entity.getUpdatedAt()).thenReturn(updatedAt);
-    when(entity.getId()).thenReturn(UUID.randomUUID());
-    return entity;
+    return new Table()
+        .withId(UUID.randomUUID())
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt);
+  }
+
+  private static EntityInterface table(UUID id, double version, long updatedAt, int upVotes) {
+    return new Table()
+        .withId(id)
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt)
+        .withVotes(new Votes().withUpVotes(upVotes).withDownVotes(0));
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
@@ -3,17 +3,21 @@ package org.openmetadata.service.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.schema.type.Votes;
 import org.openmetadata.service.exception.PreconditionFailedException;
 
 class EntityETagTest {
@@ -31,6 +35,62 @@ class EntityETagTest {
     assertEquals("W/\"1.2\"", weak);
     assertNull(EntityETag.generateETag(null));
     assertNull(EntityETag.generateWeakETag(null));
+  }
+
+  @Test
+  void etagIsStableForUnchangedEntity() {
+    EntityInterface entity = entity(1.2, 123456L);
+
+    assertEquals(EntityETag.generateETag(entity), EntityETag.generateETag(entity));
+  }
+
+  @Test
+  void etagChangesWhenVotesChangeWithoutVersionBump() {
+    // The P0 regression: an upvote writes a VOTED relationship and repopulates the entity's
+    // votes block but does NOT bump version/updatedAt. A version-only ETag stayed constant, so
+    // the post-vote conditional GET was answered 304 and the header rendered stale counts.
+    // The ETag must move when the votes block moves, even though version/updatedAt are identical.
+    UUID id = UUID.randomUUID();
+    EntityInterface before = table(id, 1.2, 123456L, 0);
+    EntityInterface after = table(id, 1.2, 123456L, 1);
+
+    assertEquals(before.getVersion(), after.getVersion());
+    assertEquals(before.getUpdatedAt(), after.getUpdatedAt());
+    assertNotEquals(EntityETag.generateETag(before), EntityETag.generateETag(after));
+  }
+
+  @Test
+  void etagChangesWhenVersionChanges() {
+    UUID id = UUID.randomUUID();
+    EntityInterface v1 = table(id, 1.0, 100L, 0);
+    EntityInterface v2 = table(id, 1.1, 200L, 0);
+
+    assertNotEquals(EntityETag.generateETag(v1), EntityETag.generateETag(v2));
+  }
+
+  @Test
+  void etagReflectsRequestedFieldsForPartialFetches() {
+    // The ETag hashes the exact partial representation that is serialized for the requested
+    // `fields`, not a canonical full entity. So `fields=tags` and `fields=owners` on the same
+    // entity are different representations and MUST get different ETags — a `fields=tags` 304 can
+    // never hand back an owners-bearing body. The same selection with unchanged data stays stable
+    // so the conditional GET still short-circuits to 304.
+    UUID id = UUID.randomUUID();
+    EntityInterface tagsOnly =
+        partialTable(id).withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+    EntityInterface ownersOnly =
+        partialTable(id)
+            .withOwners(
+                List.of(
+                    new EntityReference()
+                        .withId(UUID.randomUUID())
+                        .withType("user")
+                        .withName("u1")));
+    EntityInterface tagsOnlyUnchanged =
+        partialTable(id).withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive")));
+
+    assertNotEquals(EntityETag.generateETag(tagsOnly), EntityETag.generateETag(ownersOnly));
+    assertEquals(EntityETag.generateETag(tagsOnly), EntityETag.generateETag(tagsOnlyUnchanged));
   }
 
   @Test
@@ -67,10 +127,23 @@ class EntityETagTest {
   }
 
   private static EntityInterface entity(double version, long updatedAt) {
-    EntityInterface entity = mock(EntityInterface.class);
-    when(entity.getVersion()).thenReturn(version);
-    when(entity.getUpdatedAt()).thenReturn(updatedAt);
-    when(entity.getId()).thenReturn(UUID.randomUUID());
-    return entity;
+    return new Table()
+        .withId(UUID.randomUUID())
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt);
+  }
+
+  private static EntityInterface table(UUID id, double version, long updatedAt, int upVotes) {
+    return new Table()
+        .withId(id)
+        .withName("etag_table")
+        .withVersion(version)
+        .withUpdatedAt(updatedAt)
+        .withVotes(new Votes().withUpVotes(upVotes).withDownVotes(0));
+  }
+
+  private static Table partialTable(UUID id) {
+    return new Table().withId(id).withName("etag_table").withVersion(1.0).withUpdatedAt(100L);
   }
 }


### PR DESCRIPTION
Cherry-pick of #30497 (merged to `main` as `1a90f5cc`) onto `2.0`.

## Describe your changes

Fixes the P0 where up/down vote buttons appear unresponsive — the data asset header shows a stale vote count/status until an "Empty Cache and Hard Reload".

### Root cause

Voting persists a `VOTED` relationship and repopulates the entity's `votes` block, but **does not bump `version`/`updatedAt`** (`EntityRepository.updateVote`). `EntityETag.generateETag` fingerprinted only `version + updatedAt`, so the ETag was **unchanged across the mutation**:

1. Page GETs the asset → interceptor caches `(etag, body)`.
2. User votes → `PUT /{id}/vote` succeeds.
3. UI refetches → sends the old `ETag` in `If-None-Match`.
4. Backend recomputes the same version-based ETag → returns `304 Not Modified`.
5. `etagInterceptor` serves the cached **pre-vote** body → header shows stale votes.

An ETag that does not change when the body changes violates RFC 7232. The same class of bug affects `addFollower`/`removeFollower` and `DataContractRepository.updateLatestResult` — all relationship-only mutations that do not touch `version`.

### Fix

`EntityETag.generateETag` hashes the **serialized entity representation** (`JsonUtils.pojoToJson(entity)`) instead of `version + updatedAt`, so the ETag moves whenever the response body moves. Falls back to `version + updatedAt` if serialization throws, so a serializer hiccup degrades gracefully rather than failing the response.

One-method change; the perf model is unchanged — a truly-unchanged entity still hashes identically and still 304s.

## Type of change

- [x] Bug fix (P0)

## Tests

Carried over from #30497. `EntityETagTest` and `ETagResponseFilterTest` use **real entities** (not `mock(EntityInterface.class)`) so serialization is exercised:

- identical entity state → identical ETag (304 perf preserved)
- votes change with **identical** `version`/`updatedAt` → **different** ETag (the regression)
- `version` change → different ETag
- filter: a stale `If-None-Match` (from before a vote) is no longer short-circuited to 304; a current one still is

## Cherry-pick verification

- The PR diff applied to `2.0` with **no conflicts and no fuzz**; diffstat matches `main` exactly (42+/13-, 34+/5-, 80+/7-).
- All three resulting files are **byte-identical** to the merged versions on `main` — no drift between the branches.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes entity ETags content-based to invalidate cached responses after relationship-only mutations.
- Serializes the response entity and hashes that representation, with a version/timestamp fallback on serialization failure.
- Adds regression coverage for vote changes, unchanged entities, partial representations, and response-filter behavior.
- Replaces mocked entities in ETag tests with generated `Table` instances.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

This PR should not merge until partial-response ETags remain compatible with the existing conditional PATCH flow.

Content hashing correctly invalidates stale relationship data, but the same entity hashes differently when GET and PATCH populate different field sets, causing valid optimistic-lock updates to be rejected.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/EntityETag.java | Content hashing fixes relationship-only cache invalidation but makes ETags representation-dependent in a way that conflicts with PATCH validation. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/filters/ETagResponseFilterTest.java | Adds response-filter regression coverage for vote changes, but does not exercise reuse of a partial-response ETag for conditional updates. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java | Covers content sensitivity and stability, while explicitly confirming that different field selections generate different ETags. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant GET as GET resource/filter
  participant PATCH as PATCH repository
  Client->>GET: "GET entity?fields=tags"
  GET-->>Client: Partial entity + content ETag A
  Client->>PATCH: PATCH entity, If-Match: A
  PATCH->>PATCH: Load entity with broader patchFields
  PATCH->>PATCH: Compute content ETag B
  PATCH-->>Client: "412 because A != B"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix stale votes/followers served via 304..."](https://github.com/open-metadata/openmetadata/commit/1654811be13d9aca624843e9e7385ab1ab3d5533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47514713)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)

<!-- /greptile_comment -->