### PR TITLE
ci(playwright): move import/export specs into a dedicated lane

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -18,6 +18,7 @@ FULL_PROJECTS = {
     "chromium",
     "Basic",
     "Ingestion",
+    "ImportExport",
     "DataAssetRulesEnabled",
     "DataAssetRulesDisabled",
     "SearchRBAC",
@@ -32,6 +33,7 @@ PROJECT_LANES = {
     "chromium": "chromium",
     "Basic": "chromium",
     "Ingestion": "ingestion",
+    "ImportExport": "import-export",
     "DataAssetRulesEnabled": "data-asset-rules",
     "DataAssetRulesDisabled": "data-asset-rules",
     "SearchRBAC": "search-rbac",
@@ -48,6 +50,7 @@ PROJECT_DEPENDENCIES = {
 LANE_WORKERS = {
     "domain-isolation": 1,
     "global-state": 1,
+    "import-export": 2,
     "ingestion": 1,
     "reindex": 1,
     "search": 1,
@@ -347,6 +350,7 @@ def lane_bounds(lane: str, mode: str) -> tuple[int, int]:
     if lane in {
         "domain-isolation",
         "global-state",
+        "import-export",
         "ingestion",
         "reindex",
         "search",

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -507,6 +507,16 @@ def test_search_rbac_uses_an_isolated_single_worker_lane():
     assert planner.lane_bounds("search-rbac", "full") == (1, 8)
 
 
+def test_import_export_runs_in_its_own_lane_with_two_workers():
+    planner = load_script("build_playwright_shards")
+
+    assert "ImportExport" in planner.FULL_PROJECTS
+    assert planner.PROJECT_LANES["ImportExport"] == "import-export"
+    assert planner.LANE_WORKERS["import-export"] == 2
+    assert planner.lane_bounds("import-export", "full") == (1, 8)
+    assert planner.lane_bounds("import-export", "targeted") == (1, 2)
+
+
 def test_source_glob_matching_is_explicit():
     selector = load_script("select_playwright_tests")
 

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -552,6 +552,7 @@ jobs:
             --project=chromium \
             --project=Basic \
             --project=Ingestion \
+            --project=ImportExport \
             --project=DataAssetRulesEnabled \
             --project=DataAssetRulesDisabled \
             --project=SearchRBAC \

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -544,6 +544,7 @@ jobs:
         env:
           PLAYWRIGHT_IS_OSS: "true"
           PW_DEDICATED_INGESTION: "true"
+          PW_DEDICATED_IMPORT_EXPORT: "true"
           PW_EXECUTION_MODE: ${{ needs.detect-changes.outputs.mode }}
           PW_LINEAGE_REPRESENTATIVE_ONLY: ${{ needs.detect-changes.outputs.lineage_representative_only }}
         run: |
@@ -799,6 +800,7 @@ jobs:
         env:
           PLAYWRIGHT_IS_OSS: "true"
           PW_DEDICATED_INGESTION: "true"
+          PW_DEDICATED_IMPORT_EXPORT: "true"
         run: |
           npx playwright test --project=entity-data-setup --reporter=line
           test -s playwright/.auth/admin.json

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -41,6 +41,8 @@ const shardPlan = process.env.PW_SHARD_PLAN
   : undefined;
 const hasDedicatedIngestionLane =
   Boolean(shardPlan) || process.env.PW_DEDICATED_INGESTION === 'true';
+const hasDedicatedImportExportLane =
+  Boolean(shardPlan) || process.env.PW_DEDICATED_IMPORT_EXPORT === 'true';
 const isPlannedShard = Boolean(shardPlan);
 const hasPreseededState = process.env.PW_PRESEEDED_STATE === 'true';
 const authDependencies = hasPreseededState ? [] : ['setup'];
@@ -182,6 +184,7 @@ export default defineConfig({
         /@data-insight/,
         /@basic/,
         ...(hasDedicatedIngestionLane ? [/@ingestion/] : []),
+        ...(hasDedicatedImportExportLane ? [/@import-export/] : []),
         /@knowledge-graph/,
         /@ontology-rdf/,
       ],
@@ -309,6 +312,20 @@ export default defineConfig({
             dependencies: entityDependencies,
             fullyParallel: false,
             workers: 1,
+            teardown: entityTeardown,
+          },
+        ]
+      : []),
+    ...(hasDedicatedImportExportLane
+      ? [
+          {
+            name: 'ImportExport',
+            grep: combineGrep(/@import-export/),
+            testIgnore: '**/nightly/**',
+            use: { ...devices['Desktop Chrome'] },
+            dependencies: entityDependencies,
+            fullyParallel: true,
+            workers: 2,
             teardown: entityTeardown,
           },
         ]

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditImportPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditImportPermissions.spec.ts
@@ -129,80 +129,81 @@ test.describe(
   'Bulk Edit / Import - Non-admin permissions',
   { tag: '@import-export' },
   () => {
-  test.describe.configure({ mode: 'serial' });
+    test.describe.configure({ mode: 'serial' });
 
-  test.beforeAll(async ({ browser }) => {
-    test.setTimeout(180_000);
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await glossary.create(apiContext);
-    await glossaryTerm.create(apiContext);
-    await table.create(apiContext);
-    await editorUser.create(apiContext, false);
-    const policyResponse = await editorPolicy.create(
-      apiContext,
-      BULK_EDIT_RULES
-    );
-    const roleResponse = await editorRole.create(apiContext, [
-      policyResponse.name,
-    ]);
-    await editorUser.patch({
-      apiContext,
-      patchData: [
-        {
-          op: 'add',
-          path: '/roles/0',
-          value: {
-            id: roleResponse.id,
-            type: 'role',
-            name: roleResponse.name,
+    test.beforeAll(async ({ browser }) => {
+      test.setTimeout(180_000);
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await glossary.create(apiContext);
+      await glossaryTerm.create(apiContext);
+      await table.create(apiContext);
+      await editorUser.create(apiContext, false);
+      const policyResponse = await editorPolicy.create(
+        apiContext,
+        BULK_EDIT_RULES
+      );
+      const roleResponse = await editorRole.create(apiContext, [
+        policyResponse.name,
+      ]);
+      await editorUser.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/roles/0',
+            value: {
+              id: roleResponse.id,
+              type: 'role',
+              name: roleResponse.name,
+            },
           },
-        },
-      ],
+        ],
+      });
+      await afterAction();
     });
-    await afterAction();
-  });
 
-  test.afterAll(async ({ browser }) => {
-    test.setTimeout(120_000);
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-    await table.delete(apiContext);
-    await glossaryTerm.delete(apiContext);
-    await glossary.delete(apiContext);
-    await editorUser.delete(apiContext);
-    await editorRole.delete(apiContext);
-    await editorPolicy.delete(apiContext);
-    await afterAction();
-  });
+    test.afterAll(async ({ browser }) => {
+      test.setTimeout(120_000);
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await table.delete(apiContext);
+      await glossaryTerm.delete(apiContext);
+      await glossary.delete(apiContext);
+      await editorUser.delete(apiContext);
+      await editorRole.delete(apiContext);
+      await editorPolicy.delete(apiContext);
+      await afterAction();
+    });
 
-  test('Editor with EditAll can access every bulk edit and import page', async ({
-    bulkEditorPage,
-  }) => {
-    test.setTimeout(150_000);
-    await redirectToHomePage(bulkEditorPage);
-    await verifyAllBulkRoutes(bulkEditorPage, true);
-  });
+    test('Editor with EditAll can access every bulk edit and import page', async ({
+      bulkEditorPage,
+    }) => {
+      test.setTimeout(150_000);
+      await redirectToHomePage(bulkEditorPage);
+      await verifyAllBulkRoutes(bulkEditorPage, true);
+    });
 
-  test('Data Consumer is blocked from every bulk edit and import page', async ({
-    dataConsumerPage,
-  }) => {
-    test.setTimeout(150_000);
-    await redirectToHomePage(dataConsumerPage);
-    await verifyAllBulkRoutes(dataConsumerPage, false);
-  });
+    test('Data Consumer is blocked from every bulk edit and import page', async ({
+      dataConsumerPage,
+    }) => {
+      test.setTimeout(150_000);
+      await redirectToHomePage(dataConsumerPage);
+      await verifyAllBulkRoutes(dataConsumerPage, false);
+    });
 
-  test('Data Steward is blocked from every bulk edit and import page', async ({
-    dataStewardPage,
-  }) => {
-    test.setTimeout(150_000);
-    await redirectToHomePage(dataStewardPage);
-    await verifyAllBulkRoutes(dataStewardPage, false);
-  });
+    test('Data Steward is blocked from every bulk edit and import page', async ({
+      dataStewardPage,
+    }) => {
+      test.setTimeout(150_000);
+      await redirectToHomePage(dataStewardPage);
+      await verifyAllBulkRoutes(dataStewardPage, false);
+    });
 
-  test('View-only user is blocked from every bulk edit and import page', async ({
-    viewOnlyPage,
-  }) => {
-    test.setTimeout(150_000);
-    await redirectToHomePage(viewOnlyPage);
-    await verifyAllBulkRoutes(viewOnlyPage, false);
-  });
-});
+    test('View-only user is blocked from every bulk edit and import page', async ({
+      viewOnlyPage,
+    }) => {
+      test.setTimeout(150_000);
+      await redirectToHomePage(viewOnlyPage);
+      await verifyAllBulkRoutes(viewOnlyPage, false);
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditImportPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditImportPermissions.spec.ts
@@ -125,7 +125,10 @@ const verifyAllBulkRoutes = async (page: Page, shouldHaveAccess: boolean) => {
   }
 };
 
-test.describe('Bulk Edit / Import - Non-admin permissions', () => {
+test.describe(
+  'Bulk Edit / Import - Non-admin permissions',
+  { tag: '@import-export' },
+  () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeAll(async ({ browser }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -144,7 +144,7 @@ const storedProcedureDetails = {
   glossary: glossaryDetails,
 };
 
-test.describe.fixme('Bulk Import Export', () => {
+test.describe.fixme('Bulk Import Export', { tag: '@import-export' }, () => {
   test.beforeAll('setup pre-test', async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
@@ -148,771 +148,786 @@ test.describe(
   'Bulk Import Export with Dot in Service Name',
   { tag: '@import-export' },
   () => {
-  /**
-   * Test export and re-import of a database service with a dot in the name.
-   * This verifies that:
-   * 1. Export generates valid CSV with properly escaped FQN values
-   * 2. Import can parse the CSV with quoted FQN values
-   * 3. The full hierarchy (database, schema, table, columns) is preserved
-   */
-  test('Database service with dot in name - export and reimport', async ({
-    browser,
-  }) => {
-    test.setTimeout(300_000);
+    /**
+     * Test export and re-import of a database service with a dot in the name.
+     * This verifies that:
+     * 1. Export generates valid CSV with properly escaped FQN values
+     * 2. Import can parse the CSV with quoted FQN values
+     * 3. The full hierarchy (database, schema, table, columns) is preserved
+     */
+    test('Database service with dot in name - export and reimport', async ({
+      browser,
+    }) => {
+      test.setTimeout(300_000);
 
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    // Create a database service with a dot in the name (e.g., "local.mysql")
-    const serviceNameWithDot = `pw.db.service.${uuid()}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    // Create a database under the service
-    const databaseName = `pwdatabase${uuid().substring(0, 6)}`;
-    const database = await createDatabase(
-      apiContext,
-      databaseName,
-      service.fullyQualifiedName
-    );
-
-    // Create a schema under the database
-    const schemaName = `pwschema${uuid().substring(0, 6)}`;
-    const schema = await createDatabaseSchema(
-      apiContext,
-      schemaName,
-      database.fullyQualifiedName
-    );
-
-    // Create a table under the schema
-    const tableName = `pwtable${uuid().substring(0, 6)}`;
-    await createTable(apiContext, tableName, schema.fullyQualifiedName, [
-      {
-        name: 'id',
-        dataType: 'INT',
-        dataTypeDisplay: 'int',
-        description: 'Primary key',
-      },
-      {
-        name: 'name',
-        dataType: 'VARCHAR',
-        dataTypeDisplay: 'varchar(255)',
-        dataLength: 255,
-        description: 'Name column',
-      },
-    ]);
-
-    await redirectToHomePage(page);
-
-    await test.step('Export database service with dot in name', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-    });
-
-    await test.step('Import exported CSV and verify parsing succeeds', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
       });
-      await page.click('[data-testid="import-button-title"]');
+      const { apiContext } = await getApiContext(page);
 
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify CSV loaded correctly - this would fail before the fix
-      // because the CSV parser couldn't handle quoted FQN values
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-      await expect(page.getByTestId('add-row-btn')).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
-
-      // Verify the data rows are visible (database, schema, table, columns)
-      const rowCount = await page.locator('.rdg-row').count();
-      expect(rowCount).toBeGreaterThan(0);
-
-      // Click Next to validate
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      // Wait for validation to complete
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      // Verify no failures
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-
-      // Update
-      const updateButtonResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/importAsync') &&
-          response.url().includes('dryRun=false')
+      // Create a database service with a dot in the name (e.g., "local.mysql")
+      const serviceNameWithDot = `pw.db.service.${uuid()}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
       );
 
-      await page.getByRole('button', { name: 'Update' }).click();
-
-      await updateButtonResponse;
-
-      await page
-        .locator('.inovua-react-toolkit-load-mask__background-layer')
-        .waitFor({ state: 'detached', timeout: 60000 });
-
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
-      await page.waitForTimeout(2000);
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test that CSV with quoted FQN values can be loaded into the import grid.
-   * This is the core test for issue #24401 - verifying that the CSV parsing
-   * doesn't fail when FQN values contain escaped quotes.
-   */
-  test('CSV with quoted FQN loads correctly in import grid', async ({
-    browser,
-  }) => {
-    test.setTimeout(180_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `org.project.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    // Create a simple hierarchy
-    const database = await createDatabase(
-      apiContext,
-      `db${uid}`,
-      service.fullyQualifiedName
-    );
-    await createDatabaseSchema(
-      apiContext,
-      `schema${uid}`,
-      database.fullyQualifiedName
-    );
-
-    await redirectToHomePage(page);
-
-    await test.step('Export and verify CSV loads without parsing errors', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-
-      // Re-open import dialog
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // The main assertion - CSV should load without errors
-      // Before the fix, this would fail with CSV parsing error
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-      await expect(page.getByTestId('add-row-btn')).toBeVisible();
-      await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
-
-      // Verify rows are displayed
-      const rowCount = await page.locator('.rdg-row').count();
-      expect(rowCount).toBeGreaterThan(0);
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test the full import cycle - export, modify in grid, and reimport.
-   * This tests that the CSV reconstruction from grid data properly escapes
-   * quotes in FQN values.
-   */
-  test('Full import cycle with dot in service name', async ({ browser }) => {
-    test.setTimeout(300_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `test.mysql.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    // Create initial hierarchy
-    const database = await createDatabase(
-      apiContext,
-      `testdb${uid}`,
-      service.fullyQualifiedName
-    );
-    const schema = await createDatabaseSchema(
-      apiContext,
-      `testschema${uid}`,
-      database.fullyQualifiedName
-    );
-    await createTable(
-      apiContext,
-      `testtable${uid}`,
-      schema.fullyQualifiedName,
-      [
-        {
-          name: 'col1',
-          dataType: 'INT',
-          dataTypeDisplay: 'int',
-        },
-      ]
-    );
-
-    await redirectToHomePage(page);
-
-    await test.step('Export, load into grid, validate, and update', async () => {
-      // Export
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-
-      // Import
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify grid loaded
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Click Next to validate - this is where the CSV is reconstructed
-      // from the grid data and sent to the backend. Before the fix,
-      // this would fail because quotes in FQN weren't properly escaped.
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      // Wait for validation
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      // Verify validation passed with no failures
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-
-      // Update
-      const updateButtonResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/importAsync') &&
-          response.url().includes('dryRun=false')
+      // Create a database under the service
+      const databaseName = `pwdatabase${uuid().substring(0, 6)}`;
+      const database = await createDatabase(
+        apiContext,
+        databaseName,
+        service.fullyQualifiedName
       );
 
-      await page.getByRole('button', { name: 'Update' }).click();
-      await updateButtonResponse;
-
-      await page
-        .locator('.inovua-react-toolkit-load-mask__background-layer')
-        .waitFor({ state: 'detached', timeout: 60000 });
-
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
-      await page.waitForTimeout(2000);
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test with multiple dots in service name (e.g., "org.team.mysql.prod")
-   */
-  test('Service name with multiple dots', async ({ browser }) => {
-    test.setTimeout(180_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    // Multiple dots in service name
-    const serviceNameWithDot = `org.team.mysql.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    const database = await createDatabase(
-      apiContext,
-      `db${uid}`,
-      service.fullyQualifiedName
-    );
-    await createDatabaseSchema(
-      apiContext,
-      `schema${uid}`,
-      database.fullyQualifiedName
-    );
-
-    await redirectToHomePage(page);
-
-    await test.step('Export and reimport with multiple dots in name', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify CSV loads correctly
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-      await expect(page.getByTestId('add-row-btn')).toBeVisible();
-
-      // Validate
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test column with dot in name under a service with dot in name.
-   * This tests double quoting scenario where both service and column have dots.
-   * Column FQN: """service.name"".db.schema.table.""column.name"""
-   */
-  test('Column with dot in name under service with dot', async ({
-    browser,
-  }) => {
-    test.setTimeout(240_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `col.test.svc.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    // Create hierarchy with column that has dot in name
-    const database = await createDatabase(
-      apiContext,
-      `db${uid}`,
-      service.fullyQualifiedName
-    );
-    const schema = await createDatabaseSchema(
-      apiContext,
-      `schema${uid}`,
-      database.fullyQualifiedName
-    );
-
-    // Column with dot in name - requires quoting in FQN
-    await createTable(apiContext, `table${uid}`, schema.fullyQualifiedName, [
-      {
-        name: 'user.email',
-        dataType: 'VARCHAR',
-        dataTypeDisplay: 'varchar(255)',
-        dataLength: 255,
-        description: 'User email with dot in column name',
-      },
-      {
-        name: 'order.total',
-        dataType: 'DECIMAL',
-        dataTypeDisplay: 'decimal(10,2)',
-        description: 'Order total with dot in column name',
-      },
-    ]);
-
-    await redirectToHomePage(page);
-
-    await test.step('Export and reimport with column dots', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-
-      // Import the exported CSV
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify CSV loaded - columns with dots should be properly escaped
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Validate
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      // Verify no failures - this confirms column dots are handled
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test bulk edit via import - modify description of existing entity.
-   * This tests that editing in the grid and reimporting works with quoted FQNs.
-   */
-  test('Bulk edit existing entity with dot in service name', async ({
-    browser,
-  }) => {
-    test.setTimeout(300_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `edit.test.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    const databaseName = `editdb${uid}`;
-    const database = await createDatabase(
-      apiContext,
-      databaseName,
-      service.fullyQualifiedName
-    );
-    await createDatabaseSchema(
-      apiContext,
-      `editschema${uid}`,
-      database.fullyQualifiedName
-    );
-
-    await redirectToHomePage(page);
-
-    await test.step('Export, edit description in grid, and update', async () => {
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await performBulkDownload(page, serviceNameWithDot);
-
-      // Import
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Click on a cell to edit - find the first row's description cell
-      // Navigate to description column (3rd column) and edit
-      await page.locator('.rdg-row').nth(0).click();
-      const descriptionCell1 = page
-        .locator('.rdg-row')
-        .nth(0)
-        .locator('[aria-colindex="3"]');
-      await descriptionCell1.dblclick();
-
-      // Type new description
-      await fillDescriptionDetails(page, 'Updated description via bulk edit');
-
-      // Validate - this reconstructs CSV with edited data
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-
-      // Update
-      const updateButtonResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/importAsync') &&
-          response.url().includes('dryRun=false')
+      // Create a schema under the database
+      const schemaName = `pwschema${uuid().substring(0, 6)}`;
+      const schema = await createDatabaseSchema(
+        apiContext,
+        schemaName,
+        database.fullyQualifiedName
       );
 
-      await page.getByRole('button', { name: 'Update' }).click();
-      await updateButtonResponse;
-
-      await page
-        .locator('.inovua-react-toolkit-load-mask__background-layer')
-        .waitFor({ state: 'detached', timeout: 60000 });
-
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
-      await page.waitForTimeout(2000);
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test import at database level (not service level).
-   * This ensures the fix works when importing from database page.
-   */
-  test('Import at database level with dot in service name', async ({
-    browser,
-  }) => {
-    test.setTimeout(240_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `db.level.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    const databaseName = `leveldb${uid}`;
-    const database = await createDatabase(
-      apiContext,
-      databaseName,
-      service.fullyQualifiedName
-    );
-    const schema = await createDatabaseSchema(
-      apiContext,
-      `levelschema${uid}`,
-      database.fullyQualifiedName
-    );
-    await createTable(
-      apiContext,
-      `leveltable${uid}`,
-      schema.fullyQualifiedName,
-      [
+      // Create a table under the schema
+      const tableName = `pwtable${uuid().substring(0, 6)}`;
+      await createTable(apiContext, tableName, schema.fullyQualifiedName, [
         {
           name: 'id',
           dataType: 'INT',
           dataTypeDisplay: 'int',
+          description: 'Primary key',
         },
-      ]
-    );
-
-    await redirectToHomePage(page);
-
-    await test.step('Export and import at database level', async () => {
-      // Navigate to database page
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await page.getByTestId(databaseName).click();
-
-      // Export from database level
-      await performBulkDownload(page, databaseName);
-
-      // Import at database level
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${databaseName}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify CSV loaded
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Validate
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
-      });
-
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
-
-      // Update
-      const updateButtonResponse = page.waitForResponse(
-        (response) =>
-          response.url().includes('/importAsync') &&
-          response.url().includes('dryRun=false')
-      );
-
-      await page.getByRole('button', { name: 'Update' }).click();
-      await updateButtonResponse;
-
-      await page
-        .locator('.inovua-react-toolkit-load-mask__background-layer')
-        .waitFor({ state: 'detached', timeout: 60000 });
-
-      // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
-      await page.waitForTimeout(2000);
-    });
-
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-
-  /**
-   * Test import at schema level with dot in service name.
-   */
-  test('Import at schema level with dot in service name', async ({
-    browser,
-  }) => {
-    test.setTimeout(240_000);
-
-    const { page, afterAction } = await createNewPage(browser, {
-      navigate: true,
-    });
-    const { apiContext } = await getApiContext(page);
-
-    const uid = uuid().substring(0, 6);
-    const serviceNameWithDot = `schema.level.${uid}`;
-    const service = await createDatabaseServiceWithDot(
-      apiContext,
-      serviceNameWithDot
-    );
-
-    const databaseName = `schemadb${uid}`;
-    const database = await createDatabase(
-      apiContext,
-      databaseName,
-      service.fullyQualifiedName
-    );
-    const schemaName = `levelschema${uid}`;
-    const schema = await createDatabaseSchema(
-      apiContext,
-      schemaName,
-      database.fullyQualifiedName
-    );
-    await createTable(
-      apiContext,
-      `schematable${uid}`,
-      schema.fullyQualifiedName,
-      [
         {
-          name: 'col1',
-          dataType: 'INT',
-          dataTypeDisplay: 'int',
+          name: 'name',
+          dataType: 'VARCHAR',
+          dataTypeDisplay: 'varchar(255)',
+          dataLength: 255,
+          description: 'Name column',
         },
-      ]
-    );
+      ]);
 
-    await redirectToHomePage(page);
+      await redirectToHomePage(page);
 
-    await test.step('Export and import at schema level', async () => {
-      // Navigate to schema page
-      await visitServiceDetailsPage(
-        page,
-        { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
-        false
-      );
-      await page.getByTestId(databaseName).click();
-      await page.getByTestId(schemaName).click();
-
-      // Export from schema level
-      await performBulkDownload(page, schemaName);
-
-      // Import at schema level
-      await page.click('[data-testid="manage-button"]');
-      await page.getByTestId('manage-dropdown-list-container').waitFor({
-        state: 'visible',
-      });
-      await page.click('[data-testid="import-button-title"]');
-
-      const fileInput = page.getByTestId('upload-file-widget');
-      await fileInput?.setInputFiles([`downloads/${schemaName}.csv`]);
-
-      await startCsvPreviewAndWaitForGrid(page);
-
-      // Verify CSV loaded
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Validate
-      await page.getByRole('button', { name: 'Next' }).click();
-
-      await page.getByTestId('processed-row').waitFor({
-        timeout: 120000,
+      await test.step('Export database service with dot in name', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
       });
 
-      await expect(page.locator('[data-testid="failed-row"]')).toHaveText('0');
+      await test.step('Import exported CSV and verify parsing succeeds', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify CSV loaded correctly - this would fail before the fix
+        // because the CSV parser couldn't handle quoted FQN values
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+        await expect(page.getByTestId('add-row-btn')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
+
+        // Verify the data rows are visible (database, schema, table, columns)
+        const rowCount = await page.locator('.rdg-row').count();
+        expect(rowCount).toBeGreaterThan(0);
+
+        // Click Next to validate
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        // Wait for validation to complete
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        // Verify no failures
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+
+        // Update
+        const updateButtonResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/importAsync') &&
+            response.url().includes('dryRun=false')
+        );
+
+        await page.getByRole('button', { name: 'Update' }).click();
+
+        await updateButtonResponse;
+
+        await page
+          .locator('.inovua-react-toolkit-load-mask__background-layer')
+          .waitFor({ state: 'detached', timeout: 60000 });
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
+        await page.waitForTimeout(2000);
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
     });
 
-    // Cleanup
-    await deleteDatabaseService(apiContext, service.fullyQualifiedName);
-    await afterAction();
-  });
-});
+    /**
+     * Test that CSV with quoted FQN values can be loaded into the import grid.
+     * This is the core test for issue #24401 - verifying that the CSV parsing
+     * doesn't fail when FQN values contain escaped quotes.
+     */
+    test('CSV with quoted FQN loads correctly in import grid', async ({
+      browser,
+    }) => {
+      test.setTimeout(180_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `org.project.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      // Create a simple hierarchy
+      const database = await createDatabase(
+        apiContext,
+        `db${uid}`,
+        service.fullyQualifiedName
+      );
+      await createDatabaseSchema(
+        apiContext,
+        `schema${uid}`,
+        database.fullyQualifiedName
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export and verify CSV loads without parsing errors', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
+
+        // Re-open import dialog
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // The main assertion - CSV should load without errors
+        // Before the fix, this would fail with CSV parsing error
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+        await expect(page.getByTestId('add-row-btn')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Next' })).toBeVisible();
+
+        // Verify rows are displayed
+        const rowCount = await page.locator('.rdg-row').count();
+        expect(rowCount).toBeGreaterThan(0);
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test the full import cycle - export, modify in grid, and reimport.
+     * This tests that the CSV reconstruction from grid data properly escapes
+     * quotes in FQN values.
+     */
+    test('Full import cycle with dot in service name', async ({ browser }) => {
+      test.setTimeout(300_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `test.mysql.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      // Create initial hierarchy
+      const database = await createDatabase(
+        apiContext,
+        `testdb${uid}`,
+        service.fullyQualifiedName
+      );
+      const schema = await createDatabaseSchema(
+        apiContext,
+        `testschema${uid}`,
+        database.fullyQualifiedName
+      );
+      await createTable(
+        apiContext,
+        `testtable${uid}`,
+        schema.fullyQualifiedName,
+        [
+          {
+            name: 'col1',
+            dataType: 'INT',
+            dataTypeDisplay: 'int',
+          },
+        ]
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export, load into grid, validate, and update', async () => {
+        // Export
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
+
+        // Import
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify grid loaded
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        // Click Next to validate - this is where the CSV is reconstructed
+        // from the grid data and sent to the backend. Before the fix,
+        // this would fail because quotes in FQN weren't properly escaped.
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        // Wait for validation
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        // Verify validation passed with no failures
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+
+        // Update
+        const updateButtonResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/importAsync') &&
+            response.url().includes('dryRun=false')
+        );
+
+        await page.getByRole('button', { name: 'Update' }).click();
+        await updateButtonResponse;
+
+        await page
+          .locator('.inovua-react-toolkit-load-mask__background-layer')
+          .waitFor({ state: 'detached', timeout: 60000 });
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
+        await page.waitForTimeout(2000);
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test with multiple dots in service name (e.g., "org.team.mysql.prod")
+     */
+    test('Service name with multiple dots', async ({ browser }) => {
+      test.setTimeout(180_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      // Multiple dots in service name
+      const serviceNameWithDot = `org.team.mysql.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      const database = await createDatabase(
+        apiContext,
+        `db${uid}`,
+        service.fullyQualifiedName
+      );
+      await createDatabaseSchema(
+        apiContext,
+        `schema${uid}`,
+        database.fullyQualifiedName
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export and reimport with multiple dots in name', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
+
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify CSV loads correctly
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+        await expect(page.getByTestId('add-row-btn')).toBeVisible();
+
+        // Validate
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test column with dot in name under a service with dot in name.
+     * This tests double quoting scenario where both service and column have dots.
+     * Column FQN: """service.name"".db.schema.table.""column.name"""
+     */
+    test('Column with dot in name under service with dot', async ({
+      browser,
+    }) => {
+      test.setTimeout(240_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `col.test.svc.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      // Create hierarchy with column that has dot in name
+      const database = await createDatabase(
+        apiContext,
+        `db${uid}`,
+        service.fullyQualifiedName
+      );
+      const schema = await createDatabaseSchema(
+        apiContext,
+        `schema${uid}`,
+        database.fullyQualifiedName
+      );
+
+      // Column with dot in name - requires quoting in FQN
+      await createTable(apiContext, `table${uid}`, schema.fullyQualifiedName, [
+        {
+          name: 'user.email',
+          dataType: 'VARCHAR',
+          dataTypeDisplay: 'varchar(255)',
+          dataLength: 255,
+          description: 'User email with dot in column name',
+        },
+        {
+          name: 'order.total',
+          dataType: 'DECIMAL',
+          dataTypeDisplay: 'decimal(10,2)',
+          description: 'Order total with dot in column name',
+        },
+      ]);
+
+      await redirectToHomePage(page);
+
+      await test.step('Export and reimport with column dots', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
+
+        // Import the exported CSV
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify CSV loaded - columns with dots should be properly escaped
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        // Validate
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        // Verify no failures - this confirms column dots are handled
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test bulk edit via import - modify description of existing entity.
+     * This tests that editing in the grid and reimporting works with quoted FQNs.
+     */
+    test('Bulk edit existing entity with dot in service name', async ({
+      browser,
+    }) => {
+      test.setTimeout(300_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `edit.test.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      const databaseName = `editdb${uid}`;
+      const database = await createDatabase(
+        apiContext,
+        databaseName,
+        service.fullyQualifiedName
+      );
+      await createDatabaseSchema(
+        apiContext,
+        `editschema${uid}`,
+        database.fullyQualifiedName
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export, edit description in grid, and update', async () => {
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await performBulkDownload(page, serviceNameWithDot);
+
+        // Import
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${serviceNameWithDot}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        // Click on a cell to edit - find the first row's description cell
+        // Navigate to description column (3rd column) and edit
+        await page.locator('.rdg-row').nth(0).click();
+        const descriptionCell1 = page
+          .locator('.rdg-row')
+          .nth(0)
+          .locator('[aria-colindex="3"]');
+        await descriptionCell1.dblclick();
+
+        // Type new description
+        await fillDescriptionDetails(page, 'Updated description via bulk edit');
+
+        // Validate - this reconstructs CSV with edited data
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+
+        // Update
+        const updateButtonResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/importAsync') &&
+            response.url().includes('dryRun=false')
+        );
+
+        await page.getByRole('button', { name: 'Update' }).click();
+        await updateButtonResponse;
+
+        await page
+          .locator('.inovua-react-toolkit-load-mask__background-layer')
+          .waitFor({ state: 'detached', timeout: 60000 });
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
+        await page.waitForTimeout(2000);
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test import at database level (not service level).
+     * This ensures the fix works when importing from database page.
+     */
+    test('Import at database level with dot in service name', async ({
+      browser,
+    }) => {
+      test.setTimeout(240_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `db.level.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      const databaseName = `leveldb${uid}`;
+      const database = await createDatabase(
+        apiContext,
+        databaseName,
+        service.fullyQualifiedName
+      );
+      const schema = await createDatabaseSchema(
+        apiContext,
+        `levelschema${uid}`,
+        database.fullyQualifiedName
+      );
+      await createTable(
+        apiContext,
+        `leveltable${uid}`,
+        schema.fullyQualifiedName,
+        [
+          {
+            name: 'id',
+            dataType: 'INT',
+            dataTypeDisplay: 'int',
+          },
+        ]
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export and import at database level', async () => {
+        // Navigate to database page
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await page.getByTestId(databaseName).click();
+
+        // Export from database level
+        await performBulkDownload(page, databaseName);
+
+        // Import at database level
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${databaseName}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify CSV loaded
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        // Validate
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+
+        // Update
+        const updateButtonResponse = page.waitForResponse(
+          (response) =>
+            response.url().includes('/importAsync') &&
+            response.url().includes('dryRun=false')
+        );
+
+        await page.getByRole('button', { name: 'Update' }).click();
+        await updateButtonResponse;
+
+        await page
+          .locator('.inovua-react-toolkit-load-mask__background-layer')
+          .waitFor({ state: 'detached', timeout: 60000 });
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for async import processing to complete
+        await page.waitForTimeout(2000);
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+
+    /**
+     * Test import at schema level with dot in service name.
+     */
+    test('Import at schema level with dot in service name', async ({
+      browser,
+    }) => {
+      test.setTimeout(240_000);
+
+      const { page, afterAction } = await createNewPage(browser, {
+        navigate: true,
+      });
+      const { apiContext } = await getApiContext(page);
+
+      const uid = uuid().substring(0, 6);
+      const serviceNameWithDot = `schema.level.${uid}`;
+      const service = await createDatabaseServiceWithDot(
+        apiContext,
+        serviceNameWithDot
+      );
+
+      const databaseName = `schemadb${uid}`;
+      const database = await createDatabase(
+        apiContext,
+        databaseName,
+        service.fullyQualifiedName
+      );
+      const schemaName = `levelschema${uid}`;
+      const schema = await createDatabaseSchema(
+        apiContext,
+        schemaName,
+        database.fullyQualifiedName
+      );
+      await createTable(
+        apiContext,
+        `schematable${uid}`,
+        schema.fullyQualifiedName,
+        [
+          {
+            name: 'col1',
+            dataType: 'INT',
+            dataTypeDisplay: 'int',
+          },
+        ]
+      );
+
+      await redirectToHomePage(page);
+
+      await test.step('Export and import at schema level', async () => {
+        // Navigate to schema page
+        await visitServiceDetailsPage(
+          page,
+          { name: serviceNameWithDot, type: SERVICE_TYPE.Database },
+          false
+        );
+        await page.getByTestId(databaseName).click();
+        await page.getByTestId(schemaName).click();
+
+        // Export from schema level
+        await performBulkDownload(page, schemaName);
+
+        // Import at schema level
+        await page.click('[data-testid="manage-button"]');
+        await page.getByTestId('manage-dropdown-list-container').waitFor({
+          state: 'visible',
+        });
+        await page.click('[data-testid="import-button-title"]');
+
+        const fileInput = page.getByTestId('upload-file-widget');
+        await fileInput?.setInputFiles([`downloads/${schemaName}.csv`]);
+
+        await startCsvPreviewAndWaitForGrid(page);
+
+        // Verify CSV loaded
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
+
+        // Validate
+        await page.getByRole('button', { name: 'Next' }).click();
+
+        await page.getByTestId('processed-row').waitFor({
+          timeout: 120000,
+        });
+
+        await expect(page.locator('[data-testid="failed-row"]')).toHaveText(
+          '0'
+        );
+      });
+
+      // Cleanup
+      await deleteDatabaseService(apiContext, service.fullyQualifiedName);
+      await afterAction();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImportWithDotInName.spec.ts
@@ -144,7 +144,10 @@ async function deleteDatabaseService(
  *
  * Example FQN in CSV: """local.mysql"".default" (quotes are doubled for escaping)
  */
-test.describe('Bulk Import Export with Dot in Service Name', () => {
+test.describe(
+  'Bulk Import Export with Dot in Service Name',
+  { tag: '@import-export' },
+  () => {
   /**
    * Test export and re-import of a database service with a dot in the name.
    * This verifies that:

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportBasic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportBasic.spec.ts
@@ -111,7 +111,7 @@ const getFqn = (table: TableClass): string => {
 test.describe(
   'Test Case Bulk Import/Export - Admin User',
   {
-    tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`],
+    tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'],
   },
   () => {
     const table = new TableClass();
@@ -271,7 +271,7 @@ test.describe(
 
 test.describe(
   'Test Case Import/Export/Edits - Permissions',
-  { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality` },
+  { tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'] },
   () => {
     test.describe.configure({ mode: 'default' });
 
@@ -557,7 +557,7 @@ test.describe(
 
 test.describe(
   'Test Case Bulk Edit - Cancel Redirect',
-  { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality` },
+  { tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'] },
   () => {
     const table = new TableClass();
 
@@ -610,7 +610,7 @@ test.describe(
 
 test.describe(
   'Logical Test Suite - Bulk Import/Export/Edit Operations',
-  { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality` },
+  { tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'] },
   () => {
     const testSuiteName = `pw-logical-suite-${uuid()}`;
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts
@@ -60,7 +60,7 @@ const test = base.extend<{
 
 test.describe(
   'Test Case Import/Export/Edit - End-to-End Flow with Admin',
-  { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality` },
+  { tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'] },
   () => {
     const table = new TableClass();
 
@@ -108,7 +108,7 @@ test.describe(
 
 test.describe(
   'Test Case Import/Export/Edit - End-to-End Flow with EditAll User on TestCase resource',
-  { tag: `${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality` },
+  { tag: [`${DOMAIN_TAGS.OBSERVABILITY}:Data_Quality`, '@import-export'] },
   () => {
     const table = new TableClass();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
@@ -37,79 +37,80 @@ test.describe(
   'Lineage PNG export — snapshot regression',
   { tag: '@import-export' },
   () => {
-  test('exported PNG includes edge lines between nodes', async ({ page }) => {
-    // Navigate to the lineage view and wait for lineage data to load
-    const lineageResponsePromise = page.waitForResponse(
-      '/api/v1/lineage/getLineage*'
-    );
-    await page.goto(LINEAGE_URL);
-    await lineageResponsePromise;
+    test('exported PNG includes edge lines between nodes', async ({ page }) => {
+      // Navigate to the lineage view and wait for lineage data to load
+      const lineageResponsePromise = page.waitForResponse(
+        '/api/v1/lineage/getLineage*'
+      );
+      await page.goto(LINEAGE_URL);
+      await lineageResponsePromise;
 
-    // Wait for nodes to render, then wait until the canvas has been drawn.
-    // CanvasEdgeRenderer draws on requestAnimationFrame — polling the canvas
-    // dimensions confirms the draw cycle has completed.
-    await page
-      .locator('.react-flow__node')
-      .first()
-      .waitFor({ state: 'visible' });
-    await page.waitForFunction(() => {
-      const canvas = document.querySelector(
-        '#lineage-container canvas'
-      ) as HTMLCanvasElement | null;
+      // Wait for nodes to render, then wait until the canvas has been drawn.
+      // CanvasEdgeRenderer draws on requestAnimationFrame — polling the canvas
+      // dimensions confirms the draw cycle has completed.
+      await page
+        .locator('.react-flow__node')
+        .first()
+        .waitFor({ state: 'visible' });
+      await page.waitForFunction(() => {
+        const canvas = document.querySelector(
+          '#lineage-container canvas'
+        ) as HTMLCanvasElement | null;
 
-      return canvas !== null && canvas.width > 0 && canvas.height > 0;
+        return canvas !== null && canvas.width > 0 && canvas.height > 0;
+      });
+
+      // perform fit view to ensure all the nodes are in view
+      await page.getByTestId('fit-screen').click();
+      await expect(
+        page.getByRole('menu', { name: 'Lineage View Options' })
+      ).toBeVisible();
+
+      await page.getByRole('menuitem', { name: 'Fit to screen' }).click();
+
+      // perform zoom out to add breathing space around
+      await performZoomOut(page, 2);
+
+      // Open the export modal
+      await expect(page.getByTestId('export-button')).toBeEnabled();
+      await page.getByTestId('export-button').click();
+
+      await page
+        .locator(
+          '[data-testid="export-entity-modal"] [data-testid="submit-button"]'
+        )
+        .waitFor({ state: 'visible' });
+
+      // Select PNG (the modal defaults to CSV for entity lineage)
+      await page.getByTestId('export-type-select').click();
+      await page.getByRole('option', { name: 'PNG' }).click();
+      await expect(page.getByTestId('export-type-select')).toContainText('PNG');
+
+      // Trigger download
+      const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        page.click(
+          '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
+        ),
+      ]);
+
+      const filePath = await download.path();
+      expect(filePath).not.toBeNull();
+
+      // Edge-presence check via file size.
+      // A pixel-perfect snapshot is too fragile here because any legitimate
+      // change to the lineage layout (ELK algorithm, node padding, dark-theme
+      // tokens) shifts dimensions and trips toMatchSnapshot's strict size check
+      // before any pixel comparison runs.
+      //
+      // The original bug (#29124) stripped all edges from the PNG, leaving
+      // large contiguous white regions that compress to a very small file
+      // (<100KB). A PNG that contains edges between nodes is dominated by
+      // bezier strokes and is reliably >200KB across layout variations.
+      // This bound catches the regression without coupling to exact layout.
+      const buffer = fs.readFileSync(filePath!);
+
+      expect(buffer.length).toBeGreaterThan(200_000);
     });
-
-    // perform fit view to ensure all the nodes are in view
-    await page.getByTestId('fit-screen').click();
-    await expect(
-      page.getByRole('menu', { name: 'Lineage View Options' })
-    ).toBeVisible();
-
-    await page.getByRole('menuitem', { name: 'Fit to screen' }).click();
-
-    // perform zoom out to add breathing space around
-    await performZoomOut(page, 2);
-
-    // Open the export modal
-    await expect(page.getByTestId('export-button')).toBeEnabled();
-    await page.getByTestId('export-button').click();
-
-    await page
-      .locator(
-        '[data-testid="export-entity-modal"] [data-testid="submit-button"]'
-      )
-      .waitFor({ state: 'visible' });
-
-    // Select PNG (the modal defaults to CSV for entity lineage)
-    await page.getByTestId('export-type-select').click();
-    await page.getByRole('option', { name: 'PNG' }).click();
-    await expect(page.getByTestId('export-type-select')).toContainText('PNG');
-
-    // Trigger download
-    const [download] = await Promise.all([
-      page.waitForEvent('download'),
-      page.click(
-        '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
-      ),
-    ]);
-
-    const filePath = await download.path();
-    expect(filePath).not.toBeNull();
-
-    // Edge-presence check via file size.
-    // A pixel-perfect snapshot is too fragile here because any legitimate
-    // change to the lineage layout (ELK algorithm, node padding, dark-theme
-    // tokens) shifts dimensions and trips toMatchSnapshot's strict size check
-    // before any pixel comparison runs.
-    //
-    // The original bug (#29124) stripped all edges from the PNG, leaving
-    // large contiguous white regions that compress to a very small file
-    // (<100KB). A PNG that contains edges between nodes is dominated by
-    // bezier strokes and is reliably >200KB across layout variations.
-    // This bound catches the regression without coupling to exact layout.
-    const buffer = fs.readFileSync(filePath!);
-
-    expect(buffer.length).toBeGreaterThan(200_000);
-  });
-});
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LineageExportPNGSnapshot.spec.ts
@@ -33,7 +33,10 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 const LINEAGE_URL =
   '/table/sample_data.ecommerce_db.shopify.raw_customer/lineage?fullscreen=true';
 
-test.describe('Lineage PNG export — snapshot regression', () => {
+test.describe(
+  'Lineage PNG export — snapshot regression',
+  { tag: '@import-export' },
+  () => {
   test('exported PNG includes edge lines between nodes', async ({ page }) => {
     // Navigate to the lineage view and wait for lineage data to load
     const lineageResponsePromise = page.waitForResponse(

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -921,776 +921,793 @@ test.describe(
   'Metrics bulk import, export, and edit',
   { tag: '@import-export' },
   () => {
-  test.beforeAll(async () => {
-    test.setTimeout(180_000);
-    const adminContext = await createAdminApiContext();
-    apiContext = adminContext.apiContext;
-    disposeApiContext = adminContext.afterAction;
-    metricCustomPropertyName = `metric_cp_${getNameSuffix()}`;
-    await createMetricStringCustomProperty(metricCustomPropertyName);
-    fixtures = await createFixtures(metricCustomPropertyName);
+    test.beforeAll(async () => {
+      test.setTimeout(180_000);
+      const adminContext = await createAdminApiContext();
+      apiContext = adminContext.apiContext;
+      disposeApiContext = adminContext.afterAction;
+      metricCustomPropertyName = `metric_cp_${getNameSuffix()}`;
+      await createMetricStringCustomProperty(metricCustomPropertyName);
+      fixtures = await createFixtures(metricCustomPropertyName);
 
-    viewOnlyUser = new UserClass();
-    viewOnlyPolicy = new PolicyClass();
-    viewOnlyRole = new RolesClass();
-    await viewOnlyUser.create(apiContext, false);
-    await viewOnlyPolicy.create(apiContext, VIEW_ONLY_RULE);
-    await viewOnlyRole.create(apiContext, [viewOnlyPolicy.responseData.name]);
-    await viewOnlyUser.patch({
-      apiContext,
-      patchData: [
-        {
-          op: 'add',
-          path: '/roles/0',
-          value: {
-            id: viewOnlyRole.responseData.id,
-            type: 'role',
-            name: viewOnlyRole.responseData.name,
+      viewOnlyUser = new UserClass();
+      viewOnlyPolicy = new PolicyClass();
+      viewOnlyRole = new RolesClass();
+      await viewOnlyUser.create(apiContext, false);
+      await viewOnlyPolicy.create(apiContext, VIEW_ONLY_RULE);
+      await viewOnlyRole.create(apiContext, [viewOnlyPolicy.responseData.name]);
+      await viewOnlyUser.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/roles/0',
+            value: {
+              id: viewOnlyRole.responseData.id,
+              type: 'role',
+              name: viewOnlyRole.responseData.name,
+            },
           },
-        },
-      ],
-    });
+        ],
+      });
 
-    metricEditorUser = new UserClass();
-    metricEditorPolicy = new PolicyClass();
-    metricEditorRole = new RolesClass();
-    await metricEditorUser.create(apiContext, false);
-    await metricEditorPolicy.create(apiContext, METRIC_EDITOR_RULES);
-    await metricEditorRole.create(apiContext, [
-      metricEditorPolicy.responseData.name,
-    ]);
-    await metricEditorUser.patch({
-      apiContext,
-      patchData: [
-        {
-          op: 'add',
-          path: '/roles/0',
-          value: {
-            id: metricEditorRole.responseData.id,
-            type: 'role',
-            name: metricEditorRole.responseData.name,
+      metricEditorUser = new UserClass();
+      metricEditorPolicy = new PolicyClass();
+      metricEditorRole = new RolesClass();
+      await metricEditorUser.create(apiContext, false);
+      await metricEditorPolicy.create(apiContext, METRIC_EDITOR_RULES);
+      await metricEditorRole.create(apiContext, [
+        metricEditorPolicy.responseData.name,
+      ]);
+      await metricEditorUser.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/roles/0',
+            value: {
+              id: metricEditorRole.responseData.id,
+              type: 'role',
+              name: metricEditorRole.responseData.name,
+            },
           },
-        },
-      ],
-    });
-  });
-
-  test.afterAll(async () => {
-    test.setTimeout(120_000);
-    await Promise.allSettled([
-      viewOnlyUser?.delete(apiContext),
-      viewOnlyRole?.delete(apiContext),
-      viewOnlyPolicy?.delete(apiContext),
-      metricEditorUser?.delete(apiContext),
-      metricEditorRole?.delete(apiContext),
-      metricEditorPolicy?.delete(apiContext),
-    ]);
-    await cleanupFixtures();
-    await cleanupMetricCustomProperty();
-    await disposeApiContext?.();
-  });
-
-  test('Admin starts exactly one async export job from the metrics listing', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
-    await openMetricActions(page);
-
-    let exportRequestCount = 0;
-    page.on('request', (request) => {
-      if (request.url().includes('/api/v1/metrics/name/*/exportAsync')) {
-        exportRequestCount += 1;
-      }
+        ],
+      });
     });
 
-    const exportResponse = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/metrics/name/*/exportAsync') &&
-        response.request().method() === 'GET'
-    );
-
-    await clickMetricAction(page, 'Export');
-    const response = await exportResponse;
-    expect(response.ok()).toBeTruthy();
-    // Verify exactly one export request was fired (no duplicate calls).
-    await expect.poll(() => exportRequestCount).toBe(1);
-    await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible({
-      timeout: 30000,
-    });
-    await page.locator('.csv-jobs-tray-launcher').click();
-    await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible();
-    // Verify the export job appears in the tray. Parallel workers share the
-    // admin identity and may have their own active jobs; checking an exact
-    // count is fragile. Instead, assert that a tray item carrying the export
-    // label is visible — the exportRequestCount check above already guarantees
-    // exactly one export request was sent.
-    await expect(
-      page
-        .locator('.csv-jobs-tray-item')
-        .filter({ hasText: /Exporting Metrics|Exported Metrics/ })
-    ).toBeVisible();
-  });
-
-  test('Admin imports a metric CSV through preview and async apply', async ({
-    page,
-  }) => {
-    test.slow();
-    const importedMetricName = `${fixtures.prefix}_imported`;
-    fixtures.metrics.push({
-      id: '',
-      name: importedMetricName,
-      fullyQualifiedName: importedMetricName,
+    test.afterAll(async () => {
+      test.setTimeout(120_000);
+      await Promise.allSettled([
+        viewOnlyUser?.delete(apiContext),
+        viewOnlyRole?.delete(apiContext),
+        viewOnlyPolicy?.delete(apiContext),
+        metricEditorUser?.delete(apiContext),
+        metricEditorRole?.delete(apiContext),
+        metricEditorPolicy?.delete(apiContext),
+      ]);
+      await cleanupFixtures();
+      await cleanupMetricCustomProperty();
+      await disposeApiContext?.();
     });
 
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
-
-    const csvPath = createMetricCsvFile(importedMetricName);
-    await uploadMetricCsvAndWaitForPreview(page, csvPath);
-    await expect(
-      page.getByRole('gridcell', { exact: true, name: importedMetricName })
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /Start Import/i })
-    ).toBeVisible();
-
-    const applyResponse = waitForMetricImportResponse(page, false);
-    await page.getByRole('button', { name: /Start Import/i }).click();
-    await applyResponse;
-    await expectMetricImportStatus(page, {
-      processed: '1',
-      passed: '1',
-      failed: '0',
-    });
-
-    await expectImportedMetricComplexFields(importedMetricName);
-  });
-
-  test('Admin sees metric CSV validation failures for missing names and invalid references', async ({
-    page,
-  }) => {
-    test.slow();
-    const invalidCsvPath = createInvalidMetricCsvFile(
-      `${fixtures.prefix}_invalid_import`
-    );
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
-
-    await uploadMetricCsvAndWaitForPreview(page, invalidCsvPath);
-    await expectMetricImportStatus(page, {
-      processed: '2',
-      passed: '0',
-      failed: '2',
-    });
-    await expect(page.getByText('Missing name display')).toBeVisible();
-    await expect(page.getByText('Invalid references display')).toBeVisible();
-  });
-
-  test('Admin imports a CSV update for an existing metric', async ({
-    page,
-  }) => {
-    test.slow();
-    const existingMetricName = fixtures.metrics[1].name;
-    const updatedDisplayName = `${fixtures.prefix} Import Updated`;
-    const csv = createCsv([
-      [
-        existingMetricName,
-        updatedDisplayName,
-        'Metric updated from Playwright CSV',
-        'COUNT',
-        'COUNT',
-        '',
-        'MONTH',
-        'SQL',
-        'COUNT(order_id)',
-        fixtures.metrics[0].fullyQualifiedName,
-        fixtures.secondTag.fullyQualifiedName,
-        fixtures.nestedGlossaryTerm.fullyQualifiedName,
-        'Tier.Tier3',
-        `user:${fixtures.owner.name}`,
-        `team:${fixtures.reviewer.name}`,
-        fixtures.domain.fullyQualifiedName,
-        fixtures.dataProduct.fullyQualifiedName,
-        'Approved',
-        `${metricCustomPropertyName}:updated custom value`,
-      ],
-    ]);
-    const csvPath = test.info().outputPath(`${existingMetricName}-update.csv`);
-    fs.writeFileSync(csvPath, csv);
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
-
-    await uploadMetricCsvAndWaitForPreview(page, csvPath);
-    await expect(page.getByText(updatedDisplayName)).toBeVisible();
-
-    const applyResponse = waitForMetricImportResponse(page, false);
-    await page.getByRole('button', { name: /Start Import/i }).click();
-    const response = await applyResponse;
-    expect(response.ok()).toBeTruthy();
-    await expectMetricImportStatus(page, {
-      processed: '1',
-      passed: '1',
-      failed: '0',
-    });
-
-    const updatedMetric = await parseResponse<MetricResponse>(
-      await apiContext.get(
-        `/api/v1/metrics/name/${existingMetricName}?fields=extension&include=all`
-      ),
-      'fetch CSV-updated metric'
-    );
-    expect(updatedMetric.displayName).toBe(updatedDisplayName);
-    expect(updatedMetric.extension).toMatchObject({
-      [metricCustomPropertyName]: 'updated custom value',
-    });
-  });
-
-  test('Admin bulk edits filtered metrics from the listing API without export jobs', async ({
-    page,
-  }) => {
-    test.slow();
-    const targetMetricName = fixtures.metrics[METRIC_FIXTURE_COUNT - 1].name;
-    const updatedDisplayName = `${fixtures.prefix} Updated Display`;
-    let exportRequestCount = 0;
-    page.on('request', (request) => {
-      if (request.url().includes('/exportAsync')) {
-        exportRequestCount += 1;
-      }
-    });
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetricName);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetricName);
-
-    await expect.poll(() => exportRequestCount).toBe(0);
-
-    const nextButton = page.getByRole('button', { name: 'Next' });
-    await expect(nextButton).toBeDisabled();
-    await editFirstDisplayNameCell(page, updatedDisplayName);
-    await expect(nextButton).toBeEnabled();
-
-    const validateResponse = waitForMetricImportResponse(page, true);
-    await nextButton.click();
-    await validateResponse;
-    await expectMetricImportStatus(page, {
-      processed: '1',
-      passed: '1',
-      failed: '0',
-    });
-
-    const updateResponse = waitForMetricImportResponse(page, false);
-    await page.getByRole('button', { name: 'Update' }).click();
-    const response = await updateResponse;
-    expect(response.ok()).toBeTruthy();
-    await page.waitForURL(/\/metrics/, { timeout: 90000 });
-
-    const updatedMetric = await parseResponse<MetricResponse>(
-      await apiContext.get(`/api/v1/metrics/name/${targetMetricName}`),
-      'fetch updated metric'
-    );
-    expect(updatedMetric.displayName).toBe(updatedDisplayName);
-  });
-
-  test('Admin bulk edit keeps text edits on blur and can revert to no changes', async ({
-    page,
-  }) => {
-    const targetMetricName = fixtures.metrics[2].name;
-    const originalDisplayName = fixtures.metrics[2].displayName ?? '';
-    const updatedDisplayName = `${fixtures.prefix} Blur Saved`;
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetricName);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetricName);
-
-    const nextButton = getBulkEditNextButton(page);
-    await expect(nextButton).toBeDisabled();
-    await editFirstDisplayNameCellAndBlur(page, updatedDisplayName);
-    await expect(nextButton).toBeEnabled();
-
-    await page.getByRole('button', { name: 'Revert Changes' }).click();
-    await expect(nextButton).toBeDisabled();
-    await expect(
-      page.locator('.rdg-row').first().locator('[aria-colindex="3"]')
-    ).toContainText(originalDisplayName);
-  });
-
-  test('Admin bulk edit hydrates filtered metrics across cursor pages', async ({
-    page,
-  }) => {
-    const { getPageRequestCount, pagedMetricName } =
-      await routePagedMetricBulkHydration(page);
-    let exportRequestCount = 0;
-    page.on('request', (request) => {
-      if (request.url().includes('/exportAsync')) {
-        exportRequestCount += 1;
-      }
-    });
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, 'paged_only_metric');
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, pagedMetricName);
-
-    await expect.poll(getPageRequestCount).toBe(2);
-    await expect.poll(() => exportRequestCount).toBe(0);
-    await expect(
-      page.getByText(`${fixtures.prefix}_paged_skip`)
-    ).not.toBeVisible();
-  });
-
-  test('Admin bulk edit renders complex fields from listing hydration', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[0];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    await expect(page.getByText(targetMetric.displayName ?? '')).toBeVisible();
-    await expectVisibleAfterHorizontalScroll(
+    test('Admin starts exactly one async export job from the metrics listing', async ({
       page,
-      page.getByText(/SELECT SUM\(amount\)/)
-    );
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+      await openMetricActions(page);
 
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(fixtures.tag.fullyQualifiedName)
-    );
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.locator(
-        `[title="${fixtures.nestedGlossaryTerm.fullyQualifiedName}"]`
-      )
-    );
-    await expectVisibleAfterHorizontalScroll(page, page.getByText('Tier2'));
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(fixtures.owner.name)
-    );
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(fixtures.reviewer.name)
-    );
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(fixtures.domain.fullyQualifiedName)
-    );
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(fixtures.dataProduct.fullyQualifiedName)
-    );
-    await expectVisibleAfterHorizontalScroll(
-      page,
-      page.getByText(`${fixtures.prefix} custom property 0`)
-    );
-  });
-
-  test('Admin bulk edits only selected metric rows', async ({ page }) => {
-    let exportRequestCount = 0;
-    page.on('request', (request) => {
-      if (request.url().includes('/exportAsync')) {
-        exportRequestCount += 1;
-      }
-    });
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    const { metric: selectedMetric, row } =
-      await getFirstVisibleFixtureMetricRow(page);
-
-    // eslint-disable-next-line playwright/no-force-option -- styled checkbox control intercepts the native input.
-    await row.getByRole('checkbox').check({ force: true });
-    await expect(page.locator('.metric-list-selection-count')).toHaveText('1');
-
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, selectedMetric.name);
-
-    await expect.poll(() => exportRequestCount).toBe(0);
-    await expect(page.locator('.bulk-edit-name-value')).toHaveText([
-      selectedMetric.name,
-    ]);
-  });
-
-  test('Cancel from metric bulk edit returns to the metrics listing', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await getFirstVisibleFixtureMetricRow(page);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page);
-
-    await page.getByRole('button', { name: 'Cancel' }).click();
-    await expect(page).toHaveURL(/\/metrics/);
-  });
-
-  test('Custom metric editor role can import export and bulk edit metrics', async ({
-    browser,
-  }) => {
-    const metricEditorPage = await browser.newPage();
-    await metricEditorUser.login(metricEditorPage);
-
-    try {
-      await redirectToHomePage(metricEditorPage);
-      await waitForMetricsPage(metricEditorPage);
-      await expect(metricEditorPage.getByTestId('create-metric')).toBeVisible();
-      await expect(
-        metricEditorPage.getByTestId('bulk-edit-metric')
-      ).toBeVisible();
-      await openMetricActions(metricEditorPage);
-      await expect(
-        metricEditorPage
-          .locator('.metric-actions-menu-item')
-          .filter({ hasText: 'Export' })
-      ).toBeVisible();
-      await expect(
-        metricEditorPage
-          .locator('.metric-actions-menu-item')
-          .filter({ hasText: 'Import' })
-      ).toBeVisible();
-      await metricEditorPage.keyboard.press('Escape');
-
-      await verifyPageAccess(metricEditorPage, '/bulk/import/metric/*', true);
-      await verifyPageAccess(metricEditorPage, '/bulk/edit/metric/*', true);
-    } finally {
-      await metricEditorPage.close();
-    }
-  });
-
-  test('Restricted roles cannot access metric import or bulk edit', async ({
-    browser,
-    dataConsumerPage,
-    dataStewardPage,
-    viewOnlyPage,
-  }) => {
-    test.slow();
-    const customViewOnlyPage = await browser.newPage();
-    await viewOnlyUser.login(customViewOnlyPage);
-
-    try {
-      for (const restrictedPage of [
-        dataConsumerPage,
-        dataStewardPage,
-        viewOnlyPage,
-        customViewOnlyPage,
-      ]) {
-        await redirectToHomePage(restrictedPage);
-        await waitForMetricsPage(restrictedPage);
-        await expect(
-          restrictedPage.getByTestId('create-metric')
-        ).not.toBeVisible();
-        await expect(
-          restrictedPage.getByTestId('bulk-edit-metric')
-        ).not.toBeVisible();
-        await expect(
-          restrictedPage.getByTestId('metric-actions')
-        ).not.toBeVisible();
-        await verifyPageAccess(restrictedPage, '/bulk/import/metric/*', false);
-        await verifyPageAccess(restrictedPage, '/bulk/edit/metric/*', false);
-      }
-    } finally {
-      await customViewOnlyPage.close();
-    }
-  });
-
-  test('Bulk edit grid shows NO_CHANGE badge on unmodified rows', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[3];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    await expect(
-      page.locator('.bulk-edit-operation-badge-no_change').first()
-    ).toBeVisible();
-    await expect(page.getByTestId('bulk-edit-operation-summary')).toBeVisible();
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-no_change')
-    ).toContainText('1');
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-update')
-    ).toContainText('0');
-  });
-
-  test('Bulk edit grid shows UPDATE badge and increments summary after editing a cell', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[4];
-    const updatedDisplayName = `${fixtures.prefix} Badge Update Test`;
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    await expect(
-      page.locator('.bulk-edit-operation-badge-no_change').first()
-    ).toBeVisible();
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-update')
-    ).toContainText('0');
-
-    await editFirstDisplayNameCell(page, updatedDisplayName);
-
-    await expect(
-      page.locator('.bulk-edit-operation-badge-update').first()
-    ).toBeVisible();
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-update')
-    ).toContainText('1');
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-no_change')
-    ).toContainText('0');
-  });
-
-  test('Adding a new metric row shows CREATE badge once name is filled', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[5];
-    const newMetricName = `${fixtures.prefix}_add_row_test`;
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    await page.getByTestId('bulk-edit-add-metric').click();
-
-    await expect(page.locator('.rdg-row')).toHaveCount(2);
-
-    const newRow = page.locator('.rdg-row').last();
-    const nameCell = newRow.locator('[aria-colindex="2"]');
-    await nameCell.dblclick();
-
-    const nameEditor = page
-      .locator(`${RDG_ACTIVE_CELL_SELECTOR} input`)
-      .first();
-    await expect(nameEditor).toBeVisible();
-    await nameEditor.fill(newMetricName);
-    await nameEditor.press('Enter');
-
-    await expect(
-      page.locator('.bulk-edit-operation-badge-create')
-    ).toBeVisible();
-    await expect(
-      page.locator('.bulk-edit-operation-summary-count-create')
-    ).toContainText('1');
-  });
-
-  test('New metric row without a name shows error pill and SKIP badge', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[6];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    await page.getByTestId('bulk-edit-add-metric').click();
-
-    await expect(page.locator('.bulk-edit-error-pill')).toBeVisible();
-    await expect(
-      page.locator('.bulk-edit-operation-badge-skip').last()
-    ).toBeVisible();
-  });
-
-  test('Removing a newly added metric row restores the grid state', async ({
-    page,
-  }) => {
-    const targetMetric = fixtures.metrics[7];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, targetMetric.name);
-    await page.getByTestId('bulk-edit-metric').click();
-    await waitForMetricBulkEditGrid(page, targetMetric.name);
-
-    const rowsBefore = await page.locator('.rdg-row').count();
-
-    await page.getByTestId('bulk-edit-add-metric').click();
-    await expect(page.locator('.rdg-row')).toHaveCount(rowsBefore + 1);
-
-    await page.getByTestId('bulk-edit-remove-row').click();
-    await expect(page.locator('.rdg-row')).toHaveCount(rowsBefore);
-    await expect(page.locator('.bulk-edit-error-pill')).not.toBeVisible();
-  });
-
-  test('Bulk edit grid search filters rows to match the search term', async ({
-    page,
-  }) => {
-    const firstMetric = fixtures.metrics[0];
-    const lastMetric = fixtures.metrics[METRIC_FIXTURE_COUNT - 2];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
-    await page.getByTestId('bulk-edit-metric').click();
-    await expect(page).toHaveURL(/\/bulk\/edit\/metric\/\*/);
-    await expect(page.locator('.rdg-header-row')).toBeVisible({
-      timeout: 90_000,
-    });
-    await expect(page.locator('.rdg-row').first()).toBeVisible();
-
-    const searchInput = page.getByTestId('bulk-edit-search').locator('input');
-    await searchInput.fill(firstMetric.name);
-
-    await expect(page.getByText(firstMetric.name)).toBeVisible();
-    await expect(page.getByText(lastMetric.name)).not.toBeVisible();
-  });
-
-  test('Clearing the bulk edit search box restores all rows', async ({
-    page,
-  }) => {
-    const firstMetric = fixtures.metrics[0];
-    const lastMetric = fixtures.metrics[METRIC_FIXTURE_COUNT - 2];
-
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
-    await page.getByTestId('bulk-edit-metric').click();
-    await expect(page).toHaveURL(/\/bulk\/edit\/metric\/\*/);
-    await expect(page.locator('.rdg-header-row')).toBeVisible({
-      timeout: 90_000,
-    });
-    await expect(page.locator('.rdg-row').first()).toBeVisible();
-
-    const searchInput = page.getByTestId('bulk-edit-search').locator('input');
-    await searchInput.fill(firstMetric.name);
-    await expect(page.getByText(lastMetric.name)).not.toBeVisible();
-
-    await searchInput.fill('');
-    await expect(page.getByText(lastMetric.name)).toBeVisible();
-  });
-
-  test('Admin can cancel a metric import mid-flight and cancel API is called', async ({
-    page,
-  }) => {
-    test.slow();
-
-    const cancelMetricName = `${fixtures.prefix}_cancel_flight`;
-    const csvPath = createMetricCsvFile(cancelMetricName);
-
-    // The Cancel Import button is enabled only after the server sends a WebSocket
-    // STARTED event.  We must intercept the socket BEFORE the first navigation so
-    // the connection is routed through Playwright.  We use a flag to let the
-    // dry-run (dryRun=true) COMPLETED event pass — it renders the preview grid —
-    // while blocking the actual import COMPLETED to keep the button clickable.
-    let blockImportCompletion = false;
-
-    await page.routeWebSocket(/\/api\/v1\/push\/feed/, (ws) => {
-      const server = ws.connectToServer();
-
-      server.onMessage((msg) => {
-        if (
-          blockImportCompletion &&
-          typeof msg === 'string' &&
-          msg.includes('csvImportChannel') &&
-          (msg.includes('COMPLETED') || msg.includes('FAILED'))
-        ) {
-          return; // Drop — keeps the Cancel Import button enabled
+      let exportRequestCount = 0;
+      page.on('request', (request) => {
+        if (request.url().includes('/api/v1/metrics/name/*/exportAsync')) {
+          exportRequestCount += 1;
         }
-        ws.send(msg);
       });
 
-      ws.onMessage((msg) => server.send(msg));
+      const exportResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/metrics/name/*/exportAsync') &&
+          response.request().method() === 'GET'
+      );
+
+      await clickMetricAction(page, 'Export');
+      const response = await exportResponse;
+      expect(response.ok()).toBeTruthy();
+      // Verify exactly one export request was fired (no duplicate calls).
+      await expect.poll(() => exportRequestCount).toBe(1);
+      await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible({
+        timeout: 30000,
+      });
+      await page.locator('.csv-jobs-tray-launcher').click();
+      await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible();
+      // Verify the export job appears in the tray. Parallel workers share the
+      // admin identity and may have their own active jobs; checking an exact
+      // count is fragile. Instead, assert that a tray item carrying the export
+      // label is visible — the exportRequestCount check above already guarantees
+      // exactly one export request was sent.
+      await expect(
+        page
+          .locator('.csv-jobs-tray-item')
+          .filter({ hasText: /Exporting Metrics|Exported Metrics/ })
+      ).toBeVisible();
     });
 
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await openMetricActions(page);
-    await clickMetricAction(page, 'Import');
-    await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+    test('Admin imports a metric CSV through preview and async apply', async ({
+      page,
+    }) => {
+      test.slow();
+      const importedMetricName = `${fixtures.prefix}_imported`;
+      fixtures.metrics.push({
+        id: '',
+        name: importedMetricName,
+        fullyQualifiedName: importedMetricName,
+      });
 
-    // Dry-run preview — let COMPLETED through (blockImportCompletion is false)
-    await uploadMetricCsvAndWaitForPreview(page, csvPath);
-    await expect(
-      page.getByRole('button', { name: /Start Import/i })
-    ).toBeVisible();
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
 
-    // From this point block the actual import COMPLETED so the cancel button
-    // stays enabled after STARTED fires.
-    blockImportCompletion = true;
+      const csvPath = createMetricCsvFile(importedMetricName);
+      await uploadMetricCsvAndWaitForPreview(page, csvPath);
+      await expect(
+        page.getByRole('gridcell', { exact: true, name: importedMetricName })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: /Start Import/i })
+      ).toBeVisible();
 
-    let cancelApiCalled = false;
-    await page.route('**/api/v1/csvAsyncJobs/*/cancel', async (route) => {
-      cancelApiCalled = true;
-      await route.fulfill({
-        contentType: 'application/json',
-        json: { status: 'CANCELLING' },
+      const applyResponse = waitForMetricImportResponse(page, false);
+      await page.getByRole('button', { name: /Start Import/i }).click();
+      await applyResponse;
+      await expectMetricImportStatus(page, {
+        processed: '1',
+        passed: '1',
+        failed: '0',
+      });
+
+      await expectImportedMetricComplexFields(importedMetricName);
+    });
+
+    test('Admin sees metric CSV validation failures for missing names and invalid references', async ({
+      page,
+    }) => {
+      test.slow();
+      const invalidCsvPath = createInvalidMetricCsvFile(
+        `${fixtures.prefix}_invalid_import`
+      );
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+
+      await uploadMetricCsvAndWaitForPreview(page, invalidCsvPath);
+      await expectMetricImportStatus(page, {
+        processed: '2',
+        passed: '0',
+        failed: '2',
+      });
+      await expect(page.getByText('Missing name display')).toBeVisible();
+      await expect(page.getByText('Invalid references display')).toBeVisible();
+    });
+
+    test('Admin imports a CSV update for an existing metric', async ({
+      page,
+    }) => {
+      test.slow();
+      const existingMetricName = fixtures.metrics[1].name;
+      const updatedDisplayName = `${fixtures.prefix} Import Updated`;
+      const csv = createCsv([
+        [
+          existingMetricName,
+          updatedDisplayName,
+          'Metric updated from Playwright CSV',
+          'COUNT',
+          'COUNT',
+          '',
+          'MONTH',
+          'SQL',
+          'COUNT(order_id)',
+          fixtures.metrics[0].fullyQualifiedName,
+          fixtures.secondTag.fullyQualifiedName,
+          fixtures.nestedGlossaryTerm.fullyQualifiedName,
+          'Tier.Tier3',
+          `user:${fixtures.owner.name}`,
+          `team:${fixtures.reviewer.name}`,
+          fixtures.domain.fullyQualifiedName,
+          fixtures.dataProduct.fullyQualifiedName,
+          'Approved',
+          `${metricCustomPropertyName}:updated custom value`,
+        ],
+      ]);
+      const csvPath = test
+        .info()
+        .outputPath(`${existingMetricName}-update.csv`);
+      fs.writeFileSync(csvPath, csv);
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+
+      await uploadMetricCsvAndWaitForPreview(page, csvPath);
+      await expect(page.getByText(updatedDisplayName)).toBeVisible();
+
+      const applyResponse = waitForMetricImportResponse(page, false);
+      await page.getByRole('button', { name: /Start Import/i }).click();
+      const response = await applyResponse;
+      expect(response.ok()).toBeTruthy();
+      await expectMetricImportStatus(page, {
+        processed: '1',
+        passed: '1',
+        failed: '0',
+      });
+
+      const updatedMetric = await parseResponse<MetricResponse>(
+        await apiContext.get(
+          `/api/v1/metrics/name/${existingMetricName}?fields=extension&include=all`
+        ),
+        'fetch CSV-updated metric'
+      );
+      expect(updatedMetric.displayName).toBe(updatedDisplayName);
+      expect(updatedMetric.extension).toMatchObject({
+        [metricCustomPropertyName]: 'updated custom value',
       });
     });
 
-    await page.getByRole('button', { name: /Start Import/i }).click();
+    test('Admin bulk edits filtered metrics from the listing API without export jobs', async ({
+      page,
+    }) => {
+      test.slow();
+      const targetMetricName = fixtures.metrics[METRIC_FIXTURE_COUNT - 1].name;
+      const updatedDisplayName = `${fixtures.prefix} Updated Display`;
+      let exportRequestCount = 0;
+      page.on('request', (request) => {
+        if (request.url().includes('/exportAsync')) {
+          exportRequestCount += 1;
+        }
+      });
 
-    // Wait for STARTED WebSocket event → button becomes enabled
-    const cancelBtn = page.getByRole('button', { name: /Cancel Import/i });
-    await expect(cancelBtn).toBeEnabled({ timeout: 30_000 });
-    await cancelBtn.click();
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetricName);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetricName);
 
-    await expect.poll(() => cancelApiCalled, { timeout: 15_000 }).toBe(true);
-  });
+      await expect.poll(() => exportRequestCount).toBe(0);
 
-  test('MetricListPage header checkbox selects all visible metrics', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
+      const nextButton = page.getByRole('button', { name: 'Next' });
+      await expect(nextButton).toBeDisabled();
+      await editFirstDisplayNameCell(page, updatedDisplayName);
+      await expect(nextButton).toBeEnabled();
 
-    await expect(page.getByTestId('metric-name').first()).toBeVisible();
+      const validateResponse = waitForMetricImportResponse(page, true);
+      await nextButton.click();
+      await validateResponse;
+      await expectMetricImportStatus(page, {
+        processed: '1',
+        passed: '1',
+        failed: '0',
+      });
 
-    // The table is React Aria — click the visible <label slot="selection"> in
-    // the header to trigger select-all (no force needed; the label is visible).
-    await page.locator('thead label[slot="selection"]').click();
+      const updateResponse = waitForMetricImportResponse(page, false);
+      await page.getByRole('button', { name: 'Update' }).click();
+      const response = await updateResponse;
+      expect(response.ok()).toBeTruthy();
+      await page.waitForURL(/\/metrics/, { timeout: 90000 });
 
-    await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
-    await expect(page.locator('.metric-list-selection-count')).not.toHaveText(
-      '0'
-    );
-  });
+      const updatedMetric = await parseResponse<MetricResponse>(
+        await apiContext.get(`/api/v1/metrics/name/${targetMetricName}`),
+        'fetch updated metric'
+      );
+      expect(updatedMetric.displayName).toBe(updatedDisplayName);
+    });
 
-  test('MetricListPage unchecking header checkbox clears the selection bar', async ({
-    page,
-  }) => {
-    await redirectToHomePage(page);
-    await waitForMetricsPage(page);
-    await filterMetrics(page, fixtures.prefix);
+    test('Admin bulk edit keeps text edits on blur and can revert to no changes', async ({
+      page,
+    }) => {
+      const targetMetricName = fixtures.metrics[2].name;
+      const originalDisplayName = fixtures.metrics[2].displayName ?? '';
+      const updatedDisplayName = `${fixtures.prefix} Blur Saved`;
 
-    await expect(page.getByTestId('metric-name').first()).toBeVisible();
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetricName);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetricName);
 
-    await page.locator('thead label[slot="selection"]').click();
-    await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
+      const nextButton = getBulkEditNextButton(page);
+      await expect(nextButton).toBeDisabled();
+      await editFirstDisplayNameCellAndBlur(page, updatedDisplayName);
+      await expect(nextButton).toBeEnabled();
 
-    await page.locator('thead label[slot="selection"]').click();
-    await expect(page.locator('.metric-list-selection-bar')).not.toBeVisible();
-  });
-});
+      await page.getByRole('button', { name: 'Revert Changes' }).click();
+      await expect(nextButton).toBeDisabled();
+      await expect(
+        page.locator('.rdg-row').first().locator('[aria-colindex="3"]')
+      ).toContainText(originalDisplayName);
+    });
+
+    test('Admin bulk edit hydrates filtered metrics across cursor pages', async ({
+      page,
+    }) => {
+      const { getPageRequestCount, pagedMetricName } =
+        await routePagedMetricBulkHydration(page);
+      let exportRequestCount = 0;
+      page.on('request', (request) => {
+        if (request.url().includes('/exportAsync')) {
+          exportRequestCount += 1;
+        }
+      });
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, 'paged_only_metric');
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, pagedMetricName);
+
+      await expect.poll(getPageRequestCount).toBe(2);
+      await expect.poll(() => exportRequestCount).toBe(0);
+      await expect(
+        page.getByText(`${fixtures.prefix}_paged_skip`)
+      ).not.toBeVisible();
+    });
+
+    test('Admin bulk edit renders complex fields from listing hydration', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[0];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      await expect(
+        page.getByText(targetMetric.displayName ?? '')
+      ).toBeVisible();
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(/SELECT SUM\(amount\)/)
+      );
+
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(fixtures.tag.fullyQualifiedName)
+      );
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.locator(
+          `[title="${fixtures.nestedGlossaryTerm.fullyQualifiedName}"]`
+        )
+      );
+      await expectVisibleAfterHorizontalScroll(page, page.getByText('Tier2'));
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(fixtures.owner.name)
+      );
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(fixtures.reviewer.name)
+      );
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(fixtures.domain.fullyQualifiedName)
+      );
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(fixtures.dataProduct.fullyQualifiedName)
+      );
+      await expectVisibleAfterHorizontalScroll(
+        page,
+        page.getByText(`${fixtures.prefix} custom property 0`)
+      );
+    });
+
+    test('Admin bulk edits only selected metric rows', async ({ page }) => {
+      let exportRequestCount = 0;
+      page.on('request', (request) => {
+        if (request.url().includes('/exportAsync')) {
+          exportRequestCount += 1;
+        }
+      });
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      const { metric: selectedMetric, row } =
+        await getFirstVisibleFixtureMetricRow(page);
+
+      // eslint-disable-next-line playwright/no-force-option -- styled checkbox control intercepts the native input.
+      await row.getByRole('checkbox').check({ force: true });
+      await expect(page.locator('.metric-list-selection-count')).toHaveText(
+        '1'
+      );
+
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, selectedMetric.name);
+
+      await expect.poll(() => exportRequestCount).toBe(0);
+      await expect(page.locator('.bulk-edit-name-value')).toHaveText([
+        selectedMetric.name,
+      ]);
+    });
+
+    test('Cancel from metric bulk edit returns to the metrics listing', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await getFirstVisibleFixtureMetricRow(page);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page);
+
+      await page.getByRole('button', { name: 'Cancel' }).click();
+      await expect(page).toHaveURL(/\/metrics/);
+    });
+
+    test('Custom metric editor role can import export and bulk edit metrics', async ({
+      browser,
+    }) => {
+      const metricEditorPage = await browser.newPage();
+      await metricEditorUser.login(metricEditorPage);
+
+      try {
+        await redirectToHomePage(metricEditorPage);
+        await waitForMetricsPage(metricEditorPage);
+        await expect(
+          metricEditorPage.getByTestId('create-metric')
+        ).toBeVisible();
+        await expect(
+          metricEditorPage.getByTestId('bulk-edit-metric')
+        ).toBeVisible();
+        await openMetricActions(metricEditorPage);
+        await expect(
+          metricEditorPage
+            .locator('.metric-actions-menu-item')
+            .filter({ hasText: 'Export' })
+        ).toBeVisible();
+        await expect(
+          metricEditorPage
+            .locator('.metric-actions-menu-item')
+            .filter({ hasText: 'Import' })
+        ).toBeVisible();
+        await metricEditorPage.keyboard.press('Escape');
+
+        await verifyPageAccess(metricEditorPage, '/bulk/import/metric/*', true);
+        await verifyPageAccess(metricEditorPage, '/bulk/edit/metric/*', true);
+      } finally {
+        await metricEditorPage.close();
+      }
+    });
+
+    test('Restricted roles cannot access metric import or bulk edit', async ({
+      browser,
+      dataConsumerPage,
+      dataStewardPage,
+      viewOnlyPage,
+    }) => {
+      test.slow();
+      const customViewOnlyPage = await browser.newPage();
+      await viewOnlyUser.login(customViewOnlyPage);
+
+      try {
+        for (const restrictedPage of [
+          dataConsumerPage,
+          dataStewardPage,
+          viewOnlyPage,
+          customViewOnlyPage,
+        ]) {
+          await redirectToHomePage(restrictedPage);
+          await waitForMetricsPage(restrictedPage);
+          await expect(
+            restrictedPage.getByTestId('create-metric')
+          ).not.toBeVisible();
+          await expect(
+            restrictedPage.getByTestId('bulk-edit-metric')
+          ).not.toBeVisible();
+          await expect(
+            restrictedPage.getByTestId('metric-actions')
+          ).not.toBeVisible();
+          await verifyPageAccess(
+            restrictedPage,
+            '/bulk/import/metric/*',
+            false
+          );
+          await verifyPageAccess(restrictedPage, '/bulk/edit/metric/*', false);
+        }
+      } finally {
+        await customViewOnlyPage.close();
+      }
+    });
+
+    test('Bulk edit grid shows NO_CHANGE badge on unmodified rows', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[3];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      await expect(
+        page.locator('.bulk-edit-operation-badge-no_change').first()
+      ).toBeVisible();
+      await expect(
+        page.getByTestId('bulk-edit-operation-summary')
+      ).toBeVisible();
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-no_change')
+      ).toContainText('1');
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-update')
+      ).toContainText('0');
+    });
+
+    test('Bulk edit grid shows UPDATE badge and increments summary after editing a cell', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[4];
+      const updatedDisplayName = `${fixtures.prefix} Badge Update Test`;
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      await expect(
+        page.locator('.bulk-edit-operation-badge-no_change').first()
+      ).toBeVisible();
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-update')
+      ).toContainText('0');
+
+      await editFirstDisplayNameCell(page, updatedDisplayName);
+
+      await expect(
+        page.locator('.bulk-edit-operation-badge-update').first()
+      ).toBeVisible();
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-update')
+      ).toContainText('1');
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-no_change')
+      ).toContainText('0');
+    });
+
+    test('Adding a new metric row shows CREATE badge once name is filled', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[5];
+      const newMetricName = `${fixtures.prefix}_add_row_test`;
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      await page.getByTestId('bulk-edit-add-metric').click();
+
+      await expect(page.locator('.rdg-row')).toHaveCount(2);
+
+      const newRow = page.locator('.rdg-row').last();
+      const nameCell = newRow.locator('[aria-colindex="2"]');
+      await nameCell.dblclick();
+
+      const nameEditor = page
+        .locator(`${RDG_ACTIVE_CELL_SELECTOR} input`)
+        .first();
+      await expect(nameEditor).toBeVisible();
+      await nameEditor.fill(newMetricName);
+      await nameEditor.press('Enter');
+
+      await expect(
+        page.locator('.bulk-edit-operation-badge-create')
+      ).toBeVisible();
+      await expect(
+        page.locator('.bulk-edit-operation-summary-count-create')
+      ).toContainText('1');
+    });
+
+    test('New metric row without a name shows error pill and SKIP badge', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[6];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      await page.getByTestId('bulk-edit-add-metric').click();
+
+      await expect(page.locator('.bulk-edit-error-pill')).toBeVisible();
+      await expect(
+        page.locator('.bulk-edit-operation-badge-skip').last()
+      ).toBeVisible();
+    });
+
+    test('Removing a newly added metric row restores the grid state', async ({
+      page,
+    }) => {
+      const targetMetric = fixtures.metrics[7];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, targetMetric.name);
+      await page.getByTestId('bulk-edit-metric').click();
+      await waitForMetricBulkEditGrid(page, targetMetric.name);
+
+      const rowsBefore = await page.locator('.rdg-row').count();
+
+      await page.getByTestId('bulk-edit-add-metric').click();
+      await expect(page.locator('.rdg-row')).toHaveCount(rowsBefore + 1);
+
+      await page.getByTestId('bulk-edit-remove-row').click();
+      await expect(page.locator('.rdg-row')).toHaveCount(rowsBefore);
+      await expect(page.locator('.bulk-edit-error-pill')).not.toBeVisible();
+    });
+
+    test('Bulk edit grid search filters rows to match the search term', async ({
+      page,
+    }) => {
+      const firstMetric = fixtures.metrics[0];
+      const lastMetric = fixtures.metrics[METRIC_FIXTURE_COUNT - 2];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+      await page.getByTestId('bulk-edit-metric').click();
+      await expect(page).toHaveURL(/\/bulk\/edit\/metric\/\*/);
+      await expect(page.locator('.rdg-header-row')).toBeVisible({
+        timeout: 90_000,
+      });
+      await expect(page.locator('.rdg-row').first()).toBeVisible();
+
+      const searchInput = page.getByTestId('bulk-edit-search').locator('input');
+      await searchInput.fill(firstMetric.name);
+
+      await expect(page.getByText(firstMetric.name)).toBeVisible();
+      await expect(page.getByText(lastMetric.name)).not.toBeVisible();
+    });
+
+    test('Clearing the bulk edit search box restores all rows', async ({
+      page,
+    }) => {
+      const firstMetric = fixtures.metrics[0];
+      const lastMetric = fixtures.metrics[METRIC_FIXTURE_COUNT - 2];
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+      await page.getByTestId('bulk-edit-metric').click();
+      await expect(page).toHaveURL(/\/bulk\/edit\/metric\/\*/);
+      await expect(page.locator('.rdg-header-row')).toBeVisible({
+        timeout: 90_000,
+      });
+      await expect(page.locator('.rdg-row').first()).toBeVisible();
+
+      const searchInput = page.getByTestId('bulk-edit-search').locator('input');
+      await searchInput.fill(firstMetric.name);
+      await expect(page.getByText(lastMetric.name)).not.toBeVisible();
+
+      await searchInput.fill('');
+      await expect(page.getByText(lastMetric.name)).toBeVisible();
+    });
+
+    test('Admin can cancel a metric import mid-flight and cancel API is called', async ({
+      page,
+    }) => {
+      test.slow();
+
+      const cancelMetricName = `${fixtures.prefix}_cancel_flight`;
+      const csvPath = createMetricCsvFile(cancelMetricName);
+
+      // The Cancel Import button is enabled only after the server sends a WebSocket
+      // STARTED event.  We must intercept the socket BEFORE the first navigation so
+      // the connection is routed through Playwright.  We use a flag to let the
+      // dry-run (dryRun=true) COMPLETED event pass — it renders the preview grid —
+      // while blocking the actual import COMPLETED to keep the button clickable.
+      let blockImportCompletion = false;
+
+      await page.routeWebSocket(/\/api\/v1\/push\/feed/, (ws) => {
+        const server = ws.connectToServer();
+
+        server.onMessage((msg) => {
+          if (
+            blockImportCompletion &&
+            typeof msg === 'string' &&
+            msg.includes('csvImportChannel') &&
+            (msg.includes('COMPLETED') || msg.includes('FAILED'))
+          ) {
+            return; // Drop — keeps the Cancel Import button enabled
+          }
+          ws.send(msg);
+        });
+
+        ws.onMessage((msg) => server.send(msg));
+      });
+
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await openMetricActions(page);
+      await clickMetricAction(page, 'Import');
+      await expect(page).toHaveURL(/\/bulk\/import\/metric\/\*/);
+
+      // Dry-run preview — let COMPLETED through (blockImportCompletion is false)
+      await uploadMetricCsvAndWaitForPreview(page, csvPath);
+      await expect(
+        page.getByRole('button', { name: /Start Import/i })
+      ).toBeVisible();
+
+      // From this point block the actual import COMPLETED so the cancel button
+      // stays enabled after STARTED fires.
+      blockImportCompletion = true;
+
+      let cancelApiCalled = false;
+      await page.route('**/api/v1/csvAsyncJobs/*/cancel', async (route) => {
+        cancelApiCalled = true;
+        await route.fulfill({
+          contentType: 'application/json',
+          json: { status: 'CANCELLING' },
+        });
+      });
+
+      await page.getByRole('button', { name: /Start Import/i }).click();
+
+      // Wait for STARTED WebSocket event → button becomes enabled
+      const cancelBtn = page.getByRole('button', { name: /Cancel Import/i });
+      await expect(cancelBtn).toBeEnabled({ timeout: 30_000 });
+      await cancelBtn.click();
+
+      await expect.poll(() => cancelApiCalled, { timeout: 15_000 }).toBe(true);
+    });
+
+    test('MetricListPage header checkbox selects all visible metrics', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+
+      await expect(page.getByTestId('metric-name').first()).toBeVisible();
+
+      // The table is React Aria — click the visible <label slot="selection"> in
+      // the header to trigger select-all (no force needed; the label is visible).
+      await page.locator('thead label[slot="selection"]').click();
+
+      await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
+      await expect(page.locator('.metric-list-selection-count')).not.toHaveText(
+        '0'
+      );
+    });
+
+    test('MetricListPage unchecking header checkbox clears the selection bar', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      await filterMetrics(page, fixtures.prefix);
+
+      await expect(page.getByTestId('metric-name').first()).toBeVisible();
+
+      await page.locator('thead label[slot="selection"]').click();
+      await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
+
+      await page.locator('thead label[slot="selection"]').click();
+      await expect(
+        page.locator('.metric-list-selection-bar')
+      ).not.toBeVisible();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -917,7 +917,10 @@ const expectImportedMetricComplexFields = async (metricName: string) => {
 
 test.describe.configure({ mode: 'serial' });
 
-test.describe('Metrics bulk import, export, and edit', () => {
+test.describe(
+  'Metrics bulk import, export, and edit',
+  { tag: '@import-export' },
+  () => {
   test.beforeAll(async () => {
     test.setTimeout(180_000);
     const adminContext = await createAdminApiContext();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -73,7 +73,10 @@ const fetchCompletedExportCsv = async (
   return resultResponse.text();
 };
 
-test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
+test.describe(
+  'Search Export',
+  { tag: ['@Features', '@Discovery', '@import-export'] },
+  () => {
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -77,381 +77,390 @@ test.describe(
   'Search Export',
   { tag: ['@Features', '@Discovery', '@import-export'] },
   () => {
-  test.beforeAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    const serviceRes = await apiContext.get(
-      '/api/v1/services/databaseServices/name/sample_data'
-    );
-    const service = await serviceRes.json();
-    if (service.displayName) {
-      await apiContext.patch(
-        `/api/v1/services/databaseServices/${service.id}`,
-        {
-          data: [{ op: 'replace', path: '/displayName', value: 'sample_data' }],
-          headers: { 'Content-Type': 'application/json-patch+json' },
-        }
+      const serviceRes = await apiContext.get(
+        '/api/v1/services/databaseServices/name/sample_data'
       );
+      const service = await serviceRes.json();
+      if (service.displayName) {
+        await apiContext.patch(
+          `/api/v1/services/databaseServices/${service.id}`,
+          {
+            data: [
+              { op: 'replace', path: '/displayName', value: 'sample_data' },
+            ],
+            headers: { 'Content-Type': 'application/json-patch+json' },
+          }
+        );
 
-      await afterAction();
-    }
-  });
-
-  test.beforeEach(async ({ page }) => {
-    await redirectToExplorePage(page);
-  });
-
-  test('Export button opens scope modal with correct options', async ({
-    page,
-  }) => {
-    await test.step('Export button is visible', async () => {
-      await page.getByRole('button', { name: 'Tools' }).click();
-      const exportButton = page.getByRole('menuitemradio', { name: 'Export' });
-
-      await expect(exportButton).toBeVisible();
-      await expect(exportButton).toContainText('Export');
-      await clickOutside(page); // Close the dropdown after assertion
+        await afterAction();
+      }
     });
 
-    await test.step('Clicking Export opens scope modal with title and scope label', async () => {
+    test.beforeEach(async ({ page }) => {
+      await redirectToExplorePage(page);
+    });
+
+    test('Export button opens scope modal with correct options', async ({
+      page,
+    }) => {
+      await test.step('Export button is visible', async () => {
+        await page.getByRole('button', { name: 'Tools' }).click();
+        const exportButton = page.getByRole('menuitemradio', {
+          name: 'Export',
+        });
+
+        await expect(exportButton).toBeVisible();
+        await expect(exportButton).toContainText('Export');
+        await clickOutside(page); // Close the dropdown after assertion
+      });
+
+      await test.step('Clicking Export opens scope modal with title and scope label', async () => {
+        await openExportScopeModal(page);
+
+        const modalContent = getExportModalContent(page);
+
+        await expect(modalContent.locator('.ant-modal-title')).toContainText(
+          'Export'
+        );
+        await expect(modalContent.getByText('Export Scope')).toBeVisible();
+      });
+
+      await test.step('Modal shows tab-specific scope and All matching assets options', async () => {
+        const modalContent = getExportModalContent(page);
+
+        await expect(
+          modalContent.getByTestId('export-scope-visible-card')
+        ).toBeVisible();
+        await expect(
+          modalContent.getByTestId('export-scope-all-card')
+        ).toBeVisible();
+      });
+
+      await test.step('All matching assets is selected by default', async () => {
+        await expect(
+          getExportModalContent(page).locator('input[value="all"]')
+        ).toBeChecked();
+      });
+
+      await test.step('Selecting the tab-scope card checks the visible radio', async () => {
+        const modalContent = getExportModalContent(page);
+
+        await modalContent.locator('input[value="visible"]').click();
+        await expect(
+          modalContent.locator('input[value="visible"]')
+        ).toBeChecked();
+      });
+
+      await test.step('Cancel button closes the modal', async () => {
+        await getExportModalContent(page)
+          .getByRole('button', { name: 'Cancel' })
+          .click();
+
+        await expect(getExportModalContent(page)).not.toBeVisible();
+      });
+    });
+
+    test('Search mode visible export downloads CSV with tab-specific row count', async ({
+      page,
+      browser,
+    }) => {
+      test.slow();
+
+      await page.goto('/explore/tables?search=sample_data');
+      await expect(page.getByTestId('explore-page')).toBeVisible();
+
+      const countApiPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.status() === 200
+      );
+
+      await openExportScopeModal(page);
+      await countApiPromise;
+
+      const modalContent = getExportModalContent(page);
+
+      await modalContent.locator('input[value="visible"]').click();
+
+      const expectedCount =
+        await test.step('Read displayed count from Visible Results card', () =>
+          getExportCountFromModal(modalContent, 'export-scope-visible-count'));
+
+      const jobId = await startAsyncExport(page);
+
+      await test.step('CSV row count matches the displayed tab count', async () => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        const csvText = await fetchCompletedExportCsv(apiContext, jobId);
+
+        expect(countCsvResponseRows(csvText)).toBe(expectedCount);
+
+        await afterAction();
+      });
+    });
+
+    test('Search mode visible export count matches the first result tab count', async ({
+      page,
+    }) => {
+      const countApiPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.status() === 200
+      );
+
+      await page.goto(
+        '/explore/tables?search=sample_data.ecommerce_db.shopify.dim_customer'
+      );
+      await expect(page.getByTestId('explore-page')).toBeVisible();
+      await countApiPromise;
+
+      const firstTabCount =
+        await test.step('Read the count from the first left panel result tab', async () => {
+          const firstTabCountText = await page
+            .getByTestId('explore-left-panel')
+            .locator('[role="menuitem"]')
+            .first()
+            .getByTestId('filter-count')
+            .textContent();
+
+          return parseInt(firstTabCountText?.trim() ?? '0', 10);
+        });
+
+      await openExportScopeModal(page);
+
+      const visibleExportCount =
+        await test.step('Read the visible results count from the export modal', () =>
+          getExportCountFromModal(
+            getExportModalContent(page),
+            'export-scope-visible-count'
+          ));
+
+      await test.step('Visible export count matches the first result tab count', async () => {
+        expect(visibleExportCount).toBe(firstTabCount);
+      });
+    });
+
+    test('Filtered search visible export downloads CSV with the filtered record count', async ({
+      page,
+      browser,
+    }) => {
+      test.slow();
+
+      const searchResultsPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.status() === 200
+      );
+
+      await page.goto('/explore/tables?search=sample_data');
+      await expect(page.getByTestId('explore-page')).toBeVisible();
+      await searchResultsPromise;
+      await waitForAllLoadersToDisappear(page);
+
+      await test.step('Apply Service filter from the Explore page', async () => {
+        await page.getByTestId('search-dropdown-Service').click();
+
+        const serviceAggregatePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/aggregate') &&
+            response.url().includes('sample_data') &&
+            response.status() === 200
+        );
+
+        await page.getByTestId('search-input').fill('sample_data');
+        await serviceAggregatePromise;
+        const filteredQueryPromise = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/search/query') &&
+            response.status() === 200
+        );
+
+        await page.getByTestId('sample_data').click();
+        await expect(page.getByTestId('sample_data-checkbox')).toBeChecked();
+
+        await clickUpdateButtonIfVisible(page);
+        await filteredQueryPromise;
+        await waitForAllLoadersToDisappear(page);
+      });
+
+      const filteredCount =
+        await test.step('Read filtered count from the first left panel tab', async () => {
+          const filteredCountText = await page
+            .getByTestId('explore-left-panel')
+            .locator('[role="menuitem"]')
+            .first()
+            .getByTestId('filter-count')
+            .textContent();
+
+          return parseInt(filteredCountText?.trim() ?? '0', 10);
+        });
+
       await openExportScopeModal(page);
 
       const modalContent = getExportModalContent(page);
+      await modalContent.locator('input[value="visible"]').click();
 
-      await expect(modalContent.locator('.ant-modal-title')).toContainText(
-        'Export'
+      const visibleExportCount =
+        await test.step('Read filtered visible count from the export modal', () =>
+          getExportCountFromModal(modalContent, 'export-scope-visible-count'));
+
+      await test.step('Filtered page count matches the export modal count', async () => {
+        expect(visibleExportCount).toBe(filteredCount);
+      });
+
+      const jobId = await startAsyncExport(page);
+
+      await test.step('CSV row count matches the filtered record count', async () => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        const csvText = await fetchCompletedExportCsv(apiContext, jobId);
+
+        expect(countCsvResponseRows(csvText)).toBe(filteredCount);
+
+        await afterAction();
+      });
+    });
+
+    test('Browse mode visible export downloads CSV with current page row count', async ({
+      page,
+      browser,
+    }) => {
+      test.slow();
+
+      // Browse mode (no search term) queries the unified `dataAsset` index
+      // regardless of the tab in the URL, so wait for that rather than a
+      // per-entity `index=topic` request (which only fires for a tab search).
+      const browseQueryPromise = page.waitForResponse(
+        (response) =>
+          response.url().includes('/api/v1/search/query') &&
+          response.url().includes('index=dataAsset') &&
+          response.status() === 200
       );
-      await expect(modalContent.getByText('Export Scope')).toBeVisible();
-    });
 
-    await test.step('Modal shows tab-specific scope and All matching assets options', async () => {
-      const modalContent = getExportModalContent(page);
-
+      await page.goto('/explore/topics');
+      await expect(page.getByTestId('explore-page')).toBeVisible();
+      await browseQueryPromise;
+      await waitForAllLoadersToDisappear(page);
       await expect(
-        modalContent.getByTestId('export-scope-visible-card')
+        page.locator('[data-testid^="table-data-card_"]').first()
       ).toBeVisible();
-      await expect(
-        modalContent.getByTestId('export-scope-all-card')
-      ).toBeVisible();
-    });
 
-    await test.step('All matching assets is selected by default', async () => {
-      await expect(
-        getExportModalContent(page).locator('input[value="all"]')
-      ).toBeChecked();
-    });
+      await openExportScopeModal(page);
 
-    await test.step('Selecting the tab-scope card checks the visible radio', async () => {
       const modalContent = getExportModalContent(page);
 
       await modalContent.locator('input[value="visible"]').click();
       await expect(
         modalContent.locator('input[value="visible"]')
       ).toBeChecked();
+
+      const expectedCount =
+        await test.step('Read displayed count from Visible Results card', () =>
+          getExportCountFromModal(modalContent, 'export-scope-visible-count'));
+
+      const jobId = await startAsyncExport(page);
+
+      await test.step('CSV row count matches the displayed page count', async () => {
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        const csvText = await fetchCompletedExportCsv(apiContext, jobId);
+
+        expect(countCsvResponseRows(csvText)).toBe(expectedCount);
+
+        await afterAction();
+      });
     });
 
-    await test.step('Cancel button closes the modal', async () => {
-      await getExportModalContent(page)
-        .getByRole('button', { name: 'Cancel' })
-        .click();
-
-      await expect(getExportModalContent(page)).not.toBeVisible();
-    });
-  });
-
-  test('Search mode visible export downloads CSV with tab-specific row count', async ({
-    page,
-    browser,
-  }) => {
-    test.slow();
-
-    await page.goto('/explore/tables?search=sample_data');
-    await expect(page.getByTestId('explore-page')).toBeVisible();
-
-    const countApiPromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/query') &&
-        response.status() === 200
-    );
-
-    await openExportScopeModal(page);
-    await countApiPromise;
-
-    const modalContent = getExportModalContent(page);
-
-    await modalContent.locator('input[value="visible"]').click();
-
-    const expectedCount =
-      await test.step('Read displayed count from Visible Results card', () =>
-        getExportCountFromModal(modalContent, 'export-scope-visible-count'));
-
-    const jobId = await startAsyncExport(page);
-
-    await test.step('CSV row count matches the displayed tab count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      const csvText = await fetchCompletedExportCsv(apiContext, jobId);
-
-      expect(countCsvResponseRows(csvText)).toBe(expectedCount);
-
-      await afterAction();
-    });
-  });
-
-  test('Search mode visible export count matches the first result tab count', async ({
-    page,
-  }) => {
-    const countApiPromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/query') &&
-        response.status() === 200
-    );
-
-    await page.goto(
-      '/explore/tables?search=sample_data.ecommerce_db.shopify.dim_customer'
-    );
-    await expect(page.getByTestId('explore-page')).toBeVisible();
-    await countApiPromise;
-
-    const firstTabCount =
-      await test.step('Read the count from the first left panel result tab', async () => {
-        const firstTabCountText = await page
-          .getByTestId('explore-left-panel')
-          .locator('[role="menuitem"]')
-          .first()
-          .getByTestId('filter-count')
-          .textContent();
-
-        return parseInt(firstTabCountText?.trim() ?? '0', 10);
+    test('Export is disabled when all matching assets exceed 200k', async ({
+      page,
+    }) => {
+      await page.route('**/api/v1/search/query?*', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            took: 1,
+            hits: {
+              total: {
+                value: 200001,
+                relation: 'eq',
+              },
+              hits: [],
+            },
+            aggregations: {},
+          }),
+        });
       });
 
-    await openExportScopeModal(page);
+      await openExportScopeModal(page);
 
-    const visibleExportCount =
-      await test.step('Read the visible results count from the export modal', () =>
-        getExportCountFromModal(
-          getExportModalContent(page),
-          'export-scope-visible-count'
-        ));
+      const modalContent = getExportModalContent(page);
+      const exportButton = modalContent.getByRole('button', { name: 'Export' });
 
-    await test.step('Visible export count matches the first result tab count', async () => {
-      expect(visibleExportCount).toBe(firstTabCount);
+      await test.step('Limit alert is shown in modal', async () => {
+        await expect(
+          modalContent.getByText(
+            'Export is limited to 200000 assets. Please refine your filters or choose visible results.'
+          )
+        ).toBeVisible();
+      });
+
+      await test.step('Export button remains disabled', async () => {
+        await expect(exportButton).toBeDisabled();
+      });
     });
-  });
 
-  test('Filtered search visible export downloads CSV with the filtered record count', async ({
-    page,
-    browser,
-  }) => {
-    test.slow();
+    test('Export queues a background job and downloads from the jobs tray', async ({
+      page,
+    }) => {
+      test.slow();
 
-    const searchResultsPromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/query') &&
-        response.status() === 200
-    );
-
-    await page.goto('/explore/tables?search=sample_data');
-    await expect(page.getByTestId('explore-page')).toBeVisible();
-    await searchResultsPromise;
-    await waitForAllLoadersToDisappear(page);
-
-    await test.step('Apply Service filter from the Explore page', async () => {
-      await page.getByTestId('search-dropdown-Service').click();
-
-      const serviceAggregatePromise = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/search/aggregate') &&
-          response.url().includes('sample_data') &&
-          response.status() === 200
-      );
-
-      await page.getByTestId('search-input').fill('sample_data');
-      await serviceAggregatePromise;
-      const filteredQueryPromise = page.waitForResponse(
+      const countApiPromise = page.waitForResponse(
         (response) =>
           response.url().includes('/api/v1/search/query') &&
           response.status() === 200
       );
 
-      await page.getByTestId('sample_data').click();
-      await expect(page.getByTestId('sample_data-checkbox')).toBeChecked();
+      await page.goto('/explore/tables?search=sample_data');
+      await expect(page.getByTestId('explore-page')).toBeVisible();
+      await countApiPromise;
 
-      await clickUpdateButtonIfVisible(page);
-      await filteredQueryPromise;
-      await waitForAllLoadersToDisappear(page);
-    });
+      await openExportScopeModal(page);
 
-    const filteredCount =
-      await test.step('Read filtered count from the first left panel tab', async () => {
-        const filteredCountText = await page
-          .getByTestId('explore-left-panel')
-          .locator('[role="menuitem"]')
-          .first()
-          .getByTestId('filter-count')
-          .textContent();
+      const jobId = await startAsyncExport(page);
 
-        return parseInt(filteredCountText?.trim() ?? '0', 10);
+      await test.step('Jobs tray surfaces the export job', async () => {
+        await page
+          .getByRole('button', { name: /Background jobs|jobs running/ })
+          .click();
+
+        await expect(
+          page.getByText(/Exporting|Exported/).first()
+        ).toBeVisible();
       });
 
-    await openExportScopeModal(page);
+      await test.step('Download from the tray serves the job result CSV', async () => {
+        const downloadButton = page
+          .getByRole('button', { name: 'Download' })
+          .first();
 
-    const modalContent = getExportModalContent(page);
-    await modalContent.locator('input[value="visible"]').click();
+        await expect(downloadButton).toBeVisible({ timeout: 90_000 });
 
-    const visibleExportCount =
-      await test.step('Read filtered visible count from the export modal', () =>
-        getExportCountFromModal(modalContent, 'export-scope-visible-count'));
+        const resultResponsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes(`/api/v1/csvAsyncJobs/${jobId}/result`) &&
+            response.status() === 200
+        );
+        const downloadPromise = page.waitForEvent('download');
 
-    await test.step('Filtered page count matches the export modal count', async () => {
-      expect(visibleExportCount).toBe(filteredCount);
-    });
+        await downloadButton.click();
+        await resultResponsePromise;
 
-    const jobId = await startAsyncExport(page);
+        const download = await downloadPromise;
 
-    await test.step('CSV row count matches the filtered record count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      const csvText = await fetchCompletedExportCsv(apiContext, jobId);
-
-      expect(countCsvResponseRows(csvText)).toBe(filteredCount);
-
-      await afterAction();
-    });
-  });
-
-  test('Browse mode visible export downloads CSV with current page row count', async ({
-    page,
-    browser,
-  }) => {
-    test.slow();
-
-    // Browse mode (no search term) queries the unified `dataAsset` index
-    // regardless of the tab in the URL, so wait for that rather than a
-    // per-entity `index=topic` request (which only fires for a tab search).
-    const browseQueryPromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/query') &&
-        response.url().includes('index=dataAsset') &&
-        response.status() === 200
-    );
-
-    await page.goto('/explore/topics');
-    await expect(page.getByTestId('explore-page')).toBeVisible();
-    await browseQueryPromise;
-    await waitForAllLoadersToDisappear(page);
-    await expect(
-      page.locator('[data-testid^="table-data-card_"]').first()
-    ).toBeVisible();
-
-    await openExportScopeModal(page);
-
-    const modalContent = getExportModalContent(page);
-
-    await modalContent.locator('input[value="visible"]').click();
-    await expect(modalContent.locator('input[value="visible"]')).toBeChecked();
-
-    const expectedCount =
-      await test.step('Read displayed count from Visible Results card', () =>
-        getExportCountFromModal(modalContent, 'export-scope-visible-count'));
-
-    const jobId = await startAsyncExport(page);
-
-    await test.step('CSV row count matches the displayed page count', async () => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      const csvText = await fetchCompletedExportCsv(apiContext, jobId);
-
-      expect(countCsvResponseRows(csvText)).toBe(expectedCount);
-
-      await afterAction();
-    });
-  });
-
-  test('Export is disabled when all matching assets exceed 200k', async ({
-    page,
-  }) => {
-    await page.route('**/api/v1/search/query?*', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          took: 1,
-          hits: {
-            total: {
-              value: 200001,
-              relation: 'eq',
-            },
-            hits: [],
-          },
-          aggregations: {},
-        }),
+        expect(download.suggestedFilename()).toContain(jobId);
+        expect(download.suggestedFilename()).toContain('.csv');
       });
     });
-
-    await openExportScopeModal(page);
-
-    const modalContent = getExportModalContent(page);
-    const exportButton = modalContent.getByRole('button', { name: 'Export' });
-
-    await test.step('Limit alert is shown in modal', async () => {
-      await expect(
-        modalContent.getByText(
-          'Export is limited to 200000 assets. Please refine your filters or choose visible results.'
-        )
-      ).toBeVisible();
-    });
-
-    await test.step('Export button remains disabled', async () => {
-      await expect(exportButton).toBeDisabled();
-    });
-  });
-
-  test('Export queues a background job and downloads from the jobs tray', async ({
-    page,
-  }) => {
-    test.slow();
-
-    const countApiPromise = page.waitForResponse(
-      (response) =>
-        response.url().includes('/api/v1/search/query') &&
-        response.status() === 200
-    );
-
-    await page.goto('/explore/tables?search=sample_data');
-    await expect(page.getByTestId('explore-page')).toBeVisible();
-    await countApiPromise;
-
-    await openExportScopeModal(page);
-
-    const jobId = await startAsyncExport(page);
-
-    await test.step('Jobs tray surfaces the export job', async () => {
-      await page
-        .getByRole('button', { name: /Background jobs|jobs running/ })
-        .click();
-
-      await expect(page.getByText(/Exporting|Exported/).first()).toBeVisible();
-    });
-
-    await test.step('Download from the tray serves the job result CSV', async () => {
-      const downloadButton = page
-        .getByRole('button', { name: 'Download' })
-        .first();
-
-      await expect(downloadButton).toBeVisible({ timeout: 90_000 });
-
-      const resultResponsePromise = page.waitForResponse(
-        (response) =>
-          response.url().includes(`/api/v1/csvAsyncJobs/${jobId}/result`) &&
-          response.status() === 200
-      );
-      const downloadPromise = page.waitForEvent('download');
-
-      await downloadButton.click();
-      await resultResponsePromise;
-
-      const download = await downloadPromise;
-
-      expect(download.suggestedFilename()).toContain(jobId);
-      expect(download.suggestedFilename()).toContain('.csv');
-    });
-  });
-});
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -95,189 +95,195 @@ test.describe(
   'CSV Import with Commas and Quotes - All Entity Types',
   { tag: '@import-export' },
   () => {
-  let createCsvImportPromise: () => Promise<void>;
+    let createCsvImportPromise: () => Promise<void>;
 
-  test.beforeEach(async ({ page }) => {
-    createCsvImportPromise = await setupCsvImportListener(page);
-    await redirectToHomePage(page);
-  });
-
-  test('Create glossary with CSV, export it, create new glossary and import exported data', async ({
-    page,
-  }) => {
-    test.setTimeout(180_000);
-
-    const { apiContext } = await getApiContext(page);
-    const sourceGlossary = new Glossary(`QuotesCommas-${uuid()}`);
-    const targetGlossary = new Glossary(`QuotesCommas-Target-${uuid()}`);
-    let exportedCsvPath: string;
-
-    await test.step('Create glossary and import CSV with quotes and commas', async () => {
-      await sourceGlossary.create(apiContext);
-      await sourceGlossary.visitPage(page);
-
-      await selectGlossaryManageItem(page, 'import-button');
-
-      let tempFilePath: string | undefined;
-      try {
-        const { tempFilePath: tempFile } = await uploadCSVAndWaitForGrid(
-          page,
-          CSV_WITH_QUOTES_AND_COMMAS,
-          {
-            isContentString: true,
-            tempFileName: `temp-quotes-commas-${uuid()}.csv`,
-            csvImportCompletedPromise: createCsvImportPromise(),
-          }
-        );
-        tempFilePath = tempFile;
-
-        await expect(
-          page.getByRole('gridcell', { name: 'Term1' }).first()
-        ).toBeVisible();
-        await expect(
-          page.getByRole('gridcell', { name: 'TermWithComma,AndQuote' }).first()
-        ).toBeVisible();
-
-        const validationResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/glossaries/name/') &&
-            response.url().includes('/importAsync') &&
-            response.url().includes('dryRun=true') &&
-            response.request().method() === 'PUT'
-        );
-
-        await page.getByRole('button', { name: 'Next' }).click();
-        await validationResponse;
-        await page.getByText('Import is in progress.').waitFor({
-          state: 'detached',
-        });
-
-        await waitForImportGridLoadMaskToDisappear(page);
-
-        const expectedProcessed = await page
-          .getByTestId('processed-row')
-          .textContent();
-        await validateImportStatus(page, {
-          passed: expectedProcessed?.trim() ?? '0',
-          processed: expectedProcessed?.trim() ?? '0',
-          failed: '0',
-        });
-
-        const importResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/glossaries/name/') &&
-            response.url().includes('/importAsync') &&
-            response.url().includes('dryRun=false') &&
-            response.request().method() === 'PUT'
-        );
-        const importCompletedPromise = createCsvImportPromise();
-
-        await page.getByRole('button', { name: 'Update' }).click();
-        await importResponse;
-        await importCompletedPromise;
-        await waitForImportGridLoadMaskToDisappear(page);
-        await waitForGlossaryTerms(apiContext, sourceGlossary.responseData.id, [
-          'Term1',
-          'TermWithComma,AndQuote',
-        ]);
-      } finally {
-        cleanupTempFile(tempFilePath);
-      }
+    test.beforeEach(async ({ page }) => {
+      createCsvImportPromise = await setupCsvImportListener(page);
+      await redirectToHomePage(page);
     });
 
-    await test.step('Export CSV and verify it contains properly escaped quotes', async () => {
-      await sourceGlossary.visitPage(page);
+    test('Create glossary with CSV, export it, create new glossary and import exported data', async ({
+      page,
+    }) => {
+      test.setTimeout(180_000);
 
-      const exportResponsePromise = page.waitForResponse(
-        (response) =>
-          response.url().includes('/api/v1/glossaries/name/') &&
-          response.url().includes('/exportAsync') &&
-          response.request().method() === 'GET'
-      );
+      const { apiContext } = await getApiContext(page);
+      const sourceGlossary = new Glossary(`QuotesCommas-${uuid()}`);
+      const targetGlossary = new Glossary(`QuotesCommas-Target-${uuid()}`);
+      let exportedCsvPath: string;
 
-      await selectGlossaryManageItem(page, 'export-button');
+      await test.step('Create glossary and import CSV with quotes and commas', async () => {
+        await sourceGlossary.create(apiContext);
+        await sourceGlossary.visitPage(page);
 
-      const exportResponse = await exportResponsePromise;
-      expect(exportResponse.ok()).toBeTruthy();
+        await selectGlossaryManageItem(page, 'import-button');
 
-      const { jobId } = (await exportResponse.json()) as CsvExportResponse;
-      const csvContent = await fetchCompletedCsvAsyncJobResult(
-        apiContext,
-        jobId
-      );
+        let tempFilePath: string | undefined;
+        try {
+          const { tempFilePath: tempFile } = await uploadCSVAndWaitForGrid(
+            page,
+            CSV_WITH_QUOTES_AND_COMMAS,
+            {
+              isContentString: true,
+              tempFileName: `temp-quotes-commas-${uuid()}.csv`,
+              csvImportCompletedPromise: createCsvImportPromise(),
+            }
+          );
+          tempFilePath = tempFile;
 
-      exportedCsvPath = `downloads/exported-${uuid()}.csv`;
-      fs.mkdirSync('downloads', { recursive: true });
-      fs.writeFileSync(exportedCsvPath, csvContent);
+          await expect(
+            page.getByRole('gridcell', { name: 'Term1' }).first()
+          ).toBeVisible();
+          await expect(
+            page
+              .getByRole('gridcell', { name: 'TermWithComma,AndQuote' })
+              .first()
+          ).toBeVisible();
 
-      expect(csvContent).toContain('Term1');
-      expect(csvContent).toContain('TermWithComma,AndQuote');
-      expect(csvContent).toContain('""');
-      expect(csvContent).toContain('""quoted""');
-      expect(csvContent).toContain('""quotes""');
-    });
+          const validationResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/glossaries/name/') &&
+              response.url().includes('/importAsync') &&
+              response.url().includes('dryRun=true') &&
+              response.request().method() === 'PUT'
+          );
 
-    await test.step('Create new glossary and import exported CSV', async () => {
-      await targetGlossary.create(apiContext);
-      await targetGlossary.visitPage(page);
+          await page.getByRole('button', { name: 'Next' }).click();
+          await validationResponse;
+          await page.getByText('Import is in progress.').waitFor({
+            state: 'detached',
+          });
 
-      await selectGlossaryManageItem(page, 'import-button');
+          await waitForImportGridLoadMaskToDisappear(page);
 
-      try {
-        await uploadCSVAndWaitForGrid(page, exportedCsvPath, {
-          csvImportCompletedPromise: createCsvImportPromise(),
-        });
+          const expectedProcessed = await page
+            .getByTestId('processed-row')
+            .textContent();
+          await validateImportStatus(page, {
+            passed: expectedProcessed?.trim() ?? '0',
+            processed: expectedProcessed?.trim() ?? '0',
+            failed: '0',
+          });
 
-        await expect(
-          page.getByRole('gridcell', { name: 'Term1' }).first()
-        ).toBeVisible();
-        await expect(
-          page.getByRole('gridcell', { name: 'TermWithComma,AndQuote' }).first()
-        ).toBeVisible();
+          const importResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/glossaries/name/') &&
+              response.url().includes('/importAsync') &&
+              response.url().includes('dryRun=false') &&
+              response.request().method() === 'PUT'
+          );
+          const importCompletedPromise = createCsvImportPromise();
 
-        const validationResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/glossaries/name/') &&
-            response.url().includes('/importAsync') &&
-            response.url().includes('dryRun=true') &&
-            response.request().method() === 'PUT'
-        );
-
-        await page.getByRole('button', { name: 'Next' }).click();
-        await validationResponse;
-        await page.getByText('Import is in progress.').waitFor({
-          state: 'detached',
-        });
-
-        await waitForImportGridLoadMaskToDisappear(page);
-
-        const expectedProcessed = await page
-          .getByTestId('processed-row')
-          .textContent();
-        await validateImportStatus(page, {
-          passed: expectedProcessed?.trim() ?? '0',
-          processed: expectedProcessed?.trim() ?? '0',
-          failed: '0',
-        });
-
-        const importResponse = page.waitForResponse(
-          (response) =>
-            response.url().includes('/api/v1/glossaries/name/') &&
-            response.url().includes('/importAsync') &&
-            response.url().includes('dryRun=false') &&
-            response.request().method() === 'PUT'
-        );
-        const importCompletedPromise = createCsvImportPromise();
-
-        await page.getByRole('button', { name: 'Update' }).click();
-        await importResponse;
-        await importCompletedPromise;
-        await waitForImportGridLoadMaskToDisappear(page);
-      } finally {
-        if (exportedCsvPath && fs.existsSync(exportedCsvPath)) {
-          cleanupTempFile(exportedCsvPath);
+          await page.getByRole('button', { name: 'Update' }).click();
+          await importResponse;
+          await importCompletedPromise;
+          await waitForImportGridLoadMaskToDisappear(page);
+          await waitForGlossaryTerms(
+            apiContext,
+            sourceGlossary.responseData.id,
+            ['Term1', 'TermWithComma,AndQuote']
+          );
+        } finally {
+          cleanupTempFile(tempFilePath);
         }
-      }
+      });
+
+      await test.step('Export CSV and verify it contains properly escaped quotes', async () => {
+        await sourceGlossary.visitPage(page);
+
+        const exportResponsePromise = page.waitForResponse(
+          (response) =>
+            response.url().includes('/api/v1/glossaries/name/') &&
+            response.url().includes('/exportAsync') &&
+            response.request().method() === 'GET'
+        );
+
+        await selectGlossaryManageItem(page, 'export-button');
+
+        const exportResponse = await exportResponsePromise;
+        expect(exportResponse.ok()).toBeTruthy();
+
+        const { jobId } = (await exportResponse.json()) as CsvExportResponse;
+        const csvContent = await fetchCompletedCsvAsyncJobResult(
+          apiContext,
+          jobId
+        );
+
+        exportedCsvPath = `downloads/exported-${uuid()}.csv`;
+        fs.mkdirSync('downloads', { recursive: true });
+        fs.writeFileSync(exportedCsvPath, csvContent);
+
+        expect(csvContent).toContain('Term1');
+        expect(csvContent).toContain('TermWithComma,AndQuote');
+        expect(csvContent).toContain('""');
+        expect(csvContent).toContain('""quoted""');
+        expect(csvContent).toContain('""quotes""');
+      });
+
+      await test.step('Create new glossary and import exported CSV', async () => {
+        await targetGlossary.create(apiContext);
+        await targetGlossary.visitPage(page);
+
+        await selectGlossaryManageItem(page, 'import-button');
+
+        try {
+          await uploadCSVAndWaitForGrid(page, exportedCsvPath, {
+            csvImportCompletedPromise: createCsvImportPromise(),
+          });
+
+          await expect(
+            page.getByRole('gridcell', { name: 'Term1' }).first()
+          ).toBeVisible();
+          await expect(
+            page
+              .getByRole('gridcell', { name: 'TermWithComma,AndQuote' })
+              .first()
+          ).toBeVisible();
+
+          const validationResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/glossaries/name/') &&
+              response.url().includes('/importAsync') &&
+              response.url().includes('dryRun=true') &&
+              response.request().method() === 'PUT'
+          );
+
+          await page.getByRole('button', { name: 'Next' }).click();
+          await validationResponse;
+          await page.getByText('Import is in progress.').waitFor({
+            state: 'detached',
+          });
+
+          await waitForImportGridLoadMaskToDisappear(page);
+
+          const expectedProcessed = await page
+            .getByTestId('processed-row')
+            .textContent();
+          await validateImportStatus(page, {
+            passed: expectedProcessed?.trim() ?? '0',
+            processed: expectedProcessed?.trim() ?? '0',
+            failed: '0',
+          });
+
+          const importResponse = page.waitForResponse(
+            (response) =>
+              response.url().includes('/api/v1/glossaries/name/') &&
+              response.url().includes('/importAsync') &&
+              response.url().includes('dryRun=false') &&
+              response.request().method() === 'PUT'
+          );
+          const importCompletedPromise = createCsvImportPromise();
+
+          await page.getByRole('button', { name: 'Update' }).click();
+          await importResponse;
+          await importCompletedPromise;
+          await waitForImportGridLoadMaskToDisappear(page);
+        } finally {
+          if (exportedCsvPath && fs.existsSync(exportedCsvPath)) {
+            cleanupTempFile(exportedCsvPath);
+          }
+        }
+      });
     });
-  });
-});
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CSVImportWithQuotesAndCommas.spec.ts
@@ -91,7 +91,10 @@ const CSV_WITH_QUOTES_AND_COMMAS = `parent,name*,displayName,description,synonym
 ,"Test1234","Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.","<p>Contains a timestamp for the most recent ""login"" of this feature user, to be used for PIN expiration.</p>",,,,,,user:admin,Approved,,,,
 ,"TermWithComma,AndQuote","Display name with ""quoted"" text, and comma","<p>Description with ""quotes"" and, commas</p>",,,,,,user:admin,Approved,,,,`;
 
-test.describe('CSV Import with Commas and Quotes - All Entity Types', () => {
+test.describe(
+  'CSV Import with Commas and Quotes - All Entity Types',
+  { tag: '@import-export' },
+  () => {
   let createCsvImportPromise: () => Promise<void>;
 
   test.beforeEach(async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -102,7 +102,7 @@ const exportActiveGlossaryCsv = async (
   return fetchCompletedCsvAsyncJobResult(apiContext, jobId);
 };
 
-test.describe('Glossary Bulk Import Export', () => {
+test.describe('Glossary Bulk Import Export', { tag: '@import-export' }, () => {
   test.slow(true);
 
   test.beforeAll('setup pre-test', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExport.spec.ts
@@ -50,7 +50,7 @@ import {
 } from '../../utils/odcsImportExport';
 import { test } from '../fixtures/pages';
 
-test.describe('ODCS Import/Export', () => {
+test.describe('ODCS Import/Export', { tag: '@import-export' }, () => {
   test.slow(true);
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts
@@ -148,383 +148,396 @@ test.describe(
   'ODCS Import/Export - RBAC Permissions',
   { tag: '@import-export' },
   () => {
-  const tableWithContract = new TableClass();
-  const tableWithoutContract = new TableClass();
+    const tableWithContract = new TableClass();
+    const tableWithoutContract = new TableClass();
 
-  test.beforeAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-    // Create users with custom permissions
-    await dataContractEditUser.create(apiContext, false);
-    await dataContractViewUser.create(apiContext, false);
+      // Create users with custom permissions
+      await dataContractEditUser.create(apiContext, false);
+      await dataContractViewUser.create(apiContext, false);
 
-    // Create and assign EditAll policy/role
-    const editPolicyResponse = await dataContractEditPolicy.create(
-      apiContext,
-      DATA_CONTRACT_EDIT_RULES
-    );
-    const editRoleResponse = await dataContractEditRole.create(apiContext, [
-      editPolicyResponse.fullyQualifiedName,
-    ]);
-    await dataContractEditUser.patch({
-      apiContext,
-      patchData: [
-        {
-          op: 'add',
-          path: '/roles/0',
-          value: {
-            id: editRoleResponse.id,
-            type: 'role',
-            name: editRoleResponse.name,
-          },
-        },
-      ],
-    });
-
-    // Create and assign ViewOnly policy/role
-    const viewPolicyResponse = await dataContractViewPolicy.create(
-      apiContext,
-      DATA_CONTRACT_VIEW_ONLY_RULES
-    );
-    const viewRoleResponse = await dataContractViewRole.create(apiContext, [
-      viewPolicyResponse.fullyQualifiedName,
-    ]);
-    await dataContractViewUser.patch({
-      apiContext,
-      patchData: [
-        {
-          op: 'add',
-          path: '/roles/0',
-          value: {
-            id: viewRoleResponse.id,
-            type: 'role',
-            name: viewRoleResponse.name,
-          },
-        },
-      ],
-    });
-
-    // Create tables
-    await tableWithContract.create(apiContext);
-    await tableWithoutContract.create(apiContext);
-
-    // Create a contract on one table via API
-    await apiContext.post('/api/v1/dataContracts', {
-      data: {
-        name: `test-contract-${uuid()}`,
-        description: 'Test contract for permission testing',
-        entity: {
-          id: tableWithContract.entityResponseData.id,
-          type: 'table',
-        },
-      },
-    });
-
-    await afterAction();
-  });
-
-  test.afterAll(async ({ browser }) => {
-    const { apiContext, afterAction } = await performAdminLogin(browser);
-
-    await tableWithContract.delete(apiContext);
-    await tableWithoutContract.delete(apiContext);
-    await dataContractEditUser.delete(apiContext);
-    await dataContractViewUser.delete(apiContext);
-    await dataContractEditRole.delete(apiContext);
-    await dataContractEditPolicy.delete(apiContext);
-    await dataContractViewRole.delete(apiContext);
-    await dataContractViewPolicy.delete(apiContext);
-
-    await afterAction();
-  });
-
-  test.describe('Admin User', () => {
-    /**
-     * @description Verify admin can see all import/export options for existing contract
-     */
-    test('Admin should see all import and export options for existing contract', async ({
-      page,
-    }) => {
-      await redirectToHomePage(page);
-      await navigateToContractTab(page, tableWithContract);
-
-      await page.getByTestId('manage-contract-actions').click();
-      await page.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-      await verifyContractButtonVisibility(page, {
-        importOdcs: true,
-        importOm: true,
-        exportOdcs: true,
-        exportOm: true,
-      });
-    });
-
-    /**
-     * @description Verify admin can export ODCS contract
-     */
-    test('Admin should successfully export ODCS contract', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToContractTab(page, tableWithContract);
-
-      await page.getByTestId('manage-contract-actions').click();
-      await page.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-      const download = await performODCSExport(page);
-      expect(download.suggestedFilename()).toContain('.yaml');
-    });
-
-    /**
-     * @description Verify admin can import ODCS contract on table without contract
-     */
-    test('Admin should successfully import ODCS contract', async ({ page }) => {
-      await redirectToHomePage(page);
-      await navigateToContractTab(page, tableWithoutContract);
-
-      await openODCSImportDropdown(page);
-      await importODCSYaml(page, ODCS_VALID_BASIC_YAML, 'admin-import.yaml');
-
-      await expect(page.getByTestId('contract-title')).toBeVisible();
-    });
-  });
-
-  test.describe('Data Consumer Role', () => {
-    /**
-     * @description Data Consumer should see export options but not import options
-     */
-    test('Data Consumer should see export but not import options', async ({
-      dataConsumerPage,
-    }) => {
-      await redirectToHomePage(dataConsumerPage);
-      await navigateToContractTab(dataConsumerPage, tableWithContract);
-
-      await dataConsumerPage.getByTestId('manage-contract-actions').click();
-      await dataConsumerPage.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-
-      await verifyContractButtonVisibility(dataConsumerPage, {
-        importOdcs: false,
-        importOm: false,
-        exportOdcs: true,
-        exportOm: true,
-      });
-    });
-
-    /**
-     * @description Data Consumer can successfully export ODCS contract
-     */
-    test('Data Consumer can export ODCS contract', async ({
-      dataConsumerPage,
-    }) => {
-      await redirectToHomePage(dataConsumerPage);
-      await navigateToContractTab(dataConsumerPage, tableWithContract);
-
-      await dataConsumerPage.getByTestId('manage-contract-actions').click();
-      await dataConsumerPage.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-      const download = await performODCSExport(dataConsumerPage);
-      expect(download.suggestedFilename()).toContain('.yaml');
-    });
-  });
-
-  test.describe('Data Steward Role', () => {
-    /**
-     * @description Data Steward should see export options but not import options
-     */
-    test('Data Steward should see export but not import options', async ({
-      dataStewardPage,
-    }) => {
-      await redirectToHomePage(dataStewardPage);
-      await navigateToContractTab(dataStewardPage, tableWithContract);
-
-      await dataStewardPage.getByTestId('manage-contract-actions').click();
-      await dataStewardPage.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-      await verifyContractButtonVisibility(dataStewardPage, {
-        importOdcs: false,
-        importOm: false,
-        exportOdcs: true,
-        exportOm: true,
-      });
-    });
-
-    /**
-     * @description Data Steward can successfully export ODCS contract
-     */
-    test('Data Steward can export ODCS contract', async ({
-      dataStewardPage,
-    }) => {
-      await redirectToHomePage(dataStewardPage);
-      await navigateToContractTab(dataStewardPage, tableWithContract);
-
-      await dataStewardPage.getByTestId('manage-contract-actions').click();
-      await dataStewardPage.getByTestId('contract-action-dropdown').waitFor({
-        state: 'visible',
-      });
-      const download = await performODCSExport(dataStewardPage);
-      expect(download.suggestedFilename()).toContain('.yaml');
-    });
-  });
-
-  test.describe('User with DataContract EditAll Permission', () => {
-    /**
-     * @description User with EditAll permission should see all import and export options
-     */
-    test('User with EditAll should see all import and export options', async ({
-      dataContractEditPage,
-    }) => {
-      await redirectToHomePage(dataContractEditPage);
-      await navigateToContractTab(dataContractEditPage, tableWithContract);
-
-      await dataContractEditPage.getByTestId('manage-contract-actions').click();
-      await dataContractEditPage
-        .getByTestId('contract-action-dropdown')
-        .waitFor({
-          state: 'visible',
-        });
-      await verifyContractButtonVisibility(dataContractEditPage, {
-        importOdcs: true,
-        importOm: true,
-        exportOdcs: true,
-        exportOm: true,
-      });
-    });
-
-    /**
-     * @description User with EditAll permission can export ODCS contract
-     */
-    test('User with EditAll can export ODCS contract', async ({
-      dataContractEditPage,
-    }) => {
-      await redirectToHomePage(dataContractEditPage);
-      await navigateToContractTab(dataContractEditPage, tableWithContract);
-
-      await dataContractEditPage.getByTestId('manage-contract-actions').click();
-      await dataContractEditPage
-        .getByTestId('contract-action-dropdown')
-        .waitFor({
-          state: 'visible',
-        });
-      const download = await performODCSExport(dataContractEditPage);
-      expect(download.suggestedFilename()).toContain('.yaml');
-    });
-
-    /**
-     * @description User with EditAll permission can import ODCS contract
-     */
-    test('User with EditAll can import ODCS contract', async ({
-      dataContractEditPage,
-    }) => {
-      test.slow(true); // Marking test as slow due to setup and cleanup steps
-      // Create a new table for this test
-      const testTable = new TableClass();
-      const { apiContext: adminApi, afterAction } = await performAdminLogin(
-        dataContractEditPage.context().browser()!
+      // Create and assign EditAll policy/role
+      const editPolicyResponse = await dataContractEditPolicy.create(
+        apiContext,
+        DATA_CONTRACT_EDIT_RULES
       );
-      await testTable.create(adminApi);
+      const editRoleResponse = await dataContractEditRole.create(apiContext, [
+        editPolicyResponse.fullyQualifiedName,
+      ]);
+      await dataContractEditUser.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/roles/0',
+            value: {
+              id: editRoleResponse.id,
+              type: 'role',
+              name: editRoleResponse.name,
+            },
+          },
+        ],
+      });
+
+      // Create and assign ViewOnly policy/role
+      const viewPolicyResponse = await dataContractViewPolicy.create(
+        apiContext,
+        DATA_CONTRACT_VIEW_ONLY_RULES
+      );
+      const viewRoleResponse = await dataContractViewRole.create(apiContext, [
+        viewPolicyResponse.fullyQualifiedName,
+      ]);
+      await dataContractViewUser.patch({
+        apiContext,
+        patchData: [
+          {
+            op: 'add',
+            path: '/roles/0',
+            value: {
+              id: viewRoleResponse.id,
+              type: 'role',
+              name: viewRoleResponse.name,
+            },
+          },
+        ],
+      });
+
+      // Create tables
+      await tableWithContract.create(apiContext);
+      await tableWithoutContract.create(apiContext);
+
+      // Create a contract on one table via API
+      await apiContext.post('/api/v1/dataContracts', {
+        data: {
+          name: `test-contract-${uuid()}`,
+          description: 'Test contract for permission testing',
+          entity: {
+            id: tableWithContract.entityResponseData.id,
+            type: 'table',
+          },
+        },
+      });
+
       await afterAction();
-
-      try {
-        await redirectToHomePage(dataContractEditPage);
-        await navigateToContractTab(dataContractEditPage, testTable);
-
-        await openODCSImportDropdown(dataContractEditPage);
-        await importODCSYaml(
-          dataContractEditPage,
-          ODCS_VALID_BASIC_YAML,
-          'edit-user-import.yaml'
-        );
-
-        await expect(
-          dataContractEditPage.getByTestId('contract-title')
-        ).toBeVisible();
-      } finally {
-        const { apiContext: cleanupApi, afterAction: cleanupAfterAction } =
-          await performAdminLogin(dataContractEditPage.context().browser()!);
-        await testTable.delete(cleanupApi);
-        await cleanupAfterAction();
-      }
     });
-  });
 
-  test.describe('User with DataContract ViewOnly Permission', () => {
-    /**
-     * @description User with ViewOnly permission should see export but not import options
-     */
-    test('User with ViewOnly should see export but not import options', async ({
-      dataContractViewPage,
-    }) => {
-      await redirectToHomePage(dataContractViewPage);
-      await navigateToContractTab(dataContractViewPage, tableWithContract);
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-      await dataContractViewPage.getByTestId('manage-contract-actions').click();
-      await dataContractViewPage
-        .getByTestId('contract-action-dropdown')
-        .waitFor({
+      await tableWithContract.delete(apiContext);
+      await tableWithoutContract.delete(apiContext);
+      await dataContractEditUser.delete(apiContext);
+      await dataContractViewUser.delete(apiContext);
+      await dataContractEditRole.delete(apiContext);
+      await dataContractEditPolicy.delete(apiContext);
+      await dataContractViewRole.delete(apiContext);
+      await dataContractViewPolicy.delete(apiContext);
+
+      await afterAction();
+    });
+
+    test.describe('Admin User', () => {
+      /**
+       * @description Verify admin can see all import/export options for existing contract
+       */
+      test('Admin should see all import and export options for existing contract', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToContractTab(page, tableWithContract);
+
+        await page.getByTestId('manage-contract-actions').click();
+        await page.getByTestId('contract-action-dropdown').waitFor({
           state: 'visible',
         });
-      await verifyContractButtonVisibility(dataContractViewPage, {
-        importOdcs: false,
-        importOm: false,
-        exportOdcs: true,
-        exportOm: true,
+        await verifyContractButtonVisibility(page, {
+          importOdcs: true,
+          importOm: true,
+          exportOdcs: true,
+          exportOm: true,
+        });
+      });
+
+      /**
+       * @description Verify admin can export ODCS contract
+       */
+      test('Admin should successfully export ODCS contract', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToContractTab(page, tableWithContract);
+
+        await page.getByTestId('manage-contract-actions').click();
+        await page.getByTestId('contract-action-dropdown').waitFor({
+          state: 'visible',
+        });
+        const download = await performODCSExport(page);
+        expect(download.suggestedFilename()).toContain('.yaml');
+      });
+
+      /**
+       * @description Verify admin can import ODCS contract on table without contract
+       */
+      test('Admin should successfully import ODCS contract', async ({
+        page,
+      }) => {
+        await redirectToHomePage(page);
+        await navigateToContractTab(page, tableWithoutContract);
+
+        await openODCSImportDropdown(page);
+        await importODCSYaml(page, ODCS_VALID_BASIC_YAML, 'admin-import.yaml');
+
+        await expect(page.getByTestId('contract-title')).toBeVisible();
       });
     });
 
-    /**
-     * @description User with ViewOnly permission can export ODCS contract
-     */
-    test('User with ViewOnly can export ODCS contract', async ({
-      dataContractViewPage,
-    }) => {
-      await redirectToHomePage(dataContractViewPage);
-      await navigateToContractTab(dataContractViewPage, tableWithContract);
+    test.describe('Data Consumer Role', () => {
+      /**
+       * @description Data Consumer should see export options but not import options
+       */
+      test('Data Consumer should see export but not import options', async ({
+        dataConsumerPage,
+      }) => {
+        await redirectToHomePage(dataConsumerPage);
+        await navigateToContractTab(dataConsumerPage, tableWithContract);
 
-      await dataContractViewPage.getByTestId('manage-contract-actions').click();
-      await dataContractViewPage
-        .getByTestId('contract-action-dropdown')
-        .waitFor({
+        await dataConsumerPage.getByTestId('manage-contract-actions').click();
+        await dataConsumerPage.getByTestId('contract-action-dropdown').waitFor({
           state: 'visible',
         });
-      const download = await performODCSExport(dataContractViewPage);
-      expect(download.suggestedFilename()).toContain('.yaml');
+
+        await verifyContractButtonVisibility(dataConsumerPage, {
+          importOdcs: false,
+          importOm: false,
+          exportOdcs: true,
+          exportOm: true,
+        });
+      });
+
+      /**
+       * @description Data Consumer can successfully export ODCS contract
+       */
+      test('Data Consumer can export ODCS contract', async ({
+        dataConsumerPage,
+      }) => {
+        await redirectToHomePage(dataConsumerPage);
+        await navigateToContractTab(dataConsumerPage, tableWithContract);
+
+        await dataConsumerPage.getByTestId('manage-contract-actions').click();
+        await dataConsumerPage.getByTestId('contract-action-dropdown').waitFor({
+          state: 'visible',
+        });
+        const download = await performODCSExport(dataConsumerPage);
+        expect(download.suggestedFilename()).toContain('.yaml');
+      });
     });
-  });
 
-  test.describe('API-Level Permission Enforcement', () => {
-    /**
-     * @description Verify API allows export for users with view permission
-     */
-    test('API should allow export for users with view permission', async ({
-      dataConsumerPage,
-    }) => {
-      await redirectToHomePage(dataConsumerPage);
-      await navigateToContractTab(dataConsumerPage, tableWithContract);
+    test.describe('Data Steward Role', () => {
+      /**
+       * @description Data Steward should see export options but not import options
+       */
+      test('Data Steward should see export but not import options', async ({
+        dataStewardPage,
+      }) => {
+        await redirectToHomePage(dataStewardPage);
+        await navigateToContractTab(dataStewardPage, tableWithContract);
 
-      // Get contract ID from page
-      const { apiContext } = await getApiContext(dataConsumerPage);
+        await dataStewardPage.getByTestId('manage-contract-actions').click();
+        await dataStewardPage.getByTestId('contract-action-dropdown').waitFor({
+          state: 'visible',
+        });
+        await verifyContractButtonVisibility(dataStewardPage, {
+          importOdcs: false,
+          importOm: false,
+          exportOdcs: true,
+          exportOm: true,
+        });
+      });
 
-      // Get the contract first
-      const contractsResponse = await apiContext.get(
-        `/api/v1/dataContracts?entity=${tableWithContract.entityResponseData.id}`
-      );
-      const contracts = await contractsResponse.json();
+      /**
+       * @description Data Steward can successfully export ODCS contract
+       */
+      test('Data Steward can export ODCS contract', async ({
+        dataStewardPage,
+      }) => {
+        await redirectToHomePage(dataStewardPage);
+        await navigateToContractTab(dataStewardPage, tableWithContract);
 
-      if (contracts.data && contracts.data.length > 0) {
-        const contractId = contracts.data[0].id;
+        await dataStewardPage.getByTestId('manage-contract-actions').click();
+        await dataStewardPage.getByTestId('contract-action-dropdown').waitFor({
+          state: 'visible',
+        });
+        const download = await performODCSExport(dataStewardPage);
+        expect(download.suggestedFilename()).toContain('.yaml');
+      });
+    });
 
-        // Try to export via API
-        const exportResponse = await apiContext.get(
-          `/api/v1/dataContracts/${contractId}/odcs/yaml`
+    test.describe('User with DataContract EditAll Permission', () => {
+      /**
+       * @description User with EditAll permission should see all import and export options
+       */
+      test('User with EditAll should see all import and export options', async ({
+        dataContractEditPage,
+      }) => {
+        await redirectToHomePage(dataContractEditPage);
+        await navigateToContractTab(dataContractEditPage, tableWithContract);
+
+        await dataContractEditPage
+          .getByTestId('manage-contract-actions')
+          .click();
+        await dataContractEditPage
+          .getByTestId('contract-action-dropdown')
+          .waitFor({
+            state: 'visible',
+          });
+        await verifyContractButtonVisibility(dataContractEditPage, {
+          importOdcs: true,
+          importOm: true,
+          exportOdcs: true,
+          exportOm: true,
+        });
+      });
+
+      /**
+       * @description User with EditAll permission can export ODCS contract
+       */
+      test('User with EditAll can export ODCS contract', async ({
+        dataContractEditPage,
+      }) => {
+        await redirectToHomePage(dataContractEditPage);
+        await navigateToContractTab(dataContractEditPage, tableWithContract);
+
+        await dataContractEditPage
+          .getByTestId('manage-contract-actions')
+          .click();
+        await dataContractEditPage
+          .getByTestId('contract-action-dropdown')
+          .waitFor({
+            state: 'visible',
+          });
+        const download = await performODCSExport(dataContractEditPage);
+        expect(download.suggestedFilename()).toContain('.yaml');
+      });
+
+      /**
+       * @description User with EditAll permission can import ODCS contract
+       */
+      test('User with EditAll can import ODCS contract', async ({
+        dataContractEditPage,
+      }) => {
+        test.slow(true); // Marking test as slow due to setup and cleanup steps
+        // Create a new table for this test
+        const testTable = new TableClass();
+        const { apiContext: adminApi, afterAction } = await performAdminLogin(
+          dataContractEditPage.context().browser()!
         );
+        await testTable.create(adminApi);
+        await afterAction();
 
-        // Should succeed with 200
-        expect(exportResponse.status()).toBe(200);
-      }
+        try {
+          await redirectToHomePage(dataContractEditPage);
+          await navigateToContractTab(dataContractEditPage, testTable);
+
+          await openODCSImportDropdown(dataContractEditPage);
+          await importODCSYaml(
+            dataContractEditPage,
+            ODCS_VALID_BASIC_YAML,
+            'edit-user-import.yaml'
+          );
+
+          await expect(
+            dataContractEditPage.getByTestId('contract-title')
+          ).toBeVisible();
+        } finally {
+          const { apiContext: cleanupApi, afterAction: cleanupAfterAction } =
+            await performAdminLogin(dataContractEditPage.context().browser()!);
+          await testTable.delete(cleanupApi);
+          await cleanupAfterAction();
+        }
+      });
     });
-  });
-});
+
+    test.describe('User with DataContract ViewOnly Permission', () => {
+      /**
+       * @description User with ViewOnly permission should see export but not import options
+       */
+      test('User with ViewOnly should see export but not import options', async ({
+        dataContractViewPage,
+      }) => {
+        await redirectToHomePage(dataContractViewPage);
+        await navigateToContractTab(dataContractViewPage, tableWithContract);
+
+        await dataContractViewPage
+          .getByTestId('manage-contract-actions')
+          .click();
+        await dataContractViewPage
+          .getByTestId('contract-action-dropdown')
+          .waitFor({
+            state: 'visible',
+          });
+        await verifyContractButtonVisibility(dataContractViewPage, {
+          importOdcs: false,
+          importOm: false,
+          exportOdcs: true,
+          exportOm: true,
+        });
+      });
+
+      /**
+       * @description User with ViewOnly permission can export ODCS contract
+       */
+      test('User with ViewOnly can export ODCS contract', async ({
+        dataContractViewPage,
+      }) => {
+        await redirectToHomePage(dataContractViewPage);
+        await navigateToContractTab(dataContractViewPage, tableWithContract);
+
+        await dataContractViewPage
+          .getByTestId('manage-contract-actions')
+          .click();
+        await dataContractViewPage
+          .getByTestId('contract-action-dropdown')
+          .waitFor({
+            state: 'visible',
+          });
+        const download = await performODCSExport(dataContractViewPage);
+        expect(download.suggestedFilename()).toContain('.yaml');
+      });
+    });
+
+    test.describe('API-Level Permission Enforcement', () => {
+      /**
+       * @description Verify API allows export for users with view permission
+       */
+      test('API should allow export for users with view permission', async ({
+        dataConsumerPage,
+      }) => {
+        await redirectToHomePage(dataConsumerPage);
+        await navigateToContractTab(dataConsumerPage, tableWithContract);
+
+        // Get contract ID from page
+        const { apiContext } = await getApiContext(dataConsumerPage);
+
+        // Get the contract first
+        const contractsResponse = await apiContext.get(
+          `/api/v1/dataContracts?entity=${tableWithContract.entityResponseData.id}`
+        );
+        const contracts = await contractsResponse.json();
+
+        if (contracts.data && contracts.data.length > 0) {
+          const contractId = contracts.data[0].id;
+
+          // Try to export via API
+          const exportResponse = await apiContext.get(
+            `/api/v1/dataContracts/${contractId}/odcs/yaml`
+          );
+
+          // Should succeed with 200
+          expect(exportResponse.status()).toBe(200);
+        }
+      });
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ODCSImportExportPermissions.spec.ts
@@ -144,7 +144,10 @@ const performODCSExport = async (page: Page) => {
   return download;
 };
 
-test.describe('ODCS Import/Export - RBAC Permissions', () => {
+test.describe(
+  'ODCS Import/Export - RBAC Permissions',
+  { tag: '@import-export' },
+  () => {
   const tableWithContract = new TableClass();
   const tableWithoutContract = new TableClass();
 


### PR DESCRIPTION
## Summary

Peel ~61 minutes of bulk import/export test content off the chromium
lane and into a dedicated `import-export` lane.

Chromium is running against its shard-budget ceiling in `merge_queue`
(see #30616 for the short-term 19 → 20 min bump). The knife-edge is
here because chromium currently absorbs ~1h of import/export content
on top of everything else. Moving that content into its own lane
gives chromium real headroom instead of relying on the budget bump
alone, and lets the two workloads scale independently.

- **Planner** (`.github/scripts/build_playwright_shards.py`): register
  `ImportExport` project → `import-export` lane, 2 workers, `(1, 8)`
  shard bounds (same shape as `ingestion` / `search-rbac`).
- **`playwright.config.ts`**: new `ImportExport` project
  (`grep: /@import-export/`, `fullyParallel: true`, `workers: 2`,
  entity dependencies + teardown). Chromium's `grepInvert` excludes
  `@import-export` when the dedicated lane is on — mirrors the existing
  `@ingestion` pattern.
- **Workflow**: `PW_DEDICATED_IMPORT_EXPORT: "true"` on discover +
  seed-state steps.
- **Tag 12 specs with `@import-export`**:
  - `Features/DataQuality/TestCaseImportExport{Basic,E2eFlow}.spec.ts`
  - `Pages/ODCSImportExport{,Permissions}.spec.ts`
  - `Pages/GlossaryImportExport.spec.ts`
  - `Pages/CSVImportWithQuotesAndCommas.spec.ts`
  - `Features/BulkImport{,WithDotInName}.spec.ts`
  - `Features/MetricBulkImportExportEdit.spec.ts`
  - `Features/BulkEditImportPermissions.spec.ts`
  - `Features/SearchExport.spec.ts`
  - `Features/LineageExportPNGSnapshot.spec.ts`

Full mode (`merge_group`) still runs every project — this is purely
about how the planner packs shards.

## Test plan

- [x] `pytest .github/scripts/tests/test_playwright_ci_planning.py` — 56 passed (adds `test_import_export_runs_in_its_own_lane_with_two_workers`)
- [x] `playwright test --list --project=ImportExport` — enumerates all 12 files
- [x] `playwright test --list --project=chromium` — 0 import/export leaks; 3637 tests remain in chromium
- [x] `prettier --check` + `eslint` — clean on all touched files
- [ ] CI plan-playwright forecasts a healthy `import-export` lane and reduced chromium shard count
- [ ] Import/export shards run green under the new lane

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves tagged import/export Playwright coverage into a dedicated CI lane.
- Registers the `ImportExport` project and `import-export` planner lane with two workers and bounded shard counts.
- Adds the project to workflow discovery and enables dedicated-lane configuration during discovery and fixture seeding.
- Excludes `@import-export` tests from Chromium while routing them through the new project.
- Tags the selected import/export specifications and adds planner coverage for the new lane.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the current workflow explicitly discovers ImportExport, the planner preserves it as an executable lane, and shard execution re-enables the conditional project through the shard plan.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | Adds the ImportExport project to discovery and enables its conditional configuration during discovery and fixture seeding. |
| .github/scripts/build_playwright_shards.py | Registers the ImportExport project as a two-worker dedicated lane with full and targeted shard bounds. |
| openmetadata-ui/src/main/resources/ui/playwright.config.ts | Defines the conditional ImportExport project and excludes its tagged tests from Chromium whenever dedicated planning is active. |
| .github/scripts/tests/test_playwright_ci_planning.py | Verifies the new project's planner registration, worker count, and shard bounds. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditImportPermissions.spec.ts | Tags the existing permission suite for execution in the dedicated import/export project. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Specs[Tagged import/export specs] --> Discovery[Playwright project discovery]
  Discovery --> Planner[Shard planner]
  Planner --> ImportExport[import-export lane]
  Planner --> Chromium[chromium lane]
  ImportExport --> Matrix[Workflow matrix]
  Chromium --> Matrix
  Matrix --> Execution[Playwright shard execution]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci(playwright): include ImportExport pro..."](https://github.com/open-metadata/openmetadata/commit/54ee2aa98f9e10930d76dafdfdc07a267d81f92c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48226535)</sub>

<!-- /greptile_comment -->