### PR TITLE
Fixes #30526: mirror incident re-assignment into the TCRS timeline

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
@@ -107,7 +107,7 @@ public class IncidentTaskIntegrationIT {
     TestCaseResolutionPayload payload =
         JsonUtils.convertValue(task.getPayload(), TestCaseResolutionPayload.class);
     assertEquals(task.getId(), payload.getTestCaseResolutionStatusId());
-    assertTcrsStatusEventually(client, task.getId(), TestCaseResolutionStatusTypes.New);
+    assertLatestTcrsEventually(client, task.getId(), TestCaseResolutionStatusTypes.New, null);
   }
 
   @Test
@@ -145,7 +145,7 @@ public class IncidentTaskIntegrationIT {
 
     client.tasks().resolve(stateId.toString(), new ResolveTask().withTransitionId("ack"));
     Task ackedTask = awaitIncidentTask(client, stateId, TaskEntityStatus.InProgress, "ack", null);
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Ack);
+    assertLatestTcrsEventually(client, stateId, TestCaseResolutionStatusTypes.Ack, null);
 
     client
         .tasks()
@@ -158,7 +158,8 @@ public class IncidentTaskIntegrationIT {
         awaitIncidentTask(
             client, stateId, TaskEntityStatus.InProgress, "assigned", shared.USER1.getName());
     assertEquals(ackedTask.getId(), assignedTask.getId());
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Assigned);
+    assertLatestTcrsEventually(
+        client, stateId, TestCaseResolutionStatusTypes.Assigned, shared.USER1.getName());
 
     client
         .tasks()
@@ -177,7 +178,7 @@ public class IncidentTaskIntegrationIT {
     Task completedTask =
         awaitIncidentTask(client, stateId, TaskEntityStatus.Completed, "resolved", null);
     assertNotNull(completedTask.getResolution());
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Resolved);
+    assertLatestTcrsEventually(client, stateId, TestCaseResolutionStatusTypes.Resolved, null);
   }
 
   @Test
@@ -202,7 +203,8 @@ public class IncidentTaskIntegrationIT {
         awaitIncidentTask(
             client, task.getId(), TaskEntityStatus.InProgress, "assigned", shared.USER2.getName());
     assertEquals(task.getId(), assignedTask.getId());
-    assertTcrsStatusEventually(client, task.getId(), TestCaseResolutionStatusTypes.Assigned);
+    assertLatestTcrsEventually(
+        client, task.getId(), TestCaseResolutionStatusTypes.Assigned, shared.USER2.getName());
   }
 
   @Test
@@ -339,7 +341,7 @@ public class IncidentTaskIntegrationIT {
     Task completedTask =
         awaitIncidentTask(client, task.getId(), TaskEntityStatus.Completed, "resolved", null);
     assertEquals(task.getId(), completedTask.getId());
-    assertTcrsStatusEventually(client, task.getId(), TestCaseResolutionStatusTypes.Resolved);
+    assertLatestTcrsEventually(client, task.getId(), TestCaseResolutionStatusTypes.Resolved, null);
   }
 
   @Test
