### PR TITLE
fix(ui): render EntityNameModal above antd Drawer/Modal overlays

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
@@ -109,6 +109,10 @@ const EntityNameModal = <T extends EntityName>({
     <ModalOverlay
       isDismissable={false}
       isOpen={visible}
+      // The library overlay is `tw:z-50`, which loses to antd `Drawer`/`Modal`
+      // (z-index 1000) — so the dialog renders behind an open column/entity
+      // drawer
+      style={{ zIndex: 1300 }}
       onOpenChange={(isOpen) => !isOpen && onCancel()}>
       <Modal>
         <Dialog data-testid="entity-name-modal" width={520}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
@@ -111,8 +111,7 @@ const EntityNameModal = <T extends EntityName>({
       isOpen={visible}
       // The library overlay is `tw:z-50`, which loses to antd `Drawer`/`Modal`
       // (z-index 1000) — so the dialog renders behind an open column/entity
-      // drawer
-      style={{ zIndex: 1300 }}
+      style={{ zIndex: 'var(--om-z-modal)' }}
       onOpenChange={(isOpen) => !isOpen && onCancel()}>
       <Modal>
         <Dialog data-testid="entity-name-modal" width={520}>


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The "Edit Display Name / Edit Column" dialog (EntityNameModal) is built on the react-aria ModalOverlay whose overlay is styled `tw:z-50`. antd `Drawer` and `Modal` default to z-index 1000, so when the dialog is opened from inside a column/entity drawer it renders *behind* the drawer instead of on top.

Lift this dialog's overlay to z-index 1500 via an inline style so it clears antd's overlay tier (1000) while staying far below react-aria's positioned overlays (Select/Tooltip use inline z-index 100000), so popups opened inside the dialog still layer correctly. Inline style is used because the library's tw Merge is not `tw:`-prefix aware and would keep both z-index classes if the value were passed as a className

https://github.com/user-attachments/assets/f5639c89-bb29-42be-9fe6-b92e1c3e725b




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates EntityNameModal to use the shared modal stacking token.
- Applies `var(--om-z-modal)` to the modal overlay so it renders above standard Drawer and Modal overlays.
- Replaces the previously reviewed hard-coded stacking value with the centralized design token.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the shared modal token is globally defined at a level above the standard application overlay tier.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx | Uses the globally defined `--om-z-modal` token on ModalOverlay, resolving the prior hard-coded stacking-level concern. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into render-modal"](https://github.com/open-metadata/openmetadata/commit/c62f9e50b252a1b3b5411fc1d250a9165b3da4ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48191932)</sub>

<!-- /greptile_comment -->