### PR TITLE
Fixes #28911: attach dbt relationships tests to the model holding the foreign key

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/constants.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/constants.py
@@ -159,6 +159,7 @@ class DbtCommonEnum(Enum):
     RESOURCETYPE = "resource_type"
     MANIFEST_NODE = "manifest_node"
     UPSTREAM = "upstream"
+    UPSTREAM_BY_NAME = "upstream_by_name"
     RESULTS = "results"
     TEST_SUITE_NAME = "test_suite_name"
     DBT_TEST_SUITE = "DBT_TEST_SUITE"

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -31,7 +31,7 @@ from metadata.ingestion.source.database.dbt.constants import (
     DbtCommonEnum,
     RawQueriesEnum,
 )
-from metadata.ingestion.source.database.dbt.models import SnapshotNodeLocation
+from metadata.ingestion.source.database.dbt.models import SnapshotNodeLocation, UpstreamNode
 from metadata.utils import entity_link
 from metadata.utils.logger import ingestion_logger
 
@@ -718,10 +718,15 @@ def get_dbt_test_description(manifest_node) -> Optional[str]:  # noqa: UP045
     return description
 
 
-# Matches a dbt ``ref()``/``source()`` expression, capturing the last quoted argument,
-# which is the model or table name. Handles ref('t'), ref("pkg", "t"), source('s', 't')
-# and the get_where_subquery(...) wrapper dbt adds to test_metadata.kwargs['model'].
-_DBT_REF_PATTERN = re.compile(r"\b(?:ref|source)\(\s*['\"](?:[^'\"]+['\"]\s*,\s*['\"])*([^'\"]+)['\"]\s*\)")
+# Matches a dbt ``ref()``/``source()`` expression, capturing the optional namespace
+# (package for ref, source name for source) and the model/table name. Handles ref('t'),
+# ref("pkg", "t"), source('s', 't') and the get_where_subquery(...) wrapper dbt adds to
+# test_metadata.kwargs['model'].
+_DBT_REF_PATTERN = re.compile(r"\b(?:ref|source)\(\s*['\"]([^'\"]+)['\"]\s*(?:,\s*['\"]([^'\"]+)['\"]\s*)?\)")
+
+# Marks a bare dbt name claimed by more than one upstream table. Looking such a name up
+# must fall through to the other resolution strategies rather than pick an arbitrary one.
+_AMBIGUOUS_NAME = None
 
 
 def _get_test_kwargs(manifest_node) -> Dict[str, Any]:  # noqa: UP006
@@ -730,17 +735,58 @@ def _get_test_kwargs(manifest_node) -> Dict[str, Any]:  # noqa: UP006
     return kwargs if isinstance(kwargs, dict) else {}
 
 
-def _extract_dbt_model_name(reference: Any) -> Optional[str]:  # noqa: UP045
-    """Return the model/source name referenced by a dbt ``ref()``/``source()`` expression."""
+def _extract_dbt_reference(reference: Any) -> Optional[Tuple[Optional[str], str]]:  # noqa: UP045, UP006
+    """Return ``(namespace, name)`` for a dbt ``ref()``/``source()`` expression.
+
+    ``ref('model')`` yields ``(None, 'model')`` while the two-argument ``ref('pkg', 'model')``
+    and ``source('source_name', 'table')`` forms yield their namespace, which disambiguates
+    names reused across packages or between a model and a source table.
+    """
     match = _DBT_REF_PATTERN.search(str(reference)) if reference else None
