### PR TITLE
fix(ui): keep GenericTab's widget grid inside its container

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
@@ -94,7 +94,13 @@ export const GenericTab = ({ type, variant = 'default' }: GenericTabProps) => {
         'flat-left-panel': variant === 'flat',
       })}
       cols={8}
-      containerPadding={[0, 0]}
+      // react-grid-layout rounds each item's `left` and `width` independently, so
+      // although the two exact values sum to the container width, each rounding
+      // can add just under half a pixel and the last column can land 1px past the
+      // container -- taking the widget card's right border with it. A 1px
+      // horizontal containerPadding pulls the exact right edge in to
+      // `width - 1`, which the rounding can never exceed.
+      containerPadding={[1, 0]}
       isDraggable={false}
       isResizable={false}
       margin={[GRID_VERTICAL_MARGIN, GRID_VERTICAL_MARGIN]}


### PR DESCRIPTION
### Describe your changes:

On entity detail pages the right-hand widget column can render **1px wider than its grid container**. When it does, the widget card's **right border disappears** and the active tab pane gains a **horizontal scrollbar** for that single pixel. It looks intermittent because it depends on the grid's pixel width — it reproduces at **one width in four**.

Issue well documented: https://github.com/react-grid-layout/react-grid-layout/issues/2141

![before and after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-generic-tab-grid/.pr-assets/generic-tab-grid/pr-zoom-v2.png)

![where the crop comes from](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-generic-tab-grid/.pr-assets/generic-tab-grid/pr-context-v2.png)

#### Root cause

`react-grid-layout` derives each item's `left` and `width` in pixels and rounds the two **independently** (`calcGridItemPosition` / `calcGridItemWidthPx` in `calculateUtils.js`):

```js
left  = Math.round((colWidth + margin) * x)
width = Math.round(colWidth * w + (w - 1) * margin)
```

The exact values always sum to the container width:

```
colWidth*(x+w) + margin*(x+w-1)  =  8*colWidth + 7*margin  =  containerWidth
```

but each rounding can add just under half a pixel, so `round(left) + round(width)` can be `containerWidth + 1`.

`GenericTab` uses `cols={8}`, `margin={[16, 16]}`, `containerPadding={[0, 0]}`, and the right column is `x=6, w=2`. So `colWidth = (W - 112) / 8`, and **both** values land on exactly `.5` — and `Math.round` breaks ties upward — whenever `W % 4 == 2`.

Worked example (Table detail page, viewport 1382px, grid width **1114**):

| | exact | rounded |
|---|---|---|
| `colWidth` | `(1114 - 112) / 8` = **125.25** | |
| `left` (x=6) | `(125.25 + 16) * 6` = **847.5** | 848 ↑ |
| `width` (w=2) | `125.25 * 2 + 16` = **266.5** | 267 ↑ |
| right edge | 1114 | **1115** ← 1px outside |

At grid widths 1115, 1116 or 1117 the fractions don't collide and it renders correctly.

The stray pixel becomes visible because the active tab pane scrolls vertically, and CSS promotes the cross axis to `auto` once one axis is not `visible` — so 1px of rounding noise produces a full-width horizontal scrollbar, and where an ancestor clips instead, the border is swallowed.

#### Scope

Measured across viewports 1381–1400, reading each `.react-grid-item`'s right edge against `.grid-container`:

| page | widths where the last column escapes the grid |
|---|---|
| table, dashboard, pipeline, topic, container, mlmodel, searchIndex, storedProcedure, apiEndpoint, apiCollection, database, databaseSchema, metric | **5 / 20 each** |
| domain | 0 / 20 |

`domain` is unaffected because it uses the `flat` single-widget variant — one widget spanning all 8 columns means `x=0, w=8`, so `left` is 0 and `width` rounds to the container width exactly. The bug requires a *split*, which is why every 6 + 2 page has it.

#### The fix

```diff
- containerPadding={[0, 0]}
+ containerPadding={[1, 0]}
```

`containerPadding` is applied at the container edges, so it pulls the exact right edge in to `width - 1`. The rounding error is bounded at 1px — the two exact edges sum to the width, and each rounding adds under half a pixel — so the last column can never exceed it.

