### PR TITLE
fix(ui): render conversations alongside activity in the entity Activity tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx
@@ -17,7 +17,7 @@ import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { ReactComponent as FeedEmptyIcon } from '../../../assets/svg/ic-task-empty.svg';
 import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
 import { ActivityEvent } from '../../../generated/entity/activity/activityEvent';
-import { Thread } from '../../../generated/entity/feed/thread';
+import { GeneratedBy, Thread } from '../../../generated/entity/feed/thread';
 import { getFeedListWithRelativeDays } from '../../../utils/FeedUtilsPure';
 import ErrorPlaceHolderNew from '../../common/ErrorWithPlaceholder/ErrorPlaceHolderNew';
 import Loader from '../../common/Loader/Loader';
@@ -72,12 +72,21 @@ const ActivityFeedListV1New = ({
   const [entityThread, setEntityThread] = useState<Thread[]>([]);
   const isActivityMode = !isUndefined(activityList) && activityList.length > 0;
 
+  // System-generated threads were copied into activity_stream by the 2.0
+  // migration, so rendering them alongside the activity events would duplicate
+  // every row. Only user-authored conversations are still exclusive to the feed.
+  const userThreads = useMemo(
+    () =>
+      entityThread.filter((feed) => feed.generatedBy !== GeneratedBy.System),
+    [entityThread]
+  );
+
   useEffect(() => {
-    if (feedList && !isActivityMode) {
+    if (feedList) {
       const { updatedFeedList } = getFeedListWithRelativeDays(feedList);
       setEntityThread(updatedFeedList);
     }
-  }, [feedList, isActivityMode]);
+  }, [feedList]);
 
   useEffect(() => {
     if (isActivityMode) {
@@ -92,28 +101,27 @@ const ActivityFeedListV1New = ({
         onActivityClick(activityList ? activityList[0] : ({} as ActivityEvent));
       }
     } else {
-      const thread = entityThread.find(
-        (feed) => feed.id === selectedThread?.id
-      );
+      const thread = userThreads.find((feed) => feed.id === selectedThread?.id);
 
       if (onFeedClick && (isUndefined(selectedThread) || isUndefined(thread))) {
-        onFeedClick(entityThread[0]);
+        onFeedClick(userThreads[0]);
       }
     }
-  }, [entityThread, selectedThread, onFeedClick, isActivityMode]);
+  }, [userThreads, selectedThread, onFeedClick, isActivityMode]);
 
   useEffect(() => {
-    const listToCheck = isActivityMode ? activityList : feedList;
-    if (isEmpty(listToCheck) && handlePanelResize) {
+    const isEmptyFeed = isEmpty(activityList) && isEmpty(userThreads);
+    if (isEmptyFeed && handlePanelResize) {
       handlePanelResize?.(true);
     } else {
       handlePanelResize?.(false);
     }
-  }, [feedList, activityList, isActivityMode]);
+  }, [userThreads, activityList]);
 
   const feeds = useMemo(() => {
-    if (isActivityMode && activityList) {
-      return activityList.map((activity) => (
+    const activityItems = (activityList ?? []).map((activity) => ({
+      timestamp: activity.timestamp ?? 0,
+      node: (
         <FeedPanelBodyV1New
           activity={activity}
           handlePanelResize={handlePanelResize}
@@ -129,30 +137,36 @@ const ActivityFeedListV1New = ({
           onAfterClose={onAfterClose}
           onUpdateEntityDetails={onUpdateEntityDetails}
         />
-      ));
-    }
+      ),
+    }));
 
-    return entityThread.map((feed) => (
-      <FeedPanelBodyV1New
-        feed={feed}
-        handlePanelResize={handlePanelResize}
-        hidePopover={hidePopover}
-        isActive={activeFeedId === feed.id}
-        isFeedWidget={isFeedWidget}
-        isForFeedTab={isForFeedTab}
-        isFullSizeWidget={isFullSizeWidget}
-        isFullWidth={isFullWidth}
-        key={feed.id}
-        showThread={showThread}
-        onAfterClose={onAfterClose}
-        onFeedClick={onFeedClick}
-        onUpdateEntityDetails={onUpdateEntityDetails}
-      />
-    ));
+    const threadItems = userThreads.map((feed) => ({
+      timestamp: feed.threadTs ?? feed.updatedAt ?? 0,
+      node: (
+        <FeedPanelBodyV1New
+          feed={feed}
+          handlePanelResize={handlePanelResize}
+          hidePopover={hidePopover}
+          isActive={activeFeedId === feed.id}
+          isFeedWidget={isFeedWidget}
+          isForFeedTab={isForFeedTab}
+          isFullSizeWidget={isFullSizeWidget}
+          isFullWidth={isFullWidth}
+          key={feed.id}
+          showThread={showThread}
+          onAfterClose={onAfterClose}
+          onFeedClick={onFeedClick}
+          onUpdateEntityDetails={onUpdateEntityDetails}
+        />
+      ),
+    }));
+
+    return [...activityItems, ...threadItems]
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .map((item) => item.node);
   }, [
-    entityThread,
+    userThreads,
     activityList,
-    isActivityMode,
     activeFeedId,
     componentsVisibility,
     hidePopover,
@@ -161,14 +175,13 @@ const ActivityFeedListV1New = ({
     isFullWidth,
     isFullSizeWidget,
     onActivityClick,
+    onFeedClick,
   ]);
   if (isLoading) {
     return <Loader />;
   }
 
-  const hasNoData = isActivityMode
-    ? isEmpty(activityList)
-    : isEmpty(entityThread) && isEmpty(feedList);
+  const hasNoData = isEmpty(activityList) && isEmpty(userThreads);
 
   if (hasNoData && !isLoading) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
@@ -55,7 +55,11 @@ import { ERROR_PLACEHOLDER_TYPE } from '../../../enums/common.enum';
 import { EntityTabs, EntityType } from '../../../enums/entity.enum';
 import { FeedFilter } from '../../../enums/mydata.enum';
 import { ActivityEvent } from '../../../generated/entity/activity/activityEvent';
-import { Thread, ThreadType } from '../../../generated/entity/feed/thread';
+import {
+  GeneratedBy,
+  Thread,
+  ThreadType,
+} from '../../../generated/entity/feed/thread';
 import { useAuth } from '../../../hooks/authHooks';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { useDomainStore } from '../../../hooks/useDomainStore';
@@ -424,10 +428,22 @@ export const ActivityFeedTab = ({
     }
   }, [feedCount, activeDomain]);
 
+  // User conversations live only in the legacy feed store, so every count has to
+  // add them to the activity events rather than read either source alone.
+  const allActivityCount = useMemo(
+    () =>
+      (activityEvents?.length ?? 0) +
+      (entityThread ?? []).filter(
+        (feed) => feed.generatedBy !== GeneratedBy.System
+      ).length,
+    [activityEvents, entityThread]
+  );
+
   useEffect(() => {
-    if (activityEvents && activityEvents.length > 0) {
+    const activityCount = allActivityCount;
+
+    if (activityCount > 0) {
       setCountData((prev) => {
-        const activityCount = activityEvents.length;
         const newData = {
           ...prev.data,
           conversationCount: activityCount,
@@ -438,7 +454,7 @@ export const ActivityFeedTab = ({
         return { ...prev, data: newData };
       });
     }
-  }, [activityEvents, onUpdateFeedCount]);
+  }, [allActivityCount, onUpdateFeedCount]);
 
   const handleFeedClick = useCallback(
     (feed: Thread) => {
@@ -741,7 +757,7 @@ export const ActivityFeedTab = ({
                   <span>
                     {!isUserEntity &&
                       getCountBadge(
-                        activityEvents?.length ?? 0,
+                        allActivityCount,
                         '',
                         activeTab === ActivityFeedTabs.ALL
                       )}


### PR DESCRIPTION
## Problem

An entity's **Activity Feeds & Tasks → All** tab hides user conversations. After a 1.13 → 2.0 upgrade the tab drops from 5 items to 1 on a seeded apiCollection; the four missing items are user-authored conversations. There is no error and no empty state.

The data is intact — `thread_entity_legacy` still holds every thread, and `/v1/feed` still serves them. The tab requests them successfully and then discards them at render.

Browser network capture vs. rendered DOM, before this change:

```
/api/v1/activity/entity/apiCollection/name/<fqn>?days=30&limit=50   rows=1  EntityCreated
/api/v1/feed?entityLink=<#E::apiCollection::<fqn>>&type=Conversation rows=5  1 system + 4 user

rendered: conversation cards in DOM = 0, empty placeholder = false
```

## Cause

`ActivityFeedTab` fetches both sources (`getFeedData` and `fetchEntityActivity`), but `ActivityFeedListV1New` renders them exclusively:

```ts
const isActivityMode = !isUndefined(activityList) && activityList.length > 0;
...
if (feedList && !isActivityMode) { ... }   // threads render only when activity is empty
```

A single activity row suppresses every conversation on that entity.

This matters because 2.0 splits feed content across two **permanent** stores, by author rather than by age:

| content | store |
|---|---|
| system change-events (migrated and new) | `activity_stream` |
| user conversations (migrated **and newly created**) | thread store |

A conversation created today on 2.0 still lands in the thread store, so the two sources stay live indefinitely and the tab has to merge them. The effect is not limited to migrated history — a comment posted now is invisible on any entity that has ever had a description, tag or owner change.

The impact scales with how well the migration worked: on a seeded instance, 25 of 34 entities that own conversations have at least one activity row, hiding 136 of 172 conversations. Entities with no activity row still render normally, which is why spot checks can pass.

## Fix

- Compute `entityThread` whenever `feedList` arrives, not only when activity is empty.
- Render activity events and user-authored threads together, ordered by timestamp.
- Exclude system-generated threads: the 2.0 migration copies them into `activity_stream` and leaves the originals in the thread store, so without this filter every migrated system event renders twice.
- `hasNoData` and the panel-resize check now consider both lists.
- Counts come from one `allActivityCount` memo feeding both the tab badge and the left-rail **All** badge; the rail previously read only the activity length and disagreed with the list.

## Testing

- Automated browser check on a 1.13 → 2.0 migrated instance: the tab renders 4 conversation cards and the rail reads `All 5`, matching the pre-upgrade baseline. Before the change the same page rendered 0 conversation cards from the same network responses.
- `FeedWidget`, the only other consumer of this component, passes `activityList` and no `feedList`; its output is unchanged.
- ESLint clean on both files. Two pre-existing `tsc` errors in `ActivityFeedTab` (in the `getTaskCounts` block) are present on an unmodified checkout as well and are untouched here.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR merges user-authored conversations with activity-stream events in entity Activity tabs.
- Filters system-generated legacy threads to avoid duplicated migrated events.
- Sorts the two sources into one timestamp-ordered list and updates empty-state and panel-resize handling.
- Computes one combined count for the tab and All rail badges.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until merged-list conversation selection and zero-count propagation are fixed.

Conversations render in the combined list but cannot remain selected when activity events exist, and combined badges retain stale positive values after both source lists become empty.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx; openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx | Merges and sorts activity events with user threads, but the activity-only selection effect clears newly selected conversations whenever activity events are present. |
| openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedTab/ActivityFeedTab.component.tsx | Adds a combined count for both sources, but does not propagate the valid zero-count transition. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  AS[activity_stream events] --> Merge[Filter and merge by timestamp]
  TS[thread-store conversations] --> Filter[Exclude system-generated threads]
  Filter --> Merge
  Merge --> List[Activity tab list]
  Merge --> Count[All badges]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx`, line 93-101 ([link](https://github.com/open-metadata/openmetadata/blob/8f2005298e0ec3a5f561c89a34913d6e003598ed/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedList/ActivityFeedListV1New.component.tsx#L93-L101)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Conversation selection is overwritten**

   When both sources contain data and a user selects a conversation, this effect searches for the thread ID among activity events and falls back to the first activity. The activity callback then clears `selectedThread`, immediately replacing the selected conversation detail with an activity event.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ui): render conversations alongside ..."](https://github.com/open-metadata/openmetadata/commit/8f2005298e0ec3a5f561c89a34913d6e003598ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47835010)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->