### PR TITLE
ci(external-it): retry dependency build on transient mirror failures

### DIFF
--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -183,9 +183,12 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
-            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
-            sleep 30
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
           done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
           exit 1
 
       - name: Install Playwright browsers
@@ -368,9 +371,12 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
-            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
-            sleep 30
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
           done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
           exit 1
 
       - name: Acquire admin JWT from external cluster
@@ -512,9 +518,12 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
-            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
-            sleep 30
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
           done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
           exit 1
 
       - name: Acquire admin JWT from external cluster

--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -180,7 +180,13 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+            sleep 30
+          done
+          exit 1
 
       - name: Install Playwright browsers
         run: |
@@ -359,7 +365,13 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+            sleep 30
+          done
+          exit 1
 
       - name: Acquire admin JWT from external cluster
         env:
@@ -497,7 +509,13 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+            sleep 30
+          done
+          exit 1
 
       - name: Acquire admin JWT from external cluster
         env:


### PR DESCRIPTION
## What
Wraps the `Build dependencies for integration-tests` step (`mvn -DskipTests install -pl :openmetadata-integration-tests -am`) in all three external-IT jobs (ui / search / scale) in a 3× retry loop.

## Why
A single transient dependency-fetch failure in that step kills the whole job **before any test runs** — the artifact resolution has no retry today, unlike the login step which already uses `curl --retry 5`. On the collate-ci nightly the failing mirror is pulp (HTTP 500/404 on random jars: `jersey-media-json-jackson`, `perfmark-api`, `swagger-maven-plugin`, …); on GitHub-hosted runners this guards the same class of transient Maven Central hiccup. Different artifact every run ⇒ transient, not a real dependency problem.

## Note
This workflow (`java-playwright-external.yml`) runs on `ubuntu-latest` / Maven Central, so the retry here is generic transient-fetch resilience. The pulp-specific failures live on the nightly `openmetadata-nightly:k8s-java-it-search-release-dev.yml` (collate-ci runners) — the same wrap is applied there in a separate PR. Bounded mitigation only: rides out *transient* errors, not a sustained mirror outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The workflow now retries the integration-test dependency build up to three times in each external UI, search, and scale job, waiting 30 seconds only between failed attempts and reporting a terminal error after the final failure.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-playwright-external.yml | Adds correctly bounded Maven build retries to all three external integration-test jobs; the final attempt no longer announces or waits for another retry. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci(external-it): don&#39;t warn/sleep after ..."](https://github.com/open-metadata/openmetadata/commit/fefce7cced7ea560d780933284e3f1f3833988ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47955523)</sub>

<!-- /greptile_comment -->