### PR TITLE
ci(external-it): retry dependency build on transient mirror failures

### DIFF
--- a/.github/workflows/java-playwright-external.yml
+++ b/.github/workflows/java-playwright-external.yml
@@ -180,7 +180,16 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
+          done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
+          exit 1
 
       - name: Install Playwright browsers
         run: |
@@ -359,7 +368,16 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
+          done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
+          exit 1
 
       - name: Acquire admin JWT from external cluster
         env:
@@ -497,7 +515,16 @@ jobs:
       - name: Build dependencies for integration-tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -DskipTests install -pl :openmetadata-integration-tests -am
+        run: |
+          for attempt in 1 2 3; do
+            mvn -DskipTests install -pl :openmetadata-integration-tests -am && exit 0
+            if [ "${attempt}" -lt 3 ]; then
+              echo "::warning::Build attempt ${attempt} failed (transient dependency-mirror error); retrying in 30s"
+              sleep 30
+            fi
+          done
+          echo "::error::Build failed after 3 attempts (dependency resolution)"
+          exit 1
 
       - name: Acquire admin JWT from external cluster
         env:


### PR DESCRIPTION
## What
2.0 parity for [#30590](https://github.com/open-metadata/OpenMetadata/pull/30590). Wraps the `Build dependencies for integration-tests` step (`mvn -DskipTests install -pl :openmetadata-integration-tests -am`) in all three external-IT jobs (ui / search / scale) in a 3× retry loop.

## Why
A single transient dependency-fetch failure kills the job **before any test runs** — the resolution had no retry, unlike the login step (`curl --retry 5`). Different artifact every failing run ⇒ transient, not a real dependency problem. Warn+sleep only when a retry follows; terminal `::error::` on final failure (review feedback from #30590 already incorporated here).

## Notes
- The reindex test-hardening that went to 1.13 in [#30589](https://github.com/open-metadata/OpenMetadata/pull/30589) is **already present on 2.0** (identical to main), so no test backport is needed here.
- The collate-ci nightly (pulp mirror) build retry lives in `openmetadata-nightly#263` and is ref-agnostic, so it already covers 2.0 runs. This PR only adds the generic Maven-Central retry to 2.0's in-repo `ubuntu-latest` workflow.
- Bounded mitigation: rides out *transient* errors, not a sustained mirror outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds bounded Maven build retries to all three external integration-test jobs.
- Retries dependency builds up to three times.
- Waits 30 seconds between attempts.
- Preserves a failing step after the final unsuccessful attempt.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking diagnostics issue where arbitrary Maven failures are labeled as dependency-mirror failures.

The bounded loops preserve terminal failure and successful retries, but their annotations assert a failure category that the exit-code-only logic does not establish.

**Files Needing Attention:** .github/workflows/java-playwright-external.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/java-playwright-external.yml | Adds equivalent retry loops to the UI, search, and scale external-IT dependency builds; the loops work but overstate the cause of arbitrary Maven failures. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(external-it): retry dependency build ..."](https://github.com/open-metadata/openmetadata/commit/1e1b7cedda3ff719f91c629025878328483577d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48049382)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->