### PR TITLE
Fixes #27792: sync dbt test case descriptions on re-ingestion

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -700,6 +700,24 @@ def get_dbt_test_definition_name(manifest_node) -> str:
     return test_type or manifest_node.name
 
 
+def get_dbt_test_description(manifest_node) -> Optional[str]:  # noqa: UP045
+    """
+    Return the description of a dbt test node.
+
+    Falls back to the "description" key of the node level ``meta`` dict when the
+    node has no description of its own.  dbt only supports a first class
+    ``description`` on data tests from 1.9 onwards, so older projects carry it in
+    ``config(meta={"description": ...})`` instead, which dbt copies onto
+    ``manifest_node.meta`` while parsing.
+    """
+    description = getattr(manifest_node, "description", None)
+    if not description:
+        meta = getattr(manifest_node, "meta", None)
+        if isinstance(meta, dict):
+            description = meta.get("description")
+    return description
+
+
 def generate_entity_link(dbt_test):
     """
     Method returns entity link for dbt test cases.

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -84,6 +84,7 @@ from metadata.ingestion.models.patch_request import PatchedEntity, PatchRequest
 from metadata.ingestion.models.table_metadata import ColumnDescription
 from metadata.ingestion.ometa.client import APIError
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.database.column_type_parser import ColumnTypeParser
 from metadata.ingestion.source.database.database_service import DataModelLink
 from metadata.ingestion.source.database.dbt.constants import (
@@ -1928,12 +1929,12 @@ class DbtSource(DbtServiceSource):
         overridden when dbtUpdateDescriptions is enabled.
         """
         if description:
-            logger.debug(f"Patching DBT description for test case: {test_case.fullyQualifiedName.root}")
+            logger.debug(f"Patching DBT description for test case: {model_str(test_case.fullyQualifiedName)}")
             self.metadata.patch_description(
                 entity=TestCase,
                 source=test_case,
                 description=description,
-                force=self.source_config.dbtUpdateDescriptions,
+                force=bool(self.source_config.dbtUpdateDescriptions),
             )
 
     def add_dbt_test_result(self, dbt_test: dict):

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -119,6 +119,7 @@ from metadata.ingestion.source.database.dbt.dbt_utils import (
     get_dbt_model_name,
     get_dbt_raw_query,
     get_dbt_test_definition_name,
+    get_dbt_test_description,
     get_manifest_column_name,
     get_snapshot_effective_schema_and_database,
     map_dbt_metric_type,
@@ -1840,6 +1841,9 @@ class DbtSource(DbtServiceSource):
                     fqn=test_definition_name,
                     entity=TestDefinition,
                 )
+                # A TestDefinition is shared by every dbt test of the same type
+                # (e.g. all "not_null" tests), so its description is only set on
+                # creation and never patched from an individual node.
                 if not check_test_definition_exists:
                     entity_type = EntityType.TABLE
                     if get_manifest_column_name(manifest_node):
