### PR TITLE
Fixes #30635: report dbt enrichment failures instead of swallowing them

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -296,7 +296,9 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
         except Exception as exc:
             raise DBTConfigException(f"Error connecting to dbt Cloud: {exc}") from exc
 
-        if response is None:
+        # The client returns None for an error body it cannot classify, and can surface a raw
+        # Response on paths that bypass JSON decoding. Neither carries usable run data.
+        if not isinstance(response, dict):
             raise DBTConfigException(  # noqa: TRY301
                 f"No usable response from dbt Cloud for account '{account_id}'. The API returned "
                 "an error the client could not classify, so the status was not preserved. "

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -55,7 +55,6 @@ from metadata.readers.file.config_source_factory import get_reader
 from metadata.utils.credentials import set_google_credentials
 from metadata.utils.helpers import clean_uri
 from metadata.utils.logger import ometa_logger
-from metadata.utils.s3_utils import list_s3_objects
 from metadata.utils.ssl_registry import get_verify_ssl_fn
 
 logger = ometa_logger()
@@ -278,14 +277,32 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
                 f"Unable to connect to dbt Cloud at '{config.dbtCloudUrl}'. "
                 "Please verify the URL is correct and accessible."
             ) from exc
+        except requests.HTTPError as exc:
+            # The REST client only raises APIError for a body with a top-level "code" key.
+            # dbt Cloud nests it under "status", and an SSO gateway or proxy may answer with
+            # HTML that has no "code" at all - those reach here as a bare HTTPError, and the
+            # status line is the only thing left to classify on.
+            status_code = exc.response.status_code if exc.response is not None else None
+            if status_code in (401, 403):
+                raise DBTConfigException(
+                    "Invalid dbt Cloud auth token. Please verify your token has "
+                    "'Account Viewer' permissions and is not expired."
+                ) from exc
+            if status_code == 404:
+                raise DBTConfigException(
+                    f"dbt Cloud account ID '{account_id}' not found. Please verify the account ID is correct."
+                ) from exc
+            raise DBTConfigException(f"Error connecting to dbt Cloud: {exc}") from exc
         except Exception as exc:
             raise DBTConfigException(f"Error connecting to dbt Cloud: {exc}") from exc
 
         if response is None:
             raise DBTConfigException(  # noqa: TRY301
-                f"No response from dbt Cloud for account '{account_id}'. This usually means the "
-                "auth token is invalid or expired, or the credential lacks 'Account Viewer' "
-                "permission. Please verify your dbt Cloud credentials."
+                f"No usable response from dbt Cloud for account '{account_id}'. The API returned "
+                "an error the client could not classify, so the status was not preserved. "
+                "Possible causes: the account ID is wrong, the project or job ID is wrong, the "
+                "auth token is invalid, expired, or lacks 'Account Viewer' permission, or dbt "
+                "Cloud rate-limited the request and every retry was exhausted."
             )
 
         if not response.get("data"):
@@ -522,7 +539,7 @@ def _list_s3_buckets(client, bucket_name: str | None) -> list[dict]:
     try:
         buckets = client.list_buckets()["Buckets"]
     except ClientError as exc:
-        if aws_error_code(exc) in ("AccessDenied", "Forbidden"):
+        if aws_error_code(exc) == "AccessDenied":
             raise DBTConfigException(
                 "Access denied when listing S3 buckets. Please check your IAM permissions."
             ) from exc
@@ -532,16 +549,31 @@ def _list_s3_buckets(client, bucket_name: str | None) -> list[dict]:
     return buckets
 
 
+def _iter_s3_object_keys(client, kwargs: dict) -> Iterable[str]:
+    """
+    Paginated listing of S3 object keys that lets botocore errors propagate.
+
+    metadata.utils.s3_utils.list_s3_objects catches every exception and only logs it, so a
+    wrong bucket name or a missing IAM permission reaches the caller as an empty listing and
+    is then reported as "no dbt artifacts found". dbt needs the original error to tell the
+    user which of the two it is, so it drives the paginator itself.
+    """
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(**kwargs):
+        for obj in page.get("Contents", []):
+            yield obj["Key"]
+
+
 def _get_s3_blob_grouped(client, current_bucket: str, kwargs: dict):
     try:
-        blob_grouped = get_blobs_grouped_by_dir(blobs=(obj["Key"] for obj in list_s3_objects(client, **kwargs)))
+        blob_grouped = get_blobs_grouped_by_dir(blobs=_iter_s3_object_keys(client, kwargs))
     except ClientError as exc:
         error_code = aws_error_code(exc)
         if error_code == "NoSuchBucket":
             raise DBTConfigException(
                 f"S3 bucket '{current_bucket}' not found. Please verify the bucket name is correct."
             ) from exc
-        if error_code in ("AccessDenied", "Forbidden"):
+        if error_code == "AccessDenied":
             raise DBTConfigException(
                 f"Access denied to S3 bucket '{current_bucket}'. Please check your IAM permissions."
             ) from exc
@@ -678,15 +710,10 @@ def _get_azure_client(config: DbtAzureConfig):
     try:
         client = AzureClient(config.dbtSecurityConfig).create_blob_client()
     except ClientAuthenticationError as auth_exc:
-        logger.error(
-            f"Failed to authenticate with Azure: {str(auth_exc)}. "  # noqa: RUF010
-            "Please check your Azure credentials and permissions."
-        )
         raise DBTConfigException(
             "Azure authentication failed. Please verify your credentials and permissions."
         ) from auth_exc
     except AzureError as azure_exc:
-        logger.error(f"Failed to create Azure client: {str(azure_exc)}")  # noqa: RUF010
         raise DBTConfigException(
             "Failed to initialize Azure client. Please check your Azure configuration."
         ) from azure_exc
@@ -699,6 +726,7 @@ def _list_azure_containers(client):
 
     try:
         container_dicts = list(client.list_containers())
+        container_clients = [client.get_container_client(container["name"]) for container in container_dicts]
     except ClientAuthenticationError as exc:
         raise DBTConfigException("Access denied when listing Azure containers. Please check your permissions.") from exc
     except HttpResponseError as exc:
@@ -709,7 +737,7 @@ def _list_azure_containers(client):
         raise DBTConfigException(f"Failed to list Azure containers: {exc}") from exc
     except Exception as exc:
         raise DBTConfigException(f"Failed to list Azure containers: {exc}") from exc
-    return [client.get_container_client(container["name"]) for container in container_dicts]
+    return container_clients
 
 
 def _get_azure_container_client(client, bucket_name: str):

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -21,9 +21,11 @@ from functools import singledispatch
 from typing import Dict, Iterable, List, Optional, Tuple  # noqa: UP035
 
 import requests
+from botocore.exceptions import ClientError, NoCredentialsError, PartialCredentialsError
 
 from metadata.clients.aws_client import AWSClient
 from metadata.clients.azure_client import AzureClient
+from metadata.core.connections.test_connection.aws import aws_error_code
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtAzureConfig import (
     DbtAzureConfig,
 )