@@ -433,7 +435,7 @@ public class IncidentTaskIntegrationIT {
 
     Task reopened = awaitIncidentTask(client, stateId, TaskEntityStatus.InProgress, "ack", null);
     assertEquals(stateId, reopened.getId(), "reopen must reuse the same incident task");
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Ack);
+    assertLatestTcrsEventually(client, stateId, TestCaseResolutionStatusTypes.Ack, null);
     assertEquals(
         1,
         countIncidentTasksForTestCase(client, testCase),
@@ -467,7 +469,8 @@ public class IncidentTaskIntegrationIT {
         awaitIncidentTask(
             client, stateId, TaskEntityStatus.InProgress, "assigned", shared.USER1.getName());
     assertEquals(stateId, reopened.getId(), "reopen must reuse the same incident task");
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Assigned);
+    assertLatestTcrsEventually(
+        client, stateId, TestCaseResolutionStatusTypes.Assigned, shared.USER1.getName());
     assertEquals(
         1,
         countIncidentTasksForTestCase(client, testCase),
@@ -507,7 +510,7 @@ public class IncidentTaskIntegrationIT {
                         .withTestCaseFailureComment("Final resolution")));
 
     awaitIncidentTask(client, stateId, TaskEntityStatus.Completed, "resolved", null);
-    assertTcrsStatusEventually(client, stateId, TestCaseResolutionStatusTypes.Resolved);
+    assertLatestTcrsEventually(client, stateId, TestCaseResolutionStatusTypes.Resolved, null);
     awaitTestCaseIncidentId(client, testCase, null);
     assertEquals(
         1,
@@ -699,20 +702,6 @@ public class IncidentTaskIntegrationIT {
                 task.getAbout().getFullyQualifiedName().equals(testCase.getFullyQualifiedName()))
         .findFirst()
         .orElse(null);
-  }
-
-  private void assertTcrsStatusEventually(
-      OpenMetadataClient client, UUID stateId, TestCaseResolutionStatusTypes expectedStatus) {
-    await()
-        .atMost(TASK_TIMEOUT)
-        .pollInterval(Duration.ofMillis(250))
-        .untilAsserted(
-            () ->
-                assertTrue(
-                    listTcrsForStateId(client, stateId).stream()
-                        .anyMatch(
-                            record -> record.getTestCaseResolutionStatusType() == expectedStatus),
-                    "Expected mirrored TCRS status " + expectedStatus + " for stateId " + stateId));
   }
 
   /** The stateId's records oldest first, so the last element is the one consumers render. */

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
@@ -723,7 +723,7 @@ public class IncidentTaskIntegrationIT {
             () -> {
               List<TestCaseResolutionStatus> timeline = tcrsTimeline(client, stateId);
               assertFalse(timeline.isEmpty(), "no TCRS records for stateId " + stateId);
-              TestCaseResolutionStatus latest = timeline.get(timeline.size() - 1);
+              TestCaseResolutionStatus latest = timeline.getLast();
               assertEquals(expectedStatus, latest.getTestCaseResolutionStatusType());
               assertEquals(expectedAssignee, tcrsAssigneeName(latest));
             });

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -236,7 +237,80 @@ public class IncidentTaskIntegrationIT {
         awaitIncidentTask(
             client, task.getId(), TaskEntityStatus.InProgress, "assigned", shared.USER2.getName());
     assertEquals(task.getId(), reassignedTask.getId());
-    assertTcrsStatusEventually(client, task.getId(), TestCaseResolutionStatusTypes.Assigned);
+
+    // Reassign is a self-loop on the `assigned` stage, so the mirror has to follow the
+    // assignee rather than the stage.
+    assertLatestTcrsEventually(
+        client, task.getId(), TestCaseResolutionStatusTypes.Assigned, shared.USER2.getName());
+    assertEquals(
+        List.of(shared.USER1.getName(), shared.USER2.getName()),
+        assignedAssigneeNames(client, task.getId()),
+        "every assignment appends its own record");
+  }
+
+  @Test
+  void testUpdatesThatDoNotChangeTheMirror_AppendNothing(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    SharedEntities shared = SharedEntities.get();
+
+    TestCase testCase = createTestCase(client, ns, "incident-no-op-update");
+    createFailedTestResult(client, testCase);
+
+    Task task = awaitIncidentTaskForTestCase(client, testCase);
+    UUID stateId = task.getId();
+
+    client
+        .tasks()
+        .resolve(
+            stateId.toString(),
+            new ResolveTask()
+                .withTransitionId("assign")
+                .withPayload(assigneePayload(shared.USER1_REF)));
+    awaitIncidentTask(
+        client, stateId, TaskEntityStatus.InProgress, "assigned", shared.USER1.getName());
+    assertLatestTcrsEventually(
+        client, stateId, TestCaseResolutionStatusTypes.Assigned, shared.USER1.getName());
+
+    int recordsAfterAssign = tcrsTimeline(client, stateId).size();
+
+    client.tasks().addComment(stateId.toString(), "still investigating");
+    client
+        .tasks()
+        .patch(
+            stateId.toString(),
+            JsonUtils.readTree(
+                "[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"no mirror change\"}]"));
+
+    assertEquals(
+        recordsAfterAssign,
+        tcrsTimeline(client, stateId).size(),
+        "comments and unrelated patches must not append TCRS records");
+
+    client
+        .tasks()
+        .resolve(
+            stateId.toString(),
+            new ResolveTask()
+                .withTransitionId("resolve")
+                .withResolutionType(TaskResolutionType.Completed)
+                .withComment("Resolved via integration test")
+                .withPayload(
+                    resolutionPayload(
+                        "False positive",
+                        "Resolved via integration test",
+                        TestCaseFailureReasonType.FalsePositive)));
+    awaitIncidentTask(client, stateId, TaskEntityStatus.Completed, "resolved", null);
+    assertLatestTcrsEventually(client, stateId, TestCaseResolutionStatusTypes.Resolved, null);
+
+    int recordsAfterResolve = tcrsTimeline(client, stateId).size();
+    assertEquals(
+        recordsAfterAssign + 1, recordsAfterResolve, "resolving appends exactly one record");
+
+    client.tasks().addComment(stateId.toString(), "post-mortem note");
+    assertEquals(
+        recordsAfterResolve,
+        tcrsTimeline(client, stateId).size(),
+        "commenting on a resolved incident must not duplicate the Resolved record");
   }
 
   @Test
@@ -639,6 +713,51 @@ public class IncidentTaskIntegrationIT {
                         .anyMatch(
                             record -> record.getTestCaseResolutionStatusType() == expectedStatus),
                     "Expected mirrored TCRS status " + expectedStatus + " for stateId " + stateId));
