### PR TITLE
fix(ui): restore Enter-to-send after selecting a mention in FeedEditor

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
@@ -11,78 +11,70 @@
  *  limitations under the License.
  */
 
-import { findByTestId, fireEvent, render } from '@testing-library/react';
-import { KeyboardEvent } from 'react';
+import { act, findByTestId, fireEvent, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { FeedEditor } from './FeedEditor';
 
 const onSave = jest.fn();
 const onChangeHandler = jest.fn();
 
-const onKeyDownHandler = jest.fn().mockImplementation((e: KeyboardEvent) => {
-  if (e.key === 'Enter') {
-    if (e.nativeEvent.isComposing || e.keyCode === 229) {
-      return;
-    }
-    if (!e.shiftKey) {
-      onSave();
-    }
-  }
-});
+// Captures the props ReactQuill is rendered with so tests can drive the real
+// quill-mention handlers (onOpen/onClose/onSelect) that toggle isMentionListOpen.
+const mockCaptureQuillProps = jest.fn();
 
 const mockFeedEditorProp = {
   onChangeHandler: onChangeHandler,
   onSave: onSave,
 };
 
+// Latest ReactQuill render props (module config + the real onKeyDown handler).
+const latestQuillProps = () =>
+  mockCaptureQuillProps.mock.calls[
+    mockCaptureQuillProps.mock.calls.length - 1
+  ][0];
+
+// setupTests.js globally mocks FeedEditor with a stub; test the real component.
+jest.unmock('./FeedEditor');
+
+// Quill plugins ship untransformable ESM in jsdom — stub them (their behaviour
+// is irrelevant to the keydown/mention-state logic under test).
+jest.mock('@windmillcode/quill-emoji', () => ({ TextAreaEmoji: class {} }));
+jest.mock('quill-mention/autoregister', () => ({}), { virtual: true });
+
 jest.mock('quilljs-markdown', () => {
-  class MockQuillMarkdown {
-    constructor() {
-      // eslint-disable-next-line no-console
-      console.log('Markdown constructor');
-    }
-  }
+  class MockQuillMarkdown {}
 
-  const instance = new MockQuillMarkdown();
-
-  return instance;
+  return new MockQuillMarkdown();
 });
 
-jest.mock('react-quill-new', () => {
-  class MockQuill {
-    constructor() {
-      // eslint-disable-next-line no-console
-      console.log('Quill constructor');
-    }
+jest.mock('react-quill-new', () => ({
+  __esModule: true,
+  Quill: { register: () => undefined, import: (val: string) => val },
+  // Render a keydown-able node wired to the REAL onKeyDown so handleKeyDown (and
+  // its isMentionListOpen check) is exercised, not a test reimplementation.
+  default: (props: { modules?: unknown; onKeyDown?: unknown }) => {
+    mockCaptureQuillProps(props);
 
-    register(val: string) {
-      // eslint-disable-next-line no-console
-      console.log(`Register ${val} module`);
-    }
-
-    import(val: string) {
-      return val;
-    }
-  }
-
-  return {
-    __esModule: true,
-    Quill: new MockQuill(),
-    default: jest.fn().mockImplementation(() => {
-      return (
-        <div data-testid="react-quill" onKeyDown={onKeyDownHandler}>
-          editor
-        </div>
-      );
-    }),
-  };
-});
+    return (
+      <div
+        data-testid="react-quill"
+        onKeyDown={props.onKeyDown as React.KeyboardEventHandler}>
+        editor
+      </div>
+    );
+  },
+}));
 
 jest.mock('../../../utils/QuillLink/QuillLink', () => {
   return jest.fn();
 });
 
-describe.skip('Test FeedEditor Component', () => {
+describe('Test FeedEditor Component', () => {
+  beforeEach(() => {
+    onSave.mockClear();
+    mockCaptureQuillProps.mockClear();
+  });
+
   it('Should render FeedEditor Component', async () => {
     const { container } = render(<FeedEditor {...mockFeedEditorProp} />, {
       wrapper: MemoryRouter,
@@ -155,5 +147,49 @@ describe.skip('Test FeedEditor Component', () => {
     });
 
     expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('does not submit on the Enter that selects an @mention', async () => {
+    const { container } = render(<FeedEditor {...mockFeedEditorProp} />, {
+      wrapper: MemoryRouter,
+    });
+    const reactQuill = await findByTestId(container, 'react-quill');
+
+    // The mention suggestion list is open (user is picking a mention).
+    act(() => {
+      (latestQuillProps().modules as any).mention.onOpen();
+    });
+
+    // The Enter that selects the mention must NOT send the message.
+    fireEvent.keyDown(reactQuill, { key: 'Enter', shiftKey: false });
+
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('submits on the next Enter after an @mention has been selected', async () => {
+    jest.useFakeTimers();
+    try {
+      const { container } = render(<FeedEditor {...mockFeedEditorProp} />, {
+        wrapper: MemoryRouter,
+      });
+      const reactQuill = await findByTestId(container, 'react-quill');
+      const mention = () => (latestQuillProps().modules as any).mention;
+
+      // Open the list, pick a mention (insert only), then the list closes.
+      act(() => mention().onOpen());
+      act(() => mention().onSelect({}, jest.fn()));
+      act(() => mention().onClose());
+      // onClose defers toggling the flag a tick — flush it.
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // With the list now closed, Enter sends the message.
+      fireEvent.keyDown(reactQuill, { key: 'Enter', shiftKey: false });
+
+      expect(onSave).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
@@ -12,15 +12,31 @@
  */
 
 import { act, findByTestId, fireEvent, render } from '@testing-library/react';
+import { KeyboardEventHandler } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { FeedEditor } from './FeedEditor';
 
 const onSave = jest.fn();
 const onChangeHandler = jest.fn();
 
+// Minimal shape of the quill-mention module config the tests drive.
+interface MentionModule {
+  onOpen: () => void;
+  onClose: () => void;
+  onSelect: (
+    item: Record<string, unknown>,
+    insertItem: (item: unknown) => void
+  ) => void;
+}
+
+interface CapturedQuillProps {
+  modules?: { mention: MentionModule };
+  onKeyDown?: KeyboardEventHandler;
+}
+
 // Captures the props ReactQuill is rendered with so tests can drive the real
 // quill-mention handlers (onOpen/onClose/onSelect) that toggle isMentionListOpen.
-const mockCaptureQuillProps = jest.fn();
+const mockCaptureQuillProps = jest.fn<void, [CapturedQuillProps]>();
 
 const mockFeedEditorProp = {
   onChangeHandler: onChangeHandler,
@@ -28,10 +44,19 @@ const mockFeedEditorProp = {
 };
 
 // Latest ReactQuill render props (module config + the real onKeyDown handler).
-const latestQuillProps = () =>
+const latestQuillProps = (): CapturedQuillProps =>
   mockCaptureQuillProps.mock.calls[
     mockCaptureQuillProps.mock.calls.length - 1
   ][0];
+
+const mentionModule = (): MentionModule => {
+  const { modules } = latestQuillProps();
+  if (!modules) {
+    throw new Error('ReactQuill rendered without a mention module');
+  }
+
+  return modules.mention;
+};
 
 // setupTests.js globally mocks FeedEditor with a stub; test the real component.
 jest.unmock('./FeedEditor');
@@ -52,13 +77,11 @@ jest.mock('react-quill-new', () => ({
   Quill: { register: () => undefined, import: (val: string) => val },
   // Render a keydown-able node wired to the REAL onKeyDown so handleKeyDown (and
   // its isMentionListOpen check) is exercised, not a test reimplementation.
-  default: (props: { modules?: unknown; onKeyDown?: unknown }) => {
+  default: (props: CapturedQuillProps) => {
     mockCaptureQuillProps(props);
 
     return (
-      <div
-        data-testid="react-quill"
-        onKeyDown={props.onKeyDown as React.KeyboardEventHandler}>
+      <div data-testid="react-quill" onKeyDown={props.onKeyDown}>
         editor
       </div>
     );
@@ -157,7 +180,7 @@ describe('Test FeedEditor Component', () => {
 
     // The mention suggestion list is open (user is picking a mention).
     act(() => {
-      (latestQuillProps().modules as any).mention.onOpen();
+      mentionModule().onOpen();
     });
 
     // The Enter that selects the mention must NOT send the message.
@@ -173,12 +196,11 @@ describe('Test FeedEditor Component', () => {
         wrapper: MemoryRouter,
       });
       const reactQuill = await findByTestId(container, 'react-quill');
-      const mention = () => (latestQuillProps().modules as any).mention;
 
       // Open the list, pick a mention (insert only), then the list closes.
-      act(() => mention().onOpen());
-      act(() => mention().onSelect({}, jest.fn()));
-      act(() => mention().onClose());
+      act(() => mentionModule().onOpen());
+      act(() => mentionModule().onSelect({}, jest.fn()));
+      act(() => mentionModule().onClose());
       // onClose defers toggling the flag a tick — flush it.
       act(() => {
         jest.runAllTimers();

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx
@@ -217,17 +217,18 @@ export const FeedEditor = forwardRef<EditorContentRef, FeedEditorProp>(
           mentionDenotationChars: MENTION_DENOTATION_CHARS,
           blotName: 'link-mention',
           onOpen: () => {
-            toggleMentionList(false);
+            toggleMentionList(true);
           },
           onClose: () => {
-            toggleMentionList(true);
+            // Defer so the Enter that picks a mention still sees the list open in
+            // handleKeyDown (quill-mention closes it before React's onKeyDown).
+            setTimeout(() => toggleMentionList(false), 0);
           },
           onSelect: (
             item: Record<string, any>,
 
             insertItem: (item: Record<string, any>) => void
           ) => {
-            toggleMentionList(true);
             insertItem(item);
           },
           source: debounce(userSuggestionRenderer, 300),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

## Problem

In any `FeedEditor`-based composer (activity feed comments, task comments), once the
input contains an `@mention`, pressing **Enter** no longer sends the message — the user
has to click away and back or use the send button. This breaks the normal
Enter-to-send flow whenever a mention is involved.

## Root cause

The `quill-mention` handlers set the `isMentionListOpen` state with **inverted** logic:

```ts
onOpen:   () => toggleMentionList(false),  // list opened → set false
onClose:  () => toggleMentionList(true),   // list closed → set true
onSelect: (item, insertItem) => { toggleMentionList(true); insertItem(item); },
```

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

-->

N/A — small change. <!-- Or fill in the design above -->

https://github.com/user-attachments/assets/44d594a7-cb62-42d1-8592-9bb1ca1cce94



#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores Enter-to-send after mention selection.
- Corrects mention-list open and close state transitions.
- Defers closing the mention state until the current event completes.
- Re-enables and expands FeedEditor unit tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears safe to merge, with regression coverage still needing a more integrated event-sequence test.

The production change restores the intended mention-list state transitions, but the existing prior concern remains because the new tests manually invoke mention callbacks and would not detect removal of the deferred close ordering.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.tsx | Corrects mention-list state semantics and defers the close transition. |
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/FeedEditor/FeedEditor.test.tsx | Re-enables FeedEditor tests and adds coverage around mention state and Enter submission. |

</details>

<sub>Reviews (3): Last reviewed commit: ["address gitar"](https://github.com/open-metadata/openmetadata/commit/0182edd39d044a48f9fb54adafc83e14c7c4b387) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47627804)</sub>

<!-- /greptile_comment -->