### PR TITLE
test(playwright): config-driven TaskAllEntities suite, enable File/Directory

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
@@ -38,26 +38,54 @@ import { performAdminLogin } from '../../../utils/admin';
  * - Directory, File, DataProduct
  * - Glossary, GlossaryTerm
  *
- * Each entity type tests:
+ * Each entity type tests (where supported):
  * - DescriptionUpdate (entity level)
  * - OwnershipUpdate
  * - TierUpdate
  * - DomainUpdate
- * - TagUpdate (where applicable)
+ *
+ * Coverage is driven by a single config list so every entity runs the same
+ * generic suite instead of duplicating the same describe/test blocks.
  */
 
-// Helper function to create task and verify resolution
+type TaskResponseData = { id: string; fullyQualifiedName: string };
+
+interface EntityLike {
+  create(apiContext: APIRequestContext): Promise<unknown>;
+  delete(apiContext: APIRequestContext): Promise<unknown>;
+}
+
+interface TaskEntityConfig {
+  name: string;
+  entityType: string;
+  endpoint: string;
+  tierFQN?: string;
+  supportsDomain?: boolean;
+  build: (domain: Domain) => {
+    entity: EntityLike;
+    getData: () => TaskResponseData;
+  };
+}
+
+function toTaskData(source: {
+  id?: string;
+  fullyQualifiedName?: string;
+}): TaskResponseData {
+  return {
+    id: source.id ?? '',
+    fullyQualifiedName: source.fullyQualifiedName ?? '',
+  };
+}
+
 async function createAndResolveTask(
   apiContext: APIRequestContext,
   entityType: string,
-  entityId: string,
   entityFqn: string,
   taskType: string,
   assigneeFqn: string,
   payload: Record<string, unknown>,
   fieldPath?: string
 ) {
-  // Include fieldPath in payload if provided
   const taskPayload = { ...payload };
   if (fieldPath) {
     taskPayload.fieldPath = fieldPath;
@@ -77,12 +105,10 @@ async function createAndResolveTask(
   const task = await taskResponse.json();
   expect(taskResponse.ok()).toBe(true);
 
-  // Resolve task
   const resolveData: Record<string, unknown> = {
     resolutionType: 'Approved',
   };
 
-  // For description updates, pass the new value
   if (
     taskType === 'DescriptionUpdate' &&
     (payload.newDescription || payload.suggestedValue)
@@ -99,2027 +125,372 @@ async function createAndResolveTask(
   return task;
 }
 
-test.describe('Task Resolution - Table Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
+const TASK_ENTITY_CONFIGS: TaskEntityConfig[] = [
+  {
+    name: 'Table',
+    entityType: 'table',
+    endpoint: 'tables',
+    tierFQN: 'Tier.Tier1',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const table = new TableClass();
 
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const table = new TableClass();
-  const domain = new Domain();
+      return {
+        entity: table,
+        getData: () => toTaskData(table.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Topic',
+    entityType: 'topic',
+    endpoint: 'topics',
+    tierFQN: 'Tier.Tier2',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const topic = new TopicClass();
 
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+      return {
+        entity: topic,
+        getData: () => toTaskData(topic.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Dashboard',
+    entityType: 'dashboard',
+    endpoint: 'dashboards',
+    tierFQN: 'Tier.Tier3',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const dashboard = new DashboardClass();
 
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
+      return {
+        entity: dashboard,
+        getData: () => toTaskData(dashboard.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Pipeline',
+    entityType: 'pipeline',
+    endpoint: 'pipelines',
+    tierFQN: 'Tier.Tier4',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const pipeline = new PipelineClass();
 
-      await table.create(apiContext);
-      await apiContext.patch(`/api/v1/tables/${table.entityResponseData?.id}`, {
-        data: [
+      return {
+        entity: pipeline,
+        getData: () => toTaskData(pipeline.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Container',
+    entityType: 'container',
+    endpoint: 'containers',
+    tierFQN: 'Tier.Tier5',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const container = new ContainerClass();
+
+      return {
+        entity: container,
+        getData: () => toTaskData(container.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'MLModel',
+    entityType: 'mlmodel',
+    endpoint: 'mlmodels',
+    tierFQN: 'Tier.Tier1',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const mlModel = new MlModelClass();
+
+      return {
+        entity: mlModel,
+        getData: () => toTaskData(mlModel.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'SearchIndex',
+    entityType: 'searchIndex',
+    endpoint: 'searchIndexes',
+    tierFQN: 'Tier.Tier2',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const searchIndex = new SearchIndexClass();
+
+      return {
+        entity: searchIndex,
+        getData: () => toTaskData(searchIndex.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Metric',
+    entityType: 'metric',
+    endpoint: 'metrics',
+    tierFQN: 'Tier.Tier3',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const metric = new MetricClass();
+
+      return {
+        entity: metric,
+        getData: () => toTaskData(metric.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Glossary',
+    entityType: 'glossary',
+    endpoint: 'glossaries',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const glossary = new Glossary();
+
+      return {
+        entity: glossary,
+        getData: () => toTaskData(glossary.responseData),
+      };
+    },
+  },
+  {
+    name: 'GlossaryTerm',
+    entityType: 'glossaryTerm',
+    endpoint: 'glossaryTerms',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const glossaryTerm = new GlossaryTerm();
+
+      return {
+        entity: glossaryTerm,
+        getData: () => toTaskData(glossaryTerm.responseData),
+      };
+    },
+  },
+  {
+    name: 'File',
+    entityType: 'file',
+    endpoint: 'drives/files',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const file = new FileClass();
+
+      return {
+        entity: file,
+        getData: () => toTaskData(file.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'Directory',
+    entityType: 'directory',
+    endpoint: 'drives/directories',
+    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const directory = new DirectoryClass();
+
+      return {
+        entity: directory,
+        getData: () => toTaskData(directory.entityResponseData),
+      };
+    },
+  },
+  {
+    name: 'DataProduct',
+    entityType: 'dataProduct',
+    endpoint: 'dataProducts',
+    supportsDomain: false,
+    build: (
+      domain: Domain
+    ): { entity: EntityLike; getData: () => TaskResponseData } => {
+      const dataProduct = new DataProduct([domain]);
+      dataProduct.createDomain = false;
+
+      return {
+        entity: dataProduct,
+        getData: () => ({
+          id: dataProduct.responseData?.id ?? '',
+          fullyQualifiedName:
+            dataProduct.responseData?.fullyQualifiedName ?? '',
+        }),
+      };
+    },
+  },
+];
+
+function runTaskSuite(config: TaskEntityConfig) {
+  test.describe(`Task Resolution - ${config.name} Entity (All Task Types)`, () => {
+    test.describe.configure({ mode: 'default' });
+
+    const adminUser = new UserClass();
+    const ownerUser = new UserClass();
+    const newOwner = new UserClass();
+    const domain = new Domain();
+
+    let entity: EntityLike;
+    let getData: () => TaskResponseData;
+
+    test.beforeAll('Setup test data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await adminUser.create(apiContext);
+        await adminUser.setAdminRole(apiContext);
+        await ownerUser.create(apiContext);
+        await newOwner.create(apiContext);
+        await domain.create(apiContext);
+
+        const built = config.build(domain);
+        entity = built.entity;
+        getData = built.getData;
+
+        await entity.create(apiContext);
+        await apiContext.patch(`/api/v1/${config.endpoint}/${getData().id}`, {
+          data: [
+            {
+              op: 'add',
+              path: '/owners',
+              value: [{ id: ownerUser.responseData.id, type: 'user' }],
+            },
+          ],
+          headers: { 'Content-Type': 'application/json-patch+json' },
+        });
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test.afterAll('Cleanup test data', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        await entity.delete(apiContext);
+        await domain.delete(apiContext);
+        await newOwner.delete(apiContext);
+        await ownerUser.delete(apiContext);
+        await adminUser.delete(apiContext);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test(`DescriptionUpdate task for ${config.name}`, async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      const newDescription = `Updated ${config.name} description via task`;
+
+      try {
+        const data = getData();
+        await createAndResolveTask(
+          apiContext,
+          config.entityType,
+          data.fullyQualifiedName,
+          'DescriptionUpdate',
+          ownerUser.responseData.name,
+          { newDescription: newDescription },
+          'description'
+        );
+
+        const response = await apiContext.get(
+          `/api/v1/${config.endpoint}/${data.id}`
+        );
+        const updated = await response.json();
+        expect(updated.description).toBe(newDescription);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test(`OwnershipUpdate task for ${config.name}`, async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      try {
+        const data = getData();
+        await createAndResolveTask(
+          apiContext,
+          config.entityType,
+          data.fullyQualifiedName,
+          'OwnershipUpdate',
+          ownerUser.responseData.name,
           {
-            op: 'add',
-            path: '/owners',
-            value: [{ id: ownerUser.responseData.id, type: 'user' }],
-          },
-        ],
-        headers: { 'Content-Type': 'application/json-patch+json' },
+            currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
+            newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
+          }
+        );
+
+        const response = await apiContext.get(
+          `/api/v1/${config.endpoint}/${data.id}?fields=owners`
+        );
+        const updated = await response.json();
+        expect(updated.owners[0].id).toBe(newOwner.responseData.id);
+      } finally {
+        await afterAction();
+      }
+    });
+
+    if (config.tierFQN) {
+      test(`TierUpdate task for ${config.name}`, async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+
+        try {
+          const data = getData();
+          await createAndResolveTask(
+            apiContext,
+            config.entityType,
+            data.fullyQualifiedName,
+            'TierUpdate',
+            ownerUser.responseData.name,
+            {
+              newTier: {
+                tagFQN: config.tierFQN,
+                source: 'Classification',
+                labelType: 'Manual',
+                state: 'Confirmed',
+              },
+            }
+          );
+
+          const response = await apiContext.get(
+            `/api/v1/${config.endpoint}/${data.id}?fields=tags`
+          );
+          const updated = await response.json();
+          const hasTier = updated.tags?.some(
+            (t: { tagFQN: string }) => t.tagFQN === config.tierFQN
+          );
+          expect(hasTier).toBe(true);
+        } finally {
+          await afterAction();
+        }
       });
-    } finally {
-      await afterAction();
     }
-  });
 
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+    if (config.supportsDomain !== false) {
+      test(`DomainUpdate task for ${config.name}`, async ({ browser }) => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    try {
-      await table.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
+        try {
+          const data = getData();
+          await createAndResolveTask(
+            apiContext,
+            config.entityType,
+            data.fullyQualifiedName,
+            'DomainUpdate',
+            ownerUser.responseData.name,
+            {
+              newDomain: {
+                id: domain.responseData.id,
+                type: 'domain',
+                fullyQualifiedName: domain.responseData.fullyQualifiedName,
+              },
+            }
+          );
 
-  test('DescriptionUpdate task for Table', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Table description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'table',
-        table.entityResponseData?.id,
-        table.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/tables/${table.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Table', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'table',
-        table.entityResponseData?.id,
-        table.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
+          const response = await apiContext.get(
+            `/api/v1/${config.endpoint}/${data.id}?fields=domains`
+          );
+          const updated = await response.json();
+          expect(updated.domains?.length).toBeGreaterThan(0);
+          expect(updated.domains[0].id).toBe(domain.responseData.id);
+        } finally {
+          await afterAction();
         }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/tables/${table.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Table', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'table',
-        table.entityResponseData?.id,
-        table.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier1',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/tables/${table.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier1'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Table', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'table',
-        table.entityResponseData?.id,
-        table.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/tables/${table.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Topic Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const topic = new TopicClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await topic.create(apiContext);
-      await apiContext.patch(`/api/v1/topics/${topic.entityResponseData?.id}`, {
-        data: [
-          {
-            op: 'add',
-            path: '/owners',
-            value: [{ id: ownerUser.responseData.id, type: 'user' }],
-          },
-        ],
-        headers: { 'Content-Type': 'application/json-patch+json' },
       });
-    } finally {
-      await afterAction();
     }
   });
+}
 
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await topic.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Topic', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Topic description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'topic',
-        topic.entityResponseData?.id,
-        topic.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/topics/${topic.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Topic', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'topic',
-        topic.entityResponseData?.id,
-        topic.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/topics/${topic.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Topic', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'topic',
-        topic.entityResponseData?.id,
-        topic.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier2',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/topics/${topic.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier2'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Topic', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'topic',
-        topic.entityResponseData?.id,
-        topic.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/topics/${topic.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Dashboard Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const dashboard = new DashboardClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await dashboard.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/dashboards/${dashboard.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await dashboard.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Dashboard', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Dashboard description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dashboard',
-        dashboard.entityResponseData?.id,
-        dashboard.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dashboards/${dashboard.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Dashboard', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dashboard',
-        dashboard.entityResponseData?.id,
-        dashboard.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dashboards/${dashboard.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Dashboard', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dashboard',
-        dashboard.entityResponseData?.id,
-        dashboard.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier3',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dashboards/${dashboard.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier3'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Dashboard', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dashboard',
-        dashboard.entityResponseData?.id,
-        dashboard.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dashboards/${dashboard.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Pipeline Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const pipeline = new PipelineClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await pipeline.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/pipelines/${pipeline.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await pipeline.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Pipeline', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Pipeline description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'pipeline',
-        pipeline.entityResponseData?.id,
-        pipeline.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/pipelines/${pipeline.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Pipeline', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'pipeline',
-        pipeline.entityResponseData?.id,
-        pipeline.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/pipelines/${pipeline.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Pipeline', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'pipeline',
-        pipeline.entityResponseData?.id,
-        pipeline.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier4',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/pipelines/${pipeline.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier4'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Pipeline', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'pipeline',
-        pipeline.entityResponseData?.id,
-        pipeline.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/pipelines/${pipeline.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Container Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const container = new ContainerClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await container.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/containers/${container.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await container.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Container', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Container description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'container',
-        container.entityResponseData?.id,
-        container.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/containers/${container.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Container', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'container',
-        container.entityResponseData?.id,
-        container.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/containers/${container.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Container', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'container',
-        container.entityResponseData?.id,
-        container.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier5',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/containers/${container.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier5'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Container', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'container',
-        container.entityResponseData?.id,
-        container.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/containers/${container.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - MLModel Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const mlModel = new MlModelClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await mlModel.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/mlmodels/${mlModel.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await mlModel.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for MLModel', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated MLModel description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'mlmodel',
-        mlModel.entityResponseData?.id,
-        mlModel.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/mlmodels/${mlModel.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for MLModel', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'mlmodel',
-        mlModel.entityResponseData?.id,
-        mlModel.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/mlmodels/${mlModel.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for MLModel', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'mlmodel',
-        mlModel.entityResponseData?.id,
-        mlModel.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier1',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/mlmodels/${mlModel.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier1'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for MLModel', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'mlmodel',
-        mlModel.entityResponseData?.id,
-        mlModel.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/mlmodels/${mlModel.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - SearchIndex Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const searchIndex = new SearchIndexClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await searchIndex.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/searchIndexes/${searchIndex.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await searchIndex.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for SearchIndex', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated SearchIndex description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'searchIndex',
-        searchIndex.entityResponseData?.id,
-        searchIndex.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/searchIndexes/${searchIndex.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for SearchIndex', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'searchIndex',
-        searchIndex.entityResponseData?.id,
-        searchIndex.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/searchIndexes/${searchIndex.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for SearchIndex', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'searchIndex',
-        searchIndex.entityResponseData?.id,
-        searchIndex.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier2',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/searchIndexes/${searchIndex.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier2'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for SearchIndex', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'searchIndex',
-        searchIndex.entityResponseData?.id,
-        searchIndex.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/searchIndexes/${searchIndex.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Glossary Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const glossary = new Glossary();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await glossary.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/glossaries/${glossary.responseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await glossary.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Glossary', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Glossary description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossary',
-        glossary.responseData?.id,
-        glossary.responseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaries/${glossary.responseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Glossary', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossary',
-        glossary.responseData?.id,
-        glossary.responseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaries/${glossary.responseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Glossary', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossary',
-        glossary.responseData?.id,
-        glossary.responseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaries/${glossary.responseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - GlossaryTerm Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const glossary = new Glossary();
-  const glossaryTerm = new GlossaryTerm();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await glossary.create(apiContext);
-      glossaryTerm.data.glossary = glossary.responseData?.fullyQualifiedName;
-      await glossaryTerm.create(apiContext);
-
-      await apiContext.patch(
-        `/api/v1/glossaryTerms/${glossaryTerm.responseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await glossaryTerm.delete(apiContext);
-      await glossary.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for GlossaryTerm', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated GlossaryTerm description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossaryTerm',
-        glossaryTerm.responseData?.id,
-        glossaryTerm.responseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaryTerms/${glossaryTerm.responseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for GlossaryTerm', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossaryTerm',
-        glossaryTerm.responseData?.id,
-        glossaryTerm.responseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaryTerms/${glossaryTerm.responseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for GlossaryTerm', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'glossaryTerm',
-        glossaryTerm.responseData?.id,
-        glossaryTerm.responseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/glossaryTerms/${glossaryTerm.responseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Metric Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const metric = new MetricClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await metric.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/metrics/${metric.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await metric.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for Metric', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Metric description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'metric',
-        metric.entityResponseData?.id,
-        metric.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/metrics/${metric.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for Metric', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'metric',
-        metric.entityResponseData?.id,
-        metric.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/metrics/${metric.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('TierUpdate task for Metric', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'metric',
-        metric.entityResponseData?.id,
-        metric.entityResponseData?.fullyQualifiedName,
-        'TierUpdate',
-        ownerUser.responseData.name,
-        {
-          newTier: {
-            tagFQN: 'Tier.Tier3',
-            source: 'Classification',
-            labelType: 'Manual',
-            state: 'Confirmed',
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/metrics/${metric.entityResponseData?.id}?fields=tags`
-      );
-      const updated = await response.json();
-      const hasTier = updated.tags?.some(
-        (t: { tagFQN: string }) => t.tagFQN === 'Tier.Tier3'
-      );
-      expect(hasTier).toBe(true);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DomainUpdate task for Metric', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'metric',
-        metric.entityResponseData?.id,
-        metric.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/metrics/${metric.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - File Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const file = new FileClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await file.create(apiContext);
-      await apiContext.patch(`/api/v1/files/${file.entityResponseData?.id}`, {
-        data: [
-          {
-            op: 'add',
-            path: '/owners',
-            value: [{ id: ownerUser.responseData.id, type: 'user' }],
-          },
-        ],
-        headers: { 'Content-Type': 'application/json-patch+json' },
-      });
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await file.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: File entity task support needs investigation
-  test.skip('DescriptionUpdate task for File', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated File description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'file',
-        file.entityResponseData?.id,
-        file.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/files/${file.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: File entity task support needs investigation
-  test.skip('OwnershipUpdate task for File', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'file',
-        file.entityResponseData?.id,
-        file.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/files/${file.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: File entity task support needs investigation
-  test.skip('DomainUpdate task for File', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'file',
-        file.entityResponseData?.id,
-        file.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/files/${file.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - Directory Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const directory = new DirectoryClass();
-  const domain = new Domain();
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      await directory.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/directories/${directory.entityResponseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await directory.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: Directory entity task support needs investigation
-  test.skip('DescriptionUpdate task for Directory', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated Directory description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'directory',
-        directory.entityResponseData?.id,
-        directory.entityResponseData?.fullyQualifiedName,
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/directories/${directory.entityResponseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: Directory entity task support needs investigation
-  test.skip('OwnershipUpdate task for Directory', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'directory',
-        directory.entityResponseData?.id,
-        directory.entityResponseData?.fullyQualifiedName,
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/directories/${directory.entityResponseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  // TODO: Directory entity task support needs investigation
-  test.skip('DomainUpdate task for Directory', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'directory',
-        directory.entityResponseData?.id,
-        directory.entityResponseData?.fullyQualifiedName,
-        'DomainUpdate',
-        ownerUser.responseData.name,
-        {
-          newDomain: {
-            id: domain.responseData.id,
-            type: 'domain',
-            fullyQualifiedName: domain.responseData.fullyQualifiedName,
-          },
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/directories/${directory.entityResponseData?.id}?fields=domains`
-      );
-      const updated = await response.json();
-      expect(updated.domains?.length).toBeGreaterThan(0);
-      expect(updated.domains[0].id).toBe(domain.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
-
-test.describe('Task Resolution - DataProduct Entity (All Task Types)', () => {
-  test.describe.configure({ mode: 'default' });
-
-  const adminUser = new UserClass();
-  const ownerUser = new UserClass();
-  const newOwner = new UserClass();
-  const domain = new Domain();
-  let dataProduct: DataProduct;
-
-  test.beforeAll('Setup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await adminUser.create(apiContext);
-      await adminUser.setAdminRole(apiContext);
-      await ownerUser.create(apiContext);
-      await newOwner.create(apiContext);
-      await domain.create(apiContext);
-
-      dataProduct = new DataProduct([domain]);
-      await dataProduct.create(apiContext);
-      await apiContext.patch(
-        `/api/v1/dataProducts/${dataProduct.responseData?.id}`,
-        {
-          data: [
-            {
-              op: 'add',
-              path: '/owners',
-              value: [{ id: ownerUser.responseData.id, type: 'user' }],
-            },
-          ],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
-      );
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test.afterAll('Cleanup test data', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await dataProduct.delete(apiContext);
-      await domain.delete(apiContext);
-      await newOwner.delete(apiContext);
-      await ownerUser.delete(apiContext);
-      await adminUser.delete(apiContext);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('DescriptionUpdate task for DataProduct', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    const newDescription = 'Updated DataProduct description via task';
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dataProduct',
-        dataProduct.responseData?.id ?? '',
-        dataProduct.responseData?.fullyQualifiedName ?? '',
-        'DescriptionUpdate',
-        ownerUser.responseData.name,
-        { newDescription: newDescription },
-        'description'
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dataProducts/${dataProduct.responseData?.id}`
-      );
-      const updated = await response.json();
-      expect(updated.description).toBe(newDescription);
-    } finally {
-      await afterAction();
-    }
-  });
-
-  test('OwnershipUpdate task for DataProduct', async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    try {
-      await createAndResolveTask(
-        apiContext,
-        'dataProduct',
-        dataProduct.responseData?.id ?? '',
-        dataProduct.responseData?.fullyQualifiedName ?? '',
-        'OwnershipUpdate',
-        ownerUser.responseData.name,
-        {
-          currentOwners: [{ id: ownerUser.responseData.id, type: 'user' }],
-          newOwners: [{ id: newOwner.responseData.id, type: 'user' }],
-        }
-      );
-
-      const response = await apiContext.get(
-        `/api/v1/dataProducts/${dataProduct.responseData?.id}?fields=owners`
-      );
-      const updated = await response.json();
-      expect(updated.owners[0].id).toBe(newOwner.responseData.id);
-    } finally {
-      await afterAction();
-    }
-  });
-});
+TASK_ENTITY_CONFIGS.forEach(runTaskSuite);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
@@ -64,6 +64,7 @@ interface TaskEntityConfig {
   build: (domain: Domain) => {
     entity: EntityLike;
     getData: () => TaskResponseData;
+    cleanup?: (apiContext: APIRequestContext) => Promise<unknown>;
   };
 }
 
@@ -255,12 +256,19 @@ const TASK_ENTITY_CONFIGS: TaskEntityConfig[] = [
     name: 'GlossaryTerm',
     entityType: 'glossaryTerm',
     endpoint: 'glossaryTerms',
-    build: (): { entity: EntityLike; getData: () => TaskResponseData } => {
-      const glossaryTerm = new GlossaryTerm();
+    build: (): {
+      entity: EntityLike;
+      getData: () => TaskResponseData;
+      cleanup: (apiContext: APIRequestContext) => Promise<unknown>;
+    } => {
+      const glossary = new Glossary();
+      const glossaryTerm = new GlossaryTerm(glossary);
+      glossaryTerm.createGlossary = true;
 
       return {
         entity: glossaryTerm,
         getData: () => toTaskData(glossaryTerm.responseData),
+        cleanup: (apiContext: APIRequestContext) => glossary.delete(apiContext),
       };
     },
   },
@@ -322,8 +330,11 @@ function runTaskSuite(config: TaskEntityConfig) {
     const newOwner = new UserClass();
     const domain = new Domain();
 
-    let entity: EntityLike;
+    let entity: EntityLike | undefined;
     let getData: () => TaskResponseData;
+    let cleanup:
+      | ((apiContext: APIRequestContext) => Promise<unknown>)
+      | undefined;
 
     test.beforeAll('Setup test data', async ({ browser }) => {
       const { apiContext, afterAction } = await performAdminLogin(browser);
@@ -338,6 +349,7 @@ function runTaskSuite(config: TaskEntityConfig) {
         const built = config.build(domain);
         entity = built.entity;
         getData = built.getData;
+        cleanup = built.cleanup;
 
         await entity.create(apiContext);
         await apiContext.patch(`/api/v1/${config.endpoint}/${getData().id}`, {
@@ -359,7 +371,12 @@ function runTaskSuite(config: TaskEntityConfig) {
       const { apiContext, afterAction } = await performAdminLogin(browser);
 
       try {
-        await entity.delete(apiContext);
+        if (entity) {
+          await entity.delete(apiContext);
+        }
+        if (cleanup) {
+          await cleanup(apiContext);
+        }
         await domain.delete(apiContext);
         await newOwner.delete(apiContext);
         await ownerUser.delete(apiContext);


### PR DESCRIPTION
## What

Refactor `TaskAllEntities.spec.ts` from ~2100 lines of copy-pasted per-entity `describe` blocks into a single `TASK_ENTITY_CONFIGS` list + generic `runTaskSuite()` runner.

- Each entity = one config entry: `name`, `entityType` (about-link type), `endpoint`, optional `tierFQN`, optional `supportsDomain`, and a `build(domain)` factory returning the instance + `getData()` (hides the `entityResponseData` vs `responseData` split).
- `runTaskSuite` emits shared setup/cleanup + the Description/Ownership/Tier/Domain test bodies. Tier only when `tierFQN` set; Domain only when `supportsDomain !== false`.
- Dropped the dead `entityId` param from `createAndResolveTask` (unused — `about` uses fqn).

## Enable File + Directory

Old skips were caused by wrong endpoints (`/api/v1/files`, `/api/v1/directories`). Correct endpoints are `drives/files` / `drives/directories` (from `EntityTypeEndpoint`) with `file` / `directory` about-types. Now wired via config, no more `test.skip`.

## Coverage (unchanged, minus dedup)

- Full (Desc/Own/Tier/Domain): Table, Topic, Dashboard, Pipeline, Container, MLModel, SearchIndex, Metric
- Desc/Own/Domain: Glossary, GlossaryTerm, **File, Directory** (newly enabled)
- Desc/Own: DataProduct

## Notes

- DataProduct now sets `createDomain = false` (shared domain already created in setup), avoiding a double domain-create.
- `tsc` + ESLint + Prettier clean. Full E2E run needs a backend that supports drive-entity tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consolidates the entity task-resolution tests into a configuration-driven runner.
- Adds shared setup, teardown, and Description/Ownership/Tier/Domain task flows.
- Enables File and Directory coverage through their drive API endpoints.
- Adds explicit parent-glossary cleanup for GlossaryTerm and reuses the shared domain for DataProduct.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because partial setup or cleanup failures can leave persistent test fixtures and obscure the original failure.

The entity guard addresses the prior undefined dereference, and GlossaryTerm now has parent cleanup, but domain and user deletion remains unconditional and sequential, so partially initialized fixtures and cleanup exceptions can still break test isolation.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Tasks/TaskAllEntities.spec.ts | Replaces duplicated entity suites with a shared configurable runner and enables drive-entity tests, but partial setup can still make teardown skip cleanup of created fixtures. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[TASK_ENTITY_CONFIGS entry] --> S[Create users and domain]
  S --> B[Build and create entity]
  B --> O[Assign initial owner]
  O --> T[Run supported task tests]
  T --> E[Delete entity]
  E --> X[Run optional entity cleanup]
  X --> D[Delete domain and users]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(playwright): clean up GlossaryTerm ..."](https://github.com/open-metadata/openmetadata/commit/d6dd24ffb16a3356b7b0be34aaa78cecb4e15804) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47853154)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->