-    return match.group(1) if match else None
+    resolved = None
+    if match:
+        first, second = match.group(1), match.group(2)
+        resolved = (first, second) if second else (None, first)
+    return resolved
+
+
+def build_upstream_node(parent_node, parent_fqn: str) -> UpstreamNode:
+    """Pair a dbt manifest node with its table FQN, recording the namespace that a
+    ``ref('pkg', 'model')`` or ``source('source_name', 'table')`` reference would use."""
+    namespace = getattr(parent_node, "source_name", None) or getattr(parent_node, "package_name", None)
+    return UpstreamNode(
+        name=parent_node.name,
+        qualified_name=f"{namespace}.{parent_node.name}" if namespace else None,
+        fqn=parent_fqn,
+    )
+
+
+def build_upstream_name_map(upstream_nodes) -> Dict[str, str]:  # noqa: UP006
+    """Index upstream nodes by dbt name so a ``ref()``/``source()`` can be resolved exactly.
+
+    Both the qualified (``namespace.name``) and bare names are indexed. A bare name claimed
+    by two different tables is marked ambiguous instead of silently keeping the last one.
+    """
+    name_map = {}
+    for node in upstream_nodes:
+        if node.qualified_name:
+            name_map[node.qualified_name] = node.fqn
+        if node.name in name_map and name_map[node.name] != node.fqn:
+            name_map[node.name] = _AMBIGUOUS_NAME
+        else:
+            name_map.setdefault(node.name, node.fqn)
+    return name_map
 
 
 def _match_fqn_by_table_name(upstream_list, table_name: str) -> Optional[str]:  # noqa: UP045
     """Match on the FQN's table segment, case-insensitively so that warehouses which
-    upper-case identifiers (Snowflake) still line up with lower-case dbt model names."""
+    upper-case identifiers (Snowflake) still line up with lower-case dbt model names.
+
+    Returns nothing when several upstreams match, since the choice would be arbitrary.
+    """
     suffix = f".{table_name}".lower()
-    return next((fqn for fqn in upstream_list if fqn.lower().endswith(suffix)), None)
+    matches = [fqn for fqn in upstream_list if fqn.lower().endswith(suffix)]
+    return matches[0] if len(matches) == 1 else None
 
 
 def _resolve_upstream_fqn(upstream_list, upstream_by_name, reference) -> Optional[str]:  # noqa: UP045
@@ -750,10 +796,13 @@ def _resolve_upstream_fqn(upstream_list, upstream_by_name, reference) -> Optiona
     upstream FQN is built from the model *alias*; the two diverge whenever a project
     sets ``alias:``, and a suffix match alone then silently fails.
     """
-    model_name = _extract_dbt_model_name(reference)
+    dbt_reference = _extract_dbt_reference(reference)
     resolved = None
-    if model_name:
-        resolved = upstream_by_name.get(model_name) or _match_fqn_by_table_name(upstream_list, model_name)
+    if dbt_reference:
+        namespace, name = dbt_reference
+        if namespace:
+            resolved = upstream_by_name.get(f"{namespace}.{name}")
+        resolved = resolved or upstream_by_name.get(name) or _match_fqn_by_table_name(upstream_list, name)
     return resolved
 
 

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -718,55 +718,90 @@ def get_dbt_test_description(manifest_node) -> Optional[str]:  # noqa: UP045
     return description
 
 
