### PR TITLE
fix(ingestion): backport NoSuchTableError handling on PK constraints (#30286) to 1.13

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
+++ b/ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
@@ -16,6 +16,7 @@ import traceback
 from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy.engine.reflection import Inspector
+from sqlalchemy.exc import NoSuchTableError
 
 from metadata.generated.schema.entity.data.table import (
     Column,
@@ -138,7 +139,13 @@ class SqlColumnHandlerMixin:
     def _get_columns_with_constraints(
         schema_name: str, table_name: str, inspector: Inspector
     ) -> Tuple[List, List, List]:
-        pk_constraints = inspector.get_pk_constraint(table_name, schema_name)
+        try:
+            pk_constraints = inspector.get_pk_constraint(table_name, schema_name)
+        except (NotImplementedError, KeyError, NoSuchTableError):
+            logger.debug(
+                f"Cannot obtain primary key constraints for table [{schema_name}.{table_name}]: NotImplementedError"
+            )
+            pk_constraints = {}
         try:
             unique_constraints = inspector.get_unique_constraints(
                 table_name, schema_name


### PR DESCRIPTION
Backport of #30286 (`177e5cd07d`) to `1.13`.

`Inspector.get_pk_constraint()` raises `NoSuchTableError` when a table disappears or becomes inaccessible between listing and reflection, which aborted column ingestion for the whole table. It is now caught alongside `NotImplementedError` and `KeyError`, falling back to empty PK constraints.

**Conflict resolution:** the upstream commit only added `NoSuchTableError` to an existing `except (NotImplementedError, KeyError)`. That guard came from a main-only change that `1.13` never received — here `get_pk_constraint()` was still called unguarded at the top of `_get_columns_with_constraints`. The full guard was applied in place at the existing call site, leaving `1.13` behaviorally equivalent to `main` without pulling in the unrelated reordering.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes primary-key reflection resilient to disappearing or inaccessible tables.
- Imports SQLAlchemy's NoSuchTableError.
- Falls back to empty primary-key constraints when PK inspection raises NotImplementedError, KeyError, or NoSuchTableError.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking improvements needed for accurate diagnostics and regression coverage.

The empty primary-key fallback is handled safely downstream, while the shared debug message misidentifies KeyError and NoSuchTableError and the new fallback path is untested.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/sql_column_handler.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/sql_column_handler.py | The fallback is compatible with downstream empty-constraint handling, but its diagnostic is inaccurate for two caught exceptions and the new behavior lacks regression coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: key error -&gt; no such table (#30286)"](https://github.com/open-metadata/openmetadata/commit/0731738def3ec78fe141dc3f44e3ac7e165931e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48250399)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->