### PR TITLE
fix Column Bulk Operations tag & glossary dropdowns not selectable in the edit drawer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
@@ -136,7 +136,6 @@ function getColumnRowCheckbox(page: Page, rowId: string) {
 }
 
 test.describe('Column Bulk Operations - Tags & Glossary Select in Drawer', () => {
-
   const CLASSIFICATION_TAG_FQN = 'PII.Sensitive';
   const table = new TableClass();
   const glossaryTerm = new GlossaryTerm();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts
@@ -1,0 +1,273 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, expect, Page, test } from '@playwright/test';
+import { SidebarItem } from '../../constant/sidebar';
+import { TableClass } from '../../support/entity/TableClass';
+import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { sidebarClick } from '../../utils/sidebar';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const GRID_API_URL = '/api/v1/columns/grid';
+
+async function waitForGridResponse(page: Page) {
+  return page.waitForResponse(
+    (r) => r.url().includes(GRID_API_URL) && r.status() === 200
+  );
+}
+
+async function visitColumnBulkOperationsPage(page: Page) {
+  await redirectToHomePage(page);
+  const dataRes = waitForGridResponse(page);
+  await sidebarClick(page, SidebarItem.COLUMN_BULK_OPERATIONS);
+  await dataRes;
+  await waitForAllLoadersToDisappear(page);
+}
+
+async function searchColumn(page: Page, columnName: string) {
+  const searchInput = page.getByPlaceholder('Search columns');
+  const matchingRowLocator = page.getByTestId(`column-row-${columnName}`);
+
+  const runSearch = async () => {
+    await searchInput.clear();
+    const encodedColumnName = encodeURIComponent(columnName);
+    const responsePromise = page.waitForResponse(
+      (response) =>
+        response.url().includes(GRID_API_URL) &&
+        response.url().includes(`columnNamePattern=${encodedColumnName}`),
+      { timeout: 15000 }
+    );
+    await searchInput.fill(columnName);
+    const response = await responsePromise.catch(() => null);
+
+    if (response && response.status() !== 200) {
+      return 0;
+    }
+
+    await waitForAllLoadersToDisappear(page);
+
+    return matchingRowLocator.count();
+  };
+
+  await expect
+    .poll(async () => runSearch(), {
+      timeout: 90000,
+      intervals: [1000, 2000, 3000],
+    })
+    .toBeGreaterThan(0);
+}
+
+async function waitForColumnInGridIndex(
+  apiContext: APIRequestContext,
+  columnName: string,
+  minOccurrences = 1
+) {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/columns/grid?size=1000&columnNamePattern=${encodeURIComponent(
+            columnName
+          )}`
+        );
+
+        if (!response.ok()) {
+          return 0;
+        }
+
+        const body = await response.json();
+        const match = body.columns?.find(
+          (column: { columnName?: string }) => column.columnName === columnName
+        );
+
+        return match?.totalOccurrences ?? 0;
+      },
+      { timeout: 90000, intervals: [1000, 2000, 3000] }
+    )
+    .toBeGreaterThanOrEqual(minOccurrences);
+}
+
+async function waitForGlossaryTermInSearch(
+  apiContext: APIRequestContext,
+  termFqn: string,
+  searchText: string
+) {
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/search/query?q=${encodeURIComponent(
+            searchText
+          )}&index=glossaryTerm&size=50`
+        );
+
+        if (!response.ok()) {
+          return false;
+        }
+
+        const body = await response.json();
+        const hits: Array<{ _source?: { fullyQualifiedName?: string } }> =
+          body.hits?.hits ?? [];
+
+        return hits.some((hit) => hit._source?.fullyQualifiedName === termFqn);
+      },
+      { timeout: 90000, intervals: [1000, 2000, 3000] }
+    )
+    .toBe(true);
+}
+
+function getColumnRowCheckbox(page: Page, rowId: string) {
+  return page
+    .locator(`[data-row-id="${rowId}"]`)
+    .first()
+    .locator('[slot="selection"]');
+}
+
+test.describe('Column Bulk Operations - Tags & Glossary Select in Drawer', () => {
+
+  const CLASSIFICATION_TAG_FQN = 'PII.Sensitive';
+  const table = new TableClass();
+  const glossaryTerm = new GlossaryTerm();
+  let sharedColumnName: string;
+
+  test.beforeAll(
+    'Setup table, column and glossary term',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+      await table.create(apiContext);
+      sharedColumnName = table.columnsName[0];
+      await glossaryTerm.create(apiContext);
+
+      await waitForColumnInGridIndex(apiContext, sharedColumnName);
+      await waitForGlossaryTermInSearch(
+        apiContext,
+        glossaryTerm.responseData.fullyQualifiedName,
+        glossaryTerm.randomName
+      );
+      await afterAction();
+    }
+  );
+
+  test.afterAll('Cleanup tags/glossary test data', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await glossaryTerm.delete(apiContext);
+    await table.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await visitColumnBulkOperationsPage(page);
+  });
+
+  const openEditDrawer = async (page: Page) => {
+    await searchColumn(page, sharedColumnName);
+
+    const checkbox = getColumnRowCheckbox(page, sharedColumnName);
+    await expect(checkbox).toBeVisible();
+    await checkbox.click();
+
+    const editButton = page.getByTestId('edit-button');
+    await expect(editButton).toBeEnabled();
+    await editButton.click();
+
+    const drawer = page.getByTestId('column-bulk-operations-form-drawer');
+    await expect(drawer).toBeVisible();
+
+    return drawer;
+  };
+
+  test('should select a classification tag from the dropdown inside the drawer', async ({
+    page,
+  }) => {
+    const drawer = await openEditDrawer(page);
+    const tagsField = drawer.getByTestId('tags-field');
+
+    await test.step('Open the tags dropdown and search', async () => {
+      const tagInput = tagsField
+        .getByTestId('tag-selector')
+        .locator('input')
+        .first();
+      await tagInput.click();
+
+      const searchRes = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/search/query') &&
+          r.url().includes('index=tag')
+      );
+      await tagInput.fill('Sensitive');
+      await searchRes;
+    });
+
+    await test.step('Option renders inside the drawer top layer', async () => {
+      // Before the fix this option portaled to document.body, outside the
+      // drawer — so scoping the locator to the drawer would not find it.
+      await expect(
+        drawer.getByTestId(`tag-${CLASSIFICATION_TAG_FQN}`)
+      ).toBeVisible();
+    });
+
+    await test.step('Clicking the option selects the tag', async () => {
+      await drawer.getByTestId(`tag-${CLASSIFICATION_TAG_FQN}`).click();
+
+      await expect(
+        tagsField.locator('[data-testid^="selected-tag-"]')
+      ).toHaveCount(1);
+    });
+
+    await test.step('Close drawer', async () => {
+      await page.keyboard.press('Escape');
+    });
+  });
+
+  test('should select a glossary term from the tree dropdown inside the drawer', async ({
+    page,
+  }) => {
+    const drawer = await openEditDrawer(page);
+    const glossaryField = drawer.getByTestId('glossary-terms-field');
+    const termFqn = glossaryTerm.responseData.fullyQualifiedName;
+
+    await test.step('Open the glossary tree dropdown and search', async () => {
+      const glossaryInput = glossaryField
+        .getByTestId('tag-selector')
+        .locator('input')
+        .first();
+      await glossaryInput.click();
+
+      const searchRes = page.waitForResponse(
+        (r) =>
+          r.url().includes('/api/v1/search/query') &&
+          r.url().includes('index=glossaryTerm')
+      );
+      await glossaryInput.fill(glossaryTerm.randomName);
+      await searchRes;
+    });
+
+    await test.step('Term option renders inside the drawer top layer', async () => {
+      await expect(drawer.getByTestId(`tag-${termFqn}`)).toBeVisible();
+    });
+
+    await test.step('Clicking the term selects it', async () => {
+      await drawer.getByTestId(`tag-${termFqn}`).click();
+
+      await expect(
+        glossaryField.locator('[data-testid^="selected-tag-"]')
+      ).toHaveCount(1);
+    });
+
+    await test.step('Close drawer', async () => {
+      await page.keyboard.press('Escape');
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx
@@ -79,6 +79,7 @@ interface TreeAsyncSelectListProps
   onSubmit?: () => void;
   dropdownContainerRef?: React.RefObject<HTMLDivElement>;
   dropdownMatchSelectWidth?: boolean | number;
+  getPopupContainer?: TreeSelectProps['getPopupContainer'];
 }
 
 interface ExtendedTreeNode {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
@@ -444,6 +444,7 @@ const ColumnEditForm = forwardRef<ColumnEditFormHandle, ColumnEditFormProps>(
           <AsyncSelectList
             autoFocus={false}
             fetchOptions={tagClassBase.getTags}
+            getPopupContainer={(triggerNode) => triggerNode.parentElement}
             initialOptions={classificationTagOptions}
             key={`tags-${drawerKey}`}
             mode="multiple"
@@ -500,6 +501,7 @@ const ColumnEditForm = forwardRef<ColumnEditFormHandle, ColumnEditFormProps>(
           </Typography>
           <TreeAsyncSelectList
             hasNoActionButtons
+            getPopupContainer={(triggerNode) => triggerNode.parentElement}
             initialOptions={glossaryTermOptions}
             key={`glossaryTerms-${drawerKey}`}
             open={false}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30633 

In the Column Bulk Operations page, opening the edit drawer for one or more selected columns and trying to add a Tag or Glossary Term doesn't work — the dropdown opens and shows options, but clicking an option does nothing and no value gets selected.

Root cause:

The edit drawer is a SlideoutMenu (react-aria-components Modal), which is a focus-contained top layer. The tag (AsyncSelectList) and glossary (TreeAsyncSelectList) fields are AntD Select/TreeSelect components that, by default, portal their dropdown to document.body — i.e. outside the drawer's top layer. react-aria's focus containment and pointer isolation then swallow all clicks on those options, so selection never registers.

https://github.com/user-attachments/assets/1e6a0898-771c-4f7e-ae5c-c918d4ca6edc




#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests

- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:


#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes tag and glossary-term selection within the Column Bulk Operations edit drawer.
- Routes the tag and glossary dropdown portals into the drawer’s DOM hierarchy.
- Exposes Ant Design’s `getPopupContainer` property through `TreeAsyncSelectList`.
- Adds Playwright coverage for selecting classification tags and glossary terms from the drawer.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx | Configures both dropdowns to render beneath their trigger inside the focus-contained edit drawer. |
| openmetadata-ui/src/main/resources/ui/src/components/common/AsyncSelectList/TreeAsyncSelectList.tsx | Adds the typed popup-container property, which is forwarded to the underlying Ant Design TreeSelect through the existing props spread. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ColumnBulkOperationsTagsGlossary.spec.ts | Adds end-to-end coverage confirming that tag and glossary options render and remain selectable inside the drawer. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix lint checks"](https://github.com/open-metadata/openmetadata/commit/37edf7d8125a876097026b536c7ce8e4a704d48d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48269181)</sub>

<!-- /greptile_comment -->