### PR TITLE
Fixes #30573: search index=mlModelService no longer returns mlModel assets

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.MlModelServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateMlModel;
+import org.openmetadata.schema.entity.data.MlModel;
+import org.openmetadata.schema.entity.services.MlModelService;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.service.Entity;
+
+/**
+ * Regression test for the ML model service search alias bug: querying {@code index=mlModelService}
+ * must return only ML model <em>services</em>, never ML model <em>assets</em>.
+ *
+ * <p>The mlModel asset lists {@code mlModelService} as a {@code parentAlias}, so the ES alias
+ * {@code mlModelService} is attached to both {@code mlmodel_service_search_index} and
+ * {@code mlmodel_search_index}. For every other {@code *Service} the search resolver collapses the
+ * alias token to the single concrete service index, but the ML service's {@code entityIndexMap} key
+ * ({@code mlmodelService}) differs in casing from its alias ({@code mlModelService}) that clients
+ * send, so the by-key lookup missed and the token fell through to ES-native alias expansion —
+ * pulling in assets. Resolving the token by the entity's alias (not just its key) fixes it.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class MlModelServiceSearchAliasIT {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Duration POLL_AT_MOST = Duration.ofSeconds(60);
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
+  private static final String MLMODEL_SERVICE_INDEX = "mlModelService";
+  private static final String MLMODEL_INDEX = "mlmodel";
+
+  @Test
+  @DisplayName("index=mlModelService returns only services, not mlModel assets")
+  void mlModelServiceAliasDoesNotLeakAssets(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    MlModelService service = MlModelServiceTestFactory.createMlflow(ns);
+    String serviceFqn = service.getFullyQualifiedName();
+    String assetName = ns.prefix("mlmodel_alias_asset");
+    MlModel asset =
+        ns.trackRoot(
+            Entity.MLMODEL,
+            client
+                .mlModels()
+                .create(
+                    new CreateMlModel()
+                        .withName(assetName)
+                        .withService(serviceFqn)
+                        .withAlgorithm("regression")));
+    String assetFqn = asset.getFullyQualifiedName();
+
+    JsonNode assetHit = awaitHitByFqn(client, MLMODEL_INDEX, assetName, assetFqn);
+    assertEquals(
+        Entity.MLMODEL,
+        assetHit.path("entityType").asText(),
+        "asset must be reachable via its own index with entityType 'mlmodel'");
+
+    JsonNode serviceHit = awaitHitByFqn(client, MLMODEL_SERVICE_INDEX, serviceFqn, serviceFqn);
+    assertEquals(
+        Entity.MLMODEL_SERVICE,
+        serviceHit.path("entityType").asText(),
+        "service must be reachable via the mlModelService alias");
+
+    JsonNode leakedAsset = findHitByFqn(client, MLMODEL_SERVICE_INDEX, assetName, assetFqn);
+    assertNull(
+        leakedAsset,
+        "index=mlModelService must not return the mlModel asset " + assetFqn + " (alias leak)");
+  }
+
+  /**
+   * Poll {@code index} for {@code query} until a hit whose FQN equals {@code fqn} appears, then
+   * return its {@code _source}. ES indexing is async after the write API returns, so a fixed sleep
+   * flakes; this waits for convergence.
+   */
+  private JsonNode awaitHitByFqn(
+      OpenMetadataClient client, String index, String query, String fqn) {
+    JsonNode[] match = new JsonNode[1];
+    Awaitility.await(fqn + " indexed in " + index)
+        .pollInterval(POLL_INTERVAL)
+        .atMost(POLL_AT_MOST)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode source = findHitByFqn(client, index, query, fqn);
+              assertNotNull(source, fqn + " not yet indexed in " + index);
+              match[0] = source;
+            });
+    return match[0];
+  }
+
+  private JsonNode findHitByFqn(OpenMetadataClient client, String index, String query, String fqn)
+      throws Exception {
+    String response = client.search().query(query).index(index).size(50).deleted(false).execute();
+    JsonNode hits = OBJECT_MAPPER.readTree(response).path("hits").path("hits");
+    JsonNode result = null;
+    for (JsonNode hit : hits) {
+      JsonNode source = hit.path("_source");
+      if (fqn.equals(source.path("fullyQualifiedName").asText(""))) {
+        result = source;
+        break;
+      }
+    }
+    return result;
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java
@@ -53,7 +53,7 @@ import org.openmetadata.service.Entity;
 public class MlModelServiceSearchAliasIT {
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final Duration POLL_AT_MOST = Duration.ofSeconds(60);
+  private static final Duration POLL_AT_MOST = Duration.ofSeconds(120);
   private static final Duration POLL_INTERVAL = Duration.ofMillis(500);
   private static final String MLMODEL_SERVICE_INDEX = "mlModelService";
   private static final String MLMODEL_INDEX = "mlmodel";
@@ -64,8 +64,6 @@ public class MlModelServiceSearchAliasIT {
     OpenMetadataClient client = SdkClients.adminClient();
 
     MlModelService service = MlModelServiceTestFactory.createMlflow(ns);
-    String serviceFqn = service.getFullyQualifiedName();
-    String assetName = ns.prefix("mlmodel_alias_asset");
     MlModel asset =
         ns.trackRoot(
             Entity.MLMODEL,
@@ -73,58 +71,60 @@ public class MlModelServiceSearchAliasIT {
                 .mlModels()
                 .create(
                     new CreateMlModel()
-                        .withName(assetName)
-                        .withService(serviceFqn)
+                        .withName(ns.prefix("mlmodel_alias_asset"))
+                        .withService(service.getFullyQualifiedName())
                         .withAlgorithm("regression")));
-    String assetFqn = asset.getFullyQualifiedName();
+    String serviceId = service.getId().toString();
+    String assetId = asset.getId().toString();
 
-    JsonNode assetHit = awaitHitByFqn(client, MLMODEL_INDEX, assetName, assetFqn);
+    JsonNode assetHit = awaitHitById(client, MLMODEL_INDEX, assetId);
     assertEquals(
         Entity.MLMODEL,
         assetHit.path("entityType").asText(),
         "asset must be reachable via its own index with entityType 'mlmodel'");
 
-    JsonNode serviceHit = awaitHitByFqn(client, MLMODEL_SERVICE_INDEX, serviceFqn, serviceFqn);
+    JsonNode serviceHit = awaitHitById(client, MLMODEL_SERVICE_INDEX, serviceId);
     assertEquals(
         Entity.MLMODEL_SERVICE,
         serviceHit.path("entityType").asText(),
         "service must be reachable via the mlModelService alias");
 
-    JsonNode leakedAsset = findHitByFqn(client, MLMODEL_SERVICE_INDEX, assetName, assetFqn);
+    JsonNode leakedAsset = findHitById(client, MLMODEL_SERVICE_INDEX, assetId);
     assertNull(
         leakedAsset,
-        "index=mlModelService must not return the mlModel asset " + assetFqn + " (alias leak)");
+        "index=mlModelService must not return the mlModel asset " + assetId + " (alias leak)");
   }
 
   /**
-   * Poll {@code index} for {@code query} until a hit whose FQN equals {@code fqn} appears, then
-   * return its {@code _source}. ES indexing is async after the write API returns, so a fixed sleep
-   * flakes; this waits for convergence.
+   * Poll {@code index} for the document with id {@code id} until it appears, then return its
+   * {@code _source}. Matching by id (a keyword field) is analyzer-independent, so it behaves
+   * identically on Elasticsearch and OpenSearch. Indexing is async after the write API returns, so a
+   * fixed sleep flakes; this waits for convergence.
    */
-  private JsonNode awaitHitByFqn(
-      OpenMetadataClient client, String index, String query, String fqn) {
+  private JsonNode awaitHitById(OpenMetadataClient client, String index, String id) {
     JsonNode[] match = new JsonNode[1];
-    Awaitility.await(fqn + " indexed in " + index)
+    Awaitility.await(id + " indexed in " + index)
         .pollInterval(POLL_INTERVAL)
         .atMost(POLL_AT_MOST)
         .ignoreExceptions()
         .untilAsserted(
             () -> {
-              JsonNode source = findHitByFqn(client, index, query, fqn);
-              assertNotNull(source, fqn + " not yet indexed in " + index);
+              JsonNode source = findHitById(client, index, id);
+              assertNotNull(source, id + " not yet indexed in " + index);
               match[0] = source;
             });
     return match[0];
   }
 
-  private JsonNode findHitByFqn(OpenMetadataClient client, String index, String query, String fqn)
+  private JsonNode findHitById(OpenMetadataClient client, String index, String id)
       throws Exception {
-    String response = client.search().query(query).index(index).size(50).deleted(false).execute();
+    String response =
+        client.search().query("id:" + id).index(index).size(5).deleted(false).execute();
     JsonNode hits = OBJECT_MAPPER.readTree(response).path("hits").path("hits");
     JsonNode result = null;
     for (JsonNode hit : hits) {
       JsonNode source = hit.path("_source");
-      if (fqn.equals(source.path("fullyQualifiedName").asText(""))) {
+      if (id.equals(source.path("id").asText(""))) {
         result = source;
         break;
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -409,6 +409,7 @@ public class SearchRepository {
   }
 
   @Getter private Map<String, IndexMapping> entityIndexMap;
+  private Map<String, IndexMapping> aliasIndexMap;
 
   /**
    * Staged index names being populated by an in-flight reindex, keyed by the canonical index name
@@ -538,6 +539,21 @@ public class SearchRepository {
   private void loadIndexMappings() {
     IndexMappingLoader mappingLoader = IndexMappingLoader.getInstance();
     entityIndexMap = mappingLoader.getIndexMapping();
+    aliasIndexMap = buildAliasIndexMap(entityIndexMap);
+  }
+
+  private static Map<String, IndexMapping> buildAliasIndexMap(
+      Map<String, IndexMapping> mappingsByKey) {
+    Map<String, IndexMapping> mappingsByAlias = new HashMap<>();
+    if (mappingsByKey != null) {
+      for (IndexMapping mapping : mappingsByKey.values()) {
+        String alias = mapping.getAlias(null);
+        if (alias != null && !mappingsByKey.containsKey(alias)) {
+          mappingsByAlias.putIfAbsent(alias, mapping);
+        }
+      }
+    }
+    return mappingsByAlias;
   }
 
   public SearchClient buildSearchClient(ElasticSearchConfiguration config) {
@@ -999,6 +1015,9 @@ public class SearchRepository {
       return token;
     }
     IndexMapping mapping = entityIndexMap == null ? null : entityIndexMap.get(token);
+    if (mapping == null && aliasIndexMap != null) {
+      mapping = aliasIndexMap.get(token);
+    }
     if (mapping != null) {
       return mapping.getIndexName(clusterAlias);
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java
@@ -138,6 +138,14 @@ class SearchRepositoryBehaviorTest {
           .indexMappingFile("/elasticsearch/%s/database_service_index_mapping.json")
           .build();
 
+  private static final IndexMapping MLMODEL_SERVICE_MAPPING =
+      IndexMapping.builder()
+          .indexName("mlmodel_service_search_index")
+          .alias("mlModelService")
+          .childAliases(List.of("mlmodel"))
+          .indexMappingFile("/elasticsearch/%s/mlmodel_service_index_mapping.json")
+          .build();
+
   private static final IndexMapping DATABASE_MAPPING =
       IndexMapping.builder()
           .indexName("database_search_index")
@@ -223,6 +231,7 @@ class SearchRepositoryBehaviorTest {
                 Map.entry(Entity.DOMAIN, DOMAIN_MAPPING),
                 Map.entry(Entity.DATA_PRODUCT, DATA_PRODUCT_MAPPING),
                 Map.entry(Entity.DATABASE_SERVICE, DATABASE_SERVICE_MAPPING),
+                Map.entry(Entity.MLMODEL_SERVICE, MLMODEL_SERVICE_MAPPING),
                 Map.entry(Entity.TAG, TABLE_MAPPING),
                 Map.entry(Entity.GLOSSARY_TERM, TABLE_MAPPING),
                 Map.entry(Entity.GLOSSARY, TABLE_MAPPING),
@@ -385,6 +394,20 @@ class SearchRepositoryBehaviorTest {
   void getIndexOrAliasNameResolvesEntitySpecificAliasToCanonicalIndex() {
     assertEquals("cluster_table_search_index", repository.getIndexOrAliasName("table"));
     assertEquals("cluster_domain_search_index", repository.getIndexOrAliasName("domain"));
+  }
+
+  /**
+   * When an entity's {@code entityIndexMap} key differs from its {@code alias} (the mlModel service
+   * key is {@code mlmodelService} but its alias is {@code mlModelService}), a query for the alias
+   * must still resolve to the single canonical index. Without alias resolution the token misses the
+   * by-key lookup, passes through as a raw ES alias, and fans out to every index that carries it —
+   * for {@code mlModelService} that includes {@code mlmodel_search_index}, so the response leaks
+   * mlModel assets alongside the services.
+   */
+  @Test
+  void getIndexOrAliasNameResolvesEntityAliasWhenKeyCasingDiffers() {
+    assertEquals(
+        "cluster_mlmodel_service_search_index", repository.getIndexOrAliasName("mlModelService"));
   }
 
   /**
@@ -3470,6 +3493,7 @@ class SearchRepositoryBehaviorTest {
             Entity.DOMAIN,
             Entity.DATA_PRODUCT,
             Entity.DATABASE_SERVICE,
+            Entity.MLMODEL_SERVICE,
             Entity.TAG,
             Entity.GLOSSARY_TERM,
             Entity.GLOSSARY,


### PR DESCRIPTION
### Describe your changes:

Fixes #30573

`GET /v1/search/query?index=mlModelService` was returning both mlModel **service** entities and mlModel **asset** entities; it should return only services (as `dashboardService`, `databaseService`, etc. correctly do).

**Root cause:** the search resolver `SearchRepository.resolveSingleAliasToken` maps the `index` token to a concrete `*_search_index` only via a **by-key** lookup in `entityIndexMap`. The mlModel service's map key is `mlmodelService` (equal to `Entity.MLMODEL_SERVICE`), but its alias — the value clients/UI send — is `mlModelService` (capital M). The casing mismatch makes the by-key lookup miss, so the token falls through to native ES/OpenSearch alias expansion. That alias is attached to `mlmodel_search_index` too (the asset lists `mlModelService` as a `parentAlias`), so assets leak in. Every other `*Service` has key == alias, so its lookup hits and resolves to the single concrete service index.

**Fix:** resolve a token by an entity's own `alias` (not just its map key). A new `aliasIndexMap` (built in `loadIndexMappings()`, only for aliases that are not already keys, so by-key resolution always wins) is consulted on a key miss before falling through to ES. `index=mlModelService` now resolves to `mlmodel_service_search_index` only; compound aliases (`all`, `dataAsset`, `service`) still pass through for native expansion; `index=mlmodel` still returns assets. No schema, UI, or entity-type change.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (3 files, resolver + tests).

#
### Tests:

#### Use cases covered
- `GET /v1/search/query?index=mlModelService` returns only mlModel services, never mlModel assets.
- `GET /v1/search/query?index=mlmodel` still returns mlModel assets.

#### Unit tests
- [x] Added `SearchRepositoryBehaviorTest#getIndexOrAliasNameResolvesEntityAliasWhenKeyCasingDiffers` (fails before the fix, passes after). Added a key≠alias mapping to the suite and updated the search-entities key-set assertion. Full suite: 124/124 pass.
- Files: `openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java`

#### Backend integration tests
- [x] Added `MlModelServiceSearchAliasIT` — creates an mlModel service + asset, waits for indexing, asserts `index=mlModelService` does not return the asset (and `index=mlmodel` does).
- Files: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Ran the new IT against a full containerized stack (MySQL + Elasticsearch). Server access logs confirmed: `q=<asset>&index=mlModelService` did not return the asset, `q=<asset>&index=mlmodel` did, and `q=<service>&index=mlModelService` returned the service. `mvn spotless:check` clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (No UI changes.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates search alias resolution to map entity aliases with key-casing differences to their concrete index.
- Adds alias-based fallback resolution while preserving key precedence and native compound-alias expansion.
- Adds unit coverage for the `mlModelService` casing mismatch.
- Adds an integration regression test verifying service searches exclude ML model assets.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java | Adds a construction-time alias lookup map and consults it after canonical entity-key lookup misses. |
| openmetadata-service/src/test/java/org/openmetadata/service/search/SearchRepositoryBehaviorTest.java | Adds unit coverage proving the mixed-case ML model service alias resolves to its concrete service index. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/MlModelServiceSearchAliasIT.java | Adds end-to-end coverage confirming service alias searches exclude ML model assets while asset-index searches remain functional. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(search): make MlModelServiceSearchA..."](https://github.com/open-metadata/openmetadata/commit/ced529030dc59c42d07b8a9051d113415fbc292a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47905042)</sub>

<!-- /greptile_comment -->