### PR TITLE
chore(release): fix 2.0 branch version to 2.0.0

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <properties>

--- a/docker/docker-compose-ingestion/docker-compose-ingestion.yml
+++ b/docker/docker-compose-ingestion/docker-compose-ingestion.yml
@@ -18,7 +18,7 @@ volumes:
 services:  
   ingestion:
     container_name: openmetadata_ingestion
-    image: docker.getcollate.io/openmetadata/ingestion:2.0
+    image: docker.getcollate.io/openmetadata/ingestion:2.0.0
     environment:
       AIRFLOW__API__AUTH_BACKENDS: "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session"
       AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/docker/docker-compose-openmetadata/docker-compose-openmetadata.yml
+++ b/docker/docker-compose-openmetadata/docker-compose-openmetadata.yml
@@ -14,7 +14,7 @@ services:
   execute-migrate-all:
     container_name: execute_migrate_all
     command: "./bootstrap/openmetadata-ops.sh migrate"
-    image: docker.getcollate.io/openmetadata/server:2.0
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -240,7 +240,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:2.0
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}

--- a/docker/docker-compose-quickstart/Dockerfile
+++ b/docker/docker-compose-quickstart/Dockerfile
@@ -11,7 +11,7 @@
 
 # Build stage
 FROM alpine:3 AS build
-ARG RI_VERSION="2.0"
+ARG RI_VERSION="2.0.0"
 ENV RELEASE_URL="https://github.com/open-metadata/OpenMetadata/releases/download/${RI_VERSION}-release/openmetadata-${RI_VERSION}.tar.gz"
 
 RUN mkdir -p /opt/openmetadata && \
@@ -21,7 +21,7 @@ RUN mkdir -p /opt/openmetadata && \
 
 # Final stage
 FROM alpine:3
-ARG RI_VERSION="2.0"
+ARG RI_VERSION="2.0.0"
 ARG BUILD_DATE
 ARG COMMIT_ID
 LABEL maintainer="OpenMetadata"

--- a/docker/docker-compose-quickstart/docker-compose-postgres.yml
+++ b/docker/docker-compose-quickstart/docker-compose-postgres.yml
@@ -18,7 +18,7 @@ volumes:
 services:
   postgresql:
     container_name: openmetadata_postgresql
-    image: docker.getcollate.io/openmetadata/postgresql:2.0
+    image: docker.getcollate.io/openmetadata/postgresql:2.0.0
     restart: always
     command: "--work_mem=10MB"
     environment:
@@ -61,7 +61,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: docker.getcollate.io/openmetadata/server:2.0
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -288,7 +288,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:2.0
+    image: docker.getcollate.io/openmetadata/server:2.0.0
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -509,7 +509,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: docker.getcollate.io/openmetadata/ingestion:2.0
+    image: docker.getcollate.io/openmetadata/ingestion:2.0.0
     depends_on:
       elasticsearch:
         condition: service_started

--- a/docker/docker-compose-quickstart/docker-compose.yml
+++ b/docker/docker-compose-quickstart/docker-compose.yml
@@ -18,7 +18,7 @@ volumes:
 services:
   mysql:
     container_name: openmetadata_mysql
-    image: ${OPENMETADATA_DB_IMAGE:-docker.getcollate.io/openmetadata/db:1.12.0-SNAPSHOT}
+    image: ${OPENMETADATA_DB_IMAGE:-docker.getcollate.io/openmetadata/db:2.0.0}
     command: "--sort_buffer_size=10M"
     restart: always
     environment:
@@ -59,7 +59,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:1.12.0-SNAPSHOT}
+    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:2.0.0}
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -286,7 +286,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:1.12.0-SNAPSHOT}
+    image: ${OPENMETADATA_SERVER_IMAGE:-docker.getcollate.io/openmetadata/server:2.0.0}
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -508,7 +508,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: ${OPENMETADATA_INGESTION_IMAGE:-docker.getcollate.io/openmetadata/ingestion:1.12.0-SNAPSHOT}
+    image: ${OPENMETADATA_INGESTION_IMAGE:-docker.getcollate.io/openmetadata/ingestion:2.0.0}
     depends_on:
       elasticsearch:
         condition: service_started

--- a/openmetadata-clients/openmetadata-java-client/pom.xml
+++ b/openmetadata-clients/openmetadata-java-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-clients</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-clients/pom.xml
+++ b/openmetadata-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
 
   <artifactId>openmetadata-dist</artifactId>

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openmetadata-integration-tests</artifactId>

--- a/openmetadata-k8s-operator/pom.xml
+++ b/openmetadata-k8s-operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/openmetadata-mcp/pom.xml
+++ b/openmetadata-mcp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.open-metadata</groupId>
         <artifactId>platform</artifactId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     
     <artifactId>openmetadata-mcp</artifactId>

--- a/openmetadata-sdk/pom.xml
+++ b/openmetadata-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.open-metadata</groupId>
         <artifactId>platform</artifactId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>openmetadata-sdk</artifactId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openmetadata-service</artifactId>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java
