### PR TITLE
fix(ci): restore checkout v5 for release branches

### DIFF
--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v7
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.base_branch_name }}
     - name: Update application versions


### PR DESCRIPTION
## Summary

- restore `actions/checkout@v5` only in the release-branch creation workflow
- leave the other checkout upgrades from #30509 unchanged

## Why

#30509 moved this workflow from checkout v5 to v7. Both 1.13.2 attempts completed the version update and created the expected local commit, then GitHub rejected the branch push while validating workflows:

- https://github.com/open-metadata/OpenMetadata/actions/runs/30365030928/job/90293996174
- https://github.com/open-metadata/OpenMetadata/actions/runs/30367814364/job/90303523793

This workflow is distinct from the other upgraded workflows: checkout persists the credentials later used by `EndBug/add-and-commit` to create and push a new branch. The latest successful equivalent run used checkout v5 with `EndBug/add-and-commit@v10`, making this the smallest rollback at the regression boundary.

## Test plan

- [x] `git diff --check`
- [x] verified the PR changes one workflow line only
- [ ] rerun Create Release Branches for 1.13.2 after merge

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores `actions/checkout@v5` in the release-branch creation workflow so the subsequent commit action can reuse persisted checkout credentials when pushing the new branch.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the targeted rollback restoring the last known-compatible checkout behavior for release-branch pushes.

The workflow retains its existing trigger, write permission, branch input, version-update step, and add-and-commit configuration while changing only checkout credential handling back to the previously working action version.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/git-create-release-branch.yml | Reverts only the checkout action version for the credential-dependent release-branch workflow; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): restore checkout v5 for release..."](https://github.com/open-metadata/openmetadata/commit/fec38fa2973b34fb45efa6818448acb6a114a897) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48212848)</sub>

<!-- /greptile_comment -->