### PR TITLE
resolve entity schema path from the classpath scan instead of a hardcoded map

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -1356,6 +1356,14 @@
             <include>**/*Tests.java</include>
             <include>**/*TestCase.java</include>
           </includes>
+          <!--
+            Entity schema used only by SchemaFieldExtractorTest to prove that schema lookup follows
+            the directory layout. Kept out of src/test/resources so that it stays out of the
+            published test-jar and never registers as an entity type in dependent modules.
+          -->
+          <additionalClasspathElements>
+            <additionalClasspathElement>${project.basedir}/src/test/schema-probe</additionalClasspathElement>
+          </additionalClasspathElements>
         </configuration>
       </plugin>
     </plugins>

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
@@ -39,8 +39,20 @@ import org.openmetadata.service.jdbi3.TypeRepository;
 @Slf4j
 public class SchemaFieldExtractor {
 
+  private static final String ENTITY_SCHEMA_DIRECTORY = "json/schema/entity/";
+  private static final String DEFAULT_SCHEMA_SUBDIRECTORY = "data";
+  private static final String ENTITY_TYPE_ANNOTATION = "@om-entity-type";
+  private static final String JSON_FILE_EXTENSION = "json";
+  private static final String JSON_FILE_SUFFIX = "." + JSON_FILE_EXTENSION;
+
   private static final Map<String, Map<String, FieldDefinition>> entityFieldsCache =
       new ConcurrentHashMap<>();
+
+  /**
+   * Entity type to the classpath location of its schema, populated by {@link #getAllEntityTypes()}.
+   * Discovery and loading therefore read the same directory layout and cannot drift apart.
+   */
+  private static final Map<String, String> entityTypeToSchemaPath = new ConcurrentHashMap<>();
 
   /**
    * Entity types intentionally excluded from schema field extraction cache initialization. These
@@ -128,25 +140,14 @@ public class SchemaFieldExtractor {
 
   public static List<String> getAllEntityTypes() {
     List<String> entityTypes = new ArrayList<>();
-    String schemaDirectory = "json/schema/entity/";
 
     try (ScanResult scanResult =
-        new ClassGraph().acceptPaths(schemaDirectory).enableMemoryMapping().scan()) {
+        new ClassGraph().acceptPaths(ENTITY_SCHEMA_DIRECTORY).enableMemoryMapping().scan()) {
 
-      List<Resource> resources = scanResult.getResourcesWithExtension("json");
-
-      for (Resource resource : resources) {
-        try (InputStream is = resource.open()) {
-          JSONObject jsonSchema = new JSONObject(new JSONTokener(is));
-          if (isEntityType(jsonSchema)) {
-            String path = resource.getPath();
-            String fileName = path.substring(path.lastIndexOf('/') + 1);
-            String entityType = fileName.substring(0, fileName.length() - 5); // Remove ".json"
-            entityTypes.add(entityType);
-            LOG.debug("Found entity type: {}", entityType);
-          }
-        } catch (Exception e) {
-          LOG.error("Error reading schema file {}: {}", resource.getPath(), e.getMessage());
+      for (Resource resource : scanResult.getResourcesWithExtension(JSON_FILE_EXTENSION)) {
+        String entityType = registerEntitySchema(resource);
+        if (entityType != null) {
+          entityTypes.add(entityType);
         }
       }
     } catch (Exception e) {
@@ -156,8 +157,44 @@ public class SchemaFieldExtractor {
     return entityTypes;
   }
 
+  /**
+   * Records where an entity schema actually lives so that the loader never has to guess its
+   * subdirectory. Returns the entity type, or null when the resource is not an entity schema.
+   */
+  private static String registerEntitySchema(Resource resource) {
+    String entityType = null;
+    try (InputStream is = resource.open()) {
+      JSONObject jsonSchema = new JSONObject(new JSONTokener(is));
+      if (isEntityType(jsonSchema)) {
+        entityType = schemaNameOf(resource.getPath());
+        recordSchemaPath(entityType, resource.getPath());
+        LOG.debug("Found entity type: {} at {}", entityType, resource.getPath());
+      }
+    } catch (Exception e) {
+      LOG.error("Error reading schema file {}: {}", resource.getPath(), e.getMessage());
+    }
+    return entityType;
+  }
+
+  private static void recordSchemaPath(String entityType, String schemaPath) {
+    String previousPath = entityTypeToSchemaPath.put(entityType, schemaPath);
+    if (previousPath != null && !previousPath.equals(schemaPath)) {
+      LOG.warn(
+          "Entity type '{}' is declared by two schemas: '{}' and '{}'. Using '{}'.",
+          entityType,
+          previousPath,
+          schemaPath,
+          schemaPath);
+    }
+  }
+
+  private static String schemaNameOf(String schemaPath) {
+    String fileName = schemaPath.substring(schemaPath.lastIndexOf('/') + 1);
+    return fileName.substring(0, fileName.length() - JSON_FILE_SUFFIX.length());
+  }
+
   private static boolean isEntityType(JSONObject jsonSchema) {
-    return "@om-entity-type".equals(jsonSchema.optString("$comment"));
+    return ENTITY_TYPE_ANNOTATION.equals(jsonSchema.optString("$comment"));
   }
 
   private static Schema loadMainSchema(
@@ -610,33 +647,28 @@ public class SchemaFieldExtractor {
     return baseSchemaDirectory + schemaFileName;
   }
 
+  /**
+   * Resolves the schema path recorded while scanning {@value #ENTITY_SCHEMA_DIRECTORY}. Entity types
+   * the scan never discovered (schemas without the {@value #ENTITY_TYPE_ANNOTATION} annotation, still
+   * reachable through the {@code /fields/{entityType}} endpoint) keep the historical
+   * {@value #DEFAULT_SCHEMA_SUBDIRECTORY} subdirectory assumption.
+   */
   private static String determineSchemaPath(String entityType) {
-    String subdirectory = getEntitySubdirectory(entityType);
-    return "json/schema/entity/" + subdirectory + "/" + entityType + ".json";
+    String discoveredPath = discoveredSchemaPaths().get(entityType);
+    return discoveredPath != null
+        ? discoveredPath
+        : ENTITY_SCHEMA_DIRECTORY
+            + DEFAULT_SCHEMA_SUBDIRECTORY
+            + "/"
+            + entityType
+            + JSON_FILE_SUFFIX;
   }
 
-  private static String getEntitySubdirectory(String entityType) {
-    Map<String, String> entityTypeToSubdirectory =
-        Map.ofEntries(
-            Map.entry("dashboard", "data"),
-            Map.entry("table", "data"),
-            Map.entry("pipeline", "data"),
-            Map.entry("votes", "data"),
-            Map.entry("learningResource", "learning"),
-            Map.entry("dataProduct", "domains"),
-            Map.entry("domain", "domains"),
-            Map.entry("notificationTemplate", "events"),
-            Map.entry("tag", "classification"),
-            Map.entry("classification", "classification"),
-            Map.entry("agentExecution", "ai"),
-            Map.entry("aiApplication", "ai"),
-            Map.entry("aiGovernancePolicy", "ai"),
-            Map.entry("llmModel", "ai"),
-            Map.entry("page", "data"),
-            Map.entry("promptTemplate", "ai"),
-            Map.entry("tableColumn", "column"),
-            Map.entry("dashboardDataModelColumn", "column"));
-    return entityTypeToSubdirectory.getOrDefault(entityType, "data");
+  private static Map<String, String> discoveredSchemaPaths() {
+    if (entityTypeToSchemaPath.isEmpty()) {
+      getAllEntityTypes();
+    }
+    return entityTypeToSchemaPath;
   }
 
   @Slf4j

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.InputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -144,7 +145,8 @@ public class SchemaFieldExtractor {
     try (ScanResult scanResult =
         new ClassGraph().acceptPaths(ENTITY_SCHEMA_DIRECTORY).enableMemoryMapping().scan()) {
 
-      for (Resource resource : scanResult.getResourcesWithExtension(JSON_FILE_EXTENSION)) {
+      for (Resource resource :
+          schemasInStableOrder(scanResult.getResourcesWithExtension(JSON_FILE_EXTENSION))) {
         String entityType = registerEntitySchema(resource);
         if (entityType != null) {
           entityTypes.add(entityType);
@@ -176,15 +178,24 @@ public class SchemaFieldExtractor {
     return entityType;
   }
 
+  /**
+   * ClassGraph does not guarantee a stable order across scans, so schemas are visited by path and
+   * the first one to claim an entity type keeps it. Two modules declaring the same entity type then
+   * resolve to the same schema on every run rather than to whichever jar was scanned last.
+   */
+  private static List<Resource> schemasInStableOrder(List<Resource> resources) {
+    return resources.stream().sorted(Comparator.comparing(Resource::getPath)).toList();
+  }
+
   private static void recordSchemaPath(String entityType, String schemaPath) {
-    String previousPath = entityTypeToSchemaPath.put(entityType, schemaPath);
-    if (previousPath != null && !previousPath.equals(schemaPath)) {
+    String claimedPath = entityTypeToSchemaPath.putIfAbsent(entityType, schemaPath);
+    if (claimedPath != null && !claimedPath.equals(schemaPath)) {
       LOG.warn(
-          "Entity type '{}' is declared by two schemas: '{}' and '{}'. Using '{}'.",
+          "Entity type '{}' is declared by both '{}' and '{}'. Using '{}'.",
           entityType,
-          previousPath,
+          claimedPath,
           schemaPath,
-          schemaPath);
+          claimedPath);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/SchemaFieldExtractorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/SchemaFieldExtractorTest.java
@@ -77,6 +77,12 @@ class SchemaFieldExtractorTest {
   }
 
   @Test
+  void resolvesDuplicateEntityTypeToTheFirstSchemaPathInScanOrder() throws Throwable {
+    assertEquals(
+        "json/schema/entity/driftProbe/duplicateProbe.json", determineSchemaPath("duplicateProbe"));
+  }
+
+  @Test
   void fallsBackToDataSubdirectoryForUndiscoveredEntityType() throws Throwable {
     assertEquals(
         "json/schema/entity/data/notAnEntityType.json", determineSchemaPath("notAnEntityType"));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/SchemaFieldExtractorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/SchemaFieldExtractorTest.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,62 @@ class SchemaFieldExtractorTest {
     assertTrue(entityTypes.contains("dataContract"));
     assertTrue(entityTypes.contains("learningResource"));
     assertTrue(entityTypes.contains("aiApplication"));
+  }
+
+  @Test
+  void everyDiscoveredEntityTypeResolvesToAnExistingSchema() throws Throwable {
+    List<String> unresolved = new ArrayList<>();
+    for (String entityType : SchemaFieldExtractor.getAllEntityTypes()) {
+      String schemaPath = determineSchemaPath(entityType);
+      if (SchemaFieldExtractor.class.getClassLoader().getResource(schemaPath) == null) {
+        unresolved.add(entityType + " -> " + schemaPath);
+      }
+    }
+
+    assertTrue(
+        unresolved.isEmpty(),
+        "Entity types discovered under json/schema/entity/ that resolve to a schema path which "
+            + "does not exist on the classpath: "
+            + unresolved);
+  }
+
+  @Test
+  void resolvesSchemaPathForEntityInUnknownSubdirectory() throws Throwable {
+    assertEquals(
+        "json/schema/entity/driftProbe/schemaDriftProbe.json",
+        determineSchemaPath("schemaDriftProbe"));
+  }
+
+  @Test
+  void fallsBackToDataSubdirectoryForUndiscoveredEntityType() throws Throwable {
+    assertEquals(
+        "json/schema/entity/data/notAnEntityType.json", determineSchemaPath("notAnEntityType"));
+  }
+
+  @Test
+  void extractFieldsSupportsMcpSchemas() {
+    SchemaFieldExtractor extractor = new SchemaFieldExtractor();
+
+    Map<String, SchemaFieldExtractor.FieldDefinition> serverFields =
+        toMap(extractor.extractFields(new Type(), "mcpServer"));
+    Map<String, SchemaFieldExtractor.FieldDefinition> executionFields =
+        toMap(extractor.extractFields(new Type(), "mcpExecution"));
+
+    assertEquals("string", serverFields.get("protocolVersion").getType());
+    assertEquals("array<mcpTool>", serverFields.get("tools").getType());
+    assertEquals("string", executionFields.get("sessionId").getType());
+    assertEquals("array<toolCallRecord>", executionFields.get("toolCalls").getType());
+  }
+
+  @Test
+  void extractFieldsSupportsContextMemorySchema() {
+    SchemaFieldExtractor extractor = new SchemaFieldExtractor();
+
+    Map<String, SchemaFieldExtractor.FieldDefinition> contextMemoryFields =
+        toMap(extractor.extractFields(new Type(), "contextMemory"));
+
+    assertEquals("entityName", contextMemoryFields.get("name").getType());
+    assertNotNull(contextMemoryFields.get("memoryType"));
   }
 
   @Test
@@ -335,6 +392,11 @@ class SchemaFieldExtractorTest {
     Field cacheField = SchemaFieldExtractor.class.getDeclaredField("entityFieldsCache");
     cacheField.setAccessible(true);
     return (Map<String, Map<String, SchemaFieldExtractor.FieldDefinition>>) cacheField.get(null);
+  }
+
+  private static String determineSchemaPath(String entityType) throws Throwable {
+    return (String)
+        invokePrivateStatic("determineSchemaPath", new Class<?>[] {String.class}, entityType);
   }
 
   private static Object invokePrivateStatic(

--- a/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbe/duplicateProbe.json
+++ b/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbe/duplicateProbe.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/driftProbe/duplicateProbe.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Duplicate Probe",
+  "$comment": "@om-entity-type",
+  "description": "Test-only entity schema declaring an entity type that a second schema also declares, so that duplicate resolution stays independent of classpath scan order.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Name of the probe entity.",
+      "type": "string"
+    }
+  }
+}

--- a/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbe/schemaDriftProbe.json
+++ b/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbe/schemaDriftProbe.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/driftProbe/schemaDriftProbe.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schema Drift Probe",
+  "$comment": "@om-entity-type",
+  "description": "Test-only entity schema that lives in a subdirectory no hardcoded mapping knows about. It guards the schema path resolution against drifting from the schema layout.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Name of the probe entity.",
+      "type": "string"
+    }
+  }
+}

--- a/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbeAlt/duplicateProbe.json
+++ b/openmetadata-service/src/test/schema-probe/json/schema/entity/driftProbeAlt/duplicateProbe.json
@@ -1,0 +1,14 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/driftProbeAlt/duplicateProbe.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Duplicate Probe Alternate",
+  "$comment": "@om-entity-type",
+  "description": "Test-only duplicate of driftProbe/duplicateProbe.json placed in a second subdirectory, so that duplicate resolution stays independent of classpath scan order.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "Name of the probe entity.",
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #30533

Entity schemas are **discovered** by scanning `json/schema/entity/`, but were **loaded** by looking the entity name up in a hardcoded folder map that defaulted to `data`. The two drifted, so six entity types resolved to a folder they do not live in.

- Removed the hardcoded entity-to-folder map.
- The classpath scan already reads each schema's real path and threw it away; it now keeps it, and the loader reads from that.
- Discovery and loading share one source of truth, so they cannot drift again.
- Unknown entity types (reachable via `/fields/{entityType}`) keep the previous `data` fallback, unchanged.

Fixed on `main`: `mcpServer`, `mcpExecution`, `aiGovernanceFramework`, `aiFrameworkControl`, `auditReport`, `contextMemory`.

Also fixes 9 entity types shipped by downstream modules on the same classpath, which a map in this repo could never cover.

#
### Type of change:

- [x] Bug fix

#### Backend integration tests

- [x] Not applicable (no API changes).

#### Ingestion integration tests

- [x] Not applicable.

#### Playwright (UI) tests

- [x] Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #` above.
- [x] For JSON Schema changes: no schema changes, only how their location is resolved at load time.
- [x] I have added a test that covers the exact scenario we are fixing.

Reported by @jun-su-lee, who also proposed a fix in #30534. This takes the structural approach they suggested there.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces hardcoded entity-schema directory mappings with paths captured during classpath discovery.
- Records each discovered entity type’s schema path and uses it during field extraction.
- Preserves the existing `data` directory fallback for undiscovered entity types.
- Adds deterministic handling and warnings for duplicate entity-type declarations.
- Adds test-only schema probes and coverage for schemas in previously unsupported directories.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/SchemaFieldExtractor.java | Replaces the hardcoded schema-directory map with classpath-discovered paths while retaining the legacy fallback. |
| openmetadata-service/src/test/java/org/openmetadata/service/util/SchemaFieldExtractorTest.java | Adds coverage for nonstandard schema directories, duplicate declarations, fallback behavior, and affected entity schemas. |
| openmetadata-service/pom.xml | Adds the isolated schema-probe directory to the unit-test classpath without publishing it in the test JAR. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Scan json/schema/entity] --> B{Entity annotation present?}
  B -- Yes --> C[Record entity type to schema path]
  B -- No --> D[Ignore resource]
  E[Field extraction request] --> F{Discovered path exists?}
  F -- Yes --> G[Load recorded schema path]
  F -- No --> H[Load data/entityType.json fallback]
  C --> F
```
</details>

<sub>Reviews (2): Last reviewed commit: ["gitarbot feedback: make duplicate entity..."](https://github.com/open-metadata/openmetadata/commit/e6fdcf6828cf70af6dc72eaec32568e846a41b80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48234748)</sub>

<!-- /greptile_comment -->