### PR TITLE
fix(ui): correct domain display and data product card layout

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.test.tsx
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MOCK_PERMISSIONS } from '../../../../mocks/Glossary.mock';
+import { searchQuery } from '../../../../rest/searchAPI';
+import DataProductsTab from './DataProductsTab.component';
+
+jest.mock('../../../../hooks/useFqn', () => ({
+  useFqn: () => ({ fqn: 'Commerce' }),
+}));
+
+jest.mock('../../../../rest/searchAPI', () => ({
+  searchQuery: jest.fn(),
+}));
+
+jest.mock('../../../common/ResizablePanels/ResizablePanels', () =>
+  jest.fn().mockImplementation(({ firstPanel }) => firstPanel.children)
+);
+
+jest.mock('../../../ExploreV1/ExploreSearchCard/ExploreSearchCard', () =>
+  jest
+    .fn()
+    .mockImplementation(({ hideBreadcrumbs }) => (
+      <div data-hide-breadcrumbs={hideBreadcrumbs} data-testid="data-product" />
+    ))
+);
+
+const mockSearchQuery = searchQuery as jest.Mock;
+
+describe('DataProductsTab', () => {
+  beforeEach(() => {
+    mockSearchQuery.mockResolvedValue({
+      hits: {
+        hits: [
+          {
+            _source: {
+              id: 'data-product-id',
+              name: 'orders',
+              fullyQualifiedName: 'Commerce.orders',
+              domains: [
+                {
+                  id: 'domain-id',
+                  name: 'Commerce',
+                  fullyQualifiedName: 'Commerce',
+                  type: 'domain',
+                },
+              ],
+            },
+          },
+        ],
+        total: { value: 1 },
+      },
+    });
+  });
+
+  it('hides redundant domain breadcrumbs in the domain data product list', async () => {
+    render(
+      <DataProductsTab
+        permissions={MOCK_PERMISSIONS}
+        onAddDataProduct={jest.fn()}
+      />
+    );
+
+    expect(await screen.findByTestId('data-product')).toHaveAttribute(
+      'data-hide-breadcrumbs',
+      'true'
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainTabs/DataProductsTab/DataProductsTab.component.tsx
@@ -141,6 +141,7 @@ const DataProductsTab = forwardRef(
             <>
               {dataProducts.data.map((dataProduct) => (
                 <ExploreSearchCard
+                  hideBreadcrumbs
                   className={classNames(
                     'm-b-sm cursor-pointer',
                     selectedCard?.id === dataProduct.id ? 'highlight-card' : ''

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
@@ -95,9 +95,7 @@ export const DomainDisplay = ({
                 remainingCount <= 9 ? 'h-6 w-6' : ''
               }`}
               data-testid="domain-count-button">
-              <span className="ant-typography domain-count-label">
-                {`+${remainingCount}`}
-              </span>
+              <span className="domain-count-label">{`+${remainingCount}`}</span>
             </Typography.Text>
           </Dropdown>
         </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.component.tsx
@@ -91,7 +91,7 @@ export const DomainDisplay = ({
             }}
             trigger={['hover']}>
             <Typography.Text
-              className={`flex-center cursor-pointer align-middle ant-typography-secondary domain-count-button ${
+              className={`flex-center flex-shrink-0 cursor-pointer align-middle ant-typography-secondary domain-count-button ${
                 remainingCount <= 9 ? 'h-6 w-6' : ''
               }`}
               data-testid="domain-count-button">

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
@@ -12,6 +12,7 @@
  */
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import { ComponentProps } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { EntityReference } from '../../../generated/entity/type';
 import { DomainDisplay } from './DomainDisplay.component';
@@ -53,7 +54,7 @@ const mockDomain3: EntityReference = {
   type: 'domain',
 };
 
-const renderDomainDisplay = (props: any) =>
+const renderDomainDisplay = (props: ComponentProps<typeof DomainDisplay>) =>
   render(
     <MemoryRouter>
       <DomainDisplay {...props} />
@@ -112,7 +113,9 @@ describe('DomainDisplay Component', () => {
     });
 
     expect(screen.getByText('Domain One')).toBeInTheDocument();
-    expect(screen.getByTestId('domain-count-button')).toBeInTheDocument();
+    expect(screen.getByTestId('domain-count-button')).toHaveClass(
+      'flex-shrink-0'
+    );
     expect(screen.getByText('+2')).toHaveClass('domain-count-label');
     expect(screen.getByText('+2')).not.toHaveClass('ant-typography');
     expect(screen.queryByText('Domain Two')).not.toBeInTheDocument();

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainDisplay/DomainDisplay.test.tsx
@@ -113,7 +113,8 @@ describe('DomainDisplay Component', () => {
 
     expect(screen.getByText('Domain One')).toBeInTheDocument();
     expect(screen.getByTestId('domain-count-button')).toBeInTheDocument();
-    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toHaveClass('domain-count-label');
+    expect(screen.getByText('+2')).not.toHaveClass('ant-typography');
     expect(screen.queryByText('Domain Two')).not.toBeInTheDocument();
     expect(screen.queryByText('Domain Three')).not.toBeInTheDocument();
     expect(screen.getAllByTestId('domain-icon')).toHaveLength(1);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/domain-label.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainLabel/domain-label.less
@@ -61,7 +61,6 @@
     color: @blue-24;
   }
   border: 1px solid @blue-24;
-  margin-left: calc(-1 * var(--om-space-4));
 }
 
 .domain-count-label {


### PR DESCRIPTION
### Describe your changes:

Fixes domain presentation issues across Explore cards and the Domain Data Products tab.

- Keeps the remaining-domain count at the intended 10px size and prevents the count control from shrinking or overlapping adjacent labels.
- Removes the negative domain-count offset that caused layout collisions.
- Hides redundant domain breadcrumbs for data product cards already scoped to the current domain.
- Adds type-safe regression coverage for both domain counts and Data Products card rendering.
<img width="534" height="169" alt="Screenshot 2026-07-29 at 2 14 26 PM" src="https://github.com/user-attachments/assets/9ad5984e-e70d-4ae7-a4d6-65cec7026a0c" />
<img width="1500" height="811" alt="Screenshot 2026-07-29 at 2 16 06 PM" src="https://github.com/user-attachments/assets/e532d686-a798-4285-be89-e2bd4d111ba2" />



#
### Type of change:
- [x] Bug fix

#
### High-level design:

Small, targeted UI layout corrections using the existing domain display and Explore card APIs.

#
### Tests:

#### Use cases covered
- Explore cards with multiple domains render the `+N` count without inheriting the 12px Ant Typography rule or overlapping nearby domains.
- Domain Data Products lists do not repeat the current domain breadcrumb on every card.

#### Unit tests
- [x] `DataProductsTab.component.test.tsx` and `DomainDisplay.test.tsx`: 22 tests passed.
- [x] ESLint passed for all changed TypeScript files.
- [x] Prettier and diff validation passed for all changed files.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (covered by focused component tests).

#
### Checklist:
- [x] I have read the contributing guidelines.
- [x] I have added tests covering the fixed scenarios.
- [x] No JSON Schema or migration changes are required.