### PR TITLE
Fix #28960: seed default mcpConfiguration so SettingsCache never loads null

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
@@ -201,6 +201,15 @@ public class SystemRepository {
     return null;
   }
 
+  /**
+   * Unlike {@link #getConfigWithKey(String)}, a read failure is reported as an exception rather
+   * than as an absent setting. Callers that seed defaults must use this, because seeding writes an
+   * upsert: treating an unreadable row as a missing one would overwrite a stored configuration.
+   */
+  public boolean settingExists(String key) {
+    return dao.getConfigWithKey(key) != null;
+  }
+
   private Settings prepareFetchedSettings(Settings fetchedSettings) {
     if (fetchedSettings.getConfigType() == SettingsType.EMAIL_CONFIGURATION) {
       SmtpSettings emailConfig = (SmtpSettings) fetchedSettings.getConfigValue();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -649,6 +649,10 @@ public class SettingsCache {
         case MCP_CONFIGURATION -> {
           fetchedSettings = Entity.getSystemRepository().getConfigWithKey(settingsName);
           if (fetchedSettings == null) {
+            // getConfigWithKey() returns null both for a missing row and for a failed read, so an
+            // unreadable setting is indistinguishable from an unset one. Warn either way: falling
+            // back to the defaults narrows MCP CORS to localhost until the setting is read again.
+            LOG.warn("Setting {} could not be read, using default MCP Configuration", settingsName);
             return new Settings()
                 .withConfigType(MCP_CONFIGURATION)
                 .withConfigValue(getDefaultMcpConfiguration());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -288,9 +288,7 @@ public class SettingsCache {
     }
 
     // Initialize MCP Configuration
-    Settings storedMcpConfig =
-        Entity.getSystemRepository().getConfigWithKey(MCP_CONFIGURATION.toString());
-    if (storedMcpConfig == null) {
+    if (isMcpConfigurationAbsent()) {
       // YAML only overrides the defaults, so the setting is seeded even when it is absent there
       MCPConfiguration mcpConfig = applicationConfig.getMcpConfiguration();
       if (mcpConfig == null) {
@@ -563,6 +561,21 @@ public class SettingsCache {
 
   private static MCPConfiguration getDefaultMcpConfiguration() {
     return new MCPConfiguration();
+  }
+
+  /**
+   * Seeding upserts, so it must run only on a row that is known to be missing. A read failure is
+   * reported as "present" to leave a stored configuration untouched; the loader serves the defaults
+   * for that startup instead.
+   */
+  static boolean isMcpConfigurationAbsent() {
+    boolean absent = false;
+    try {
+      absent = !Entity.getSystemRepository().settingExists(MCP_CONFIGURATION.toString());
+    } catch (Exception ex) {
+      LOG.error("Could not read setting {}, skipping default seeding", MCP_CONFIGURATION, ex);
+    }
+    return absent;
   }
 
   private static SmtpSettings getDefaultSmtpSettings() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -47,6 +47,7 @@ import org.openmetadata.api.configuration.ThemeConfiguration;
 import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.common.utils.CommonUtil;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
+import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.api.lineage.LineageLayer;
 import org.openmetadata.schema.api.lineage.LineageSettings;
 import org.openmetadata.schema.api.search.AssetTypeConfiguration;
@@ -290,14 +291,14 @@ public class SettingsCache {
     Settings storedMcpConfig =
         Entity.getSystemRepository().getConfigWithKey(MCP_CONFIGURATION.toString());
     if (storedMcpConfig == null) {
-      org.openmetadata.schema.api.configuration.MCPConfiguration mcpConfig =
-          applicationConfig.getMcpConfiguration();
-      if (mcpConfig != null) {
-        Settings setting =
-            new Settings().withConfigType(MCP_CONFIGURATION).withConfigValue(mcpConfig);
-
-        Entity.getSystemRepository().createNewSetting(setting);
+      // YAML only overrides the defaults, so the setting is seeded even when it is absent there
+      MCPConfiguration mcpConfig = applicationConfig.getMcpConfiguration();
+      if (mcpConfig == null) {
+        mcpConfig = getDefaultMcpConfiguration();
       }
+      Settings setting =
+          new Settings().withConfigType(MCP_CONFIGURATION).withConfigValue(mcpConfig);
+      Entity.getSystemRepository().createNewSetting(setting);
     }
 
     Settings storedScimConfig =
@@ -560,6 +561,10 @@ public class SettingsCache {
     }
   }
 
+  private static MCPConfiguration getDefaultMcpConfiguration() {
+    return new MCPConfiguration();
+  }
+
   private static SmtpSettings getDefaultSmtpSettings() {
     return new SmtpSettings()
         .withPassword(StringUtils.EMPTY)
@@ -640,6 +645,15 @@ public class SettingsCache {
                 .withConfigValue(getDefaultSmtpSettings());
           }
           LOG.info("Loaded Email Setting");
+        }
+        case MCP_CONFIGURATION -> {
+          fetchedSettings = Entity.getSystemRepository().getConfigWithKey(settingsName);
+          if (fetchedSettings == null) {
+            return new Settings()
+                .withConfigType(MCP_CONFIGURATION)
+                .withConfigValue(getDefaultMcpConfiguration());
+          }
+          LOG.info("Loaded MCP Configuration");
         }
         case OPEN_METADATA_BASE_URL_CONFIGURATION -> fetchedSettings =
             Entity.getSystemRepository().getOMBaseUrlConfigInternal();

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
@@ -16,20 +16,21 @@ import org.openmetadata.service.jdbi3.SystemRepository;
 
 class SettingsCacheDefaultCaseTest {
 
+  // Any settings type handled by the loader's default branch, i.e. one without its own case
+  private static final SettingsType SETTINGS_TYPE = SettingsType.WORKFLOW_SETTINGS;
+
   @AfterEach
   void cleanup() {
-    SettingsCache.CACHE.invalidate(SettingsType.MCP_CONFIGURATION.toString());
+    SettingsCache.CACHE.invalidate(SETTINGS_TYPE.toString());
   }
 
   @Test
   void testDefaultCaseWithNonNullResult() throws Exception {
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       SystemRepository mockSystemRepo = mock(SystemRepository.class);
-      String key = SettingsType.MCP_CONFIGURATION.toString();
+      String key = SETTINGS_TYPE.toString();
       Settings settings =
-          new Settings()
-              .withConfigType(SettingsType.MCP_CONFIGURATION)
-              .withConfigValue("test-value");
+          new Settings().withConfigType(SETTINGS_TYPE).withConfigValue("test-value");
       when(mockSystemRepo.getConfigWithKey(key)).thenReturn(settings);
       entityMock.when(Entity::getSystemRepository).thenReturn(mockSystemRepo);
 
@@ -45,7 +46,7 @@ class SettingsCacheDefaultCaseTest {
   void testDefaultCaseWithNullResult() {
     try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
       SystemRepository mockSystemRepo = mock(SystemRepository.class);
-      String key = SettingsType.MCP_CONFIGURATION.toString();
+      String key = SETTINGS_TYPE.toString();
       when(mockSystemRepo.getConfigWithKey(key)).thenReturn(null);
       entityMock.when(Entity::getSystemRepository).thenReturn(mockSystemRepo);
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheMcpConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheMcpConfigurationTest.java
@@ -1,0 +1,73 @@
+package org.openmetadata.service.resources.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.schema.settings.SettingsType.MCP_CONFIGURATION;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.configuration.MCPConfiguration;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.SystemRepository;
+
+/**
+ * MCP configuration is read on the main thread while the server boots. Fresh installs have no row
+ * for it, so the loader has to answer with the schema defaults instead of null - a null makes
+ * Guava throw InvalidCacheLoadException and leaves the MCP server without CORS origins.
+ */
+class SettingsCacheMcpConfigurationTest {
+
+  private static final String KEY = MCP_CONFIGURATION.toString();
+
+  @AfterEach
+  void cleanup() {
+    SettingsCache.CACHE.invalidate(KEY);
+  }
+
+  @Test
+  void testMcpConfigurationFallsBackToSchemaDefaultsWhenRowIsAbsent() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      stubStoredSetting(entityMock, null);
+
+      MCPConfiguration mcpConfig =
+          SettingsCache.getSettingOrDefault(MCP_CONFIGURATION, null, MCPConfiguration.class);
+
+      assertNotNull(mcpConfig);
+      assertEquals("/api/v1/mcp", mcpConfig.getPath());
+      assertEquals(Boolean.TRUE, mcpConfig.getEnabled());
+      assertEquals(30000, mcpConfig.getConnectTimeout());
+      assertEquals(30000, mcpConfig.getReadTimeout());
+      assertTrue(mcpConfig.getAllowedOrigins().contains("http://localhost:8585"));
+    }
+  }
+
+  @Test
+  void testMcpConfigurationLoadsStoredRow() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      MCPConfiguration storedConfig =
+          new MCPConfiguration().withBaseUrl("https://openmetadata.example.com").withEnabled(false);
+      stubStoredSetting(
+          entityMock,
+          new Settings().withConfigType(MCP_CONFIGURATION).withConfigValue(storedConfig));
+
+      MCPConfiguration mcpConfig =
+          SettingsCache.getSettingOrDefault(MCP_CONFIGURATION, null, MCPConfiguration.class);
+
+      assertEquals("https://openmetadata.example.com", mcpConfig.getBaseUrl());
+      assertEquals(Boolean.FALSE, mcpConfig.getEnabled());
+    }
+  }
+
+  private void stubStoredSetting(MockedStatic<Entity> entityMock, Settings storedSetting) {
+    SystemRepository mockSystemRepo = mock(SystemRepository.class);
+    when(mockSystemRepo.getConfigWithKey(KEY)).thenReturn(storedSetting);
+    entityMock.when(Entity::getSystemRepository).thenReturn(mockSystemRepo);
+    SettingsCache.CACHE.invalidate(KEY);
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheMcpConfigurationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheMcpConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.resources.settings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -61,6 +62,18 @@ class SettingsCacheMcpConfigurationTest {
 
       assertEquals("https://openmetadata.example.com", mcpConfig.getBaseUrl());
       assertEquals(Boolean.FALSE, mcpConfig.getEnabled());
+    }
+  }
+
+  @Test
+  void testSeedingIsSkippedWhenTheSettingCannotBeRead() {
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      SystemRepository mockSystemRepo = mock(SystemRepository.class);
+      when(mockSystemRepo.settingExists(KEY)).thenThrow(new IllegalStateException("db is down"));
+      entityMock.when(Entity::getSystemRepository).thenReturn(mockSystemRepo);
+
+      // Seeding upserts, so an unreadable row must never be treated as a missing one
+      assertFalse(SettingsCache.isMcpConfigurationAbsent());
     }
   }
 


### PR DESCRIPTION
### Describe your changes:

Fixes #28960

- Seed `mcpConfiguration` with the schema defaults when neither the DB row nor a YAML block exists. It was previously seeded only if `conf/openmetadata.yaml` had an `mcpConfiguration:` block, and that block has never shipped, so on a fresh install the row was simply never created.
- Make the `SettingsCache` loader return the default MCP config instead of `null`, so Guava can no longer raise `InvalidCacheLoadException` for this key.
- Two side effects of the row now existing: MCP OAuth CORS gets its documented default origins instead of an empty (reject-all) list, and `GET /api/v1/system/mcp/config` returns the config instead of 404.

YAML stays an override, which is how every other default-seeded setting in `SettingsCache` already behaves.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A, small change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Seeds a default MCP configuration safely and prevents null MCP cache loads.
- Adds a repository existence check that propagates read failures so startup seeding cannot overwrite an unreadable stored row.
- Seeds schema defaults when neither a database row nor YAML override exists.
- Gives MCP configuration a dedicated cache-loader fallback and warning.
- Adds unit coverage for missing, stored, and unreadable MCP settings.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until transient MCP configuration read failures stop replacing administrator-configured production origins with cached localhost defaults.

The loader still maps both an absent row and a failed database read to a default MCP configuration, so a transient read failure can override active origin behavior for the cache lifetime.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java; openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SystemRepository.java | Adds a direct setting-existence query whose database errors remain distinguishable from an absent setting. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java | Safely seeds MCP defaults and avoids null cache loads, while the previously reported transient-read fallback remains outstanding. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java | Moves generic loader coverage to a setting that still uses the default branch. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheMcpConfigurationTest.java | Covers MCP schema-default fallback, stored-row loading, and safe handling of seeding read failures. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: don&#39;t seed MCP defaults over a stor..."](https://github.com/open-metadata/openmetadata/commit/e64f7d4799310a89a31530fe203047f4309ec9ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48235125)</sub>

<!-- /greptile_comment -->