### PR TITLE
Fixes #30637: Re-enable skipped DataInsightReportApplication and SearchRBAC Playwright suites

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -4,7 +4,8 @@
     "playwright/e2e/Auth/**",
     "playwright/e2e/nightly/**",
     "playwright/e2e/Http2/**",
-    "playwright/e2e/Pages/DataInsight*.spec.ts",
+    "playwright/e2e/Pages/DataInsight.spec.ts",
+    "playwright/e2e/Pages/DataInsightSettings.spec.ts",
     "playwright/e2e/Features/KnowledgeGraph.spec.ts",
     "playwright/e2e/Features/OntologyExplorerRdf.spec.ts",
     "playwright/e2e/Features/OntologyImportRdf.spec.ts"

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
@@ -147,8 +147,7 @@ for (const entity of searchRBACEntities) {
   });
 }
 
-// unskip test once the backend issue get fixed #3289
-test.describe.skip(`Table Column`, () => {
+test.describe(`Table Column`, () => {
   const table = new TableClass();
   const user1 = new UserClass();
   const user2 = new UserClass();
@@ -160,6 +159,11 @@ test.describe.skip(`Table Column`, () => {
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await table.create(apiContext);
+    await waitForSearchIndexed(
+      apiContext,
+      table.entityResponseData?.columns?.[0]?.fullyQualifiedName,
+      'tableColumn'
+    );
 
     const promises = [user1.create(apiContext), user2.create(apiContext)];
 
@@ -224,6 +228,20 @@ test.describe.skip(`Table Column`, () => {
     await afterAction();
   });
 
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await Promise.all([
+      table.delete(apiContext),
+      user1.delete(apiContext),
+      user2.delete(apiContext),
+    ]);
+    await Promise.all([role1.delete(apiContext), role2.delete(apiContext)]);
+    await Promise.all([policy1.delete(apiContext), policy2.delete(apiContext)]);
+
+    await afterAction();
+  });
+
   test(`User with permission`, async ({ browser }) => {
     const userWithPermissionPage = await newStrippedPage(browser);
     const column = table.entityResponseData?.columns?.[0];
@@ -232,7 +250,7 @@ test.describe.skip(`Table Column`, () => {
 
     await searchForEntityShouldWork(
       column.fullyQualifiedName ?? '',
-      column.displayName ?? '',
+      column.displayName ?? column.name ?? '',
       userWithPermissionPage
     );
   });
@@ -245,7 +263,7 @@ test.describe.skip(`Table Column`, () => {
 
     await searchForEntityShouldWorkShowNoResult(
       column.fullyQualifiedName ?? '',
-      column.displayName ?? '',
+      column.displayName ?? column.name ?? '',
       userWithoutPermissionPage
     );
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts
@@ -113,7 +113,7 @@ test.describe.serial('Data Insight Report Application', () => {
     await expect(page.locator('#root\\/sendToTeams')).not.toBeChecked();
   });
 
-  test.fixme('Run application', async ({ page }) => {
+  test('Run application', async ({ page }) => {
     await page.click(
       '[data-testid="data-insights-report-application-card"] [data-testid="config-btn"]'
     );


### PR DESCRIPTION
Fixes #30637

### Describe your changes:

Two Playwright suites have been skipped for months. Both underlying causes are resolved, so this restores the coverage.

**1. `DataInsightReportApplication.spec.ts` — `Run application`**

Skipped by `c04e1a1dd6` (Apr 2025) with the message *"skip DI run app tests since it's not working as expected"* — no issue link and no code change, so no root cause was ever recorded.

Nothing in the path is broken today. `DataInsightsReportApplication` is an internal app (`appType: internal`, `scheduleType: ScheduledOrManual`), so `run-now` goes `AppResource.triggerApplication` → `ApplicationHandler.triggerApplicationOnDemand` → `AppScheduler` (in-process Quartz) — no Airflow and no ingestion container. SMTP is not required either: `EmailUtil` no-ops when `enableSmtpServer` is false, and the preceding `Edit application` test unchecks both `sendToAdmins` and `sendToTeams`, so `DataInsightsReportApp.execute` is a no-op. `OmAppJobListener` records `AppRunRecord.Status.SUCCESS`, which is what the test polls for. `SearchIndexApplication.spec.ts` already exercises the identical run-now + status-poll flow and is green in CI.

Unskipped as-is, no other edits to that file.

**2. `SearchRBAC.spec.ts` — `Table Column`**

Skipped by #26733 for `openmetadata-collate#3289` *"tableColumn index is giving all the column data"* — a column-FQN query against `index=tableColumn` returned every column doc, so the negative half could never reach its "No result found." assertion. That issue is closed ("Completed with 1.13"); the alias-expansion fix landed in #27813.

Table-level RBAC does cascade to columns today: a rule scoped to resource `table` expands through `SearchRepository.RBAC_CHILD_TYPES` → `getChildIndexAliases` → `RBACConditionEvaluator.getIndexFilter` into a `terms _index` covering the column index, and `ColumnSearchIndex` denormalises the parent table's owners/domains/tags/tier. Those are covered by unit tests, but this block is the only end-to-end coverage that a denied user cannot search a column.

Three latent problems are fixed alongside the unskip:

- `TableClass` columns have no `displayName`, so `column.displayName ?? ''` was the empty string and `hasText: ''` matched any card — the positive assertion was vacuous and the negative one failed on any rendered result. Now falls back to the column name, matching what the entity loop above already does.
- `beforeAll` did not wait for the column to be indexed, racing the async indexing pipeline.
- The block never cleaned up its table or users, leaking fixtures into a serial project.

### How I tested:

Against a full local stack, three consecutive runs each:

```
npx playwright test --project=SearchRBAC playwright/e2e/Flow/SearchRBAC.spec.ts \
  --grep "Table Column" --repeat-each=3
  → 9 passed (1.2m)   # incl. search-rbac setup/teardown

npx playwright test playwright/e2e/Pages/DataInsightReportApplication.spec.ts \
  --project=chromium --repeat-each=3
  → 12 passed (27.3s) # full serial suite: Install / Edit / Run / Uninstall
```

### Cherry-pick to 1.13

Structured as two commits, one per spec file. Both cherry-pick onto `origin/1.13` cleanly (verified in a scratch worktree — auto-merge, no conflicts).

`SearchRBAC.spec.ts` has diverged between branches: on `main` the RBAC toggle lives in the `search-rbac-setup`/`teardown` projects and the file imports `waitForSearchIndexed`; on `1.13` neither is true. The 1.13 PR therefore needs these 4 extra lines after the cherry-pick:

```diff
 import { uuid } from '../../utils/common';
+import { waitForSearchIndexed } from '../../utils/polling';
 import {
   enableDisableSearchRBAC,
```
```diff
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await enableDisableSearchRBAC(apiContext, true);
+
     await table.create(apiContext);
```

Neither belongs on `main`: `enableDisableSearchRBAC` is not imported here, and a trailing `afterAll(false)` would break the `Explore browse respects search RBAC across users` describe that relies on the flag staying on.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Re-enables two previously skipped Playwright suites and improves their CI coverage and reliability.
- Runs the Data Insight Report Application trigger-and-status test again.
- Restores table-column Search RBAC coverage with indexing synchronization, meaningful column-name assertions, and fixture cleanup.
- Updates the Playwright impact map so the report-application spec is directly selected when changed.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/playwright/impact-map.json | Replaces the broad delegated Data Insight pattern with explicit entries so the report-application spec participates in direct changed-spec selection. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts | Re-enables table-column RBAC tests and adds search-index synchronization, robust column-name matching, and ordered fixture teardown. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataInsightReportApplication.spec.ts | Re-enables the serial run-now test that polls the report application's latest execution status. |

</details>

<sub>Reviews (3): Last reviewed commit: ["ci(playwright): stop delegating DataInsi..."](https://github.com/open-metadata/openmetadata/commit/eac54435aca55ec73a1dce4c97c33b867a00fb24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48274240)</sub>

<!-- /greptile_comment -->