@@ -201,7 +201,7 @@ import org.quartz.SchedulerException;
     info =
         @Info(
             title = "OpenMetadata APIs",
-            version = "2.0.0-SNAPSHOT",
+            version = "2.0.0",
             description = "Common types and API definition for OpenMetadata",
             contact =
                 @Contact(

--- a/openmetadata-shaded-deps/elasticsearch-dep/pom.xml
+++ b/openmetadata-shaded-deps/elasticsearch-dep/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-shaded-deps</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-deps</artifactId>

--- a/openmetadata-shaded-deps/opensearch-dep/pom.xml
+++ b/openmetadata-shaded-deps/opensearch-dep/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-shaded-deps</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>opensearch-deps</artifactId>

--- a/openmetadata-shaded-deps/pom.xml
+++ b/openmetadata-shaded-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openmetadata-shaded-deps</artifactId>

--- a/openmetadata-spec/pom.xml
+++ b/openmetadata-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>2.0</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-ui-core-components/pom.xml
+++ b/openmetadata-ui-core-components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-ui/pom.xml
+++ b/openmetadata-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>2.0</version>
+    <version>2.0.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     based on Open Metadata Standards/APIs, supporting connectors to a wide range of data services,
     OpenMetadata enables end-to-end metadata management, giving you the freedom to unlock the value of your data assets.
   </description>
-  <version>2.0</version>
+  <version>2.0.0</version>
   <url>https://github.com/open-metadata/OpenMetadata</url>
   <modules>
     <module>openmetadata-spec</module>


### PR DESCRIPTION
## Describe your changes

Branch `2.0` was cut with its Maven version set to `2.0` instead of `2.0.0`. **The branch name itself is correct** — `2.0` is the release *line* branch, same convention as `1.13`, and the 3-part branches (`1.13.0`, `1.13.1`, `1.12.14`) are cut off the line at each release. Only the version string inside the branch is wrong.

This matters because the version reaches runtime: it flows into `catalog/VERSION` → `/api/v1/system/version`, and the ingestion client parses it with `re.match(r"\d+.\d+.\d+", ...)` ([`__version__.py:45`](https://github.com/open-metadata/OpenMetadata/blob/2.0/ingestion/src/metadata/__version__.py#L45)). `2.0` has no third component, so every OMeta client init on the branch dies with `Can't extract server version from 2.0` — which is what's failing Sample Data Ingestion, Python Tests, AskCollate E2E and Java IT on the `2.0` nightly. A qualifier suffix is fine (`2.0.0-SNAPSHOT` on `main` parses to `2.0.0`); a missing digit is not.

`1.13` was cut the same way and fixed with the same bump in [6396657](https://github.com/open-metadata/OpenMetadata/commit/6396657791fe1f95a2dd05c0029de85d45cb9b7f) — this PR is the equivalent for `2.0`, plus the Docker/OpenAPI rows the release script missed.

| Area | Before | After |
|---|---|---|
| Root + 15 module `pom.xml` | `2.0` | `2.0.0` |
| `docker-compose-ingestion.yml`, `docker-compose-openmetadata.yml`, `docker-compose-postgres.yml` image tags | `:2.0` | `:2.0.0` |
| `docker-compose-quickstart/Dockerfile` `RI_VERSION` (x2) | `2.0` | `2.0.0` |
| `docker-compose-quickstart/docker-compose.yml` image tags | `:1.12.0-SNAPSHOT` | `:2.0.0` |
| `OpenMetadataApplication.java` `@Info(version)` | `2.0.0-SNAPSHOT` | `2.0.0` |

Python package versions (`ingestion/pyproject.toml`, `openmetadata-airflow-apis/pyproject.toml` and the ingestion `RI_VERSION`s) were already corrected to `2.0.0.0` in c7d9c5e and are untouched here.

### Note for the release tooling

The last two rows were missed by `chore(release): Prepare Branch for 2.0` because two regexes in `scripts/update_version.py` no longer match what's on `main`:

- `update_docker_tag` expects a literal `image: docker.getcollate.io/...`, but `docker-compose.yml` now uses `image: ${OPENMETADATA_DB_IMAGE:-docker.getcollate.io/...}`.
- `update_openapi_version` matches `\d+\.\d+\.\d+"`, which never matches a `…-SNAPSHOT"` value. (This is why `1.13` still ships `version = "1.13"` in its OpenAPI spec.)

Those script fixes are intentionally **not** in this PR — happy to open a separate one against `main`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document
- [x] My PR title is `chore(release): fix 2.0 branch version to 2.0.0`
- [x] `mvn -B validate` passes (`Building OpenMetadata-Platform 2.0.0`, 16 modules, BUILD SUCCESS)
- [x] `mvn -B spotless:check -pl openmetadata-service` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Aligns the 2.0 release branch on the canonical 2.0.0 release version.
- Updates the root and module Maven coordinates to 2.0.0.
- Updates OpenMetadata Docker image defaults and quickstart release artifact references to 2.0.0.
- Changes the advertised OpenAPI version from 2.0.0-SNAPSHOT to 2.0.0.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the Maven, container, release-artifact, and OpenAPI versions consistently aligned to 2.0.0.

The updated Maven coordinates are consistent across the reactor, the quickstart artifact URL matches the release packaging convention, and all changed OpenMetadata image defaults and application metadata use the same finalized version.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Changes the reactor project version to 2.0.0, consistently matched by all changed child POM parent references. |
| docker/docker-compose-quickstart/docker-compose.yml | Aligns the default database, server, migration, and ingestion images on the 2.0.0 release tag. |
| docker/docker-compose-quickstart/Dockerfile | Updates the release input so its GitHub tag and archive URL match the 2.0.0 artifact produced by Maven. |
| openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplication.java | Updates the OpenAPI metadata to advertise the finalized 2.0.0 release rather than a snapshot. |
| docker/docker-compose-quickstart/docker-compose-postgres.yml | Consistently updates the PostgreSQL quickstart's OpenMetadata component images to 2.0.0. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): fix 2.0 branch version t..."](https://github.com/open-metadata/openmetadata/commit/f36664ce10d50c76e1da26f2b330e0a2f80f9ae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47852714)</sub>

<!-- /greptile_comment -->
