### PR TITLE
test(playwright): unskip alert permission tests in AUT environment

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts
@@ -434,12 +434,6 @@ test('Alert operations for a user with and without permissions', async ({
   userWithPermissionsPage,
   userWithoutPermissionsPage,
 }) => {
-  // Todo: Re-enable after fixing the https://github.com/open-metadata/openmetadata-collate/issues/3280 @sonika-shah
-  test.fixme(
-    process.env.PLAYWRIGHT_IS_OSS !== 'true',
-    'Skipping in AUT environment'
-  );
-
   test.slow();
   const ALERT_NAME = generateAlertName();
   const { apiContext } = await getApiContext(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts
@@ -405,11 +405,6 @@ test('Alert operations for a user with and without permissions', async ({
   userWithPermissionsPage,
   userWithoutPermissionsPage,
 }) => {
-  // Todo: Re-enable after fixing the https://github.com/open-metadata/openmetadata-collate/issues/3280 @sonika-shah
-  test.fixme(
-    process.env.PLAYWRIGHT_IS_OSS !== 'true',
-    'Skipping in AUT environment'
-  );
   test.slow();
 
   const ALERT_NAME = generateAlertName();


### PR DESCRIPTION
## Description

Fixes #30547


Re-enables the **'Alert operations for a user with and without permissions'** Playwright test in both alert flow specs for the AUT (non-OSS) environment. These tests were previously skipped via `test.fixme(process.env.PLAYWRIGHT_IS_OSS !== 'true', ...)` while a blocking bug was outstanding.

### Files changed
- `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts`
- `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts`

Removed from each:
```ts
// Todo: Re-enable after fixing the https://github.com/open-metadata/openmetadata-collate/issues/3280 @sonika-shah
test.fixme(
  process.env.PLAYWRIGHT_IS_OSS !== 'true',
  'Skipping in AUT environment'
);
```

## Why now

The blocking issue is resolved:

- **Issue:** [open-metadata/openmetadata-collate#3280](https://github.com/open-metadata/openmetadata-collate/issues/3280) — "Owner search in NotificationAlerts is throwing error" — **CLOSED / COMPLETED** (2026-03-30)
- **Fixed by:** [open-metadata/OpenMetadata#26794](https://github.com/open-metadata/OpenMetadata/pull/26794) — "Fix search failure on user index due to nested owners query" — **MERGED** (2026-03-30)

With the owner-search fix in `main`, these tests can run in the AUT environment again.

## Testing
- These are the Playwright E2E permission tests themselves; they will now execute in AUT CI instead of being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Re-enables existing Playwright permission tests in AUT environments.
- Removes the AUT-specific `test.fixme` guard from the notification alert permission flow.
- Removes the equivalent guard from the observability alert permission flow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only re-enables existing permission tests in AUT.

The removed guards were the sole AUT-specific skips, and the enabled tests already use environment-agnostic fixtures, setup, alert operations, and cleanup.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/NotificationAlerts.spec.ts | Re-enables the existing notification alert permission test in AUT without changing its test behavior. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ObservabilityAlerts.spec.ts | Re-enables the existing observability alert permission test in AUT without changing its test behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(playwright): unskip alert permissio..."](https://github.com/open-metadata/openmetadata/commit/a9e407acfac12c421a211e44864b3be3a5de164f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47852082)</sub>

<!-- /greptile_comment -->