+  }
+
+  /** The stateId's records oldest first, so the last element is the one consumers render. */
+  private List<TestCaseResolutionStatus> tcrsTimeline(OpenMetadataClient client, UUID stateId) {
+    return listTcrsForStateId(client, stateId).stream()
+        .sorted(Comparator.comparing(TestCaseResolutionStatus::getTimestamp))
+        .toList();
+  }
+
+  private void assertLatestTcrsEventually(
+      OpenMetadataClient client,
+      UUID stateId,
+      TestCaseResolutionStatusTypes expectedStatus,
+      String expectedAssignee) {
+    await()
+        .atMost(TASK_TIMEOUT)
+        .pollInterval(Duration.ofMillis(250))
+        .untilAsserted(
+            () -> {
+              List<TestCaseResolutionStatus> timeline = tcrsTimeline(client, stateId);
+              assertFalse(timeline.isEmpty(), "no TCRS records for stateId " + stateId);
+              TestCaseResolutionStatus latest = timeline.get(timeline.size() - 1);
+              assertEquals(expectedStatus, latest.getTestCaseResolutionStatusType());
+              assertEquals(expectedAssignee, tcrsAssigneeName(latest));
+            });
+  }
+
+  private List<String> assignedAssigneeNames(OpenMetadataClient client, UUID stateId) {
+    return tcrsTimeline(client, stateId).stream()
+        .filter(
+            record ->
+                record.getTestCaseResolutionStatusType() == TestCaseResolutionStatusTypes.Assigned)
+        .map(IncidentTaskIntegrationIT::tcrsAssigneeName)
+        .toList();
+  }
+
+  private static String tcrsAssigneeName(TestCaseResolutionStatus record) {
+    if (record.getTestCaseResolutionStatusType() != TestCaseResolutionStatusTypes.Assigned) {
+      return null;
+    }
+    Assigned assigned =
+        JsonUtils.convertValue(record.getTestCaseResolutionStatusDetails(), Assigned.class);
+    return assigned != null && assigned.getAssignee() != null
+        ? assigned.getAssignee().getName()
+        : null;
   }
 
   @SuppressWarnings("unchecked")

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java
@@ -45,7 +45,8 @@ import org.openmetadata.service.jdbi3.TestCaseResolutionStatusRepository;
  * workflow stage (new → ack → assigned → resolved). But many downstream consumers — the
  * profiler data-quality page's "Incidents" badge, search aggregations, dashboards, and
  * external metrics exporters — still read from the TCRS time series. This handler keeps
