### PR TITLE
fix(dq): backport #30464 to 2.0 — scope Data Observability locator + restore incident reopen

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -12,6 +12,7 @@
  */
 
 import test, { expect, Page } from '@playwright/test';
+import { TestCaseResolutionStatusTypes } from '../../../../src/generated/tests/testCaseResolutionStatus';
 import { DataQualityDimensions } from '../../../../src/generated/tests/testDefinition';
 import { getCurrentMillis } from '../../../../src/utils/date-time/DateTimeUtils';
 import { DOMAIN_TAGS } from '../../../constant/config';
@@ -23,7 +24,7 @@ import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { ClassificationClass } from '../../../support/tag/ClassificationClass';
 import { TagClass } from '../../../support/tag/TagClass';
 import { UserClass } from '../../../support/user/UserClass';
-import { createNewPage, uuid } from '../../../utils/common';
+import { createNewPage, getApiContext, uuid } from '../../../utils/common';
 import {
   applyDashboardCertificationFilter,
   applyDashboardTagFilter,
@@ -637,17 +638,14 @@ test.describe(
         ).toContainText('New');
       });
 
-      await test.step('Verify no active incident for resolved Uniqueness test case on table4 DQ tab', async () => {
+      await test.step('Verify Resolved incident chip for Uniqueness test case on table4 DQ tab', async () => {
         await visitDataQualityTab(page, table4);
         await expect(
           page.locator(`[data-testid="status-badge-${uniquenessTestCaseName}"]`)
         ).toContainText('Failed');
         await expect(
-          page
-            .getByRole('row', { name: uniquenessTestCaseName })
-            .getByRole('gridcell', { exact: true, name: '--' })
-            .last()
-        ).toHaveText('--');
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Resolved');
       });
 
       await test.step('Filter by Certification and verify Uniqueness widget shows 1 Failed test case', async () => {
@@ -671,6 +669,93 @@ test.describe(
           failed: '1',
           aborted: '0',
         });
+      });
+    });
+
+    // Regression for #30455: a resolved incident must stay visible with its
+    // edit affordance so it can be reopened in place, continuing the SAME
+    // incident (stateId) instead of forking a new one.
+    test('Reopen resolved incident in place from the Test Case page', async ({
+      page,
+    }) => {
+      let resolvedStateId = '';
+
+      await test.step('Open the resolved test case from the DQ tab', async () => {
+        await visitDataQualityTab(page, table4);
+        await page
+          .getByTestId(uniquenessTestCaseName)
+          .getByText(uniquenessTestCaseName)
+          .click();
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      await test.step('Test Case page shows the resolved incident with its edit affordance', async () => {
+        const { apiContext } = await getApiContext(page);
+        const fetchLatestIncident = () =>
+          apiContext
+            .get(
+              `/api/v1/dataQuality/testCases/testCaseIncidentStatus?latest=true` +
+                `&startTs=0&endTs=${getCurrentMillis()}` +
+                `&testCaseFQN=${uniquenessTestCaseFqn}`
+            )
+            .then((res) => res.json());
+
+        let latest = await fetchLatestIncident();
+        // A failed earlier attempt may have left the incident reopened;
+        // restore the resolved precondition so retries stay deterministic.
+        if (
+          latest.data?.[0]?.testCaseResolutionStatusType !==
+          TestCaseResolutionStatusTypes.Resolved
+        ) {
+          await apiContext.post(
+            '/api/v1/dataQuality/testCases/testCaseIncidentStatus',
+            {
+              data: {
+                testCaseReference: uniquenessTestCaseFqn,
+                testCaseResolutionStatusType:
+                  TestCaseResolutionStatusTypes.Resolved,
+              },
+            }
+          );
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+          latest = await fetchLatestIncident();
+        }
+        resolvedStateId = latest.data?.[0]?.stateId ?? '';
+
+        expect(resolvedStateId).not.toBe('');
+
+        await expect(
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Resolved');
+        await expect(
+          page.locator('[data-testid="edit-resolution-icon"]')
+        ).toBeVisible();
+      });
+
+      await test.step('Reopen the incident as Acknowledged from the header', async () => {
+        await page.click('[data-testid="edit-resolution-icon"]');
+        await page.click('[data-testid="test-case-resolution-status-type"]');
+        await page.click('[title="Ack"]');
+
+        const reopenResponse = page.waitForResponse(
+          (response) =>
+            response
+              .url()
+              .includes('/dataQuality/testCases/testCaseIncidentStatus') &&
+            response.request().method() === 'POST'
+        );
+        await page.click('#update-status-button');
+        const reopened = await (await reopenResponse).json();
+
+        expect(reopened.stateId).toBe(resolvedStateId);
+        expect(reopened.testCaseResolutionStatusType).toBe(
+          TestCaseResolutionStatusTypes.ACK
+        );
+
+        await expect(
+          page.locator(`[data-testid="${uniquenessTestCaseName}-status"]`)
+        ).toContainText('Ack');
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts
@@ -53,7 +53,10 @@ test(
      * selects the new test case, sets a weekly schedule, deploys, and verifies success modal.
      */
     await test.step('Create a new pipeline', async () => {
-      await page.getByText('Data Observability').click();
+      await page
+        .getByTestId('profiler')
+        .getByText('Data Observability')
+        .click();
       await page
         .getByRole('tab', {
           name: 'Table Profile',
@@ -257,7 +260,7 @@ test(
       testCaseNames
     );
     await table.visitEntityPage(page, table.entity.displayName);
-    await page.getByText('Data Observability').click();
+    await page.getByTestId('profiler').getByText('Data Observability').click();
     await page.getByRole('tab', { name: 'Data Quality' }).click();
 
     const ingestionPipelinesListResponse =

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -189,7 +189,7 @@ export const visitCreateTestCasePanelFromEntityPage = async (
       table.entityResponseData?.['fullyQualifiedName'] ?? ''
     )}/tableProfile/latest?includeColumnProfile=false`
   );
-  await page.getByText('Data Observability').click();
+  await page.getByTestId('profiler').getByText('Data Observability').click();
   await profileResponse;
   await page.getByRole('tab', { name: 'Table Profile' }).click();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx
@@ -12,7 +12,11 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
-import { Severities } from '../../../../generated/tests/testCaseResolutionStatus';
+import {
+  Severities,
+  TestCaseResolutionStatus,
+  TestCaseResolutionStatusTypes,
+} from '../../../../generated/tests/testCaseResolutionStatus';
 import {
   MOCK_TASK_DATA,
   MOCK_TEST_CASE_DATA,
@@ -100,7 +104,10 @@ jest.mock('react-router-dom', () => ({
 
 const mockUseTestCaseStore = {
   testCase: { ...MOCK_TEST_CASE_DATA, incidentId: '123' } as
-    | (typeof MOCK_TEST_CASE_DATA & { incidentId?: string })
+    | (typeof MOCK_TEST_CASE_DATA & {
+        incidentId?: string;
+        incidentStatus?: TestCaseResolutionStatus;
+      })
     | undefined,
   testCasePermission: mockEntityPermissions,
   setTestCase: jest.fn(),
@@ -181,6 +188,68 @@ describe('useTestCaseIncidentHeader', () => {
     expect(getIncidentTaskByStateId).not.toHaveBeenCalled();
     expect(getListTestCaseIncidentByStateId).not.toHaveBeenCalled();
     expect(result.current.testCaseStatusData).toBeUndefined();
+  });
+
+  it('should render the resolved inline status when there is no incident id', async () => {
+    const resolvedInlineStatus = {
+      ...MOCK_TEST_CASE_INCIDENT.data[0],
+      testCaseResolutionStatusType: TestCaseResolutionStatusTypes.Resolved,
+    } as unknown as TestCaseResolutionStatus;
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentStatus: resolvedInlineStatus,
+    };
+
+    const { result } = renderIncidentHeaderHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getListTestCaseIncidentByStateId).not.toHaveBeenCalled();
+    expect(getIncidentTaskByStateId).toHaveBeenCalledWith(
+      resolvedInlineStatus.stateId
+    );
+    expect(result.current.testCaseStatusData).toEqual(resolvedInlineStatus);
+    expect(result.current.incidentTask).toEqual(MOCK_TASK_DATA[1]);
+  });
+
+  it('should ignore a non-resolved inline status when there is no incident id', async () => {
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentStatus: MOCK_TEST_CASE_INCIDENT
+        .data[0] as unknown as TestCaseResolutionStatus,
+    };
+
+    const { result } = renderIncidentHeaderHook();
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getIncidentTaskByStateId).not.toHaveBeenCalled();
+    expect(getListTestCaseIncidentByStateId).not.toHaveBeenCalled();
+    expect(result.current.testCaseStatusData).toBeUndefined();
+  });
+
+  it('should clear stale incident state when moving to a test case without an incident', async () => {
+    mockUseTestCaseStore.testCase = {
+      ...MOCK_TEST_CASE_DATA,
+      incidentId: '123',
+    };
+
+    const { result, rerender } = renderIncidentHeaderHook();
+
+    await waitFor(() =>
+      expect(result.current.testCaseStatusData).toEqual(
+        MOCK_TEST_CASE_INCIDENT.data[0]
+      )
+    );
+
+    mockUseTestCaseStore.testCase = { ...MOCK_TEST_CASE_DATA };
+    rerender();
+
+    await waitFor(() =>
+      expect(result.current.testCaseStatusData).toBeUndefined()
+    );
+
+    expect(result.current.incidentTask).toBeNull();
   });
 
   it('should expose the owner version diff only on the version page', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts
@@ -215,18 +215,17 @@ export const useTestCaseIncidentHeader = ({
     try {
       const { data } = await getListTestCaseIncidentByStateId(id);
 
-      setTestCaseStatusData(first(data));
+      return first(data);
     } catch {
-      setTestCaseStatusData(undefined);
+      return undefined;
     }
   };
 
   const fetchIncidentTask = async (stateId: string) => {
     try {
-      const task = await getIncidentTaskByStateId(stateId);
-      setIncidentTask(task);
+      return await getIncidentTaskByStateId(stateId);
     } catch {
-      setIncidentTask(null);
+      return null;
     }
   };
 
@@ -248,16 +247,51 @@ export const useTestCaseIncidentHeader = ({
   }, [testCaseResolutionStatus, incidentStateId, fetchTaskCount]);
 
   useEffect(() => {
-    if (testCaseData?.incidentId) {
-      setIsLoading(true);
-      Promise.allSettled([
-        fetchTestCaseResolution(testCaseData.incidentId),
-        fetchIncidentTask(testCaseData.incidentId),
-      ]).finally(() => setIsLoading(false));
-    } else {
+    const inlineStatus = testCaseData?.incidentStatus;
+    const resolvedStatus =
+      inlineStatus?.testCaseResolutionStatusType ===
+      TestCaseResolutionStatusTypes.Resolved
+        ? inlineStatus
+        : undefined;
+    const incidentId = testCaseData?.incidentId;
+    const stateId = incidentId ?? resolvedStatus?.stateId;
+
+    if (!stateId) {
+      setTestCaseStatusData(undefined);
+      setIncidentTask(null);
       setIsLoading(false);
+
+      return;
     }
-  }, [testCaseData?.incidentId]);
+
+    // Guard against a stale response landing after the test case changed:
+    // both fetches below resolve asynchronously, so the cleanup flips `active`
+    // and the late writer is dropped instead of showing the prior incident.
+    let active = true;
+    setIsLoading(true);
+
+    Promise.all([
+      incidentId
+        ? fetchTestCaseResolution(incidentId)
+        : Promise.resolve(resolvedStatus),
+      fetchIncidentTask(stateId),
+    ])
+      .then(([status, task]) => {
+        if (active) {
+          setTestCaseStatusData(status);
+          setIncidentTask(task);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [testCaseData?.incidentId, testCaseData?.incidentStatus]);
 
   const handleDomainUpdate = async (
     selectedDomain: EntityReference | EntityReference[]

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.test.ts
@@ -80,6 +80,7 @@ describe('TestCaseClassBase', () => {
       'testDefinition',
       'owners',
       'incidentId',
+      'incidentStatus',
       'tags',
       'dataProducts',
       'domains',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts
@@ -155,6 +155,7 @@ class TestCaseClassBase {
       TabSpecificField.TEST_DEFINITION,
       TabSpecificField.OWNERS,
       TabSpecificField.INCIDENT_ID,
+      TabSpecificField.INCIDENT_STATUS,
       TabSpecificField.TAGS,
       TabSpecificField.DATA_PRODUCTS,
       TabSpecificField.DOMAINS,


### PR DESCRIPTION
## What

Backports #30464 to the `2.0` release branch.

## Why

`2.0` Playwright E2E is red on the DataQuality and TestSuiteMultiPipeline shards with a strict-mode violation:

```
strict mode violation: getByText('Data Observability') resolved to 2 elements:
  1) getByTestId('profiler').getByText('Data Observability')                    (the tab)
  2) getByTestId('asset-health-row-dataObservability').getByText('Data Observability')  (Asset Health widget row)
```

The Asset Health widget added a second "Data Observability" text node, so the bare `getByText('Data Observability')` — including the one in the shared `visitCreateTestCasePanelFromEntityPage` helper (`utils/dataQuality.ts`) that nearly every DataQuality spec routes through — now matches two elements and fails. This was fixed on `main` by #30464 but `2.0` diverged before it landed, so it never got the fix.

Evidence: run [30228314274](https://github.com/open-metadata/OpenMetadata/actions/runs/30228314274) — shard 3 (DataQuality) 100 hits, shard 5 (TestSuiteMultiPipeline) 14 hits, all the same collision.

## What's included

Straight cherry-pick of #30464 (`2ce362e00734`), which contains:
- **the locator fix** — scopes `getByText('Data Observability')` to `getByTestId('profiler')` in `utils/dataQuality.ts` and `TestSuiteMultiPipeline.spec.ts` (unblocks the whole DQ suite)
- the accompanying product fix from that PR — restore in-place reopen of resolved incidents on the Test Case page (`useTestCaseIncidentHeader.ts` + tests)

Cherry-picked cleanly with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores reliable Data Quality navigation and resolved-incident reopening.
- Scopes Playwright’s “Data Observability” locator to the profiler tab to avoid strict-mode collisions.
- Requests inline incident status on Test Case detail pages and hydrates resolved incident/task state in the header.
- Prevents stale asynchronous incident responses from overwriting state after navigation.
- Adds unit and end-to-end coverage for resolved incident visibility and in-place reopening.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the locator and resolved-incident changes aligned with existing UI and backend contracts.

The scoped locators remove the demonstrated strict-mode collision, while incidentStatus is supported by the Test Case API and the hook safely resolves its associated task without allowing obsolete asynchronous responses to overwrite current state.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.ts | Adds resolved inline-status hydration, coordinated task/status loading, stale-response cancellation, and explicit state cleanup. |
| openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerDetailPage/TestCaseClassBase.ts | Requests the backend-supported incidentStatus field when loading Test Case details. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts | Scopes the shared Data Observability locator to the profiler container. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/TestSuiteMultiPipeline.spec.ts | Applies the scoped profiler locator to both multi-pipeline test flows. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts | Updates resolved-incident expectations and adds coverage proving an incident reopens without changing its state ID. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/IncidentManagerPageHeader/useTestCaseIncidentHeader.test.tsx | Covers resolved inline status, ignored non-resolved inline status, task retrieval, and stale-state cleanup. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Page as Test Case Page
  participant API as Test Case API
  participant Header as Incident Header
  participant Tasks as Task API
  Page->>API: Fetch test case with incidentStatus
  API-->>Page: Resolved inline incident status
  Page->>Header: Store test case data
  Header->>Tasks: Fetch task by status stateId
  Tasks-->>Header: Resolved incident task
  Header-->>Page: Show status and edit affordance
  Page->>API: Reopen incident
  API-->>Page: Same stateId with active status
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dq): restore in-place reopen of reso..."](https://github.com/open-metadata/openmetadata/commit/512a888f94604e7e62a27bcbe6a1e4226c60ff0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47575388)</sub>

<!-- /greptile_comment -->