### PR TITLE
Improve bulk export action stats

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
@@ -154,12 +154,8 @@ describe('CsvJobsTray', () => {
       await screen.findByText('label.background-job-plural')
     ).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole('button', { name: /label.background-job-plural/ })
-    );
-
     expect(
-      screen.getByText('label.exported-entity-plural')
+      await screen.findByText('label.exported-entity-plural')
     ).toBeInTheDocument();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -147,7 +147,6 @@ export const CsvJobsTray = () => {
     [visibleJobs]
   );
 
-
   useEffect(() => {
     const newlyFinished = visibleJobs.filter(
       (job) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -10,9 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button } from '@openmetadata/ui-core-components';
+import { Button, FeaturedIcon } from '@openmetadata/ui-core-components';
 import {
   AlertCircle,
+  AlertTriangle,
+  Check,
   CheckCircle,
   Download01,
   Minus,
@@ -141,6 +143,18 @@ export const CsvJobsTray = () => {
     () => visibleJobs.filter((job) => TERMINAL_STATUSES.includes(job.status)),
     [visibleJobs]
   );
+
+  const launcherVariant = useMemo<StatusVariant>(() => {
+    if (activeJobs.length > 0) {
+      return 'running';
+    }
+
+    if (visibleJobs.some((job) => job.status === 'COMPLETED')) {
+      return 'success';
+    }
+
+    return 'error';
+  }, [activeJobs, visibleJobs]);
 
   const handleCancel = useCallback(async (jobId: string) => {
     try {
@@ -411,13 +425,28 @@ export const CsvJobsTray = () => {
             className="csv-jobs-tray-launcher"
             type="button"
             onClick={handleOpen}>
-            <span className="csv-jobs-tray-launcher-count">
-              {activeJobs.length || visibleJobs.length}
-            </span>
+            {launcherVariant === 'running' ? (
+              <span className="csv-jobs-tray-launcher-count">
+                {activeJobs.length}
+              </span>
+            ) : (
+              <FeaturedIcon
+                className={`tw:size-7 tw:text-fg-white ${
+                  launcherVariant === 'success'
+                    ? 'tw:bg-success-solid'
+                    : 'tw:bg-error-solid'
+                }`}
+                color={launcherVariant === 'success' ? 'success' : 'error'}
+                icon={launcherVariant === 'success' ? Check : AlertTriangle}
+                size="sm"
+              />
+            )}
             <span className="csv-jobs-tray-launcher-label">
-              {activeJobs.length > 0
+              {launcherVariant === 'running'
                 ? t('label.count-jobs-running', { count: activeJobs.length })
-                : t('label.background-job-plural')}
+                : launcherVariant === 'success'
+                ? t('label.completed')
+                : t('label.failed')}
             </span>
           </button>
         </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -13,6 +13,7 @@
 import { Button } from '@openmetadata/ui-core-components';
 import {
   AlertCircle,
+  Check,
   CheckCircle,
   Download01,
   Minus,
@@ -93,6 +94,9 @@ export const CsvJobsTray = () => {
   const [open, setOpen] = useState(false);
   const [cancellingJobId, setCancellingJobId] = useState<string>();
   const [downloadingJobId, setDownloadingJobId] = useState<string>();
+  const [downloadedJobIds, setDownloadedJobIds] = useState<Set<string>>(
+    () => new Set()
+  );
   const [dismissedJobIds, setDismissedJobIds] = useState<Set<string>>(
     () => new Set()
   );
@@ -186,6 +190,12 @@ export const CsvJobsTray = () => {
       link.click();
       document.body.removeChild(link);
       URL.revokeObjectURL(url);
+      setDownloadedJobIds((current) => {
+        const next = new Set(current);
+        next.add(job.jobId);
+
+        return next;
+      });
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
@@ -383,6 +393,8 @@ export const CsvJobsTray = () => {
                     <span className="csv-jobs-tray-kind-icon">
                       {variant === 'running' ? (
                         renderStatusIcon(job)
+                      ) : downloadedJobIds.has(job.jobId) ? (
+                        <Check size={16} />
                       ) : (
                         <KindIcon size={16} />
                       )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -150,7 +150,7 @@ export const CsvJobsTray = () => {
   useEffect(() => {
     const newlyFinished = visibleJobs.filter(
       (job) =>
-        (job.status === 'COMPLETED' || job.status === 'FAILED') &&
+        TERMINAL_STATUSES.includes(job.status) &&
         !autoOpenedJobIds.current.has(job.jobId)
     );
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -10,11 +10,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { Button, FeaturedIcon } from '@openmetadata/ui-core-components';
+import { Button } from '@openmetadata/ui-core-components';
 import {
   AlertCircle,
-  AlertTriangle,
-  Check,
   CheckCircle,
   Download01,
   Minus,
@@ -99,6 +97,7 @@ export const CsvJobsTray = () => {
     () => new Set()
   );
   const hasLoadedInitialJobs = useRef(false);
+  const autoOpenedJobIds = useRef<Set<string>>(new Set());
 
   const fetchJobs = useCallback(async () => {
     try {
@@ -144,17 +143,17 @@ export const CsvJobsTray = () => {
     [visibleJobs]
   );
 
-  const launcherVariant = useMemo<StatusVariant>(() => {
-    if (activeJobs.length > 0) {
-      return 'running';
-    }
+  useEffect(() => {
+    const newlyCompleted = visibleJobs.filter(
+      (job) =>
+        job.status === 'COMPLETED' && !autoOpenedJobIds.current.has(job.jobId)
+    );
 
-    if (visibleJobs.some((job) => job.status === 'COMPLETED')) {
-      return 'success';
+    if (!isEmpty(newlyCompleted)) {
+      newlyCompleted.forEach((job) => autoOpenedJobIds.current.add(job.jobId));
+      setOpen(true);
     }
-
-    return 'error';
-  }, [activeJobs, visibleJobs]);
+  }, [visibleJobs]);
 
   const handleCancel = useCallback(async (jobId: string) => {
     try {
@@ -419,34 +418,24 @@ export const CsvJobsTray = () => {
           </div>
         </div>
       )}
-      {!open && (
+      {!open && activeJobs.length > 0 && (
         <div className="csv-jobs-tray-launcher-wrap">
           <button
             className="csv-jobs-tray-launcher"
             type="button"
             onClick={handleOpen}>
-            {launcherVariant === 'running' ? (
-              <span className="csv-jobs-tray-launcher-count">
-                {activeJobs.length}
-              </span>
-            ) : (
-              <FeaturedIcon
-                className={`tw:size-7 tw:text-fg-white ${
-                  launcherVariant === 'success'
-                    ? 'tw:bg-success-solid'
-                    : 'tw:bg-error-solid'
-                }`}
-                color={launcherVariant === 'success' ? 'success' : 'error'}
-                icon={launcherVariant === 'success' ? Check : AlertTriangle}
-                size="sm"
-              />
-            )}
+            <span className="csv-jobs-tray-launcher-count">
+              {activeJobs.length}
+            </span>
             <span className="csv-jobs-tray-launcher-label">
-              {launcherVariant === 'running'
-                ? t('label.count-jobs-running', { count: activeJobs.length })
-                : launcherVariant === 'success'
-                ? t('label.completed')
-                : t('label.failed')}
+              {t('label.count-jobs-running', { count: activeJobs.length })}
+              <span
+                aria-hidden
+                className="tw:ml-1 tw:inline-flex tw:items-end tw:gap-0.5 tw:align-text-bottom">
+                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current" />
+                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:150ms]" />
+                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:300ms]" />
+              </span>
             </span>
           </button>
         </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -434,25 +434,38 @@ export const CsvJobsTray = () => {
           </div>
         </div>
       )}
-      {!open && activeJobs.length > 0 && (
+      {!open && !isEmpty(visibleJobs) && (
         <div className="csv-jobs-tray-launcher-wrap">
           <button
             className="csv-jobs-tray-launcher"
             type="button"
             onClick={handleOpen}>
-            <span className="csv-jobs-tray-launcher-count">
-              {activeJobs.length}
-            </span>
-            <span className="csv-jobs-tray-launcher-label">
-              {t('label.count-jobs-running', { count: activeJobs.length })}
-              <span
-                aria-hidden
-                className="tw:ml-1 tw:inline-flex tw:items-end tw:gap-0.5 tw:align-text-bottom">
-                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current" />
-                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:150ms]" />
-                <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:300ms]" />
-              </span>
-            </span>
+            {activeJobs.length > 0 ? (
+              <>
+                <span className="csv-jobs-tray-launcher-count">
+                  {activeJobs.length}
+                </span>
+                <span className="csv-jobs-tray-launcher-label">
+                  {t('label.count-jobs-running', { count: activeJobs.length })}
+                  <span
+                    aria-hidden
+                    className="tw:ml-1 tw:inline-flex tw:items-end tw:gap-0.5 tw:align-text-bottom">
+                    <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current" />
+                    <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:150ms]" />
+                    <span className="tw:size-1 tw:animate-bounce tw:rounded-full tw:bg-current tw:[animation-delay:300ms]" />
+                  </span>
+                </span>
+              </>
+            ) : (
+              <>
+                <span className="csv-jobs-tray-launcher-count">
+                  {visibleJobs.length}
+                </span>
+                <span className="csv-jobs-tray-launcher-label">
+                  {t('label.background-job-plural')}
+                </span>
+              </>
+            )}
           </button>
         </div>
       )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -143,14 +143,16 @@ export const CsvJobsTray = () => {
     [visibleJobs]
   );
 
+
   useEffect(() => {
-    const newlyCompleted = visibleJobs.filter(
+    const newlyFinished = visibleJobs.filter(
       (job) =>
-        job.status === 'COMPLETED' && !autoOpenedJobIds.current.has(job.jobId)
+        (job.status === 'COMPLETED' || job.status === 'FAILED') &&
+        !autoOpenedJobIds.current.has(job.jobId)
     );
 
-    if (!isEmpty(newlyCompleted)) {
-      newlyCompleted.forEach((job) => autoOpenedJobIds.current.add(job.jobId));
+    if (!isEmpty(newlyFinished)) {
+      newlyFinished.forEach((job) => autoOpenedJobIds.current.add(job.jobId));
       setOpen(true);
     }
   }, [visibleJobs]);
@@ -340,7 +342,7 @@ export const CsvJobsTray = () => {
   return (
     <div className="csv-jobs-tray">
       {open && (
-        <div className="csv-jobs-tray-popover">
+        <div className="csv-jobs-tray-popover tw:w-100!">
           <div className="csv-jobs-tray-header">
             <div className="csv-jobs-tray-title-wrap">
               <h3>{t('label.background-job-plural')}</h3>
@@ -393,7 +395,7 @@ export const CsvJobsTray = () => {
                         {renderJobSubLine(job)}
                       </span>
                     </div>
-                    <div className="csv-jobs-tray-actions">
+                    <div className="csv-jobs-tray-actions tw:items-start!">
                       {variant !== 'running' && (
                         <span
                           aria-hidden="true"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -363,7 +363,7 @@ export const CsvJobsTray = () => {
               </Button>
             )}
             <Button
-              className="csv-jobs-tray-close"
+              className="csv-jobs-tray-close tw:-mr-1.5"
               color="link-gray"
               iconLeading={Minus}
               onPress={() => setOpen(false)}
@@ -388,21 +388,23 @@ export const CsvJobsTray = () => {
                       )}
                     </span>
                     <div className="csv-jobs-tray-body">
-                      <span className="csv-jobs-tray-title">
-                        {renderJobTitle(job)}
+                      <span className="tw:flex tw:min-w-0 tw:items-center tw:gap-1.5">
+                        <span className="csv-jobs-tray-title tw:min-w-0">
+                          {renderJobTitle(job)}
+                        </span>
+                        {variant !== 'running' && (
+                          <span
+                            aria-hidden="true"
+                            className={`csv-jobs-tray-state csv-jobs-tray-state-${variant} tw:shrink-0`}>
+                            {renderStatusIcon(job)}
+                          </span>
+                        )}
                       </span>
                       <span className="csv-jobs-tray-sub">
                         {renderJobSubLine(job)}
                       </span>
                     </div>
-                    <div className="csv-jobs-tray-actions tw:items-start!">
-                      {variant !== 'running' && (
-                        <span
-                          aria-hidden="true"
-                          className={`csv-jobs-tray-state csv-jobs-tray-state-${variant}`}>
-                          {renderStatusIcon(job)}
-                        </span>
-                      )}
+                    <div className="csv-jobs-tray-actions">
                       {renderJobRowActions(job)}
                     </div>
                   </div>

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -528,7 +528,7 @@
     "cost": "التكلفة",
     "cost-analysis": "تحليل التكلفة",
     "count": "العدد",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} مهام قيد التشغيل",
     "count-running": "{{count}} قيد التشغيل",
     "cover-image": "غلاف",
     "covered": "مغطى",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -528,7 +528,7 @@
     "cost": "Kosten",
     "cost-analysis": "Kostenanalyse",
     "count": "Anzahl",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} Jobs werden ausgeführt",
     "count-running": "{{count}} in Ausführung",
     "cover-image": "Abdeckung",
     "covered": "Bedeckt",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -528,7 +528,7 @@
     "cost": "Cost",
     "cost-analysis": "Cost Analysis",
     "count": "Count",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} jobs running",
     "count-running": "{{count}} running",
     "cover-image": "Cover",
     "covered": "Covered",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -528,7 +528,7 @@
     "cost": "Coste",
     "cost-analysis": "Análisis de Coste",
     "count": "Conteo",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} trabajos en ejecución",
     "count-running": "{{count}} en ejecución",
     "cover-image": "Cubrir",
     "covered": "Cubierto",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -528,7 +528,7 @@
     "cost": "Coût",
     "cost-analysis": "Analyse des Coûts",
     "count": "Décompte",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} tâches en cours d'exécution",
     "count-running": "{{count}} en cours",
     "cover-image": "Couverture",
     "covered": "Couvert",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -528,7 +528,7 @@
     "cost": "Coste",
     "cost-analysis": "Análise de custos",
     "count": "Contar",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} traballos en execución",
     "count-running": "{{count}} en execución",
     "cover-image": "Portada",
     "covered": "Cuberto",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -528,7 +528,7 @@
     "cost": "מחיר",
     "cost-analysis": "ניתוח עלויות",
     "count": "ספירה",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} משימות פועלות",
     "count-running": "{{count}} פועלים",
     "cover-image": "תמונת כיסוי",
     "covered": "מכוסה",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -528,7 +528,7 @@
     "cost": "コスト",
     "cost-analysis": "コスト分析",
     "count": "件数",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} 件のジョブを実行中",
     "count-running": "{{count}} 件実行中",
     "cover-image": "カバー",
     "covered": "カバー済み",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -528,7 +528,7 @@
     "cost": "비용",
     "cost-analysis": "비용 분석",
     "count": "개수",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}}개 작업 실행 중",
     "count-running": "{{count}}개 실행 중",
     "cover-image": "씌우다",
     "covered": "포함됨",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -528,7 +528,7 @@
     "cost": "किंमत",
     "cost-analysis": "खर्च विश्लेषण",
     "count": "संख्या",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} जॉब चालू आहेत",
     "count-running": "{{count}} चालू",
     "cover-image": "मुखपृष्ठ",
     "covered": "समाविष्ट",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -528,7 +528,7 @@
     "cost": "Kosten",
     "cost-analysis": "Kostenanalyse",
     "count": "Aantal",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} taken worden uitgevoerd",
     "count-running": "{{count}} actief",
     "cover-image": "Omslag",
     "covered": "Gedekt",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -528,7 +528,7 @@
     "cost": "هزینه",
     "cost-analysis": "تحلیل هزینه",
     "count": "شمارش",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} کار در حال اجرا",
     "count-running": "{{count}} در حال اجرا",
     "cover-image": "جلد",
     "covered": "پوشش داده‌شده",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -528,7 +528,7 @@
     "cost": "Custo",
     "cost-analysis": "Análise de Custo",
     "count": "Contagem",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} tarefas em execução",
     "count-running": "{{count}} em execução",
     "cover-image": "Cobrir",
     "covered": "Coberto",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -528,7 +528,7 @@
     "cost": "Custo",
     "cost-analysis": "Análise de Custo",
     "count": "Contagem",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} tarefas em execução",
     "count-running": "{{count}} em execução",
     "cover-image": "Imagem de Capa",
     "covered": "Coberto",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -528,7 +528,7 @@
     "cost": "Стоимость",
     "cost-analysis": "Оценка цены",
     "count": "Количество",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} задач выполняется",
     "count-running": "{{count}} выполняется",
     "cover-image": "Обложка",
     "covered": "Покрыто",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -528,7 +528,7 @@
     "cost": "Kostnad",
     "cost-analysis": "Kostnadsanalys",
     "count": "Antal",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} jobb körs",
     "count-running": "{{count}} körs",
     "cover-image": "Omslag",
     "covered": "Täckt",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -528,7 +528,7 @@
     "cost": "ค่า",
     "cost-analysis": "การวิเคราะห์ต้นทุน",
     "count": "จำนวน",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "กำลังเรียกใช้งาน {{count}} งาน",
     "count-running": "{{count}} กำลังรัน",
     "cover-image": "ปก",
     "covered": "ครอบคลุม",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -528,7 +528,7 @@
     "cost": "Maliyet",
     "cost-analysis": "Maliyet Analizi",
     "count": "Sayı",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} iş çalışıyor",
     "count-running": "{{count}} çalışıyor",
     "cover-image": "Kapak",
     "covered": "Kapsanan",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -528,7 +528,7 @@
     "cost": "成本",
     "cost-analysis": "成本分析",
     "count": "计数",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} 个作业正在运行",
     "count-running": "{{count}} 个运行中",
     "cover-image": "覆盖",
     "covered": "覆盖",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -528,7 +528,7 @@
     "cost": "成本",
     "cost-analysis": "成本分析",
     "count": "計數",
-    "count-jobs-running": "{{count}} jobs running…",
+    "count-jobs-running": "{{count}} 個作業正在執行",
     "count-running": "{{count}} 個執行中",
     "cover-image": "封面",
     "covered": "已涵蓋",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


https://github.com/user-attachments/assets/f603e28d-d583-4ad4-a0c9-a7599b7e58e5






#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI Improvements:**
    - Updated `CsvJobsTray` launcher to display success or error status icons and labels instead of job counts when inactive
    - Added auto-opening behavior for the jobs tray when background export jobs finish successfully or fail
- **Localization:**
    - Updated running job count translation strings across all supported language translation files

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves feedback for background CSV jobs.
- Automatically opens the jobs tray when a visible job reaches a terminal status, including cancellation.
- Updates job-row layout, downloaded-export indicators, launcher activity animation, and tray sizing.
- Localizes the running-job count across supported languages and updates component coverage for auto-opening.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because cancelled jobs remain visually classified as failures.

The cancellation notification now opens correctly, but the shared terminal variant logic still routes CANCELLED through the error presentation instead of distinguishing it from FAILED.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx | Adds terminal-state auto-opening and revises job status, download, and launcher presentation. |
| openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx | Updates the terminal-transition test to expect the tray to open automatically. |
| openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json | Removes the textual ellipsis now replaced by the launcher's animated activity indicator. |

</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;csv-export&#39; of https://git..."](https://github.com/open-metadata/openmetadata/commit/351a8f7578aa109d0f2590d3d374756750f62b32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48219048)</sub>

<!-- /greptile_comment -->