### PR TITLE
fix(ci): restore proven release branch workflow

### DIFF
--- a/.github/workflows/git-create-release-branch.yml
+++ b/.github/workflows/git-create-release-branch.yml
@@ -11,31 +11,21 @@ on:
         required: true
         default: "main"
 permissions:
-  contents: read
+  contents: write
 jobs:
   create-release-branch:
     name: Create Release Branch ${{ inputs.release_branch_name }}
     runs-on: ubuntu-latest
     steps:
-    - name: Generate GitHub App token
-      id: generate_token
-      uses: actions/create-github-app-token@v3
-      with:
-        app-id: ${{ secrets.GH_BOT_ID }}
-        private-key: ${{ secrets.GH_BOT_PK }}
-        permission-contents: write
-        permission-workflows: write
-
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.base_branch_name }}
-        token: ${{ steps.generate_token.outputs.token }}
     - name: Update application versions
       run: |
         make update_all RELEASE_VERSION=${{ inputs.release_branch_name }}
     - name: Commit changes to ${{ inputs.release_branch_name }} branch
-      uses: EndBug/add-and-commit@v10
+      uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
         message: 'chore(release): Prepare Branch for `${{ inputs.release_branch_name }}`'


### PR DESCRIPTION
## Summary

- Restore `.github/workflows/git-create-release-branch.yml` exactly as it ran successfully for release branch 1.13.1 in run 28278574650 at commit 420b8d1.
- Remove the GitHub App token step and its unavailable GH_BOT_ID / GH_BOT_PK secret dependency.
- Restore the built-in token to Contents write.
- Keep actions/checkout at v4 and restore EndBug/add-and-commit to v9.

## Why

#30631 merged successfully, but the first 1.13.2 retry failed before checkout because GH_BOT_ID and GH_BOT_PK were not available to the OpenMetadata workflow. This rollback removes that unprovisioned dependency and returns the complete workflow—not only checkout—to the exact configuration that successfully created the 1.13.1 release branch.

Reference: https://github.com/open-metadata/OpenMetadata/actions/runs/28278574650/workflow
Failed App-token retry: https://github.com/open-metadata/OpenMetadata/actions/runs/30437792896/job/90529574364

## Validation

- Confirmed `git diff --exit-code 420b8d1 -- .github/workflows/git-create-release-branch.yml` is clean
- git diff --check
- Parsed the workflow as YAML
- After merge, rerun Create Release Branch for 1.13.2

## Risk

This is an exact operational rollback. It removes the new missing-secret failure, but it does not claim to eliminate GitHub server-side workflow-validation timeouts if they recur.

## Metadata

This operational release rollback has no linked product issue; the repository-standard skip-pr-checks maintainer bypass is applied. The two workflow runs above are the incident evidence.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores the previously successful release-branch workflow configuration.
- Removes the unavailable GitHub App credential dependency.
- Grants the built-in workflow token contents write access.
- Restores EndBug/add-and-commit v9 while retaining actions/checkout v4.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified in the restored release-branch workflow.

The workflow removes credentials known to be unavailable and restores the contents-write token and action configuration previously used successfully for release branch creation.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/git-create-release-branch.yml | Restores built-in-token authentication and the previously proven action versions needed to create and push release branches. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): restore proven release branch w..."](https://github.com/open-metadata/openmetadata/commit/4ce0b6fc7e85fd6d96b305868bb9f4a326d8d8e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48260670)</sub>

<!-- /greptile_comment -->