@@ -496,33 +498,65 @@ def download_dbt_files(
         raise DBTConfigException(f"No valid dbt manifest.json found. {error_details}")
 
 
+def _get_s3_client(config: DbtS3Config):
+    try:
+        client = AWSClient(config.dbtSecurityConfig).get_client(service_name="s3")
+    except (NoCredentialsError, PartialCredentialsError) as exc:
+        raise DBTConfigException(
+            "AWS authentication failed. Please verify your AWS Access Key ID and Secret Access Key are correct."
+        ) from exc
+    except ClientError as exc:
+        if aws_error_code(exc) in ("AccessDenied", "InvalidAccessKeyId", "SignatureDoesNotMatch"):
+            raise DBTConfigException(
+                "AWS authentication failed. Please verify your AWS Access Key ID and Secret Access Key are correct."
+            ) from exc
+        raise DBTConfigException(f"Failed to initialize AWS S3 client: {exc}") from exc
+    except Exception as exc:
+        raise DBTConfigException(f"Failed to initialize AWS S3 client: {exc}") from exc
+    return client
+
+
+def _list_s3_buckets(client, bucket_name: str | None) -> list[dict]:
+    if bucket_name:
+        return [{"Name": bucket_name}]
+    try:
+        buckets = client.list_buckets()["Buckets"]
+    except ClientError as exc:
+        if aws_error_code(exc) in ("AccessDenied", "Forbidden"):
+            raise DBTConfigException(
+                "Access denied when listing S3 buckets. Please check your IAM permissions."
+            ) from exc
+        raise DBTConfigException(f"Failed to list S3 buckets: {exc}") from exc
+    except Exception as exc:
+        raise DBTConfigException(f"Failed to list S3 buckets: {exc}") from exc
+    return buckets
+
+
+def _get_s3_blob_grouped(client, current_bucket: str, kwargs: dict):
+    try:
+        blob_grouped = get_blobs_grouped_by_dir(blobs=(obj["Key"] for obj in list_s3_objects(client, **kwargs)))
+    except ClientError as exc:
+        error_code = aws_error_code(exc)
+        if error_code == "NoSuchBucket":
+            raise DBTConfigException(
+                f"S3 bucket '{current_bucket}' not found. Please verify the bucket name is correct."
+            ) from exc
+        if error_code in ("AccessDenied", "Forbidden"):
+            raise DBTConfigException(
+                f"Access denied to S3 bucket '{current_bucket}'. Please check your IAM permissions."
+            ) from exc
+        raise DBTConfigException(f"Failed to list objects in S3 bucket '{current_bucket}': {exc}") from exc
+    except Exception as exc:
+        raise DBTConfigException(f"Failed to list objects in S3 bucket '{current_bucket}': {exc}") from exc
+    return blob_grouped
+
+
 @get_dbt_details.register
 def _(config: DbtS3Config):
     try:
         bucket_name, prefix = get_dbt_prefix_config(config)
-
-        try:
-            client = AWSClient(config.dbtSecurityConfig).get_client(service_name="s3")
-        except Exception as exc:
-            error_msg = str(exc).lower()
-            if "credentials" in error_msg or "accessdenied" in error_msg:
-                raise DBTConfigException(
-                    "AWS authentication failed. Please verify your AWS Access Key ID and Secret Access Key are correct."
-                ) from exc
-            raise DBTConfigException(f"Failed to initialize AWS S3 client: {exc}") from exc
-
-        if not bucket_name:
-            try:
-                buckets = client.list_buckets()["Buckets"]
-            except Exception as exc:
-                error_msg = str(exc).lower()
-                if "accessdenied" in error_msg or "forbidden" in error_msg:
-                    raise DBTConfigException(
-                        "Access denied when listing S3 buckets. Please check your IAM permissions."
-                    ) from exc
-                raise DBTConfigException(f"Failed to list S3 buckets: {exc}") from exc
-        else:
-            buckets = [{"Name": bucket_name}]
+        client = _get_s3_client(config)
+        buckets = _list_s3_buckets(client, bucket_name)
 
         for bucket in buckets:
             current_bucket = bucket["Name"]
@@ -531,19 +565,7 @@ def _(config: DbtS3Config):
                 kwargs["Prefix"] = prefix if prefix.endswith("/") else f"{prefix}/"
 
             logger.debug(f"Listing S3 objects in s3://{current_bucket}/{prefix or ''}")
-            try:
-                blob_grouped = get_blobs_grouped_by_dir(blobs=(obj["Key"] for obj in list_s3_objects(client, **kwargs)))
-            except Exception as exc:
-                error_msg = str(exc).lower()
-                if "nosuchbucket" in error_msg:
-                    raise DBTConfigException(
-                        f"S3 bucket '{current_bucket}' not found. Please verify the bucket name is correct."
-                    ) from exc
-                if "accessdenied" in error_msg or "forbidden" in error_msg:
-                    raise DBTConfigException(
-                        f"Access denied to S3 bucket '{current_bucket}'. Please check your IAM permissions."
-                    ) from exc
-                raise DBTConfigException(f"Failed to list objects in S3 bucket '{current_bucket}': {exc}") from exc
+            blob_grouped = _get_s3_blob_grouped(client, current_bucket, kwargs)
 
             if not blob_grouped:
                 prefix_path = prefix or ""

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -42,8 +42,6 @@ from metadata.generated.schema.metadataIngestion.dbtconfig.dbtLocalConfig import
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtS3Config import (
     DbtS3Config,
 )
-from metadata.ingestion.connections.source_api_client import TrackedREST
-from metadata.ingestion.ometa.client import APIError, ClientConfig, RestTransportError
 from metadata.ingestion.source.database.dbt.constants import (
     DBT_CATALOG_FILE_NAME,
     DBT_MANIFEST_FILE_NAME,
@@ -231,6 +229,10 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
     dbt_manifest = None
     dbt_run_results = None
     try:
+        # pylint: disable=import-outside-toplevel
+        from metadata.ingestion.connections.source_api_client import TrackedREST  # noqa: PLC0415
+        from metadata.ingestion.ometa.client import APIError, ClientConfig, RestTransportError  # noqa: PLC0415
+
         expiry = 0
         auth_token = config.dbtCloudAuthToken.get_secret_value(), expiry
         client_config = ClientConfig(

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -231,8 +231,8 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
     dbt_run_results = None
     try:
         # pylint: disable=import-outside-toplevel
-        from metadata.ingestion.connections.source_api_client import TrackedREST  # noqa: PLC0415
-        from metadata.ingestion.ometa.client import APIError, ClientConfig, RestTransportError  # noqa: PLC0415
+        from metadata.ingestion.connections.source_api_client import TrackedREST
+        from metadata.ingestion.ometa.client import APIError, ClientConfig, RestTransportError
 
         expiry = 0
         auth_token = config.dbtCloudAuthToken.get_secret_value(), expiry
@@ -707,7 +707,7 @@ def _(config: DbtGcsConfig):
 
 def _get_azure_client(config: DbtAzureConfig):
     # pylint: disable=import-outside-toplevel
-    from azure.core.exceptions import AzureError, ClientAuthenticationError  # noqa: PLC0415
+    from azure.core.exceptions import AzureError, ClientAuthenticationError
 
     try:
         client = AzureClient(config.dbtSecurityConfig).create_blob_client()
@@ -724,7 +724,7 @@ def _get_azure_client(config: DbtAzureConfig):
 
 def _list_azure_containers(client):
     # pylint: disable=import-outside-toplevel
-    from azure.core.exceptions import ClientAuthenticationError, HttpResponseError  # noqa: PLC0415
+    from azure.core.exceptions import ClientAuthenticationError, HttpResponseError
 
     try:
         container_dicts = list(client.list_containers())
@@ -744,7 +744,7 @@ def _list_azure_containers(client):
 
 def _get_azure_container_client(client, bucket_name: str):
     # pylint: disable=import-outside-toplevel
-    from azure.core.exceptions import (  # noqa: PLC0415
+    from azure.core.exceptions import (
         ClientAuthenticationError,
         HttpResponseError,
         ResourceNotFoundError,

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -671,57 +671,92 @@ def _(config: DbtGcsConfig):
         raise DBTConfigException(f"Error fetching dbt files from GCS: {exc}")  # noqa: B904
 
 
+def _get_azure_client(config: DbtAzureConfig):
+    # pylint: disable=import-outside-toplevel
+    from azure.core.exceptions import AzureError, ClientAuthenticationError  # noqa: PLC0415
+
+    try:
+        client = AzureClient(config.dbtSecurityConfig).create_blob_client()
+    except ClientAuthenticationError as auth_exc:
+        logger.error(
+            f"Failed to authenticate with Azure: {str(auth_exc)}. "  # noqa: RUF010
+            "Please check your Azure credentials and permissions."
+        )
+        raise DBTConfigException(
+            "Azure authentication failed. Please verify your credentials and permissions."
+        ) from auth_exc
+    except AzureError as azure_exc:
+        logger.error(f"Failed to create Azure client: {str(azure_exc)}")  # noqa: RUF010
+        raise DBTConfigException(
+            "Failed to initialize Azure client. Please check your Azure configuration."
+        ) from azure_exc
+    return client
+
+
+def _list_azure_containers(client):
+    # pylint: disable=import-outside-toplevel
+    from azure.core.exceptions import ClientAuthenticationError, HttpResponseError  # noqa: PLC0415
+
+    try:
+        container_dicts = list(client.list_containers())
+    except ClientAuthenticationError as exc:
+        raise DBTConfigException("Access denied when listing Azure containers. Please check your permissions.") from exc
+    except HttpResponseError as exc:
+        if exc.status_code == 403:
+            raise DBTConfigException(
+                "Access denied when listing Azure containers. Please check your permissions."
+            ) from exc
+        raise DBTConfigException(f"Failed to list Azure containers: {exc}") from exc
+    except Exception as exc:
+        raise DBTConfigException(f"Failed to list Azure containers: {exc}") from exc
+    return [client.get_container_client(container["name"]) for container in container_dicts]
+
+
+def _get_azure_container_client(client, bucket_name: str):
+    # pylint: disable=import-outside-toplevel
+    from azure.core.exceptions import (  # noqa: PLC0415
+        ClientAuthenticationError,
+        HttpResponseError,
+        ResourceNotFoundError,
+    )
+
+    try:
+        container_client = client.get_container_client(bucket_name)
+        # Verify container exists by attempting to get properties
+        container_client.get_container_properties()
+    except ResourceNotFoundError as exc:
+        raise DBTConfigException(
+            f"Azure container '{bucket_name}' not found. Please verify the container name is correct."
+        ) from exc
+    except ClientAuthenticationError as exc:
+        raise DBTConfigException(
+            f"Access denied to Azure container '{bucket_name}'. Please check your permissions."
+        ) from exc
+    except HttpResponseError as exc:
+        if exc.status_code == 404:
+            raise DBTConfigException(
+                f"Azure container '{bucket_name}' not found. Please verify the container name is correct."
+            ) from exc
+        if exc.status_code == 403:
+            raise DBTConfigException(
+                f"Access denied to Azure container '{bucket_name}'. Please check your permissions."
+            ) from exc
+        raise DBTConfigException(f"Failed to access Azure container '{bucket_name}': {exc}") from exc
+    except Exception as exc:
+        raise DBTConfigException(f"Failed to access Azure container '{bucket_name}': {exc}") from exc
+    return container_client
+
+
 @get_dbt_details.register
 def _(config: DbtAzureConfig):
     try:
         bucket_name, prefix = get_dbt_prefix_config(config)
-        # pylint: disable=import-outside-toplevel
-        from azure.core.exceptions import AzureError, ClientAuthenticationError
-
-        try:
-            client = AzureClient(config.dbtSecurityConfig).create_blob_client()
-        except ClientAuthenticationError as auth_exc:
-            logger.error(
-                f"Failed to authenticate with Azure: {str(auth_exc)}. "  # noqa: RUF010
-                "Please check your Azure credentials and permissions."
-            )
-            raise DBTConfigException(
-                "Azure authentication failed. Please verify your credentials and permissions."
-            ) from auth_exc
-        except AzureError as azure_exc:
-            logger.error(f"Failed to create Azure client: {str(azure_exc)}")  # noqa: RUF010
-            raise DBTConfigException(
-                "Failed to initialize Azure client. Please check your Azure configuration."
-            ) from azure_exc
+        client = _get_azure_client(config)
 
         if not bucket_name:
-            try:
-                container_dicts = list(client.list_containers())
-            except Exception as exc:
-                error_msg = str(exc).lower()
-                if "authorization" in error_msg or "forbidden" in error_msg:
-                    raise DBTConfigException(
-                        "Access denied when listing Azure containers. Please check your permissions."
-                    ) from exc
-                raise DBTConfigException(f"Failed to list Azure containers: {exc}") from exc
-            containers = [client.get_container_client(container["name"]) for container in container_dicts]
+            containers = _list_azure_containers(client)
         else:
-            try:
-                container_client = client.get_container_client(bucket_name)
-                # Verify container exists by attempting to get properties
-                container_client.get_container_properties()
-            except Exception as exc:
-                error_msg = str(exc).lower()
-                if "not found" in error_msg or "does not exist" in error_msg:
-                    raise DBTConfigException(
-                        f"Azure container '{bucket_name}' not found. Please verify the container name is correct."
-                    ) from exc
-                if "authorization" in error_msg or "forbidden" in error_msg:
-                    raise DBTConfigException(
-                        f"Access denied to Azure container '{bucket_name}'. Please check your permissions."
-                    ) from exc
-                raise DBTConfigException(f"Failed to access Azure container '{bucket_name}': {exc}") from exc
-            containers = [container_client]
+            containers = [_get_azure_container_client(client, bucket_name)]
 
         for container_client in containers:
             container_name = container_client.container_name

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py
@@ -42,6 +42,8 @@ from metadata.generated.schema.metadataIngestion.dbtconfig.dbtLocalConfig import
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtS3Config import (
     DbtS3Config,
 )
+from metadata.ingestion.connections.source_api_client import TrackedREST
+from metadata.ingestion.ometa.client import APIError, ClientConfig, RestTransportError
 from metadata.ingestion.source.database.dbt.constants import (
     DBT_CATALOG_FILE_NAME,
     DBT_MANIFEST_FILE_NAME,
@@ -229,10 +231,6 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
     dbt_manifest = None
     dbt_run_results = None
     try:
-        # pylint: disable=import-outside-toplevel
-        from metadata.ingestion.connections.source_api_client import TrackedREST
-        from metadata.ingestion.ometa.client import ClientConfig
-
         expiry = 0
         auth_token = config.dbtCloudAuthToken.get_secret_value(), expiry
         client_config = ClientConfig(
@@ -260,25 +258,33 @@ def _(config: DbtCloudConfig):  # pylint: disable=too-many-locals  # noqa: C901
 
         try:
             response = client.get(f"/accounts/{account_id}/runs", data=params_data)
-        except Exception as exc:
-            error_msg = str(exc).lower()
-            if "401" in error_msg or "unauthorized" in error_msg:
+        except APIError as exc:
+            if exc.code == 401:
                 raise DBTConfigException(
                     "Invalid dbt Cloud auth token. Please verify your token has "
                     "'Account Viewer' permissions and is not expired."
                 ) from exc
-            if "404" in error_msg:
+            if exc.code == 404:
                 raise DBTConfigException(
                     f"dbt Cloud account ID '{account_id}' not found. Please verify the account ID is correct."
                 ) from exc
-            if "connection" in error_msg or "timeout" in error_msg:
-                raise DBTConfigException(
-                    f"Unable to connect to dbt Cloud at '{config.dbtCloudUrl}'. "
-                    "Please verify the URL is correct and accessible."
-                ) from exc
+            raise DBTConfigException(f"dbt Cloud API error {exc.code}: {exc}") from exc
+        except RestTransportError as exc:
+            raise DBTConfigException(
+                f"Unable to connect to dbt Cloud at '{config.dbtCloudUrl}'. "
+                "Please verify the URL is correct and accessible."
+            ) from exc
+        except Exception as exc:
             raise DBTConfigException(f"Error connecting to dbt Cloud: {exc}") from exc
 
-        if not response or not response.get("data"):
+        if response is None:
+            raise DBTConfigException(  # noqa: TRY301
+                f"No response from dbt Cloud for account '{account_id}'. This usually means the "
+                "auth token is invalid or expired, or the credential lacks 'Account Viewer' "
+                "permission. Please verify your dbt Cloud credentials."
+            )
+
+        if not response.get("data"):
             filter_info = []
             if project_id:
                 filter_info.append(f"project ID '{project_id}'")

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -161,6 +161,11 @@ class DbtSource(DbtServiceSource):
         self.omd_custom_properties = {}
         self.extracted_custom_properties = {}
         self.extracted_domains = {}
+        # Upstream nodes already reported as unresolved, so a dbt project whose source
+        # database was never ingested reports each missing upstream once instead of once
+        # per referencing model. Bounded by the number of distinct upstream nodes in the
+        # project and reset per project in yield_data_models.
+        self.reported_unresolved_upstreams: set[str] = set()
         self._load_omd_custom_properties()
 
     @classmethod
@@ -751,6 +756,7 @@ class DbtSource(DbtServiceSource):
         """
         Yield the data models
         """
+        self.reported_unresolved_upstreams.clear()
         if self.source_config.dbtConfigSource and dbt_objects.dbt_manifest:
             logger.debug("Parsing DBT Data Models")
             manifest_entities = {
@@ -1166,11 +1172,16 @@ class DbtSource(DbtServiceSource):
                             override_lineage=self.source_config.overrideLineage,
                         )
                     )
-                else:
+                elif upstream_node not in self.reported_unresolved_upstreams:
+                    self.reported_unresolved_upstreams.add(upstream_node)
                     self.status.warning(
                         upstream_node,
-                        f"dbt lineage edge dropped: upstream table '{upstream_node}' "
-                        f"could not be resolved in OpenMetadata for '{to_entity.fullyQualifiedName.root}'.",
+                        f"dbt lineage edge dropped: upstream table '{upstream_node}' was not "
+                        f"returned by OpenMetadata, so no edge was created to "
+                        f"'{to_entity.fullyQualifiedName.root}'. Either the table has not been "
+                        "ingested or the lookup itself failed - check the logs above for a "
+                        "search or API error. Further models referencing this upstream are not "
+                        "reported again.",
                     )
 
             except Exception as exc:  # pylint: disable=broad-except
@@ -1264,11 +1275,15 @@ class DbtSource(DbtServiceSource):
                             override_lineage=self.source_config.overrideLineage,
                         )
                     )
-                else:
+                elif upstream_node not in self.reported_unresolved_upstreams:
+                    self.reported_unresolved_upstreams.add(upstream_node)
                     self.status.warning(
                         upstream_node,
-                        f"dbt exposure lineage edge dropped: upstream table '{upstream_node}' "
-                        f"could not be resolved in OpenMetadata for exposure '{manifest_node.name}'.",
+                        f"dbt exposure lineage edge dropped: upstream table '{upstream_node}' was "
+                        f"not returned by OpenMetadata, so no edge was created to exposure "
+                        f"'{manifest_node.name}'. Either the table has not been ingested or the "
+                        "lookup itself failed - check the logs above for a search or API error. "
+                        "Further nodes referencing this upstream are not reported again.",
                     )
 
             except Exception as exc:  # pylint: disable=broad-except
@@ -2016,7 +2031,6 @@ class DbtSource(DbtServiceSource):
 
         except Exception as err:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
-            logger.warning(f"Failed to capture test results for node '{node_name}': {err}")
             self.status.failed(
                 StackTraceError(
                     name=f"DBT Test Result {node_name}",

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1160,24 +1160,18 @@ class DbtSource(DbtServiceSource):
                             ),
                         )
                     )
-                    if lineage_request is not None:
-                        yield Either(
-                            right=OMetaLineageRequest(
-                                lineage_request=lineage_request,
-                                override_lineage=self.source_config.overrideLineage,
-                            )
+                    yield Either(
+                        right=OMetaLineageRequest(
+                            lineage_request=lineage_request,
+                            override_lineage=self.source_config.overrideLineage,
                         )
-                    else:
-                        yield Either(
-                            left=StackTraceError(
-                                name="DBT Lineage upstream nodes",
-                                error=(
-                                    "Error to create DBT lineage from upstream nodes ",
-                                    f"{str(data_model_link.datamodel.upstream)}",  # noqa: RUF010
-                                ),
-                                stackTrace=traceback.format_exc(),
-                            )
-                        )
+                    )
+                else:
+                    self.status.warning(
+                        upstream_node,
+                        f"dbt lineage edge dropped: upstream table '{upstream_node}' "
+                        f"could not be resolved in OpenMetadata for '{to_entity.fullyQualifiedName.root}'.",
+                    )
 
             except Exception as exc:  # pylint: disable=broad-except
                 logger.debug(traceback.format_exc())
@@ -1264,24 +1258,18 @@ class DbtSource(DbtServiceSource):
                             lineageDetails=LineageDetails(source=LineageSource.DbtLineage),
                         )
                     )
-                    if lineage_request is not None:
-                        yield Either(
-                            right=OMetaLineageRequest(
-                                lineage_request=lineage_request,
-                                override_lineage=self.source_config.overrideLineage,
-                            )
+                    yield Either(
+                        right=OMetaLineageRequest(
+                            lineage_request=lineage_request,
+                            override_lineage=self.source_config.overrideLineage,
                         )
-                    else:
-                        yield Either(
-                            left=StackTraceError(
-                                name="DBT Exposure lineage",
-                                error=(
-                                    "Error to create DBT Exposure lineage",
-                                    f"{str(exposure_spec)[:20]}...",
-                                ),
-                                stackTrace=traceback.format_exc(),
-                            )
-                        )
+                    )
+                else:
+                    self.status.warning(
+                        upstream_node,
+                        f"dbt exposure lineage edge dropped: upstream table '{upstream_node}' "
+                        f"could not be resolved in OpenMetadata for exposure '{manifest_node.name}'.",
+                    )
 
             except Exception as exc:  # pylint: disable=broad-except
                 logger.debug(traceback.format_exc())

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1929,11 +1929,13 @@ class DbtSource(DbtServiceSource):
         """
         After test cases has been processed, add the tests results info
         """
+        node_name = "unknown"
         try:
             # Process the Test Status
             manifest_node = dbt_test.get(DbtCommonEnum.MANIFEST_NODE.value)
             if manifest_node:
-                logger.debug(f"Adding DBT Test Case Results for node: {manifest_node.name}")
+                node_name = manifest_node.name
+                logger.debug(f"Adding DBT Test Case Results for node: {node_name}")
                 dbt_test_result = dbt_test.get(DbtCommonEnum.RESULTS.value)
                 if not dbt_test_result:
                     logger.debug(f"DBT Test Case Results not found for node: {manifest_node.name}")
@@ -2014,7 +2016,14 @@ class DbtSource(DbtServiceSource):
 
         except Exception as err:  # pylint: disable=broad-except
             logger.debug(traceback.format_exc())
-            logger.debug(f"Failed to capture tests results for node: {manifest_node.name} {err}")
+            logger.warning(f"Failed to capture test results for node '{node_name}': {err}")
+            self.status.failed(
+                StackTraceError(
+                    name=f"DBT Test Result {node_name}",
+                    error=f"Failed to capture test results for node '{node_name}': {err}",
+                    stackTrace=traceback.format_exc(),
+                )
+            )
 
     def close(self):
         self.metadata.close()

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1178,7 +1178,7 @@ class DbtSource(DbtServiceSource):
                         upstream_node,
                         f"dbt lineage edge dropped: upstream table '{upstream_node}' was not "
                         f"returned by OpenMetadata, so no edge was created to "
-                        f"'{to_entity.fullyQualifiedName.root}'. Either the table has not been "
+                        f"'{model_str(to_entity.fullyQualifiedName)}'. Either the table has not been "
                         "ingested or the lookup itself failed - check the logs above for a "
                         "search or API error. Further models referencing this upstream are not "
                         "reported again.",

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3161,8 +3161,7 @@ class TestStorageStreamingBehavior(TestCase):
 
     @patch("metadata.ingestion.source.database.dbt.dbt_config.download_dbt_files")
     @patch("metadata.ingestion.source.database.dbt.dbt_config.get_blobs_grouped_by_dir")
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
-    def test_s3_passes_generator_to_grouping(self, mock_list_s3, mock_get_blobs, mock_download):
+    def test_s3_passes_generator_to_grouping(self, mock_get_blobs, mock_download):
         """Test that S3 handler passes a generator (not a list) to get_blobs_grouped_by_dir"""
         from types import GeneratorType
 
@@ -3174,8 +3173,6 @@ class TestStorageStreamingBehavior(TestCase):
         # Get the registered handler for DbtS3Config directly
         s3_handler = get_dbt_details.dispatch(DbtS3Config)
 
-        mock_list_s3.return_value = iter([{"Key": "project/manifest.json"}, {"Key": "project/catalog.json"}])
-
         mock_get_blobs.return_value = {}
         mock_download.return_value = iter([])
 
@@ -3184,6 +3181,9 @@ class TestStorageStreamingBehavior(TestCase):
         config.dbtPrefixConfig.dbtObjectPrefix = None
 
         mock_client = MagicMock()
+        mock_client.get_paginator.return_value.paginate.return_value = iter(
+            [{"Contents": [{"Key": "project/manifest.json"}, {"Key": "project/catalog.json"}]}]
+        )
 
         with patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient") as mock_aws:
             mock_aws.return_value.get_client.return_value = mock_client
@@ -3656,6 +3656,7 @@ class TestDbtLineageUnresolvedUpstream:
         source = MagicMock(spec=DbtSource)
         source.status = MagicMock()
         source.source_config = MagicMock(overrideLineage=False)
+        source.reported_unresolved_upstreams = set()
         return source
 
     def test_unresolved_upstream_records_a_status_warning(self):
@@ -3695,6 +3696,55 @@ class TestDbtLineageUnresolvedUpstream:
         assert len(results) == 1
         assert results[0].right is not None
         source.status.warning.assert_not_called()
+
+    def test_unresolved_upstream_does_not_over_assert_the_cause(self):
+        """_get_table_entity returns None for a search outage too, so the reason must not
+        claim the table was never ingested."""
+        source = self._source()
+        source._get_table_entity.return_value = None
+
+        to_entity = MagicMock()
+        to_entity.fullyQualifiedName.root = "svc.db.sch.orders"
+        data_model_link = MagicMock()
+        data_model_link.table_entity = to_entity
+        data_model_link.datamodel.upstream = ["svc.db.sch.raw_orders"]
+
+        list(DbtSource.create_dbt_lineage(source, data_model_link))
+
+        _key, reason = source.status.warning.call_args[0]
+        assert "could not be resolved" not in reason
+        assert "lookup itself failed" in reason
+
+    def test_same_missing_upstream_is_reported_once_per_run(self):
+        """A never-ingested source database is referenced by every model in the project;
+        one warning per (model x upstream) buries everything else in the report."""
+        source = self._source()
+        source._get_table_entity.return_value = None
+
+        for model in ("orders", "customers", "payments"):
+            to_entity = MagicMock()
+            to_entity.fullyQualifiedName.root = f"svc.db.sch.{model}"
+            data_model_link = MagicMock()
+            data_model_link.table_entity = to_entity
+            data_model_link.datamodel.upstream = ["svc.db.sch.raw_orders"]
+            list(DbtSource.create_dbt_lineage(source, data_model_link))
+
+        assert source.status.warning.call_count == 1
+        assert source.reported_unresolved_upstreams == {"svc.db.sch.raw_orders"}
+
+    def test_distinct_missing_upstreams_are_each_reported(self):
+        source = self._source()
+        source._get_table_entity.return_value = None
+
+        to_entity = MagicMock()
+        to_entity.fullyQualifiedName.root = "svc.db.sch.orders"
+        data_model_link = MagicMock()
+        data_model_link.table_entity = to_entity
+        data_model_link.datamodel.upstream = ["svc.db.sch.raw_orders", "svc.db.sch.raw_customers"]
+
+        list(DbtSource.create_dbt_lineage(source, data_model_link))
+
+        assert source.status.warning.call_count == 2
 
 
 class TestAddDbtTestResultFailureReporting:

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3645,3 +3645,51 @@ class TestRemoveManifestNonRequiredKeys(TestCase):
         assert manifest_dict["parent_map"] == {}
         assert manifest_dict["child_map"] == {}
         assert manifest_dict["group_map"] == []
+
+
+class TestDbtLineageUnresolvedUpstream:
+    """create_dbt_lineage / create_dbt_exposures_lineage must report dropped edges."""
+
+    def _source(self):
+        source = MagicMock(spec=DbtSource)
+        source.status = MagicMock()
+        source.source_config = MagicMock(overrideLineage=False)
+        return source
+
+    def test_unresolved_upstream_records_a_status_warning(self):
+        source = self._source()
+        source._get_table_entity.return_value = None
+
+        to_entity = MagicMock()
+        to_entity.fullyQualifiedName.root = "svc.db.sch.orders"
+        data_model_link = MagicMock()
+        data_model_link.table_entity = to_entity
+        data_model_link.datamodel.upstream = ["svc.db.sch.raw_orders"]
+
+        results = list(DbtSource.create_dbt_lineage(source, data_model_link))
+
+        assert results == []
+        source.status.warning.assert_called_once()
+        _key, reason = source.status.warning.call_args[0]
+        assert "svc.db.sch.raw_orders" in reason
+        assert "svc.db.sch.orders" in reason
+
+    def test_resolved_upstream_emits_no_warning(self):
+        source = self._source()
+        from_entity = MagicMock()
+        from_entity.id.root = uuid.uuid4()
+        source._get_table_entity.return_value = from_entity
+
+        to_entity = MagicMock()
+        to_entity.id.root = uuid.uuid4()
+        to_entity.fullyQualifiedName.root = "svc.db.sch.orders"
+        data_model_link = MagicMock()
+        data_model_link.table_entity = to_entity
+        data_model_link.datamodel.upstream = ["svc.db.sch.raw_orders"]
+        data_model_link.datamodel.sql = None
+
+        results = list(DbtSource.create_dbt_lineage(source, data_model_link))
+
+        assert len(results) == 1
+        assert results[0].right is not None
+        source.status.warning.assert_not_called()

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -35,7 +35,9 @@ from metadata.generated.schema.type.tagLabel import (
     TagSource,
 )
 from metadata.ingestion.api.models import Either
+from metadata.ingestion.ometa.client import APIError
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.ingestion.source.database.dbt.constants import DbtCommonEnum
 from metadata.ingestion.source.database.dbt.dbt_utils import (
     convert_java_to_python_format,
     find_domain_by_name,
@@ -3693,3 +3695,60 @@ class TestDbtLineageUnresolvedUpstream:
         assert len(results) == 1
         assert results[0].right is not None
         source.status.warning.assert_not_called()
+
+
+class TestAddDbtTestResultFailureReporting:
+    """The outer handler must report, not swallow at debug."""
+
+    def _source(self):
+        from datetime import datetime
+
+        source = MagicMock(spec=DbtSource)
+        source.status = MagicMock()
+        source.metadata = MagicMock()
+        source.context.get.return_value.run_results_generate_time = datetime(2026, 7, 29, 9, 0, 0)
+        return source
+
+    def _dbt_test(self):
+        manifest_node = MagicMock()
+        manifest_node.name = "not_null_orders_id"
+        manifest_node.column_name = None
+        manifest_node.test_metadata = None
+        result = MagicMock()
+        result.message = "FAIL 3"
+        result.status.value = "fail"
+        result.unique_id = "test.demo.not_null_orders_id"
+        result.timing = []
+        return {
+            DbtCommonEnum.MANIFEST_NODE.value: manifest_node,
+            DbtCommonEnum.RESULTS.value: result,
+            DbtCommonEnum.UPSTREAM.value: ["svc.db.sch.orders"],
+        }
+
+    def test_api_error_is_recorded_as_failed(self):
+        source = self._source()
+        source.metadata.add_test_case_results.side_effect = APIError({"code": 500, "message": "boom"})
+
+        DbtSource.add_dbt_test_result(source, self._dbt_test())
+
+        source.status.failed.assert_called_once()
+        recorded = source.status.failed.call_args[0][0]
+        assert "not_null_orders_id" in recorded.name
+        assert isinstance(recorded.error, str)
+
+    def test_conflict_409_is_not_recorded_as_failed(self):
+        source = self._source()
+        source.metadata.add_test_case_results.side_effect = APIError({"code": 409, "message": "already exists"})
+
+        DbtSource.add_dbt_test_result(source, self._dbt_test())
+
+        source.status.failed.assert_not_called()
+
+    def test_malformed_input_does_not_raise_from_the_handler(self):
+        source = self._source()
+
+        DbtSource.add_dbt_test_result(source, "not-a-dict")
+
+        source.status.failed.assert_called_once()
+        recorded = source.status.failed.call_args[0][0]
+        assert "unknown" in recorded.name

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -20,6 +20,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from botocore.exceptions import ClientError, NoCredentialsError
 
+from metadata.generated.schema.metadataIngestion.dbtconfig.dbtAzureConfig import (
+    DbtAzureConfig,
+)
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtCloudConfig import (
     DbtCloudConfig,
 )
@@ -167,5 +170,64 @@ class TestS3ErrorClassification:
 
         with pytest.raises(DBTConfigException) as exc_info:
             list(get_dbt_details(_s3_config()))
+
+        assert "permission" in str(exc_info.value).lower()
+
+
+def _azure_config():
+    config = MagicMock()
+    # singledispatch dispatches on args[0].__class__, so this is what routes the mock to the
+    # DbtAzureConfig handler; spec= cannot be used because pydantic v2 does not expose model
+    # field names via dir() on the class, which would block attribute mocking below.
+    config.__class__ = DbtAzureConfig
+    config.dbtPrefixConfig.dbtBucketName = "my-container"
+    config.dbtPrefixConfig.dbtObjectPrefix = "dbt/"
+    return config
+
+
+class TestAzureErrorClassification:
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AzureClient")
+    def test_missing_container_reports_container_name(self, azure_client):
+        from azure.core.exceptions import ResourceNotFoundError
+
+        blob_client = azure_client.return_value.create_blob_client.return_value
+        blob_client.get_container_client.return_value.get_container_properties.side_effect = ResourceNotFoundError(
+            "container not found"
+        )
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_azure_config()))
+
+        assert "my-container" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AzureClient")
+    def test_auth_error_reports_permissions(self, azure_client):
+        from azure.core.exceptions import ClientAuthenticationError
+
+        blob_client = azure_client.return_value.create_blob_client.return_value
+        blob_client.get_container_client.return_value.get_container_properties.side_effect = ClientAuthenticationError(
+            "forbidden"
+        )
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_azure_config()))
+
+        assert "permission" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AzureClient")
+    def test_disabled_account_http_error_reports_permissions(self, azure_client):
+        """A 403 HttpResponseError whose message never says 'forbidden' or 'authorization' —
+        the substring matcher this replaced fell through to the generic 'Failed to access
+        Azure container' message for this case instead of the permissions message."""
+        from azure.core.exceptions import HttpResponseError
+
+        exc = HttpResponseError("The specified account is disabled.")
+        exc.status_code = 403
+        blob_client = azure_client.return_value.create_blob_client.return_value
+        blob_client.get_container_client.return_value.get_container_properties.side_effect = exc
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_azure_config()))
 
         assert "permission" in str(exc_info.value).lower()

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -31,6 +31,9 @@ from metadata.ingestion.source.database.dbt.dbt_config import (
 
 def _dbt_cloud_config():
     config = MagicMock()
+    # singledispatch dispatches on args[0].__class__, so this is what routes the mock to the
+    # DbtCloudConfig handler; spec= cannot be used because pydantic v2 does not expose model
+    # field names via dir() on the class, which would block attribute mocking below.
     config.__class__ = DbtCloudConfig
     config.dbtCloudAccountId = "12345"
     config.dbtCloudProjectId = None
@@ -41,7 +44,7 @@ def _dbt_cloud_config():
 
 
 class TestDbtCloudErrorClassification:
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_401_api_error_reports_invalid_token(self, tracked_rest):
         tracked_rest.return_value.get.side_effect = APIError({"code": 401, "message": "unauthorized"})
 
@@ -50,7 +53,7 @@ class TestDbtCloudErrorClassification:
 
         assert "auth token" in str(exc_info.value).lower()
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_404_api_error_reports_bad_account_id(self, tracked_rest):
         tracked_rest.return_value.get.side_effect = APIError({"code": 404, "message": "not found"})
 
@@ -59,7 +62,7 @@ class TestDbtCloudErrorClassification:
 
         assert "12345" in str(exc_info.value)
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_transport_error_reports_connectivity(self, tracked_rest):
         tracked_rest.return_value.get.side_effect = RestTransportError("GET", "/runs", Exception("refused"))
 
@@ -68,7 +71,7 @@ class TestDbtCloudErrorClassification:
 
         assert "cloud.getdbt.com" in str(exc_info.value)
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_none_response_is_not_reported_as_no_runs_found(self, tracked_rest):
         """A swallowed 401 returns None from the client. That is a credential
         problem, not an empty account, and must not be mislabelled."""
@@ -81,7 +84,7 @@ class TestDbtCloudErrorClassification:
         assert "no completed dbt runs" not in message
         assert "credential" in message or "token" in message
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_empty_data_still_reports_no_runs_found(self, tracked_rest):
         tracked_rest.return_value.get.return_value = {"data": []}
 

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -1,0 +1,91 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Error-classification tests for the dbt config sources.
+
+These cover the branches that translate a provider exception into a
+DBTConfigException message shown to the user.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.generated.schema.metadataIngestion.dbtconfig.dbtCloudConfig import (
+    DbtCloudConfig,
+)
+from metadata.ingestion.ometa.client import APIError, RestTransportError
+from metadata.ingestion.source.database.dbt.dbt_config import (
+    DBTConfigException,
+    get_dbt_details,
+)
+
+
+def _dbt_cloud_config():
+    config = MagicMock()
+    config.__class__ = DbtCloudConfig
+    config.dbtCloudAccountId = "12345"
+    config.dbtCloudProjectId = None
+    config.dbtCloudJobId = None
+    config.dbtCloudUrl = "https://cloud.getdbt.com"
+    config.dbtCloudAuthToken.get_secret_value.return_value = "tok"
+    return config
+
+
+class TestDbtCloudErrorClassification:
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    def test_401_api_error_reports_invalid_token(self, tracked_rest):
+        tracked_rest.return_value.get.side_effect = APIError({"code": 401, "message": "unauthorized"})
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "auth token" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    def test_404_api_error_reports_bad_account_id(self, tracked_rest):
+        tracked_rest.return_value.get.side_effect = APIError({"code": 404, "message": "not found"})
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "12345" in str(exc_info.value)
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    def test_transport_error_reports_connectivity(self, tracked_rest):
+        tracked_rest.return_value.get.side_effect = RestTransportError("GET", "/runs", Exception("refused"))
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "cloud.getdbt.com" in str(exc_info.value)
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    def test_none_response_is_not_reported_as_no_runs_found(self, tracked_rest):
+        """A swallowed 401 returns None from the client. That is a credential
+        problem, not an empty account, and must not be mislabelled."""
+        tracked_rest.return_value.get.return_value = None
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        message = str(exc_info.value).lower()
+        assert "no completed dbt runs" not in message
+        assert "credential" in message or "token" in message
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.TrackedREST")
+    def test_empty_data_still_reports_no_runs_found(self, tracked_rest):
+        tracked_rest.return_value.get.return_value = {"data": []}
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "no completed dbt runs" in str(exc_info.value).lower()

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -18,6 +18,7 @@ DBTConfigException message shown to the user.
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from botocore.exceptions import ClientError, NoCredentialsError
 
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtAzureConfig import (
@@ -50,6 +51,21 @@ def _dbt_cloud_config():
     return config
 
 
+def _http_error(status_code: int) -> requests.HTTPError:
+    """A requests.HTTPError as raise_for_status builds it, which is what reaches the dbt
+    Cloud handler when the error body has no top-level "code" key for the REST client to
+    turn into an APIError."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.url = "https://cloud.getdbt.com/api/v2/accounts/12345/runs"
+    response.reason = "Unauthorized"
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        return exc
+    raise AssertionError(f"status {status_code} did not raise")
+
+
 class TestDbtCloudErrorClassification:
     @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_401_api_error_reports_invalid_token(self, tracked_rest):
@@ -67,7 +83,7 @@ class TestDbtCloudErrorClassification:
         with pytest.raises(DBTConfigException) as exc_info:
             list(get_dbt_details(_dbt_cloud_config()))
 
-        assert "12345" in str(exc_info.value)
+        assert "account ID '12345' not found" in str(exc_info.value)
 
     @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_transport_error_reports_connectivity(self, tracked_rest):
@@ -78,10 +94,43 @@ class TestDbtCloudErrorClassification:
 
         assert "cloud.getdbt.com" in str(exc_info.value)
 
+    @pytest.mark.parametrize("status_code", [401, 403])
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
+    def test_http_error_reports_invalid_token(self, tracked_rest, status_code):
+        """dbt Cloud nests its error code under "status", and an SSO gateway answers with
+        HTML, so neither body reaches the APIError branch - a bare HTTPError does."""
+        tracked_rest.return_value.get.side_effect = _http_error(status_code)
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "auth token" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
+    def test_http_error_404_reports_bad_account_id(self, tracked_rest):
+        tracked_rest.return_value.get.side_effect = _http_error(404)
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        # The generic fallback also renders the account ID via the request URL, so assert
+        # on the wording that only the 404 branch produces.
+        assert "account ID '12345' not found" in str(exc_info.value)
+
+    @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
+    def test_http_error_other_status_falls_back_to_generic(self, tracked_rest):
+        tracked_rest.return_value.get.side_effect = _http_error(500)
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_dbt_cloud_config()))
+
+        assert "error connecting to dbt cloud" in str(exc_info.value).lower()
+
     @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_none_response_is_not_reported_as_no_runs_found(self, tracked_rest):
-        """A swallowed 401 returns None from the client. That is a credential
-        problem, not an empty account, and must not be mislabelled."""
+        """The client returns None for any error body it cannot classify - a 404 on a
+        mistyped account ID lands here just as a 401 does - so the message must name the
+        account and enumerate the causes rather than assert the token is bad."""
         tracked_rest.return_value.get.return_value = None
 
         with pytest.raises(DBTConfigException) as exc_info:
@@ -89,7 +138,10 @@ class TestDbtCloudErrorClassification:
 
         message = str(exc_info.value).lower()
         assert "no completed dbt runs" not in message
-        assert "credential" in message or "token" in message
+        assert "12345" in message
+        assert "account id is wrong" in message
+        assert "token is invalid" in message
+        assert "rate-limited" in message
 
     @patch("metadata.ingestion.connections.source_api_client.TrackedREST")
     def test_empty_data_still_reports_no_runs_found(self, tracked_rest):
@@ -153,20 +205,43 @@ class TestS3ErrorClassification:
 
         assert "authentication failed" in str(exc_info.value).lower()
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
     @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
-    def test_no_such_bucket_reports_bucket_name(self, aws_client, list_objects):
-        list_objects.side_effect = _client_error("NoSuchBucket")
+    def test_no_such_bucket_reports_bucket_name(self, aws_client):
+        """Raised from the boto3 paginator, the way a real bucket typo surfaces.
+
+        metadata.utils.s3_utils.list_s3_objects swallows every exception and only logs, so
+        going through it here would prove nothing about this classification."""
+        aws_client.return_value.get_client.return_value.get_paginator.return_value.paginate.side_effect = _client_error(
+            "NoSuchBucket"
+        )
 
         with pytest.raises(DBTConfigException) as exc_info:
             list(get_dbt_details(_s3_config()))
 
         assert "my-bucket" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
 
-    @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
     @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
-    def test_access_denied_reports_iam_permissions(self, aws_client, list_objects):
-        list_objects.side_effect = _client_error("AccessDenied")
+    def test_access_denied_reports_iam_permissions(self, aws_client):
+        aws_client.return_value.get_client.return_value.get_paginator.return_value.paginate.side_effect = _client_error(
+            "AccessDenied"
+        )
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_s3_config()))
+
+        assert "permission" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
+    def test_listing_error_raised_mid_pagination_is_still_classified(self, aws_client):
+        """The paginator yields lazily, so the error can arrive after the first page has
+        already been consumed by the grouping generator."""
+
+        def _pages(**_):
+            yield {"Contents": [{"Key": "dbt/manifest.json"}]}
+            raise _client_error("AccessDenied")
+
+        aws_client.return_value.get_client.return_value.get_paginator.return_value.paginate.side_effect = _pages
 
         with pytest.raises(DBTConfigException) as exc_info:
             list(get_dbt_details(_s3_config()))

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -18,9 +18,13 @@ DBTConfigException message shown to the user.
 from unittest.mock import MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
 
 from metadata.generated.schema.metadataIngestion.dbtconfig.dbtCloudConfig import (
     DbtCloudConfig,
+)
+from metadata.generated.schema.metadataIngestion.dbtconfig.dbtS3Config import (
+    DbtS3Config,
 )
 from metadata.ingestion.ometa.client import APIError, RestTransportError
 from metadata.ingestion.source.database.dbt.dbt_config import (
@@ -92,3 +96,49 @@ class TestDbtCloudErrorClassification:
             list(get_dbt_details(_dbt_cloud_config()))
 
         assert "no completed dbt runs" in str(exc_info.value).lower()
+
+
+def _s3_config():
+    config = MagicMock()
+    # singledispatch dispatches on args[0].__class__, so this is what routes the mock to the
+    # DbtS3Config handler; spec= cannot be used because pydantic v2 does not expose model
+    # field names via dir() on the class, which would block attribute mocking below.
+    config.__class__ = DbtS3Config
+    config.dbtPrefixConfig.dbtBucketName = "my-bucket"
+    config.dbtPrefixConfig.dbtObjectPrefix = "dbt/"
+    return config
+
+
+def _client_error(code):
+    return ClientError({"Error": {"Code": code, "Message": code}}, "ListObjectsV2")
+
+
+class TestS3ErrorClassification:
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
+    def test_missing_credentials_reports_auth_failure(self, aws_client):
+        aws_client.return_value.get_client.side_effect = NoCredentialsError()
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_s3_config()))
+
+        assert "authentication failed" in str(exc_info.value).lower()
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
+    def test_no_such_bucket_reports_bucket_name(self, aws_client, list_objects):
+        list_objects.side_effect = _client_error("NoSuchBucket")
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_s3_config()))
+
+        assert "my-bucket" in str(exc_info.value)
+
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
+    def test_access_denied_reports_iam_permissions(self, aws_client, list_objects):
+        list_objects.side_effect = _client_error("AccessDenied")
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_s3_config()))
+
+        assert "permission" in str(exc_info.value).lower()

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -123,6 +123,33 @@ class TestS3ErrorClassification:
 
         assert "authentication failed" in str(exc_info.value).lower()
 
+    @pytest.mark.parametrize(
+        ("error_code", "message"),
+        [
+            (
+                "InvalidAccessKeyId",
+                "The AWS Access Key Id you provided does not exist in our records.",
+            ),
+            (
+                "SignatureDoesNotMatch",
+                "The request signature we calculated does not match the signature you provided. "
+                "Check your key and signing method.",
+            ),
+        ],
+    )
+    @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
+    def test_bad_key_client_error_reports_auth_failure(self, aws_client, error_code, message):
+        """These AWS codes render no 'credentials'/'accessdenied' text into str(exc), so the
+        substring matcher this replaced misreported them as a generic client-init failure."""
+        aws_client.return_value.get_client.side_effect = ClientError(
+            {"Error": {"Code": error_code, "Message": message}}, "ListBuckets"
+        )
+
+        with pytest.raises(DBTConfigException) as exc_info:
+            list(get_dbt_details(_s3_config()))
+
+        assert "authentication failed" in str(exc_info.value).lower()
+
     @patch("metadata.ingestion.source.database.dbt.dbt_config.list_s3_objects")
     @patch("metadata.ingestion.source.database.dbt.dbt_config.AWSClient")
     def test_no_such_bucket_reports_bucket_name(self, aws_client, list_objects):

--- a/ingestion/tests/unit/test_dbt_config_errors.py
+++ b/ingestion/tests/unit/test_dbt_config_errors.py
@@ -92,7 +92,7 @@ class TestDbtCloudErrorClassification:
         with pytest.raises(DBTConfigException) as exc_info:
             list(get_dbt_details(_dbt_cloud_config()))
 
-        assert "cloud.getdbt.com" in str(exc_info.value)
+        assert "Unable to connect to dbt Cloud" in str(exc_info.value)
 
     @pytest.mark.parametrize("status_code", [401, 403])
     @patch("metadata.ingestion.connections.source_api_client.TrackedREST")


### PR DESCRIPTION
### Describe your changes:

Fixes #30635

I made three failure paths in the `dbt` connector report instead of discard, because a broken run was indistinguishable from a working one: unresolvable lineage edges vanished with no log or status entry, `add_dbt_test_result` swallowed every exception at `logger.debug`, and an expired dbt Cloud token was reported to users as "No completed dbt runs found for account X". Error classification across the dbt Cloud, S3 and Azure config handlers now uses typed exceptions rather than substring-matching `str(exc).lower()`, and two unreachable `else` branches whose `StackTraceError(error=...)` passed a tuple to a `str`-typed field were removed.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Connector-scoped — no shared base class, no change to `ometa/client.py` or `topology_runner.py`.

- **Lineage (`metadata.py`)** — added the missing `else` on `if from_entity and to_entity:` in `create_dbt_lineage` / `create_dbt_exposures_lineage`, reporting via `status.warning` rather than `status.failed`: an upstream table not yet ingested is a common, legitimate state, and using `failed` would bury real errors. Warnings are deduped per run so a missing source database yields one entry per upstream rather than one per (model × upstream).
- **Test results (`metadata.py`)** — the outer handler in `add_dbt_test_result` now logs at `warning` and records `status.failed`. The two legitimate skips (missing results, compiled-only entries) stay at `debug`. Also fixes an `UnboundLocalError` raised from inside that handler when the failure occurred before `manifest_node` was bound.
- **Config handlers (`dbt_config.py`)** — `APIError` / `requests.HTTPError` / `RestTransportError` for dbt Cloud, `botocore` `ClientError` + the existing `aws_error_code()` helper for S3, and `azure.core` exception types for Azure. Each keeps a trailing `except Exception` so nothing regresses into an unhandled crash. The dbt Cloud `response is None` case is split out from "no runs found", since the REST client returns `None` for an error body it cannot classify. Function-local imports for the optional `azure` and `boto3` dependencies were deliberately left function-local; helper extraction was required to stay under ruff's C901 limit.

Alternatives rejected: switching dbt Cloud to `REST.get_raw` would classify the status exactly, but it returns the response before the `"code"` check and never re-raises, making both the `APIError` and `requests.HTTPError` clauses dead — so the message enumerates causes instead.

#
### Tests:

#### Use cases covered
- A dbt model whose upstream table is not ingested in OpenMetadata produces a warning naming both endpoints, instead of silently dropping the edge
- A 500 from `add_test_case_results` is recorded as a failure instead of being discarded at debug level
- A malformed `dbt_test` payload no longer raises `UnboundLocalError` from inside the error handler
- An invalid dbt Cloud token reports an authentication problem instead of "no completed dbt runs found"
- S3 `InvalidAccessKeyId` / `SignatureDoesNotMatch` (whose messages contain neither substring the old matcher searched for) are classified as authentication failures
- Azure authorization and container-not-found errors are classified by exception type

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `ingestion/tests/unit/test_dbt_config_errors.py` (new), `ingestion/tests/unit/test_dbt.py`
- 207 passing across the dbt suite. Each new error-classification test was verified red-first against a scratch revert — the S3 and dbt Cloud classifications fail without the fix.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (unit coverage added; no integration-test harness changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified end-to-end against a live OpenMetadata 2.0.0 instance and a real AWS account:
1. **HTTP config** — 30 records, 0 errors. Confirmed in-instance: 21 test cases, 3 `DbtLineage` edges, `dataModel.upstream` resolved, descriptions ingested.
2. **S3 config** — 50 records, 0 errors. Confirmed 3 lineage edges with column lineage, 20 test cases, `dbtTags` classification and tag created.
3. **dbt Cloud config** — invalid token, A/B against `main`. `main` reports *"No completed dbt runs found for account '12345'"*; this branch reports the account ID plus the plausible causes including an invalid or expired token.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #30635` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves reporting and classification of dbt enrichment failures.
- Records unresolved dbt lineage endpoints and test-result submission failures in ingestion status.
- Classifies dbt Cloud, S3, and Azure failures using typed provider exceptions.
- Adds focused unit coverage for lineage warnings, test-result failures, and storage or cloud error classification.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR should not merge until exposure lineage failures remain visible when model lineage has already reported the same unresolved upstream.

The model lineage phase inserts unresolved upstreams into a set shared with the later exposure phase, causing the exposure path to omit its distinct dropped-edge warning for matching upstreams.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/dbt/metadata.py | Adds status reporting and per-run deduplication for unresolved lineage endpoints and records test-result processing failures. |
| ingestion/src/metadata/ingestion/source/database/dbt/dbt_config.py | Replaces string-based cloud and object-storage error classification with typed exception handling and direct paginated S3 listing. |
| ingestion/tests/unit/test_dbt.py | Adds coverage for unresolved lineage reporting, deduplication, and dbt test-result failure handling. |
| ingestion/tests/unit/test_dbt_config_errors.py | Adds provider-specific tests for dbt Cloud, S3, and Azure error classification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(dbt): assert on the message, not th..."](https://github.com/open-metadata/openmetadata/commit/d1df033929fc24e3af1fbd049f3be743edcddb07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48273360)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->