### PR TITLE
ci(playwright): raise chromium shard budget 19 → 20 min

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -54,7 +54,16 @@ LANE_WORKERS = {
     "search-rbac": 1,
 }
 TARGET_MS = 20 * 60 * 1000
-COMMON_SHARD_BUDGET_MS = 19 * 60 * 1000
+# Chromium lane budget. Was 19 min; bumped to align with TARGET_MS after the
+# chromium suite grew to ~1053 min of test content on 2026-07-28 (~90% of the
+# 24-shard × 3-worker × EFFICIENCY ceiling). The heaviest LPT-balanced shard
+# was predicted at 19.1 min — 0.1 min over budget — and the planner refused
+# to build a plan, blocking the merge queue. Matching TARGET_MS gives enough
+# headroom for that plan without changing runtime; the predicted shard time
+# is unchanged, we're just widening the acceptance threshold. Longer-term,
+# split the top individual tests (two 10-min TestCaseImportExportE2eFlow
+# cases lead the list) instead of raising this ceiling again.
+COMMON_SHARD_BUDGET_MS = 20 * 60 * 1000
 EFFICIENCY = 0.85
 COMMON_MAX_SHARDS = 24
 FALLBACK_TEST_MS = 20_000

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -61,10 +61,16 @@ def test_full_common_shard_count_is_capped_at_24():
     assert planner.shard_count(units, "chromium", "full") == 24
 
 
-def test_common_lane_keeps_one_minute_of_allocation_reserve():
+def test_common_lane_matches_target_execution_budget():
+    # Chromium was previously held one minute below TARGET_MS as a safety
+    # reserve; that reserve was removed when the suite grew to ~90% of the
+    # 24-shard × 3-worker capacity ceiling — the planner started refusing
+    # otherwise-valid plans whose heaviest shard was 0.1 min over the old
+    # 19-min budget. Aligning chromium with TARGET_MS is the stop-gap;
+    # follow-up work is trimming the heaviest individual tests.
     planner = load_script("build_playwright_shards")
 
-    assert planner.shard_budget_ms_for_lane("chromium") == 19 * 60 * 1000
+    assert planner.shard_budget_ms_for_lane("chromium") == 20 * 60 * 1000
     assert planner.shard_budget_ms_for_lane("search") == 20 * 60 * 1000
 
 
@@ -449,7 +455,7 @@ def test_hook_heavy_subsuites_in_audited_suite_stay_atomic():
     ]
 
 
-def test_common_shards_enforce_the_nineteen_minute_budget(tmp_path):
+def test_common_shards_enforce_the_twenty_minute_budget(tmp_path):
     planner = load_script("build_playwright_shards")
     within_budget = planner.Unit(
         "chromium",
@@ -457,7 +463,7 @@ def test_common_shards_enforce_the_nineteen_minute_budget(tmp_path):
         "within",
         grep_titles={("chromium", "within.spec.ts", "within")},
         test_ids={"within"},
-        weight_ms=19 * 60 * 1000,
+        weight_ms=20 * 60 * 1000,
     )
     above_budget = planner.Unit(
         "chromium",
@@ -465,11 +471,11 @@ def test_common_shards_enforce_the_nineteen_minute_budget(tmp_path):
         "above",
         grep_titles={("chromium", "above.spec.ts", "above")},
         test_ids={"above"},
-        weight_ms=19 * 60 * 1000 + 1,
+        weight_ms=20 * 60 * 1000 + 1,
     )
 
     planner.write_plan(tmp_path, "chromium", 0, [within_budget])
-    with pytest.raises(SystemExit, match="above the 19-minute plan budget"):
+    with pytest.raises(SystemExit, match="above the 20-minute plan budget"):
         planner.write_plan(tmp_path, "chromium", 1, [above_budget])
 
 


### PR DESCRIPTION
## Summary

The chromium lane hit the shard planner's hard ceiling on the merge queue for PR #30563 ([run 30394014577](https://github.com/open-metadata/OpenMetadata/actions/runs/30394014577)):

\`\`\`
Lane chromium needs more than 24 shards to stay within the 19-minute plan budget;
the heaviest shard is predicted at 19.1m
##[error]Process completed with exit code 1.
\`\`\`

The planner refused to build a valid plan → \`plan-playwright\` failed → all downstream jobs skipped → \`playwright-summary\` failed → merge queue blocked.

## Root cause

Aggregate growth. The chromium suite currently holds **~1053 min of test content** per the committed timing baseline — **90.6 % of the 1163 min planner ceiling** (24 shards × 3 workers × 19 min × 0.85 efficiency). LPT bin-packing is working; there's just no headroom left, and the current heaviest-shard prediction is 0.1 min over the hard budget.

## Change

One constant: raise the chromium shard budget from 19 → 20 min (aligns it with \`TARGET_MS\` used by the other lanes).

\`\`\`python
- COMMON_SHARD_BUDGET_MS = 19 * 60 * 1000
+ COMMON_SHARD_BUDGET_MS = 20 * 60 * 1000
\`\`\`

**Wall clock is unaffected** — the change only widens the acceptance threshold. The predicted heaviest shard runtime is unchanged; the planner will now accept a plan it previously refused.

## Follow-up (not in this PR)

This is a stop-gap. Investigation of the timing baseline turned up the actual load hot spots:

| Duration | Test |
|---:|---|
| **605 s (10.1 min!)** | \`TestCaseImportExportE2eFlow.spec.ts › EditAll User: Complete export-import-validate flow\` |
| **603 s (10.0 min!)** | \`TestCaseImportExportE2eFlow.spec.ts › Admin: Complete export-import-validate flow\` |
| **362 s (6.0 min)** | \`ContextCenterArticles.spec.ts › Article edits and navigation-flushed titles persist\` |

Two ~10-minute tests in a single file are effectively immovable in LPT scheduling — they consume 20 % of a shard budget between them. Splitting or trimming those three tests would give ~15 min of aggregate breathing room without another budget bump. Filing separately.

## Test plan

- [ ] Retriggering PR #30563 in the merge queue: \`plan-playwright\` completes past \"Build duration-aware shard plans\" and emits a valid \`matrix.json\`.
- [ ] Any subsequent PR going through the queue is unblocked.
- [ ] Full-suite dispatch / nightly runs succeed with no wall-clock regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Playwright shard planner and its tests:
- Raises the Chromium shard budget from 19 to 20 minutes.
- Updates Chromium budget and boundary assertions to match the new threshold.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported stale Chromium budget assertions now match the production 20-minute threshold, and no blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/build_playwright_shards.py | Raises the Chromium shard acceptance budget to 20 minutes while leaving shard runtime prediction unchanged. |
| .github/scripts/tests/test_playwright_ci_planning.py | Correctly updates the previously stale budget and rejection-boundary assertions from 19 to 20 minutes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["address greptile P1: update planning tes..."](https://github.com/open-metadata/openmetadata/commit/a624cd32875ed59104c2fc6d0b9aad287e26dc65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48221456)</sub>

<!-- /greptile_comment -->