-def generate_entity_link(dbt_test):
-    """
-    Method returns entity link for dbt test cases.
+# Matches a dbt ``ref()``/``source()`` expression, capturing the last quoted argument,
+# which is the model or table name. Handles ref('t'), ref("pkg", "t"), source('s', 't')
+# and the get_where_subquery(...) wrapper dbt adds to test_metadata.kwargs['model'].
+_DBT_REF_PATTERN = re.compile(r"\b(?:ref|source)\(\s*['\"](?:[^'\"]+['\"]\s*,\s*['\"])*([^'\"]+)['\"]\s*\)")
 
-    For test cases with multiple upstream dependencies (e.g., relationship tests),
-    we must identify the primary table being tested. This is explicitly specified in
-    test_metadata.kwargs['model'] for generic tests. Using this explicit reference
-    is more reliable than guessing based on upstream order (fixes issue #24636).
+
+def _get_test_kwargs(manifest_node) -> Dict[str, Any]:  # noqa: UP006
+    test_metadata = getattr(manifest_node, "test_metadata", None)
+    kwargs = getattr(test_metadata, "kwargs", None) if test_metadata else None
+    return kwargs if isinstance(kwargs, dict) else {}
+
+
+def _extract_dbt_model_name(reference: Any) -> Optional[str]:  # noqa: UP045
+    """Return the model/source name referenced by a dbt ``ref()``/``source()`` expression."""
+    match = _DBT_REF_PATTERN.search(str(reference)) if reference else None
+    return match.group(1) if match else None
+
+
+def _match_fqn_by_table_name(upstream_list, table_name: str) -> Optional[str]:  # noqa: UP045
+    """Match on the FQN's table segment, case-insensitively so that warehouses which
+    upper-case identifiers (Snowflake) still line up with lower-case dbt model names."""
+    suffix = f".{table_name}".lower()
+    return next((fqn for fqn in upstream_list if fqn.lower().endswith(suffix)), None)
+
+
+def _resolve_upstream_fqn(upstream_list, upstream_by_name, reference) -> Optional[str]:  # noqa: UP045
+    """Resolve a dbt ref()/source() expression to one of the test's upstream FQNs.
+
+    Prefers the dbt node name map because ``ref()`` carries the model *name* while the
+    upstream FQN is built from the model *alias*; the two diverge whenever a project
+    sets ``alias:``, and a suffix match alone then silently fails.
+    """
+    model_name = _extract_dbt_model_name(reference)
+    resolved = None
+    if model_name:
+        resolved = upstream_by_name.get(model_name) or _match_fqn_by_table_name(upstream_list, model_name)
+    return resolved
+
+
+def _resolve_by_excluding_referenced_table(upstream_list, upstream_by_name, kwargs) -> Optional[str]:  # noqa: UP045
+    """Last resort for ``relationships`` tests: the ``to:`` upstream is the referenced
+    parent, so if removing it leaves exactly one candidate that must be the tested table."""
+    referenced_fqn = _resolve_upstream_fqn(upstream_list, upstream_by_name, kwargs.get("to"))
+    candidates = [fqn for fqn in upstream_list if fqn != referenced_fqn] if referenced_fqn else []
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def get_dbt_test_primary_table_fqn(dbt_test) -> Optional[str]:  # noqa: UP045
+    """
+    Return the FQN of the table a dbt test belongs to.
+
+    A test can have several upstreams (a ``relationships`` test depends on both the
+    tested model and the model it references). dbt records the tested model in
+    ``test_metadata.kwargs['model']`` and the referenced parent in ``kwargs['to']``,
+    and orders ``depends_on.nodes`` parent-first. Falling back to the first upstream
+    therefore attaches the test - and its foreign key column - to the referenced table,
+    which rejects it with "Invalid column name" (issue #28911).
     """
     manifest_node = dbt_test.get(DbtCommonEnum.MANIFEST_NODE.value)
-    upstream_list = dbt_test.get(DbtCommonEnum.UPSTREAM.value, [])
+    upstream_list = dbt_test.get(DbtCommonEnum.UPSTREAM.value) or []
+    upstream_by_name = dbt_test.get(DbtCommonEnum.UPSTREAM_BY_NAME.value) or {}
+    kwargs = _get_test_kwargs(manifest_node)
 
-    if not upstream_list:
-        return []
-
-    primary_table_fqn = None
-
-    # Try to extract the primary table from test_metadata.kwargs['model']
-    # This field contains the main table being tested (order-independent)
-    if hasattr(manifest_node, "test_metadata"):
-        kwargs = getattr(manifest_node.test_metadata, "kwargs", {})
-        if isinstance(kwargs, dict):
-            model_str = kwargs.get("model", "")
-            if model_str:
-                # Extract table name from ref() pattern
-                # Handles: ref('table'), ref("table"), ref('pkg', 'table'), ref("pkg", "table")
-                match = re.search(
-                    r"ref\(['\"](?:[^'\"]+['\"],\s*['\"])?([^'\"]+)['\"]\)",
-                    str(model_str),
-                )
-                if match:
-                    primary_table_name = match.group(1)
-                    # Find the matching FQN in upstream_list
-                    for fqn in upstream_list:
-                        if fqn.endswith(f".{primary_table_name}"):
-                            primary_table_fqn = fqn
-                            break
-
-    # Fallback: use the first upstream table if model field is not available
+    primary_table_fqn = _resolve_upstream_fqn(upstream_list, upstream_by_name, kwargs.get("model"))
+    if not primary_table_fqn:
+        primary_table_fqn = _resolve_by_excluding_referenced_table(upstream_list, upstream_by_name, kwargs)
     if not primary_table_fqn and upstream_list:
         primary_table_fqn = upstream_list[0]
 
+    return primary_table_fqn
+
+
+def generate_entity_link(dbt_test):
+    """
+    Method returns entity link for dbt test cases.
+    """
+    primary_table_fqn = get_dbt_test_primary_table_fqn(dbt_test)
     if not primary_table_fqn:
         return []
 
     entity_link_str = entity_link.get_entity_link(
         Table,
         fqn=primary_table_fqn,
-        column_name=get_manifest_column_name(manifest_node),
+        column_name=get_manifest_column_name(dbt_test.get(DbtCommonEnum.MANIFEST_NODE.value)),
     )
     return [entity_link_str]
 

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -121,6 +121,7 @@ from metadata.ingestion.source.database.dbt.dbt_utils import (
     get_dbt_raw_query,
     get_dbt_test_definition_name,
     get_dbt_test_description,
+    get_dbt_test_primary_table_fqn,
     get_manifest_column_name,
     get_snapshot_effective_schema_and_database,
     map_dbt_metric_type,
@@ -653,10 +654,10 @@ class DbtSource(DbtServiceSource):
         """
         Method to append dbt test cases for later processing
         """
+        upstream_nodes = self.parse_upstream_nodes_with_names(manifest_entities, manifest_node)
         self.context.get().dbt_tests[key] = {DbtCommonEnum.MANIFEST_NODE.value: manifest_node}
-        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM.value] = self.parse_upstream_nodes(
-            manifest_entities, manifest_node
-        )
+        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM.value] = [fqn for _, fqn in upstream_nodes]
+        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM_BY_NAME.value] = dict(upstream_nodes)
         self.context.get().dbt_tests[key][DbtCommonEnum.RESULTS.value] = self._get_latest_result(dbt_objects, key)
 
     def add_dbt_exposure(self, key: str, manifest_node, manifest_entities):
@@ -687,9 +688,13 @@ class DbtSource(DbtServiceSource):
         )
 
         if freshness_test_result:
+            upstream_nodes = self.parse_upstream_nodes_with_names(manifest_entities, manifest_node)
             self.context.get().dbt_tests[key + "_freshness"] = {DbtCommonEnum.MANIFEST_NODE.value: manifest_node_new}
-            self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM.value] = self.parse_upstream_nodes(
-                manifest_entities, manifest_node
+            self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM.value] = [
+                fqn for _, fqn in upstream_nodes
+            ]
+            self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM_BY_NAME.value] = dict(
+                upstream_nodes
             )
             self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.RESULTS.value] = freshness_test_result
 
@@ -935,6 +940,15 @@ class DbtSource(DbtServiceSource):
         """
         Method to fetch the upstream nodes
         """
+        return [fqn for _, fqn in self.parse_upstream_nodes_with_names(manifest_entities, dbt_node)]
+
+    def parse_upstream_nodes_with_names(self, manifest_entities, dbt_node):
+        """
+        Method to fetch the upstream nodes as (dbt node name, table FQN) pairs.
+
+        The dbt node name is kept alongside the FQN because the FQN is built from the
+        model alias, while dbt ``ref()`` expressions carry the model name.
+        """
         upstream_nodes = []
         if (
             hasattr(dbt_node, "depends_on")
@@ -971,7 +985,7 @@ class DbtSource(DbtServiceSource):
                     # check if the node is an ephemeral node
                     # Recursively store the upstream of the ephemeral node in the upstream list
                     if check_ephemeral_node(parent_node):
-                        upstream_nodes.extend(self.parse_upstream_nodes(manifest_entities, parent_node))
+                        upstream_nodes.extend(self.parse_upstream_nodes_with_names(manifest_entities, parent_node))
                     else:
                         parent_fqn = fqn.build(
                             self.metadata,
@@ -984,7 +998,7 @@ class DbtSource(DbtServiceSource):
 
                         # check if the parent table exists in OM before adding it to the upstream list
                         if self._get_table_entity(table_fqn=parent_fqn):
-                            upstream_nodes.append(parent_fqn)
+                            upstream_nodes.append((parent_node.name, parent_fqn))
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.debug(traceback.format_exc())
                     logger.warning(f"Failed to parse the DBT node {node} to get upstream nodes: {exc}")
@@ -2000,8 +2014,10 @@ class DbtSource(DbtServiceSource):
                     result=(dbt_test_result.message if test_case_status != TestCaseStatus.Success else None),
                 )
 
-                # Create the test case fqns and add the results
-                for table_fqn in dbt_test.get(DbtCommonEnum.UPSTREAM.value):
+                # Results belong to the single table the test case was created against,
+                # which for multi-upstream tests is not every entry in the upstream list
+                table_fqn = get_dbt_test_primary_table_fqn(dbt_test)
+                if table_fqn:
                     source_elements = fqn.split(table_fqn)
                     test_case_fqn = fqn.build(
                         self.metadata,

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1001,7 +1001,7 @@ class DbtSource(DbtServiceSource):
                         )
 
                         # check if the parent table exists in OM before adding it to the upstream list
-                        if self._get_table_entity(table_fqn=parent_fqn):
+                        if parent_fqn and self._get_table_entity(table_fqn=parent_fqn):
                             upstream_nodes.append(build_upstream_node(parent_node, parent_fqn))
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.debug(traceback.format_exc())

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -104,6 +104,8 @@ from metadata.ingestion.source.database.dbt.dbt_service import (
     DbtServiceSource,
 )
 from metadata.ingestion.source.database.dbt.dbt_utils import (
+    build_upstream_name_map,
+    build_upstream_node,
     check_ephemeral_node,
     create_test_case_parameter_definitions,
     create_test_case_parameter_values,
@@ -656,8 +658,10 @@ class DbtSource(DbtServiceSource):
         """
         upstream_nodes = self.parse_upstream_nodes_with_names(manifest_entities, manifest_node)
         self.context.get().dbt_tests[key] = {DbtCommonEnum.MANIFEST_NODE.value: manifest_node}
-        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM.value] = [fqn for _, fqn in upstream_nodes]
-        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM_BY_NAME.value] = dict(upstream_nodes)
+        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM.value] = [node.fqn for node in upstream_nodes]
+        self.context.get().dbt_tests[key][DbtCommonEnum.UPSTREAM_BY_NAME.value] = build_upstream_name_map(
+            upstream_nodes
+        )
         self.context.get().dbt_tests[key][DbtCommonEnum.RESULTS.value] = self._get_latest_result(dbt_objects, key)
 
     def add_dbt_exposure(self, key: str, manifest_node, manifest_entities):