Nothing is clipped, so a widget that is genuinely wider than the grid still overflows exactly as it does today. The vertical component stays `0`, so row spacing is untouched.

Across widths 600–2400 and **every** column split that reaches the right edge:

| | failing widths |
|---|---|
| `containerPadding={[0, 0]}` (today) | **1575 / 1801** |
| `containerPadding={[1, 0]}` | **0 / 1801** |

**Why not adjust `margin`?** It is the gutter *between* items, and sits inside the sum that always equals the container width — so changing it only moves which widths collide, never removes the collision. Every integer margin from 0 to 24 leaves 175–176 of 701 widths failing; `[1, 1]` merely shifts them from `W % 4 == 2` to `W % 4 == 1`, and would collapse the 16px gutter.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one CSS rule plus the class it hangs off.

**Alternatives considered**

1. **Quantize the width so `colWidth` is an integer** (floor the measured width to `112 + 8n`). Removes the rounding entirely, but costs up to 7px on the right and visibly de-aligns the widget column from the header card above it. Measured: 5/17 broken widths → 0/17, at that cost.
2. **`overflow-x: clip` on the tab pane.** Hides the scrollbar but not the cause — the pane still reports the overflow, and the border stays clipped. It would also suppress legitimate horizontal overflow in sibling tabs.
3. **A 1px CSS `padding-right` on the grid element.** Equivalent arithmetic — `WidthProvider` reads `contentRect.width`, so padding shrinks what the grid lays out against — but it needs a dedicated class to scope it, because `.grid-container` is shared with `CustomizeTabWidget` (the draggable customize surface), `LeftPanelContainer` (a grid nested *inside* this one), `CustomizeMyData`, `MyDataPage` and `DataMarketplacePage`. The prop expresses the same intent with no new class and no CSS rule.
4. **Replace `react-grid-layout` with CSS Grid in view mode.** `GenericTab` passes `isDraggable={false} isResizable={false}`, so the library's pixel positioning isn't needed here at all. Measured over widths 900–1600: CSS Grid **0/701** failures vs react-grid-layout's arithmetic **175/701**. Better long-term fix and worth its own issue, but a much larger change to a component used by every entity page, and the customize/edit page does need real drag-resize. Out of scope here.

#
### Tests:

#### Use cases covered
- Entity detail pages render the right-hand widget column with its border intact at every viewport width.
- The active tab pane no longer gains a horizontal scrollbar from grid rounding.
- Widgets that are legitimately wider than the grid still overflow and scroll as before (verified on the Metric page's Expression and Lineage tabs).
- The customize/edit grid, the nested left-panel grid, MyData and Data Marketplace are untouched — the change is a prop on this component only.

Swept viewports 1381–1400 on a running instance, reading `.react-grid-item` right edges and the tab pane's `scrollWidth - clientWidth`:

| page | before | after |
|---|---|---|
| table | 5/20 widths overflow | **0/20** |
| dashboard | 5/20 | **0/20** |
| topic | 5/20 | **0/20** |
| databaseSchema | 5/20 | **0/20** |
| metric | 5/20 | **0/20** |

#### Unit tests
Not added — this is a CSS change with no JS branch to cover, and the behaviour depends on layout geometry that jsdom does not compute, so a unit test could not observe it. A Playwright assertion on `.grid-container` `scrollWidth <= clientWidth` across a few widths would be the meaningful regression guard; happy to add one if you'd like it here.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates GenericTab’s react-grid-layout configuration to reserve one horizontal pixel through `containerPadding`, preventing independently rounded item positions and widths from extending the final widget beyond its container.
- Replaces the zero horizontal container padding with one pixel.
- Documents the rounding behavior that necessitates the workaround.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx | Applies the overflow workaround directly through react-grid-layout’s container padding; the superseded Less-based concerns no longer apply. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): keep GenericTab&#39;s widget grid i..."](https://github.com/open-metadata/openmetadata/commit/de424eda37e802db26ede50c4016416243ef0b8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48237694)</sub>

<!-- /greptile_comment -->