- * those consumers fed by writing one TCRS record per workflow stage transition.
+ * those consumers fed by appending a TCRS record whenever the mirrored view of the task
+ * changes.
  *
  * <p>Key design choices:
  *
@@ -59,12 +60,13 @@ import org.openmetadata.service.jdbi3.TestCaseResolutionStatusRepository;
  *       a static {@code Map.of(...)} rather than being derived from the workflow
  *       definition. Keeps the dependency simple; costs a code edit if a new workflow stage
  *       is ever added.
- *   <li><b>Fires on stage transition only</b>. Assignee-only PATCHes, comment adds, watcher
- *       changes, etc. don't write TCRS records — only {@code workflowStageId} changes
- *       (plus initial task creation) count.
- *   <li><b>Idempotent</b>. If the latest TCRS record for this {@code stateId} already has
- *       the target status, the handler skips. This protects against duplicate inserts from
- *       repeated updates.
+ *   <li><b>Driven by the mirrored projection, not by the trigger</b>. The mirrored view of a
+ *       task is its status plus, in the {@code assigned} stage, its assignee. Every task
+ *       lifecycle event runs the handler, and a record is appended only when that projection
+ *       differs from the latest one already stored for the {@code stateId}. Comment adds and
+ *       watcher changes therefore write nothing, while a re-assignment does — even though it
+ *       leaves {@code workflowStageId} on {@code assigned}, because the workflow models it as
+ *       a self-loop.
  *   <li><b>Best-effort</b>. A TCRS write failure must never roll back a task update. All
  *       work is wrapped in try/catch and errors are logged at WARN level.
  * </ul>