@@ -691,10 +695,10 @@ class DbtSource(DbtServiceSource):
             upstream_nodes = self.parse_upstream_nodes_with_names(manifest_entities, manifest_node)
             self.context.get().dbt_tests[key + "_freshness"] = {DbtCommonEnum.MANIFEST_NODE.value: manifest_node_new}
             self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM.value] = [
-                fqn for _, fqn in upstream_nodes
+                node.fqn for node in upstream_nodes
             ]
-            self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM_BY_NAME.value] = dict(
-                upstream_nodes
+            self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.UPSTREAM_BY_NAME.value] = (
+                build_upstream_name_map(upstream_nodes)
             )
             self.context.get().dbt_tests[key + "_freshness"][DbtCommonEnum.RESULTS.value] = freshness_test_result
 
@@ -940,14 +944,14 @@ class DbtSource(DbtServiceSource):
         """
         Method to fetch the upstream nodes
         """
-        return [fqn for _, fqn in self.parse_upstream_nodes_with_names(manifest_entities, dbt_node)]
+        return [node.fqn for node in self.parse_upstream_nodes_with_names(manifest_entities, dbt_node)]
 
     def parse_upstream_nodes_with_names(self, manifest_entities, dbt_node):
         """
-        Method to fetch the upstream nodes as (dbt node name, table FQN) pairs.
+        Method to fetch the upstream nodes as UpstreamNode entries.
 
-        The dbt node name is kept alongside the FQN because the FQN is built from the
-        model alias, while dbt ``ref()`` expressions carry the model name.
+        The dbt names are kept alongside the FQN because the FQN is built from the model
+        alias, while dbt ``ref()`` expressions carry the model name.
         """
         upstream_nodes = []
         if (
@@ -998,7 +1002,7 @@ class DbtSource(DbtServiceSource):
 
                         # check if the parent table exists in OM before adding it to the upstream list
                         if self._get_table_entity(table_fqn=parent_fqn):
-                            upstream_nodes.append((parent_node.name, parent_fqn))
+                            upstream_nodes.append(build_upstream_node(parent_node, parent_fqn))
                 except Exception as exc:  # pylint: disable=broad-except
                     logger.debug(traceback.format_exc())
                     logger.warning(f"Failed to parse the DBT node {node} to get upstream nodes: {exc}")

--- a/ingestion/src/metadata/ingestion/source/database/dbt/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/models.py
@@ -54,3 +54,15 @@ class SnapshotNodeLocation(BaseModel):
 
     schema_: str
     database: Optional[str] = None  # noqa: UP045
+
+
+class UpstreamNode(BaseModel):
+    """An upstream dependency of a dbt node, keeping the dbt names alongside the table FQN.
+
+    ``ref()``/``source()`` expressions carry the dbt *name*, while the FQN is built from
+    the model *alias*, so both are needed to map a reference back to its table.
+    """
+
+    name: str
+    qualified_name: Optional[str] = None  # noqa: UP045
+    fqn: str

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -37,6 +37,8 @@ from metadata.generated.schema.type.tagLabel import (
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.dbt.dbt_utils import (
+    build_upstream_name_map,
+    build_upstream_node,
     convert_java_to_python_format,
     find_domain_by_name,
     find_entity_by_type_and_fqn,
@@ -59,7 +61,7 @@ from metadata.ingestion.source.database.dbt.dbt_utils import (
     validate_time_interval,
 )
 from metadata.ingestion.source.database.dbt.metadata import DbtSource
-from metadata.ingestion.source.database.dbt.models import DbtFiles, DbtObjects
+from metadata.ingestion.source.database.dbt.models import DbtFiles, DbtObjects, UpstreamNode
 from metadata.utils.logger import ingestion_logger, set_loggers_level
 from metadata.utils.tag_utils import get_tag_labels
 
@@ -714,6 +716,71 @@ class DbtUnitTest(TestCase):
             "results": "",
         }
         self.assertEqual("svc.db.sch.ORDERS", get_dbt_test_primary_table_fqn(dbt_test))
+
+    def test_build_upstream_name_map_marks_duplicate_names_ambiguous(self):
+        """A model and a source table can share a dbt name; the bare name must not
+        silently resolve to whichever happened to be indexed last."""
+        name_map = build_upstream_name_map(
+            [
+                UpstreamNode(name="orders", qualified_name="jaffle_shop.orders", fqn="svc.db.sch.orders"),
+                UpstreamNode(name="orders", qualified_name="raw.orders", fqn="svc.db.raw.orders"),
+            ]
+        )
+        self.assertIsNone(name_map["orders"])
+        self.assertEqual("svc.db.sch.orders", name_map["jaffle_shop.orders"])
+        self.assertEqual("svc.db.raw.orders", name_map["raw.orders"])
+
+    def test_build_upstream_name_map_keeps_unambiguous_names(self):
+        name_map = build_upstream_name_map(
+            [
+                UpstreamNode(name="orders", qualified_name="jaffle_shop.orders", fqn="svc.db.sch.orders"),
+                UpstreamNode(name="customers", qualified_name="jaffle_shop.customers", fqn="svc.db.sch.customers"),
+            ]
+        )
+        self.assertEqual("svc.db.sch.orders", name_map["orders"])
+        self.assertEqual("svc.db.sch.customers", name_map["customers"])
+
+    def test_dbt_relationships_test_resolves_via_source_namespace(self):
+        """When a model and a source table share a name, the source() namespace must
+        disambiguate rather than the lookup collapsing to one of them."""
+        manifest_node = SimpleNamespace(
+            name="relationships_orders_customer_id",
+            column_name="customer_id",
+            test_metadata=SimpleNamespace(
+                name="relationships",
+                kwargs={
+                    "to": "source('raw', 'orders')",
+                    "field": "id",
+                    "column_name": "customer_id",
+                    "model": "{{ get_where_subquery(ref('jaffle_shop', 'orders')) }}",
+                },
+            ),
+        )
+        source_node = UpstreamNode(name="orders", qualified_name="raw.orders", fqn="svc.db.raw.orders")
+        model_node = UpstreamNode(name="orders", qualified_name="jaffle_shop.orders", fqn="svc.db.sch.orders")
+
+        # Asserted for both orderings so the result cannot depend on which entry the
+        # name map happened to index last
+        for upstream_nodes in ([source_node, model_node], [model_node, source_node]):
+            dbt_test = {
+                "manifest_node": manifest_node,
+                "upstream": [node.fqn for node in upstream_nodes],
+                "upstream_by_name": build_upstream_name_map(upstream_nodes),
+                "results": "",
+            }
+            self.assertEqual("svc.db.sch.orders", get_dbt_test_primary_table_fqn(dbt_test))
+
+    def test_build_upstream_node_namespaces_source_and_model(self):
+        model_node = SimpleNamespace(name="orders", package_name="jaffle_shop")
+        self.assertEqual(
+            "jaffle_shop.orders",
+            build_upstream_node(model_node, "svc.db.sch.orders").qualified_name,
+        )
+        source_node = SimpleNamespace(name="orders", package_name="jaffle_shop", source_name="raw")
+        self.assertEqual(
+            "raw.orders",
+            build_upstream_node(source_node, "svc.db.raw.orders").qualified_name,
+        )
 
     def test_get_manifest_column_name(self):
         self.assertEqual(

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -48,6 +48,7 @@ from metadata.ingestion.source.database.dbt.dbt_utils import (
     get_data_model_path,
     get_dbt_compiled_query,
     get_dbt_raw_query,
+    get_dbt_test_primary_table_fqn,
     get_manifest_column_name,
     get_snapshot_effective_schema_and_database,
     validate_custom_property_value,
@@ -637,6 +638,82 @@ class DbtUnitTest(TestCase):
             ["<#E::table::local_redshift_dbt2.dev.dbt_jaffle.stg_customers::columns::order_id>"],
             result,
         )
+
+    def _get_relationships_test_node(self):
+        _, dbt_objects = self.get_dbt_object_files(mock_manifest=MOCK_SAMPLE_MANIFEST_VERSIONLESS)
+
+        return dbt_objects.dbt_manifest.nodes.get(
+            "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2"
+        )
+
+    def test_dbt_relationships_test_resolves_to_child_table_when_aliased(self):
+        """A relationships test must land on the model holding the foreign key even when
+        the upstream FQNs are built from a dbt alias that differs from the model name."""
+        manifest_node = self._get_relationships_test_node()
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["svc.db.sch.CUSTOMERS", "svc.db.sch.ORDERS"],
+            "upstream_by_name": {"customers": "svc.db.sch.CUSTOMERS", "orders": "svc.db.sch.ORDERS"},
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        self.assertListEqual(
+            ["<#E::table::svc.db.sch.ORDERS::columns::customer_id>"],
+            result,
+        )
+
+    def test_dbt_relationships_test_excludes_referenced_table_without_name_map(self):
+        """Without a name map the `to:` table must still be excluded rather than
+        falling back to depends_on[0], which dbt orders parent-first."""
+        manifest_node = self._get_relationships_test_node()
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["svc.db.sch.CUSTOMERS", "svc.db.sch.ORDERS"],
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        self.assertListEqual(
+            ["<#E::table::svc.db.sch.ORDERS::columns::customer_id>"],
+            result,
+        )
+
+    def test_dbt_relationships_test_resolves_child_table_by_name(self):
+        manifest_node = self._get_relationships_test_node()
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["svc.db.sch.customers", "svc.db.sch.orders"],
+            "upstream_by_name": {"customers": "svc.db.sch.customers", "orders": "svc.db.sch.orders"},
+            "results": "",
+        }
+        result = generate_entity_link(dbt_test=dbt_test)
+        self.assertListEqual(
+            ["<#E::table::svc.db.sch.orders::columns::customer_id>"],
+            result,
+        )
+
+    def test_dbt_test_primary_table_fqn_single_upstream(self):
+        _, dbt_objects = self.get_dbt_object_files(mock_manifest=MOCK_SAMPLE_MANIFEST_TEST_NODE)
+        manifest_node = dbt_objects.dbt_manifest.nodes.get("test.jaffle_shop.unique_orders_order_id.fed79b3a6e")
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["local_redshift_dbt2.dev.dbt_jaffle.stg_customers"],
+            "results": "",
+        }
+        self.assertEqual(
+            "local_redshift_dbt2.dev.dbt_jaffle.stg_customers",
+            get_dbt_test_primary_table_fqn(dbt_test),
+        )
+
+    def test_dbt_test_primary_table_fqn_relationships(self):
+        """Test results must be recorded against the child table only, not every upstream."""
+        manifest_node = self._get_relationships_test_node()
+        dbt_test = {
+            "manifest_node": manifest_node,
+            "upstream": ["svc.db.sch.CUSTOMERS", "svc.db.sch.ORDERS"],
+            "upstream_by_name": {"customers": "svc.db.sch.CUSTOMERS", "orders": "svc.db.sch.ORDERS"},
+            "results": "",
+        }
+        self.assertEqual("svc.db.sch.ORDERS", get_dbt_test_primary_table_fqn(dbt_test))
 
     def test_get_manifest_column_name(self):
         self.assertEqual(


### PR DESCRIPTION
## Describe your changes

dbt `relationships` tests were created on the referenced (parent) table instead of the model holding the foreign key, so the server rejected them with `Invalid column name`. This resolves the tested model by dbt node name, so the test lands on the correct table.

Fixes #28911

## Root cause

The reporter's diagnosis ("the parser assigns tests to `to: ref('target_table')`") is not quite right — logic to read `test_metadata.kwargs['model']` already exists (#27366, present in 1.12.10 and 1.13). The defect is in how the extracted name is matched, and what happens when the match fails:

1. `re.search(r"ref\(...")` on `kwargs['model']` yields the dbt model **name** (`orders`).
2. It is matched with `fqn.endswith(f".{name}")` against `upstream_list`, whose FQNs are built in `parse_upstream_nodes` from `get_dbt_model_name(parent_node)` = **`alias` if set, else name**.
3. Name vs alias (or case) diverge → no match → silent fallback to `upstream_list[0]`.
4. `upstream_list` preserves `depends_on.nodes` order, and dbt lists the **parent `to` model first**.

So the fallback deterministically picks the referenced table and attaches the FK column to it. Verified against this repo's own fixture `manifest_versionless.json`, where a test on `orders.customer_id` has `depends_on = ['...customers', '...orders']`.

Three confirmed triggers for the match failing:
- model has an `alias` differing from its name (common on Snowflake with `FACT_`/`DIM_` uppercase naming)
- the test targets a `source()` — the old regex only handled `ref(`
- the child table is absent from `upstream_list` (filtered by `is_filtered`, or an `_get_table_entity` ES miss)

This explains the reporter's partial 66% failure rate: it is per-model, not universal.

## Changes

**`dbt_utils.py`** — new `get_dbt_test_primary_table_fqn()` resolves the tested table in three steps:
1. exact lookup of the `ref()`/`source()` name against a new dbt node name → FQN map
2. case-insensitive suffix match (handles warehouses that upper-case identifiers)
3. for relationships tests, exclude the `to:` upstream — if exactly one candidate remains it is the tested table

`_DBT_REF_PATTERN` now also handles `source('schema', 'table')` and multi-arg `ref('pkg', 'model')`.

**`metadata.py`** — `parse_upstream_nodes_with_names()` returns `(dbt node name, FQN)` pairs; `parse_upstream_nodes()` keeps its existing FQN-list contract, so lineage/exposure/data-model callers are unaffected.

**Second defect fixed:** `create_dbt_test_case_results` looped over *every* upstream and posted results to a test case FQN on each, so multi-upstream tests wrote results to a table that never had the test case (the failure was swallowed at debug level). It now resolves the same single table.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Five regression tests added to `ingestion/tests/unit/test_dbt.py`, driven by the real `relationships` node in `manifest_versionless.json` parsed through `collate_dbt_artifacts_parser` — covering the aliased-upstream case, resolution without a name map, name-based resolution, and `get_dbt_test_primary_table_fqn` for both single- and multi-upstream tests.

Confirmed non-vacuous by running the same scenarios against the pre-fix code, which returns `CUSTOMERS` where the fixed code returns `ORDERS`.

```
157 passed in 4.06s
ruff check: All checks passed!
ruff format --check: 9 files already formatted
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects dbt test ownership and result association.
- Preserves dbt node names and namespaces alongside upstream table FQNs.
- Resolves `ref()` and `source()` expressions to the tested table, including aliases, case differences, and multi-upstream relationship tests.
- Posts test results only to the table on which the test case was created.
- Adds regression coverage for aliases, ambiguous names, namespaces, and relationship-test resolution.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The functional changes appear safe to merge, with only the previously reported test-style cleanup still outstanding.

The package-qualified identity fix now retains namespace-qualified keys and marks ambiguous bare names rather than silently selecting one table; no blocking failure remains, while the added tests still use the previously flagged unittest assertion style.

**Files Needing Attention:** ingestion/tests/unit/test_dbt.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py | Adds namespace-aware upstream indexing and centralized primary-table resolution for dbt tests. |
| ingestion/src/metadata/ingestion/source/database/dbt/metadata.py | Retains upstream node identity during parsing and routes each test result to one resolved table. |
| ingestion/src/metadata/ingestion/source/database/dbt/models.py | Introduces the typed upstream-node representation used to retain dbt identity alongside table FQNs. |
| ingestion/tests/unit/test_dbt.py | Adds behavioral regression coverage for relationship-test ownership, aliases, ambiguous names, and source namespaces. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[dbt test manifest node] --> D[Resolve upstream dependencies]
  D --> N[Build bare and namespace-qualified name map]
  M --> R[Extract model ref or source expression]
  N --> P[Resolve primary tested table FQN]
  R --> P
  P --> T[Create test case entity link]
  P --> O[Post test result to the same table]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ingestion): skip upstream nodes whos..."](https://github.com/open-metadata/openmetadata/commit/c58163bc3e7e0f24399b67454ec33a989a91c09b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48061236)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->