### PR TITLE
fix(ci): use app token for release branch pushes

### DIFF
--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -27,7 +27,7 @@ jobs:
         permission-workflows: write
 
     - name: Checkout Repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@v4
       with:
         ref: ${{ inputs.base_branch_name }}
         token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -11,16 +11,26 @@ on:
         required: true
         default: "main"
 permissions:
-  contents: write
+  contents: read
 jobs:
   create-release-branch:
     name: Create Release Branch ${{ inputs.release_branch_name }}
     runs-on: ubuntu-latest
     steps:
+    - name: Generate GitHub App token
+      id: generate_token
+      uses: actions/create-github-app-token@v3
+      with:
+        app-id: ${{ secrets.GH_BOT_ID }}
+        private-key: ${{ secrets.GH_BOT_PK }}
+        permission-contents: write
+        permission-workflows: write
+
     - name: Checkout Repo
       uses: actions/checkout@v5
       with:
         ref: ${{ inputs.base_branch_name }}
+        token: ${{ steps.generate_token.outputs.token }}
     - name: Update application versions
       run: |
         make update_all RELEASE_VERSION=${{ inputs.release_branch_name }}


### PR DESCRIPTION
## Summary

- Generate a current-repository GitHub App token for release-branch creation.
- Grant that token only Contents write and Workflows write, then persist it through checkout for the branch push.
- Reduce the built-in GITHUB_TOKEN permission from Contents write to Contents read.
- Restore actions/checkout v4, the last release-proven version and the version used by the working Collate release workflow.
- Keep EndBug/add-and-commit at v10.

## Why

The release workflow still failed after #30611 restored actions/checkout v5. In [run 30432253628](https://github.com/open-metadata/OpenMetadata/actions/runs/30432253628/job/90511912732), the version update and local release commit succeeded, but GitHub rejected the new branch push while validating workflows and reported that Workflows scope may be required.

The [Collate release-branch workflow](https://github.com/open-metadata/openmetadata-collate/blob/main/.github/workflows/git-create-release-branch.yml) uses checkout v4 with a GitHub App token for checkout and push. This PR adopts that proven authentication path without copying Collate-specific submodule steps.

Checkout v4 is an incident risk reduction, not the root fix or a guarantee: actions/checkout#2287 reports v4 as a mitigation, while later reports indicate the server-side timeout can also occur on v4. The scoped App token is the durable change that avoids relying on GitHub to determine whether this branch creation updates workflow files.

## Deployment prerequisite

Before rerunning the release, verify that GH_BOT_ID and GH_BOT_PK are available to this repository and that the GitHub App installation grants Contents: write and Workflows: write. The action scopes the generated token to the current repository.

## Test plan

- git diff --check
- Parsed the workflow as YAML
- Verified actions/create-github-app-token@v3 declares permission-contents and permission-workflows inputs
- After merge, rerun Create Release Branch for 1.13.2 and verify that the remote branch is created and downstream release jobs start

## Metadata

This operational release unblock has no linked product issue; the repository-standard skip-pr-checks maintainer bypass is applied. The failed release run above is the incident evidence.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR changes release-branch authentication:
- Generates a current-repository GitHub App token with contents-write and workflows-write permissions.
- Supplies that token to checkout so subsequent branch creation can push workflow changes.
- Reduces the built-in GITHUB_TOKEN permission to contents-read.
- Changes the checkout action from v5 to v4.
</details>

<details open><summary><h3>Confidence Score: 2/5</h3></summary>

The PR does not appear safe to merge until the shell-injection path and mutable privileged action references are addressed.

The caller-controlled release name still reaches an unquoted shell command before a privileged commit and push, while both the token-generation action and the checkout action handling write-capable credentials are selected through mutable tags.

**Files Needing Attention:** .github/workflows/git-create-release-branch.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

The newly privileged checkout step is also selected through a mutable major-version tag, leaving a separate dependency-integrity path after the token-generation action is pinned.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/git-create-release-branch.yml | Adds and persists a workflow-write App token for release pushes, but the privileged checkout dependency is mutable and the two previously reported security paths remain present. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Release workflow
  participant T as App token action
  participant C as Checkout action
  participant U as Version update
  participant P as Commit and push
  W->>T: App ID and private key
  T-->>W: Contents/workflows-write token
  W->>C: Checkout selected base branch with token
  C-->>U: Working tree and persisted credentials
  U->>U: Update release versions
  U->>P: Modified files
  P->>P: Create and push release branch
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): use release-proven checkout ver..."](https://github.com/open-metadata/openmetadata/commit/57bfe06e1e653075f7e2512f47a86267b587c8cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48255637)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->