@@ -87,28 +89,12 @@ public final class IncidentTcrsSyncHandler {
 
   private IncidentTcrsSyncHandler() {}
 
-  /** Invoked from {@code TaskRepository.postCreate} after a task row is first persisted. */
-  public static void handleTaskCreate(Task task) {
+  /** Invoked from {@code TaskRepository.postCreate} and {@code TaskRepository.postUpdate}. */
+  public static void sync(Task task) {
     if (!isIncidentTask(task)) {
       return;
     }
     syncStage(task);
-  }
-
-  /**
-   * Invoked from {@code TaskRepository.postUpdate}. Only fires a TCRS write when the task's
-   * {@code workflowStageId} actually changed between {@code original} and {@code updated}.
-   */
-  public static void handleTaskUpdate(Task original, Task updated) {
-    if (!isIncidentTask(updated)) {
-      return;
-    }
-    String originalStage = original != null ? original.getWorkflowStageId() : null;
-    String updatedStage = updated.getWorkflowStageId();
-    if (Objects.equals(originalStage, updatedStage)) {
-      return;
-    }
-    syncStage(updated);
   }
 
   private static boolean isIncidentTask(Task task) {
@@ -137,12 +123,16 @@ public final class IncidentTcrsSyncHandler {
               Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESOLUTION_STATUS);
 
       UUID stateId = task.getId();
+      Object details = buildDetailsForStage(tcrsType, task);
 
-      // Idempotency: skip if the latest record for this stateId already has the target status
       TestCaseResolutionStatus latest = repo.getLatestRecordForStateId(stateId);
-      if (latest != null && latest.getTestCaseResolutionStatusType() == tcrsType) {
+      if (latest != null
+          && latest.getTestCaseResolutionStatusType() == tcrsType
+          && Objects.equals(
+              mirroredAssigneeId(tcrsType, latest.getTestCaseResolutionStatusDetails()),
+              mirroredAssigneeId(tcrsType, details))) {
         LOG.debug(
-            "[TCRS Sync] Task {} already at status {} for stateId {}; skipping",
+            "[TCRS Sync] Task {} already mirrored at status {} for stateId {}; skipping",
             task.getId(),
             tcrsType,
             stateId);
@@ -165,7 +155,7 @@ public final class IncidentTcrsSyncHandler {
               .withId(UUID.randomUUID())
               .withStateId(stateId)
               .withTestCaseResolutionStatusType(tcrsType)
-              .withTestCaseResolutionStatusDetails(buildDetailsForStage(tcrsType, task))
+              .withTestCaseResolutionStatusDetails(details)
               .withTestCaseReference(task.getAbout())
               .withTimestamp(task.getUpdatedAt())
               .withUpdatedAt(task.getUpdatedAt())
@@ -205,6 +195,21 @@ public final class IncidentTcrsSyncHandler {
             task.getAbout().getFullyQualifiedName(),
             TestCaseRepository.INCIDENTS_FIELD,
             stateId != null ? stateId.toString() : null);
+  }
+
+  /**
+   * The assignee carried by a mirrored record, or null for the statuses that don't carry one.
+   * Comparing the id rather than the whole details object avoids false mismatches on the
+   * incidental fields a stored {@link EntityReference} picks up when it is read back.
+   */
+  private static UUID mirroredAssigneeId(TestCaseResolutionStatusTypes type, Object details) {
+    if (type != TestCaseResolutionStatusTypes.Assigned || details == null) {
+      return null;
+    }
+    Assigned assigned = JsonUtils.convertValue(details, Assigned.class);
+    return assigned != null && assigned.getAssignee() != null
+        ? assigned.getAssignee().getId()
+        : null;
   }
 
   private static Object buildDetailsForStage(TestCaseResolutionStatusTypes type, Task task) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java
@@ -1399,13 +1399,13 @@ public class TaskRepository extends EntityRepository<Task> {
   protected void postCreate(Task entity) {
     super.postCreate(entity);
     triggerWorkflowManagedTask(entity);
-    IncidentTcrsSyncHandler.handleTaskCreate(entity);
+    IncidentTcrsSyncHandler.sync(entity);
   }
 
   @Override
   protected void postUpdate(Task original, Task updated) {
     super.postUpdate(original, updated);
-    IncidentTcrsSyncHandler.handleTaskUpdate(original, updated);
+    IncidentTcrsSyncHandler.sync(updated);
   }
 
   private void initializeWorkflowManagedTask(Task task, boolean update) {


### PR DESCRIPTION
### Describe your changes:

Fixes #30526

Re-assigning an open incident returned 200 and updated the Task, but every UI surface kept showing the previous assignee.

Task is the source of truth for incidents; `IncidentTcrsSyncHandler` mirrors it into the TCRS time series for the legacy consumers (DQ page badge, search aggregations, dashboards, exporters). Both the test case page header and the Incident Manager list write to the Task and then read the assignee back out of TCRS, so a mirror that misses the change is a mirror that shows a stale assignee.

`reassign` is a self-loop: `TestCaseResolutionTaskWorkflow.json` targets stage `assigned` and the edge is `AssignedStage -> AssignedStage`, so `workflowStageId` is identical before and after. The handler had two guards, and neither looked at the assignee:

* the pre-image guard returned early whenever the stage was unchanged, so nothing was written;
* the idempotency guard compared only the status type, so `Assigned -> Assigned` would have been skipped anyway.

The result was that `testCaseResolutionStatusDetails.assignee` stayed frozen at the first assignee for the life of the incident, on `/testCaseIncidentStatus/stateId/{id}`, `?latest=true`, `/search/list` and the inline `testCase.incidentStatus`.

#### What changed

The mirrored projection of a task is its status plus, in the `assigned` stage, its assignee. That is now the only thing the handler keys off:

* `handleTaskCreate` and `handleTaskUpdate` collapse into one `sync(Task)`, called from both `postCreate` and `postUpdate`. The stage pre-image guard is gone: it was a performance filter that had quietly become the correctness filter, which is how a same-stage transition slipped through.
* The remaining guard compares status **and** assignee id against the latest stored record, so a re-assignment appends and everything else still skips.

Appending rather than patching matches `cleanUpAssignees`, which already treats an assignee change as a new record, and matches the pre-task-first behaviour the mirror exists to preserve. Severity survives because `syncFromTask` inherits it from the previous record for the `stateId`, and `setResolutionMetrics` is unaffected since it only writes on `New -> *` and on `Resolved`.

The assignee id is compared rather than the whole details object because a stored `EntityReference` comes back hydrated with extra fields; a deep compare would report a difference on every unrelated task update and append duplicates.

No UI change is needed: the write happens inside the resolve request, so the existing read-back picks it up.

Cost: `getLatestRecordForStateId` now runs on every incident-task update instead of only on stage changes. Incident tasks change at human rate, and a repeated failure on an open incident does not touch the task, so this is a few small indexed reads per incident.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Re-assigning an incident already in the `assigned` stage updates the assignee shown on the test case page header and in the Incident Manager list.
- Each assignment appends its own record, so the incident timeline keeps the reassignment history.
- Comments and unrelated patches on an incident task still write nothing.
- Commenting on a resolved incident does not duplicate the `Resolved` record.

#### Backend integration tests

- [x] `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java`
  - `testReassignment_AssignedToAssigned` strengthened: it asserted the Task assignee and the TCRS status *type*, but the type was already `Assigned` from the first assign and the helper used `anyMatch`, so it passed without a record ever being written. It now asserts the latest TCRS record's assignee and the full assignment timeline.
  - `testUpdatesThatDoNotChangeTheMirror_AppendNothing` added, covering the no-op update and duplicate-`Resolved` cases.
  - `assertTcrsStatusEventually` deleted. It asserted `anyMatch(status)` over the whole timeline, which is what made the reassign test vacuous, and it is blind to the same class of bug elsewhere: in `testResolveAfterReopen_CompletesSameTask` the timeline is `New -> Resolved -> Ack -> Resolved`, so `anyMatch(Resolved)` passes on the first record even if the second is never mirrored. All 9 remaining call sites now assert the latest record and, where the incident is assigned, its assignee.
  - `assertLatestTcrsEventually` / `tcrsTimeline` helpers added.

#### Manual testing performed

Local stack on this branch:

1. Created a test case, posted a failed result to open an incident.
2. `POST /v1/tasks/{id}/resolve {"transitionId":"assign"}` to user A, confirmed `Assigned` / A.
3. `POST /v1/tasks/{id}/resolve {"transitionId":"reassign"}` to user B.
4. Confirmed the Task and all four TCRS read paths now report B, and that exactly one record was appended.

Before the change, step 4 reported A on every TCRS path.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates incident-to-TCRS synchronization and its integration coverage.
- Mirrors both incident status and assigned-user identity.
- Runs projection comparison for every persisted incident-task update.
- Adds latest-record, reassignment-history, and no-op-update assertions.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because concurrent incident updates can leave legacy consumers observing a stale final TCRS projection.

The previously reported race remains: post-commit synchronization independently reads the latest TCRS record and later inserts a new one without per-state serialization or an atomic compare-and-append operation, so concurrent task updates can persist projections in the wrong final order.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java; openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java | Replaces stage-transition filtering with status-and-assignee projection comparison. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java | Invokes the unified incident projection synchronizer after Task creation and updates. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IncidentTaskIntegrationIT.java | Strengthens latest-record assertions and covers reassignment history and projection-preserving updates. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant Task as TaskRepository
  participant Sync as IncidentTcrsSyncHandler
  participant TCRS as TCRS Repository
  Client->>Task: Update incident task
  Task->>Task: Commit canonical task state
  Task->>Sync: sync(updated)
  Sync->>TCRS: Read latest projection
  Sync->>Sync: Compare status and assignee ID
  alt Projection changed
    Sync->>TCRS: Append projected record
  else Projection unchanged
    Sync-->>Task: Skip append
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(dq): use SequencedCollection getLas..."](https://github.com/open-metadata/openmetadata/commit/c6d91d7f405d645748789761f4a0d830b85238f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47568813)</sub>

<!-- /greptile_comment -->