### PR TITLE
test: extend ETag stale-304 regression matrix (customMetrics, testSuite, domains/dataProducts, tags, roles/persona)

### DIFF
--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
@@ -15,6 +15,8 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.tests.CustomMetric;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.Votes;
@@ -94,6 +96,56 @@ class EntityETagTest {
   }
 
   @Test
+  void etagReflectsRelationshipOnlyMutations() {
+    // Regression matrix (Slack thread, validated against AUT): every mutation that rewrites the
+    // response body WITHOUT bumping version/updatedAt must still move the ETag. votes/followers are
+    // covered above; this locks in the rest of the stale-304 class. Each pair shares id + version +
+    // updatedAt and differs only in the named field — exactly the shape a version-only ETag missed.
+    UUID t = UUID.randomUUID();
+    UUID u = UUID.randomUUID();
+    record Case(String field, EntityInterface before, EntityInterface after) {}
+    List<Case> cases =
+        List.of(
+            new Case(
+                "customMetrics",
+                partialTable(t).withCustomMetrics(List.of(new CustomMetric().withName("cm1"))),
+                partialTable(t).withCustomMetrics(List.of(new CustomMetric().withName("cm2")))),
+            new Case(
+                "testSuite",
+                partialTable(t).withTestSuite(ref("testSuite", "ts1")),
+                partialTable(t).withTestSuite(ref("testSuite", "ts2"))),
+            new Case(
+                "domains",
+                partialTable(t).withDomains(List.of(ref("domain", "d1"))),
+                partialTable(t).withDomains(List.of(ref("domain", "d2")))),
+            new Case(
+                "dataProducts",
+                partialTable(t).withDataProducts(List.of(ref("dataProduct", "dp1"))),
+                partialTable(t).withDataProducts(List.of(ref("dataProduct", "dp2")))),
+            new Case(
+                "tags",
+                partialTable(t).withTags(List.of(new TagLabel().withTagFQN("PII.Sensitive"))),
+                partialTable(t).withTags(List.of(new TagLabel().withTagFQN("PII.None")))),
+            new Case(
+                "user.roles",
+                user(u).withRoles(List.of(ref("role", "r1"))),
+                user(u).withRoles(List.of(ref("role", "r2")))),
+            new Case(
+                "user.defaultPersona",
+                user(u).withDefaultPersona(ref("persona", "p1")),
+                user(u).withDefaultPersona(ref("persona", "p2"))));
+
+    for (Case c : cases) {
+      assertEquals(c.before().getVersion(), c.after().getVersion());
+      assertEquals(c.before().getUpdatedAt(), c.after().getUpdatedAt());
+      assertNotEquals(
+          EntityETag.generateETag(c.before()),
+          EntityETag.generateETag(c.after()),
+          c.field() + " change must move the ETag");
+    }
+  }
+
+  @Test
   void validateETagSupportsExactWildcardWeakAndMultipleMatches() {
     EntityInterface entity = entity(2.5, 98765L);
     String etag = EntityETag.generateETag(entity);
@@ -145,5 +197,13 @@ class EntityETagTest {
 
   private static Table partialTable(UUID id) {
     return new Table().withId(id).withName("etag_table").withVersion(1.0).withUpdatedAt(100L);
+  }
+
+  private static User user(UUID id) {
+    return new User().withId(id).withName("etag_user").withVersion(1.0).withUpdatedAt(100L);
+  }
+
+  private static EntityReference ref(String type, String name) {
+    return new EntityReference().withId(UUID.randomUUID()).withType(type).withName(name);
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java
@@ -136,6 +136,7 @@ class EntityETagTest {
                 user(u).withDefaultPersona(ref("persona", "p2"))));
 
     for (Case c : cases) {
+      assertEquals(c.before().getId(), c.after().getId());
       assertEquals(c.before().getVersion(), c.after().getVersion());
       assertEquals(c.before().getUpdatedAt(), c.after().getUpdatedAt());
       assertNotEquals(


### PR DESCRIPTION
## Describe your changes

Follow-up to #30497 (content-based ETag). That PR fixed the root cause — the ETag now hashes the serialized entity body, so it moves whenever the body moves, not just on `version`/`updatedAt`.

Validated #30497 against AUT: stripping `If-None-Match` at the Playwright layer (the test-side equivalent of the server fix) took failures **139 → 14**, and the **131 that cleared are all the stale-ETag pattern**. Beyond votes / followers / data-contract result (already called out in #30497), the same "body changed without a `version`/`updatedAt` bump → served stale via `304`" pattern was hitting:

- `customMetrics`
- DQ `testSuite` (+ test-case result where it rides an entity GET)
- inherited `domains`/`dataProducts` on **restore** (restore flips `deleted` and re-derives inherited fields)
- asset `tags` on glossary/term delete
- user `roles` / `persona`

This adds `etagReflectsRelationshipOnlyMutations`, a matrix asserting — for each of the above, in the exact shape Shailesh suggested — **same `id`+`version`+`updatedAt`, different field → different ETag**. This is precisely the case a version-only ETag collided on, so each case fails against the pre-#30497 implementation and passes now.

### Why these are all covered by #30497
The ETag is computed over `responseContext.getEntity()` — the fully-hydrated entity for the request's `fields`, i.e. the exact bytes returned. So any field the UI fetches to display (which is what makes it visible in the first place) is in the hash. Inherited fields (`domains`/`dataProducts`) are populated by `setInheritedFields` on every read, so restore re-derivation and parent-driven changes both move the ETag even though the child's own version doesn't bump.

One boundary worth noting: `ETagResponseFilter` only fires when the response is an `EntityInterface`. Values served purely through a non-entity response (e.g. a raw `ResultList` time-series endpoint) were never a `304` path to begin with — this covers every case where a `304` could have returned a stale body.

## Type of change
- [x] Tests

## Tests
`EntityETagTest` — `mvn spotless:check` clean, 9/9 green (7 new field cases + the existing vote/partial-fields/format cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a regression-test matrix verifying that relationship-only entity-body mutations change generated ETags while entity ID, version, and update timestamp remain unchanged.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/test/java/org/openmetadata/service/util/EntityETagTest.java | Extends EntityETag coverage across custom metrics, test suites, inherited domains and data products, tags, roles, and default personas without introducing an eligible follow-up issue. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test: assert entity id is unchanged acro..."](https://github.com/open-metadata/openmetadata/commit/e56f5119ae3cf8e8a13dd7cb75b50453574cb008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47546180)</sub>

<!-- /greptile_comment -->