### PR TITLE
don't log an unset optional setting as an ERROR

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -534,13 +534,18 @@ public class SettingsCache {
 
   public static <T> T getSettingOrDefault(
       SettingsType settingName, T defaultValue, Class<T> clazz) {
+    T result = defaultValue;
     try {
       Object configValue = CACHE.get(settingName.toString()).getConfigValue();
-      return JsonUtils.convertValue(configValue, clazz);
+      result = JsonUtils.convertValue(configValue, clazz);
+    } catch (CacheLoader.InvalidCacheLoadException ex) {
+      // The loader returns null for a setting that was never configured. Serving the caller's
+      // default is what this method exists for, so it is not a failure.
+      LOG.debug("Setting {} is not configured, using the supplied default", settingName);
     } catch (Exception ex) {
       LOG.error("Failed to fetch Settings . Setting {}", settingName, ex);
-      return defaultValue;
     }
+    return result;
   }
 
   public static void cleanUp() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java
@@ -1,18 +1,27 @@
 package org.openmetadata.service.resources.settings;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.google.common.cache.CacheLoader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.settings.Settings;
 import org.openmetadata.schema.settings.SettingsType;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.SystemRepository;
+import org.slf4j.LoggerFactory;
 
 class SettingsCacheDefaultCaseTest {
 
@@ -51,7 +60,45 @@ class SettingsCacheDefaultCaseTest {
 
       SettingsCache.CACHE.invalidate(key);
 
-      assertThrows(Exception.class, () -> SettingsCache.CACHE.get(key));
+      // An unset setting surfaces as InvalidCacheLoadException, which is what
+      // getSettingOrDefault() distinguishes from a genuine load failure
+      assertThrows(CacheLoader.InvalidCacheLoadException.class, () -> SettingsCache.CACHE.get(key));
     }
+  }
+
+  @Test
+  void testUnsetSettingReturnsTheDefaultWithoutLoggingAnError() {
+    final Logger logger = (Logger) LoggerFactory.getLogger(SettingsCache.class);
+    final ListAppender<ILoggingEvent> appender = attachListAppender(logger);
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      SystemRepository mockSystemRepo = mock(SystemRepository.class);
+      String key = SettingsType.MCP_CONFIGURATION.toString();
+      when(mockSystemRepo.getConfigWithKey(key)).thenReturn(null);
+      entityMock.when(Entity::getSystemRepository).thenReturn(mockSystemRepo);
+
+      SettingsCache.CACHE.invalidate(key);
+
+      MCPConfiguration fallback = new MCPConfiguration();
+      assertSame(
+          fallback,
+          SettingsCache.getSettingOrDefault(
+              SettingsType.MCP_CONFIGURATION, fallback, MCPConfiguration.class));
+      assertNoErrorLogged(appender);
+    } finally {
+      logger.detachAppender(appender);
+      appender.stop();
+    }
+  }
+
+  private static ListAppender<ILoggingEvent> attachListAppender(final Logger logger) {
+    final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+    appender.start();
+    logger.addAppender(appender);
+    return appender;
+  }
+
+  private static void assertNoErrorLogged(final ListAppender<ILoggingEvent> appender) {
+    assertTrue(appender.list.stream().noneMatch(event -> event.getLevel() == Level.ERROR));
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #28960

- `getSettingOrDefault()` now tells "this setting was never configured" apart from "the read failed". The first is what the method exists to serve, so it logs at DEBUG; the second still logs at ERROR with the stack trace.
- That removes the startup `ERROR ... CacheLoader returned null for key mcpConfiguration` on fresh installs.

No behaviour changes: no new settings row, no migration, no schema change, no change to MCP CORS, and `GET /api/v1/system/mcp/config` still answers 404 when unset. `mcpConfiguration` is optional by design (`SecurityConfigurationManager:134` says so, and every consumer null-checks it), so the only thing wrong was reporting an expected state as an error.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR refines optional-setting fallback logging without changing returned values.
- Handles Guava’s null-loader exception separately and logs the unset setting at DEBUG.
- Preserves the supplied default for absent or failed setting reads.
- Adds focused coverage for the fallback value and absence of an ERROR from `SettingsCache`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness, security, or compatibility issues identified.

The changed method continues returning the supplied default, suppresses only the redundant SettingsCache ERROR for the null-loader case, and genuine repository read exceptions remain ERROR-logged by SystemRepository before becoming a null cache load.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java | Separates the expected unset-setting cache exception from other exceptions while retaining existing fallback behavior. |
| openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/SettingsCacheDefaultCaseTest.java | Adds focused log-level and identity assertions and tightens the expected cache exception type. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(settings): don&#39;t log an unset option..."](https://github.com/open-metadata/openmetadata/commit/0b690c9467bc9c30d25c6a76b63b493d83f45485) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48241099)</sub>

<!-- /greptile_comment -->