@@ -1847,7 +1851,7 @@ class DbtSource(DbtServiceSource):
                     yield Either(
                         right=CreateTestDefinitionRequest(
                             name=test_definition_name,
-                            description=manifest_node.description,
+                            description=get_dbt_test_description(manifest_node),
                             entityType=entity_type,
                             testPlatforms=[TestPlatform.dbt],
                             parameterDefinition=create_test_case_parameter_definitions(manifest_node),
@@ -1889,12 +1893,13 @@ class DbtSource(DbtServiceSource):
                     )
 
                     test_case = self.metadata.get_by_name(TestCase, test_case_fqn, fields=["testDefinition,testSuite"])
+                    description = get_dbt_test_description(manifest_node)
                     if test_case is None:
                         # Create the test case only if it does not exist
                         yield Either(
                             right=CreateTestCaseRequest(
                                 name=manifest_node.name,
-                                description=manifest_node.description,
+                                description=description,
                                 testDefinition=FullyQualifiedEntityName(get_dbt_test_definition_name(manifest_node)),
                                 entityLink=entity_link_str,
                                 parameterValues=create_test_case_parameter_values(dbt_test),
@@ -1902,7 +1907,9 @@ class DbtSource(DbtServiceSource):
                                 owners=None,
                             )
                         )
-                    logger.debug(f"Test case Already Exists: {test_case_fqn}")
+                    else:
+                        logger.debug(f"Test case Already Exists: {test_case_fqn}")
+                        self.patch_dbt_test_case_description(test_case, description)
         except Exception as err:  # pylint: disable=broad-except
             yield Either(
                 left=StackTraceError(
@@ -1910,6 +1917,23 @@ class DbtSource(DbtServiceSource):
                     error=f"Failed to parse the node to capture tests {err}",
                     stackTrace=traceback.format_exc(),
                 )
+            )
+
+    def patch_dbt_test_case_description(self, test_case: TestCase, description: Optional[str]) -> None:  # noqa: UP045
+        """
+        Keep the description of an already ingested test case in sync with dbt.
+
+        Mirrors how table and column descriptions are handled: an empty
+        description is always filled in, while an existing one is only
+        overridden when dbtUpdateDescriptions is enabled.
+        """
+        if description:
+            logger.debug(f"Patching DBT description for test case: {test_case.fullyQualifiedName.root}")
+            self.metadata.patch_description(
+                entity=TestCase,
+                source=test_case,
+                description=description,
+                force=self.source_config.dbtUpdateDescriptions,
             )
 
     def add_dbt_test_result(self, dbt_test: dict):

--- a/ingestion/tests/unit/test_dbt_test_descriptions.py
+++ b/ingestion/tests/unit/test_dbt_test_descriptions.py
@@ -1,0 +1,175 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Tests that dbt test descriptions are resolved from the node meta when the node
+has no description of its own, and that the description of an already ingested
+test case is kept in sync on re-ingestion.
+
+Regression tests for https://github.com/open-metadata/OpenMetadata/issues/27792
+"""
+
+from unittest.mock import MagicMock, patch
+
+from metadata.generated.schema.tests.testCase import TestCase
+from metadata.ingestion.source.database.dbt.constants import DbtCommonEnum
+from metadata.ingestion.source.database.dbt.dbt_utils import get_dbt_test_description
+from metadata.ingestion.source.database.dbt.metadata import DbtSource
+
+UPSTREAM_TABLE_FQN = "local_bigquery.ecommerce.dbt_jaffle.dim_customers"
+DBT_TEST_CASE_NAME = "unique_dim_customers_customer_id"
+DBT_TEST_TYPE = "unique"
+TEST_CASE_FQN = f"{UPSTREAM_TABLE_FQN}.customer_id.{DBT_TEST_CASE_NAME}"
+NODE_DESCRIPTION = "Customer ids are unique"
+META_DESCRIPTION = "Customer ids are unique, from the config block"
+
+
+def _make_generic_test_node(description=None, meta=None):
+    node = MagicMock()
+    node.name = DBT_TEST_CASE_NAME
+    node.description = description
+    node.meta = meta
+    node.column_name = "customer_id"
+    node.test_metadata.name = DBT_TEST_TYPE
+    node.test_metadata.kwargs = {
+        "column_name": "customer_id",
+        "model": "{{ get_where_subquery(ref('dim_customers')) }}",
+    }
+    return node
+
+
+def _make_dbt_test(manifest_node):
+    return {
+        DbtCommonEnum.MANIFEST_NODE.value: manifest_node,
+        DbtCommonEnum.UPSTREAM.value: [UPSTREAM_TABLE_FQN],
+    }
+
+
+def _make_dbt_source(existing_entity=None, update_descriptions=False):
+    source = MagicMock(spec=DbtSource)
+    for method_name in ("create_dbt_test_case", "create_dbt_tests_definition", "patch_dbt_test_case_description"):
+        setattr(source, method_name, getattr(DbtSource, method_name).__get__(source, DbtSource))
+    source.metadata = MagicMock()
+    source.metadata.get_by_name.return_value = existing_entity
+    source.source_config = MagicMock(dbtUpdateDescriptions=update_descriptions)
+    return source
+
+
+def _make_existing_test_case():
+    test_case = MagicMock()
+    test_case.fullyQualifiedName.root = TEST_CASE_FQN
+    return test_case
+
+
+def _run_create_test_case(source, manifest_node):
+    with patch("metadata.ingestion.source.database.dbt.metadata.fqn") as mock_fqn:
+        mock_fqn.split.return_value = UPSTREAM_TABLE_FQN.split(".")
+        mock_fqn.build.return_value = TEST_CASE_FQN
+
+        return list(source.create_dbt_test_case(_make_dbt_test(manifest_node)))
+
+
+class TestGetDbtTestDescription:
+    def test_node_description_is_used_when_present(self):
+        node = _make_generic_test_node(description=NODE_DESCRIPTION, meta={"description": META_DESCRIPTION})
+
+        assert get_dbt_test_description(node) == NODE_DESCRIPTION
+
+    def test_meta_description_is_used_when_node_description_is_empty(self):
+        node = _make_generic_test_node(description="", meta={"description": META_DESCRIPTION})
+
+        assert get_dbt_test_description(node) == META_DESCRIPTION
+
+    def test_meta_description_is_used_when_node_description_is_none(self):
+        node = _make_generic_test_node(meta={"description": META_DESCRIPTION})
+
+        assert get_dbt_test_description(node) == META_DESCRIPTION
+
+    def test_none_when_neither_description_nor_meta_is_set(self):
+        assert get_dbt_test_description(_make_generic_test_node(meta={})) is None
+
+    def test_none_when_meta_has_no_description_key(self):
+        assert get_dbt_test_description(_make_generic_test_node(meta={"owner": "data-team"})) is None
+
+    def test_non_dict_meta_is_ignored(self):
+        assert get_dbt_test_description(_make_generic_test_node(meta="not-a-dict")) is None
+
+
+class TestDbtTestCaseDescriptionOnCreate:
+    def test_test_case_is_created_with_meta_description(self):
+        source = _make_dbt_source()
+
+        results = _run_create_test_case(source, _make_generic_test_node(meta={"description": META_DESCRIPTION}))
+
+        assert len(results) == 1
+        assert results[0].left is None, results[0].left
+        assert results[0].right.description.root == META_DESCRIPTION
+        source.metadata.patch_description.assert_not_called()
+
+    def test_test_definition_is_created_with_meta_description(self):
+        source = _make_dbt_source()
+
+        results = list(
+            source.create_dbt_tests_definition(
+                _make_dbt_test(_make_generic_test_node(meta={"description": META_DESCRIPTION}))
+            )
+        )
+
+        assert len(results) == 1
+        assert results[0].left is None, results[0].left
+        assert results[0].right.description.root == META_DESCRIPTION
+
+
+class TestDbtTestCaseDescriptionOnReIngestion:
+    def test_existing_test_case_description_is_patched(self):
+        existing_test_case = _make_existing_test_case()
+        source = _make_dbt_source(existing_entity=existing_test_case, update_descriptions=True)
+
+        results = _run_create_test_case(source, _make_generic_test_node(description=NODE_DESCRIPTION))
+
+        assert results == []
+        source.metadata.patch_description.assert_called_once_with(
+            entity=TestCase,
+            source=existing_test_case,
+            description=NODE_DESCRIPTION,
+            force=True,
+        )
+
+    def test_existing_test_case_description_is_patched_from_meta(self):
+        existing_test_case = _make_existing_test_case()
+        source = _make_dbt_source(existing_entity=existing_test_case, update_descriptions=True)
+
+        _run_create_test_case(source, _make_generic_test_node(meta={"description": META_DESCRIPTION}))
+
+        assert source.metadata.patch_description.call_args.kwargs["description"] == META_DESCRIPTION
+
+    def test_existing_description_is_not_forced_when_update_descriptions_is_disabled(self):
+        source = _make_dbt_source(existing_entity=_make_existing_test_case(), update_descriptions=False)
+
+        _run_create_test_case(source, _make_generic_test_node(description=NODE_DESCRIPTION))
+
+        assert source.metadata.patch_description.call_args.kwargs["force"] is False
+
+    def test_nothing_is_patched_when_dbt_has_no_description(self):
+        source = _make_dbt_source(existing_entity=_make_existing_test_case(), update_descriptions=True)
+
+        _run_create_test_case(source, _make_generic_test_node(meta={}))
+
+        source.metadata.patch_description.assert_not_called()
+
+    def test_existing_test_definition_description_is_never_patched(self):
+        source = _make_dbt_source(existing_entity=MagicMock(), update_descriptions=True)
+
+        results = list(
+            source.create_dbt_tests_definition(_make_dbt_test(_make_generic_test_node(description=NODE_DESCRIPTION)))
+        )
+
+        assert results == []
+        source.metadata.patch_description.assert_not_called()


### PR DESCRIPTION
## Fixes #27792

dbt test case descriptions were only ever written at creation time, so a description corrected in dbt never reached OpenMetadata on the next run — even with `dbtUpdateDescriptions` enabled. Table and column descriptions have honoured that flag since forever; test cases silently did not.

### Changes

**`metadata.py`**
- `create_dbt_test_case` now patches the description of an already ingested test case instead of skipping it. Extracted into `patch_dbt_test_case_description`, which mirrors `process_dbt_descriptions`: an empty description is always filled in, an existing one is only overridden when `dbtUpdateDescriptions` is set (`force=`).
- The stray `logger.debug("Test case Already Exists")` moved into the `else` branch — it previously logged on creation too.

**`dbt_utils.py`**
- New `get_dbt_test_description` helper: node description, falling back to `meta["description"]`.

**`test_dbt_test_descriptions.py`** — 13 tests covering description resolution (node wins over meta, meta fallback, empty/absent/non-dict meta), creation from meta, and the re-ingestion patch paths (force on/off, no-description no-op, TestDefinition never patched).

### Notes for reviewers

**`TestDefinition` is deliberately not patched.** Since #28927, `get_dbt_test_definition_name` returns the dbt test *type*, so one `not_null` TestDefinition is shared by every `not_null` test in the project. Patching its description per node would be last-writer-wins churn on every ingestion run. Only `TestCase` — which is per test — is patched. This is the one place this PR departs from the fix suggested in the issue, which predates #28927.

**The `meta` fallback reads `node.meta`, not `node.config.meta`.** The issue reports the description landing at `node.config.meta.description`. dbt copies config meta up to the node level while parsing (`dbt/parser/base.py`, *"If we have meta in the config, copy to node level, for backwards compatibility with earlier node-only config"*), so `config(meta={...})` populates both, and `node.meta` is what the rest of this connector already reads. Worth noting this fallback is a convenience for dbt < 1.9 — dbt has supported a first class `description` on data tests since 1.9, and that path already worked.

Supersedes #27793, which was closed by the stale bot without review and predates #28927.

### Type

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title follows the pattern `Fixes <issue-number>: <short explanation>`.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that cover exactly the scenarios fixed.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR synchronizes dbt test descriptions during creation and re-ingestion.
- Resolves test descriptions from the node-level description with a `meta.description` fallback.
- Patches existing TestCase descriptions according to `dbtUpdateDescriptions` while leaving shared TestDefinition descriptions unchanged.
- Adds unit coverage for description resolution, creation, re-ingestion, force behavior, and missing descriptions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py | Adds centralized resolution of dbt test descriptions from the node description or node-level metadata. |
| ingestion/src/metadata/ingestion/source/database/dbt/metadata.py | Applies resolved descriptions when creating test entities and patches existing TestCase descriptions during re-ingestion. |
| ingestion/tests/unit/test_dbt_test_descriptions.py | Adds regression coverage for description resolution and TestCase creation and update behavior. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant dbt as dbt Manifest
  participant Source as DbtSource
  participant OM as OpenMetadata
  dbt->>Source: Test node
  Source->>Source: Resolve node or meta description
  Source->>OM: Look up TestCase
  alt TestCase does not exist
    Source-->>OM: Yield CreateTestCaseRequest
  else TestCase exists
    Source->>OM: Patch description according to dbtUpdateDescriptions
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ingestion): satisfy basedpyright in ..."](https://github.com/open-metadata/openmetadata/commit/1e18259654d77bdaaabd35f669dc8ac32b94ef2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48061150)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->