### PR TITLE
fix(governance): restore exclusion filter semantics + sanitize poisoned trigger filters

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
@@ -3035,25 +3035,29 @@ public class WorkflowDefinitionResourceIT {
     Glossary glossary = client.glossaries().create(createGlossary);
     LOG.debug("Created glossary: {}", glossary.getName());
 
-    // Create glossary term that SHOULD trigger workflow (has description)
+    // Trigger filter is an EXCLUSION filter: a matching JsonLogic tells the workflow to
+    // NOT trigger for that entity. A term whose description contains "workflow" therefore
+    // matches the filter and is EXCLUDED; a term without "workflow" in its description does
+    // not match, so the workflow runs and rewrites its displayName.
     CreateGlossaryTerm createTermToMatch =
         new CreateGlossaryTerm()
             .withName("createTermToMatch")
-            .withDisplayName("Complete Term")
-            .withDescription("This term has a description and should trigger workflow")
+            .withDisplayName("Excluded Term")
+            .withDescription("This term description contains workflow so it is excluded")
             .withGlossary(glossary.getFullyQualifiedName());
     GlossaryTerm termToMatch = client.glossaryTerms().create(createTermToMatch);
-    LOG.debug("Created glossary term that should match filter: {}", termToMatch.getName());
+    LOG.debug("Created glossary term that matches filter (excluded): {}", termToMatch.getName());
 
-    // Create glossary term that should NOT trigger workflow (will not match filter)
     CreateGlossaryTerm createTermNotToMatch =
         new CreateGlossaryTerm()
             .withName("createTermNotToMatch")
-            .withDisplayName("Incomplete Term")
+            .withDisplayName("Triggering Term")
             .withDescription("Simple description without the magic word")
             .withGlossary(glossary.getFullyQualifiedName());
     GlossaryTerm termNotToMatch = client.glossaryTerms().create(createTermNotToMatch);
-    LOG.debug("Created glossary term that should NOT match filter: {}", termNotToMatch.getName());
+    LOG.debug(
+        "Created glossary term that does not match filter (triggers): {}",
+        termNotToMatch.getName());
 
     // Ensure WorkflowEventConsumer is active
     ensureWorkflowEventConsumerIsActive(client);
@@ -3084,31 +3088,32 @@ public class WorkflowDefinitionResourceIT {
             .withDatabase(database.getFullyQualifiedName());
     DatabaseSchema dbSchema = client.databaseSchemas().create(createSchema);
 
-    // Create table that SHOULD trigger workflow (production table)
+    // Same exclusion semantics for the table entity: names containing "production" match the
+    // table filter and are EXCLUDED; names without "production" do not match, so the workflow
+    // triggers and rewrites the displayName.
     CreateTable createProdTable =
         new CreateTable()
             .withName("production_customer_data")
             .withDatabaseSchema(dbSchema.getFullyQualifiedName())
-            .withDescription("Production table that should trigger workflow")
+            .withDescription("Production table (matches filter -> excluded)")
             .withColumns(
                 List.of(
                     new Column().withName("id").withDataType(ColumnDataType.INT),
                     new Column().withName("data").withDataType(ColumnDataType.STRING)));
     Table prodTable = client.tables().create(createProdTable);
-    LOG.debug("Created production table that should match filter: {}", prodTable.getName());
+    LOG.debug("Created production table that matches filter (excluded): {}", prodTable.getName());
 
-    // Create table that should NOT trigger workflow (dev/test table)
     CreateTable createDevTable =
         new CreateTable()
             .withName("dev_test_table")
             .withDatabaseSchema(dbSchema.getFullyQualifiedName())
-            .withDescription("Dev table that should NOT trigger workflow")
+            .withDescription("Dev table (does not match filter -> triggers)")
             .withColumns(
                 List.of(
                     new Column().withName("id").withDataType(ColumnDataType.INT),
                     new Column().withName("test_data").withDataType(ColumnDataType.STRING)));
     Table devTable = client.tables().create(createDevTable);
-    LOG.debug("Created dev table that should NOT match filter: {}", devTable.getName());
+    LOG.debug("Created dev table that does not match filter (triggers): {}", devTable.getName());
 
     // Create workflow with entity-specific filters - using raw JSON like reference test
     String workflowJson =
@@ -3227,8 +3232,9 @@ public class WorkflowDefinitionResourceIT {
     JsonNode devTablePatch = MAPPER.readTree(devTablePatchStr);
     client.tables().patch(devTableId, devTablePatch);
 
-    // Wait for workflow processing using Awaitility
-    LOG.info("Waiting for workflow to process entities...");
+    // Wait for the non-matching entities to be processed by the workflow. Matching entities are
+    // silently excluded by the trigger filter, so we cannot wait on them — they never change.
+    LOG.info("Waiting for workflow to process non-matching entities...");
     await()
         .atMost(Duration.ofSeconds(180))
         .pollDelay(Duration.ofMillis(500))
@@ -3236,19 +3242,18 @@ public class WorkflowDefinitionResourceIT {
         .until(
             () -> {
               try {
-                // Check if entities that match filters got processed
-                GlossaryTerm updatedTermToMatch = client.glossaryTerms().get(termToMatchId);
-                Table updatedProdTable = client.tables().get(prodTableId);
+                GlossaryTerm updatedTermNotToMatch = client.glossaryTerms().get(termNotToMatchId);
+                Table updatedDevTable = client.tables().get(devTableId);
 
                 boolean termProcessed =
-                    updatedTermToMatch.getDisplayName() != null
-                        && updatedTermToMatch.getDisplayName().startsWith("[FILTERED]");
+                    updatedTermNotToMatch.getDisplayName() != null
+                        && updatedTermNotToMatch.getDisplayName().startsWith("[FILTERED]");
                 boolean tableProcessed =
-                    updatedProdTable.getDisplayName() != null
-                        && updatedProdTable.getDisplayName().startsWith("[FILTERED]");
+                    updatedDevTable.getDisplayName() != null
+                        && updatedDevTable.getDisplayName().startsWith("[FILTERED]");
 
                 if (termProcessed && tableProcessed) {
-                  LOG.debug("Both matching entities have been processed by workflow");
+                  LOG.debug("Both non-matching entities have been processed by workflow");
                   return true;
                 }
 
@@ -3266,35 +3271,34 @@ public class WorkflowDefinitionResourceIT {
     // Verify results
     LOG.info("Verifying workflow results");
 
-    // Entities that match filter should be processed
-    GlossaryTerm finalTermToMatch = client.glossaryTerms().get(termToMatchId);
-    assertTrue(
-        finalTermToMatch.getDisplayName().startsWith("[FILTERED]"),
-        "GlossaryTerm with description should have been processed by workflow");
-    LOG.info(
-        "✓ GlossaryTerm with description was correctly processed using glossaryterm-specific filter");
-
-    Table finalProdTable = client.tables().get(prodTableId);
-    assertTrue(
-        finalProdTable.getDisplayName().startsWith("[FILTERED]"),
-        "Production table should have been processed by workflow");
-    LOG.info(
-        "✓ Table with 'production' in name was correctly processed using table-specific filter");
-
-    // Entities that don't match filter should NOT be processed
+    // Entities that do NOT match filter should be processed (exclusion filter fell through).
     GlossaryTerm finalTermNotToMatch = client.glossaryTerms().get(termNotToMatchId);
-    assertFalse(
-        finalTermNotToMatch.getDisplayName() != null
-            && finalTermNotToMatch.getDisplayName().startsWith("[FILTERED]"),
-        "GlossaryTerm without description should NOT have been processed by workflow");
-    LOG.info("✓ GlossaryTerm without description was correctly filtered out");
+    assertTrue(
+        finalTermNotToMatch.getDisplayName().startsWith("[FILTERED]"),
+        "GlossaryTerm without the excluded keyword should have been processed by workflow");
+    LOG.info(
+        "✓ GlossaryTerm without 'workflow' in description was processed (exclusion filter did not match)");
 
     Table finalDevTable = client.tables().get(devTableId);
+    assertTrue(
+        finalDevTable.getDisplayName().startsWith("[FILTERED]"),
+        "Table without 'production' in name should have been processed by workflow");
+    LOG.info("✓ Table without 'production' in name was processed (exclusion filter did not match)");
+
+    // Entities that MATCH the filter must be excluded — the workflow must not touch them.
+    GlossaryTerm finalTermToMatch = client.glossaryTerms().get(termToMatchId);
     assertFalse(
-        finalDevTable.getDisplayName() != null
-            && finalDevTable.getDisplayName().startsWith("[FILTERED]"),
-        "Dev table should NOT have been processed by workflow");
-    LOG.info("✓ Table without 'production' in name was correctly filtered out");
+        finalTermToMatch.getDisplayName() != null
+            && finalTermToMatch.getDisplayName().startsWith("[FILTERED]"),
+        "GlossaryTerm matching the exclusion filter should NOT have been processed by workflow");
+    LOG.info("✓ GlossaryTerm with 'workflow' in description was correctly excluded");
+
+    Table finalProdTable = client.tables().get(prodTableId);
+    assertFalse(
+        finalProdTable.getDisplayName() != null
+            && finalProdTable.getDisplayName().startsWith("[FILTERED]"),
+        "Production table matching the exclusion filter should NOT have been processed");
+    LOG.info("✓ Table with 'production' in name was correctly excluded");
 
     try {
       WorkflowDefinition wd = client.workflowDefinitions().getByName(workflowName, null);

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java
@@ -10630,4 +10630,160 @@ public class WorkflowDefinitionResourceIT {
       LOG.warn("Cleanup error: {}", e.getMessage());
     }
   }
+
+  /**
+   * Trigger filter is an EXCLUSION filter: if the JsonLogic evaluates to TRUE for the entity, the
+   * workflow does NOT trigger; if it evaluates to FALSE, or the filter is unparseable garbage
+   * (returns false from RuleEngine on any exception), the workflow triggers normally.
+   *
+   * <p>Original design: PR #22437 (return {@code !jsonFilter}, comment: "if jsonLogic evaluates
+   * to true, then don't trigger the workflow"). Task Redesign (PR #25894) accidentally dropped
+   * the {@code !} inversion and flipped this to inclusion, breaking every customer with a real
+   * JsonLogic filter or a legacy poisoned filter value like {@code "\"\""}.
+   *
+   * <p>Test exercises three cases end to end against the real trigger BPMN + FilterEntityImpl:
+   * a valid filter that does NOT match (triggers), a valid filter that matches (excludes), and
+   * a poisoned filter that fails to parse (falls open, triggers).
+   */
+  @Test
+  @Order(200)
+  void test_EventTriggerFilterIsExclusionAndFailsOpen(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ensureWorkflowEventConsumerIsActive(client);
+
+    String workflowName = ns.prefix("exclusionFilterWorkflow").substring(0, 30);
+    String glossaryName = ns.prefix("exclusionGlossary").substring(0, 30);
+    String triggerMarker = "trigger";
+    String excludeMarker = "skipme";
+
+    createExclusionFilterWorkflow(client, workflowName, excludeMarker);
+    Glossary glossary = createExclusionGlossary(client, glossaryName);
+
+    GlossaryTerm triggeringTerm =
+        createTerm(client, glossary, "triggering_term", triggerMarker + " content");
+    GlossaryTerm excludedTerm =
+        createTerm(client, glossary, "excluded_term", excludeMarker + " content");
+
+    awaitDisplayNamePrefixedWith(client, triggeringTerm.getId(), "[TRIGGERED]");
+    assertDisplayNameUnchangedAfterQuietPeriod(client, excludedTerm.getId());
+
+    patchFilterOn(client, workflowName, "\"\\\"\\\"\"");
+    GlossaryTerm poisonedTerm =
+        createTerm(client, glossary, "poisoned_term", "any content, filter is broken");
+    awaitDisplayNamePrefixedWith(client, poisonedTerm.getId(), "[TRIGGERED]");
+  }
+
+  private void createExclusionFilterWorkflow(
+      OpenMetadataClient client, String workflowName, String excludeMarker) throws Exception {
+    // JsonLogic: description contains excludeMarker → excludes term from workflow trigger.
+    String filterLogic =
+        String.format(
+            "{\\\"in\\\": [\\\"%s\\\", {\\\"var\\\": \\\"description\\\"}]}", excludeMarker);
+    String workflowJson =
+        String.format(
+            """
+            {
+              "name": "%s",
+              "displayName": "Exclusion Filter Test Workflow",
+              "description": "Verifies the trigger filter behaves as an exclusion filter",
+              "trigger": {
+                "type": "eventBasedEntity",
+                "config": {
+                  "entityTypes": ["glossaryTerm"],
+                  "events": ["Created", "Updated"],
+                  "exclude": ["reviewers"],
+                  "filter": {"glossaryTerm": "%s"}
+                },
+                "output": ["relatedEntity", "updatedBy"]
+              },
+              "nodes": [
+                {"type": "startEvent", "subType": "startEvent", "name": "start", "displayName": "Start"},
+                {
+                  "type": "automatedTask",
+                  "subType": "setEntityAttributeTask",
+                  "name": "MarkTriggered",
+                  "displayName": "Mark Triggered",
+                  "config": {"fieldName": "displayName", "fieldValue": "[TRIGGERED]"},
+                  "input": ["relatedEntity", "updatedBy"],
+                  "inputNamespaceMap": {"relatedEntity": "global", "updatedBy": "global"},
+                  "output": []
+                },
+                {"type": "endEvent", "subType": "endEvent", "name": "end", "displayName": "End"}
+              ],
+              "edges": [
+                {"from": "start", "to": "MarkTriggered"},
+                {"from": "MarkTriggered", "to": "end"}
+              ],
+              "config": {"storeStageStatus": false}
+            }
+            """,
+            workflowName, filterLogic);
+    CreateWorkflowDefinition workflow =
+        MAPPER.readValue(workflowJson, CreateWorkflowDefinition.class);
+    String response =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.POST, BASE_PATH, workflow, RequestOptions.builder().build());
+    trackWorkflowFromJson(MAPPER.readTree(response));
+    waitForWorkflowDeployment(client, workflowName);
+  }
+
+  private Glossary createExclusionGlossary(OpenMetadataClient client, String name)
+      throws Exception {
+    CreateGlossary create =
+        new CreateGlossary()
+            .withName(name)
+            .withDisplayName(name)
+            .withDescription("Glossary for exclusion filter test");
+    return client.glossaries().create(create);
+  }
+
+  private GlossaryTerm createTerm(
+      OpenMetadataClient client, Glossary glossary, String name, String description)
+      throws Exception {
+    CreateGlossaryTerm create =
+        new CreateGlossaryTerm()
+            .withName(name)
+            .withDisplayName(name)
+            .withDescription(description)
+            .withGlossary(glossary.getFullyQualifiedName());
+    return client.glossaryTerms().create(create);
+  }
+
+  private void patchFilterOn(
+      OpenMetadataClient client, String workflowName, String filterMapJsonValue) throws Exception {
+    WorkflowDefinition workflow = client.workflowDefinitions().getByName(workflowName, null);
+    String patchStr =
+        String.format(
+            "[{\"op\":\"replace\",\"path\":\"/trigger/config/filter\",\"value\":{\"glossaryTerm\":%s}}]",
+            filterMapJsonValue);
+    client.workflowDefinitions().patch(workflow.getId(), MAPPER.readTree(patchStr));
+  }
+
+  private void awaitDisplayNamePrefixedWith(
+      OpenMetadataClient client, UUID termId, String expectedPrefix) {
+    await("glossary term " + termId + " displayName starts with " + expectedPrefix)
+        .atMost(Duration.ofSeconds(60))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .until(
+            () -> {
+              GlossaryTerm current = client.glossaryTerms().get(termId);
+              return current.getDisplayName() != null
+                  && current.getDisplayName().startsWith(expectedPrefix);
+            });
+  }
+
+  private void assertDisplayNameUnchangedAfterQuietPeriod(OpenMetadataClient client, UUID termId)
+      throws Exception {
+    String originalDisplayName = client.glossaryTerms().get(termId).getDisplayName();
+    simulateWork(Duration.ofSeconds(20).toMillis());
+    GlossaryTerm current = client.glossaryTerms().get(termId);
+    assertEquals(
+        originalDisplayName,
+        current.getDisplayName(),
+        "Excluded term must not be touched by workflow, but displayName changed to "
+            + current.getDisplayName());
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImpl.java
@@ -5,6 +5,7 @@ import static org.openmetadata.service.governance.workflows.Workflow.RELATED_ENT
 import static org.openmetadata.service.governance.workflows.Workflow.TRIGGERING_OBJECT_ID_VARIABLE;
 import static org.openmetadata.service.governance.workflows.elements.triggers.EventBasedEntityTrigger.PASSES_FILTER_VARIABLE;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +33,8 @@ import org.slf4j.LoggerFactory;
 
 public class FilterEntityImpl implements JavaDelegate {
   private static final Logger log = LoggerFactory.getLogger(FilterEntityImpl.class);
+  private static final TypeReference<java.util.Map<String, String>> FILTER_MAP_TYPE =
+      new TypeReference<>() {};
   private Expression excludedFieldsExpr;
   private Expression includeFieldsExpr;
   private Expression filterExpr;
@@ -89,7 +92,10 @@ public class FilterEntityImpl implements JavaDelegate {
       return null;
     }
 
-    // Parse JSON string into map if needed
+    // Flowable's Expression#getValue returns Object; the trigger BPMN feeds it the raw
+    // Config#filter, itself typed as Object because the JSON Schema is a oneOf of string
+    // (legacy top-level JsonLogic) and object (per-entity map). Both variants have to be
+    // decoded here.
     if (filterObj instanceof String filterStr) {
       // Handle empty string as "no filter"
       if (filterStr.trim().isEmpty()) {
@@ -98,8 +104,7 @@ public class FilterEntityImpl implements JavaDelegate {
       // Check if it's a JSON object string
       if (filterStr.trim().startsWith("{") && filterStr.trim().endsWith("}")) {
         try {
-          java.util.Map<String, String> filterMap =
-              JsonUtils.readValue(filterStr, java.util.Map.class);
+          java.util.Map<String, String> filterMap = JsonUtils.readValue(filterStr, FILTER_MAP_TYPE);
           return extractFromFilterMap(filterMap, entityType);
         } catch (Exception e) {
           log.error(
@@ -112,10 +117,11 @@ public class FilterEntityImpl implements JavaDelegate {
       return null;
     }
 
-    // Handle map format with entity-specific filters
+    // Second variant of the oneOf: entity-specific filter map already deserialized as a Map.
+    // Use JsonUtils.convertValue so the coercion to Map<String,String> is done by Jackson with a
+    // typed TypeReference instead of an unchecked cast.
     if (filterObj instanceof java.util.Map) {
-      @SuppressWarnings("unchecked")
-      java.util.Map<String, String> filterMap = (java.util.Map<String, String>) filterObj;
+      java.util.Map<String, String> filterMap = JsonUtils.convertValue(filterObj, FILTER_MAP_TYPE);
       return extractFromFilterMap(filterMap, entityType);
     }
 
@@ -127,20 +133,25 @@ public class FilterEntityImpl implements JavaDelegate {
     if (filterMap == null || entityType == null) {
       return null;
     }
-
-    // First check for entity-specific filter
-    String specificFilter = filterMap.get(entityType);
-    if (specificFilter != null && !specificFilter.trim().isEmpty()) {
+    String specificFilter = sanitizeFilterValue(filterMap.get(entityType));
+    if (specificFilter != null) {
       return specificFilter;
     }
+    return sanitizeFilterValue(filterMap.get("default"));
+  }
 
-    // Fall back to default filter if no specific filter found
-    String defaultFilter = filterMap.get("default");
-    if (defaultFilter != null && !defaultFilter.trim().isEmpty()) {
-      return defaultFilter;
+  // A saved-but-empty filter from the UI can serialize as a JSON-encoded empty
+  // string (\"\") or empty object ({}) instead of being dropped. Treat those as
+  // "no filter" so RuleEngine never sees garbage that it can't parse.
+  private static String sanitizeFilterValue(String filter) {
+    String sanitized = null;
+    if (filter != null) {
+      String trimmed = filter.trim();
+      if (!trimmed.isEmpty() && !"\"\"".equals(trimmed) && !"{}".equals(trimmed)) {
+        sanitized = filter;
+      }
     }
-
-    return null;
+    return sanitized;
   }
 
   private boolean isTagFeedbackCreation(WorkflowVariableHandler varHandler) {
@@ -202,15 +213,22 @@ public class FilterEntityImpl implements JavaDelegate {
               || passesFieldBasedFilter(changedFields, includeFields, excludedFilter);
     }
 
-    // Apply JSON filter
-    boolean passesJsonFilter = true;
+    return fieldBasedFilter && !matchesExclusionFilter(filterLogic, entity);
+  }
+
+  // Trigger filter is EXCLUSION: if the JsonLogic evaluates to TRUE, the entity
+  // is excluded from triggering the workflow. Non-match (FALSE) or unparseable
+  // filter (RuleEngine returns false on any exception) → NOT excluded, workflow
+  // triggers. Restoring the original design from PR #22437; Task Redesign (#25894)
+  // accidentally dropped the "!" inversion and flipped this to inclusion.
+  private boolean matchesExclusionFilter(String filterLogic, EntityInterface entity) {
+    boolean matches = false;
     if (filterLogic != null && !filterLogic.trim().isEmpty()) {
-      passesJsonFilter =
+      matches =
           Boolean.TRUE.equals(
               RuleEngine.getInstance().apply(filterLogic, JsonUtils.getMap(entity)));
     }
-
-    return fieldBasedFilter && passesJsonFilter;
+    return matches;
   }
 
   private List<FieldChange> getAllChangedFields(ChangeDescription changeDescription) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1133/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1133/Migration.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.migration.mysql.v1133;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.MYSQL;
 import static org.openmetadata.service.migration.utils.v1133.MigrationUtil.backfillDataContractTestSuiteRelationships;
+import static org.openmetadata.service.migration.utils.v1133.MigrationUtil.sanitizePoisonedTriggerFilters;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -18,10 +19,16 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
+    initializeWorkflowHandler();
     try {
       backfillDataContractTestSuiteRelationships(handle, MYSQL);
     } catch (Exception e) {
       LOG.error("v1133: failed to backfill dataContract -> testSuite relationships", e);
+    }
+    try {
+      sanitizePoisonedTriggerFilters();
+    } catch (Exception e) {
+      LOG.error("v1133: failed to sanitize poisoned trigger filters", e);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1133/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1133/Migration.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.migration.postgres.v1133;
 
 import static org.openmetadata.service.jdbi3.locator.ConnectionType.POSTGRES;
 import static org.openmetadata.service.migration.utils.v1133.MigrationUtil.backfillDataContractTestSuiteRelationships;
+import static org.openmetadata.service.migration.utils.v1133.MigrationUtil.sanitizePoisonedTriggerFilters;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -18,10 +19,16 @@ public class Migration extends MigrationProcessImpl {
   @Override
   @SneakyThrows
   public void runDataMigration() {
+    initializeWorkflowHandler();
     try {
       backfillDataContractTestSuiteRelationships(handle, POSTGRES);
     } catch (Exception e) {
       LOG.error("v1133: failed to backfill dataContract -> testSuite relationships", e);
+    }
+    try {
+      sanitizePoisonedTriggerFilters();
+    } catch (Exception e) {
+      LOG.error("v1133: failed to sanitize poisoned trigger filters", e);
     }
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1133/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1133/MigrationUtil.java
@@ -1,16 +1,31 @@
 package org.openmetadata.service.migration.utils.v1133;
 
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Handle;
 import org.openmetadata.schema.exception.JsonParsingException;
+import org.openmetadata.schema.governance.workflows.WorkflowDefinition;
+import org.openmetadata.schema.governance.workflows.elements.triggers.Config;
+import org.openmetadata.schema.governance.workflows.elements.triggers.EventBasedEntityTriggerDefinition;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.ListFilter;
+import org.openmetadata.service.jdbi3.WorkflowDefinitionRepository;
 import org.openmetadata.service.jdbi3.locator.ConnectionType;
+import org.openmetadata.service.util.EntityUtil;
 
 @Slf4j
 public class MigrationUtil {
+  private static final String ADMIN_USER_NAME = "admin";
+  private static final TypeReference<Map<String, String>> FILTER_MAP_TYPE =
+      new TypeReference<>() {};
+
   private MigrationUtil() {}
 
   private static final int BATCH_SIZE = 500;
@@ -112,6 +127,126 @@ public class MigrationUtil {
       }
     }
     return hit;
+  }
+
+  /**
+   * Sanitize poisoned trigger filter values on every eventBasedEntity WorkflowDefinition.
+   *
+   * <p>Prior UI versions serialized incomplete filter trees (user picked a field but no
+   * operator) as the JSON-encoded empty string {@code "\"\""}. The v1.10.5 migration then
+   * copied that value into per-entity keys and an unused {@code default} key. Task Redesign
+   * (2.0) dropped the {@code !} inversion in FilterEntityImpl, flipping the trigger filter
+   * from exclusion to inclusion, so every poisoned row now silently skips its workflow.
+   *
+   * <p>This migration walks every workflowDefinition and drops any filter map entry
+   * whose value is empty / whitespace / {@code "\"\""} / {@code "{}"} — including a
+   * poisoned {@code default} key left behind by the v1.10.5 migration. A non-poisoned
+   * {@code default} entry is preserved because {@code FilterEntityImpl.extractFromFilterMap}
+   * still falls back to it. Complements the runtime sanitizer in
+   * {@code FilterEntityImpl.sanitizeFilterValue}.
+   */
+  public static void sanitizePoisonedTriggerFilters() {
+    LOG.info("v1133: scanning workflowDefinitions to sanitize poisoned trigger filters");
+    int scanned = 0;
+    int fixed = 0;
+    try {
+      WorkflowDefinitionRepository repository =
+          (WorkflowDefinitionRepository) Entity.getEntityRepository(Entity.WORKFLOW_DEFINITION);
+      List<WorkflowDefinition> workflowDefinitions =
+          repository.listAll(EntityUtil.Fields.EMPTY_FIELDS, new ListFilter());
+      for (WorkflowDefinition workflowDefinition : listOrEmpty(workflowDefinitions)) {
+        scanned++;
+        if (dropPoisonedFilterEntries(workflowDefinition)) {
+          try {
+            repository.createOrUpdate(null, workflowDefinition, ADMIN_USER_NAME);
+            fixed++;
+            LOG.info(
+                "v1133: sanitized poisoned trigger filter on '{}'", workflowDefinition.getName());
+          } catch (Exception e) {
+            LOG.warn(
+                "v1133: failed to persist sanitized filter for '{}': {}",
+                workflowDefinition.getName(),
+                e.getMessage());
+          }
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("v1133: failed to sanitize poisoned trigger filters", e);
+    }
+    LOG.info("v1133: trigger filter sanitizer scanned={} fixed={}", scanned, fixed);
+  }
+
+  private static boolean dropPoisonedFilterEntries(WorkflowDefinition workflowDefinition) {
+    boolean modified = false;
+    // WorkflowDefinition#getTrigger() returns the schema-generated TriggerDefinition base
+    // (schema-first oneOf across eventBasedEntity / periodicBatchEntity / noOp); this migration
+    // only touches eventBasedEntity, hence the pattern-match on the concrete subtype.
+    if (workflowDefinition.getTrigger() instanceof EventBasedEntityTriggerDefinition eventTrigger) {
+      Config config = eventTrigger.getConfig();
+      if (config != null && config.getFilter() != null) {
+        Map<String, String> filterMap = coerceToStringMap(config.getFilter());
+        if (filterMap != null) {
+          Map<String, String> cleaned = retainNonPoisonedEntries(filterMap);
+          if (cleaned.size() != filterMap.size()) {
+            config.setFilter(cleaned);
+            modified = true;
+          }
+        }
+      }
+    }
+    return modified;
+  }
+
+  private static Map<String, String> retainNonPoisonedEntries(Map<String, String> filterMap) {
+    Map<String, String> cleaned = new HashMap<>();
+    for (Map.Entry<String, String> entry : filterMap.entrySet()) {
+      if (!isPoisonedFilterValue(entry.getValue())) {
+        cleaned.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return cleaned;
+  }
+
+  // Config#getFilter() is generated as Object because the JSON Schema declares filter as a
+  // "oneOf" of string (legacy top-level JsonLogic) and object (per-entity map). Rows written
+  // before v1.10.5 still carry the string variant, so both shapes have to be handled here.
+  private static Map<String, String> coerceToStringMap(Object filter) {
+    Map<String, String> result = null;
+    if (filter instanceof Map<?, ?> raw) {
+      result = coerceMapEntries(raw);
+    } else if (filter instanceof String filterStr && !filterStr.isBlank()) {
+      result = parseFilterJson(filterStr);
+    }
+    return result;
+  }
+
+  private static Map<String, String> coerceMapEntries(Map<?, ?> raw) {
+    Map<String, String> result = new HashMap<>();
+    for (Map.Entry<?, ?> entry : raw.entrySet()) {
+      if (entry.getKey() != null && entry.getValue() != null) {
+        result.put(entry.getKey().toString(), entry.getValue().toString());
+      }
+    }
+    return result;
+  }
+
+  private static Map<String, String> parseFilterJson(String filterStr) {
+    Map<String, String> result = null;
+    try {
+      result = JsonUtils.readValue(filterStr, FILTER_MAP_TYPE);
+    } catch (Exception ignored) {
+      // Legacy string filter that isn't a JSON object → left for FilterEntityImpl to reject.
+    }
+    return result;
+  }
+
+  private static boolean isPoisonedFilterValue(String value) {
+    boolean poisoned = true;
+    if (value != null) {
+      String trimmed = value.trim();
+      poisoned = trimmed.isEmpty() || "\"\"".equals(trimmed) || "{}".equals(trimmed);
+    }
+    return poisoned;
   }
 
   private static String extractTestSuiteId(String contractJson) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImplTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImplTest.java
@@ -13,11 +13,15 @@
 
 package org.openmetadata.service.governance.workflows.elements.triggers.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.type.FieldChange;
@@ -26,6 +30,8 @@ class FilterEntityImplTest {
 
   private FilterEntityImpl filterEntity;
   private Method passesFieldBasedFilter;
+  private Method sanitizeFilterValue;
+  private Method extractFromFilterMap;
 
   @BeforeEach
   void setUp() throws Exception {
@@ -34,6 +40,12 @@ class FilterEntityImplTest {
         FilterEntityImpl.class.getDeclaredMethod(
             "passesFieldBasedFilter", List.class, List.class, List.class);
     passesFieldBasedFilter.setAccessible(true);
+    sanitizeFilterValue =
+        FilterEntityImpl.class.getDeclaredMethod("sanitizeFilterValue", String.class);
+    sanitizeFilterValue.setAccessible(true);
+    extractFromFilterMap =
+        FilterEntityImpl.class.getDeclaredMethod("extractFromFilterMap", Map.class, String.class);
+    extractFromFilterMap.setAccessible(true);
   }
 
   @Test
@@ -215,11 +227,92 @@ class FilterEntityImplTest {
     assertTrue(invokeFilter(List.of(fieldChange("schema")), null, excludeFields));
   }
 
+  // sanitizeFilterValue: guards against the historical UI bug where an incomplete
+  // filter tree was serialized as a JSON-encoded empty string \"\" and persisted
+  // per entity in the trigger config. Also handles \"{}\" and whitespace forms.
+
+  @Test
+  void testSanitizeFilterValueTreatsNullAsNoFilter() throws Exception {
+    assertNull(invokeSanitize(null));
+  }
+
+  @Test
+  void testSanitizeFilterValueTreatsEmptyStringAsNoFilter() throws Exception {
+    assertNull(invokeSanitize(""));
+    assertNull(invokeSanitize("   "));
+  }
+
+  @Test
+  void testSanitizeFilterValueTreatsJsonEncodedEmptyAsNoFilter() throws Exception {
+    assertNull(invokeSanitize("\"\""));
+    assertNull(invokeSanitize("  \"\"  "));
+  }
+
+  @Test
+  void testSanitizeFilterValueTreatsEmptyObjectAsNoFilter() throws Exception {
+    assertNull(invokeSanitize("{}"));
+    assertNull(invokeSanitize("  {}  "));
+  }
+
+  @Test
+  void testSanitizeFilterValuePreservesRealFilter() throws Exception {
+    String filter = "{\"==\":[{\"var\":\"name\"},\"foo\"]}";
+    assertEquals(filter, invokeSanitize(filter));
+  }
+
+  // extractFromFilterMap: entity-specific value wins over default; poisoned values
+  // are skipped instead of leaking into RuleEngine (which fails and would flip the
+  // exclusion filter's fail-open semantics into a hard reject).
+
+  @Test
+  void testExtractFromFilterMapPrefersEntitySpecificOverDefault() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("default", "{\"==\":[1,1]}");
+    map.put("glossaryTerm", "{\"==\":[{\"var\":\"name\"},\"foo\"]}");
+    assertEquals("{\"==\":[{\"var\":\"name\"},\"foo\"]}", invokeExtract(map, "glossaryTerm"));
+  }
+
+  @Test
+  void testExtractFromFilterMapFallsBackToDefault() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("default", "{\"==\":[1,1]}");
+    assertEquals("{\"==\":[1,1]}", invokeExtract(map, "glossaryTerm"));
+  }
+
+  @Test
+  void testExtractFromFilterMapPoisonedEntitySpecificFallsBackToDefault() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("default", "{\"==\":[1,1]}");
+    map.put("glossaryTerm", "\"\"");
+    assertEquals("{\"==\":[1,1]}", invokeExtract(map, "glossaryTerm"));
+  }
+
+  @Test
+  void testExtractFromFilterMapAllPoisonedReturnsNull() throws Exception {
+    Map<String, String> map = new HashMap<>();
+    map.put("default", "\"\"");
+    map.put("glossaryTerm", "\"\"");
+    assertNull(invokeExtract(map, "glossaryTerm"));
+  }
+
+  @Test
+  void testExtractFromFilterMapEmptyMapReturnsNull() throws Exception {
+    assertNull(invokeExtract(new HashMap<>(), "glossaryTerm"));
+  }
+
   private boolean invokeFilter(
       List<FieldChange> changedFields, List<String> includeFields, List<String> excludeFields)
       throws Exception {
     return (boolean)
         passesFieldBasedFilter.invoke(filterEntity, changedFields, includeFields, excludeFields);
+  }
+
+  private String invokeSanitize(String filter) throws Exception {
+    return (String) sanitizeFilterValue.invoke(null, filter);
+  }
+
+  private String invokeExtract(Map<String, String> map, String entityType) throws Exception {
+    return (String) extractFromFilterMap.invoke(filterEntity, map, entityType);
   }
 
   private FieldChange fieldChange(String name) {


### PR DESCRIPTION
## Summary

Trigger filter on eventBasedEntity workflows was designed as an **exclusion filter** in PR #22437 (code comment: *"if jsonLogic evaluates to true, then don't trigger the workflow"*, `return !jsonFilter`). Task Redesign (PR #25894) accidentally dropped the `!` inversion, flipping it to **inclusion**. Match now triggers, unparseable garbage skips — the exact opposite of the intent. This silently broke:

1. Every customer with a real JsonLogic filter (semantics inverted).
2. Every historical row carrying the `"\"\""` poison left behind by the old UI + v1.10.5 migration (workflow silently halted at trigger).

Confirmed live on divisionsinc-beta: Glossary Approval Workflow stopped firing on new terms after upgrade past Task Redesign.

## Fix

**`FilterEntityImpl`**
- Restore exclusion: `return fieldBasedFilter && !matchesExclusionFilter(...)`.
- New `sanitizeFilterValue` guards against JSON-encoded empty (`"\"\""`), empty-object (`"{}"`), and whitespace values in per-entity filter maps. Poisoned values are treated as no-filter instead of being handed to RuleEngine, which would throw and turn the intended fail-open into a hard reject.

**`v210/MigrationUtil.sanitizePoisonedTriggerFilters`**
- Walks every eventBasedEntity WorkflowDefinition on upgrade.
- Drops filter-map entries whose values are empty / whitespace / JSON-encoded-empty / empty-object.
- Idempotent; non-destructive on real filters.
- Wired into new `v210/Migration` for both MySQL and Postgres.

## Semantics — before / after

| JsonLogic result | Before this PR (broken inclusion) | After (restored exclusion) |
|---|---|---|
| TRUE (matches) | trigger workflow | **skip** (excluded) |
| FALSE (no match) | skip | **trigger** |
| Unparseable (RuleEngine returns false) | skip (hard reject) | **trigger** (fail-open) |

## Tests

- **`FilterEntityImplTest`** — unit tests for `sanitizeFilterValue` and `extractFromFilterMap` covering null / empty / `"\"\""` / `"{}"` / real-filter cases plus fall-back-to-default when the entity-specific value is poisoned.
- **`WorkflowDefinitionResourceIT.test_EventTriggerFilterIsExclusionAndFailsOpen`** — end-to-end IT creating a dedicated workflow with an exclusion filter, verifying:
  1. Non-matching term (`description="trigger content"`) → workflow triggers → displayName rewritten to `[TRIGGERED]`.
  2. Matching term (`description="skipme content"`) → workflow skipped → displayName unchanged after 20s quiet period.
  3. Poisoned `"\"\""` filter → RuleEngine throws → fall-open → new term triggers.

  Passed against a full Postgres + Elasticsearch + Flowable stack (testcontainers). `Tests run: 1, Failures: 0, Errors: 0`, elapsed 23.4s.

## References

- Original design: PR #22437 (exclusion, `return !jsonFilter`)
- Regression: PR #25894 (Task Redesign, dropped the `!`)
- Follow-ups (Collate): #5355 (UI: label field as exclusion + guard incomplete-tree emit), #5356 (backend tracking)

## Test plan

- [x] `mvn test -pl openmetadata-service -Dtest=FilterEntityImplTest`
- [x] `mvn test -pl openmetadata-integration-tests -Dtest='WorkflowDefinitionResourceIT#test_EventTriggerFilterIsExclusionAndFailsOpen'`
- [x] Manual repro on live server 8585: inject `"\"\""` poison → workflow halted; PATCH filter to `{}` → workflow triggers again.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores governance workflow trigger filters to exclusion semantics and cleans up historically poisoned filter values.
- Sanitizes empty filter encodings both at runtime and during the v1.13.3 data migration.
- Adds equivalent MySQL and PostgreSQL migration hooks.
- Updates unit and integration coverage for matching, non-matching, and poisoned filters.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because the migration classes still lack mandatory license headers and will fail repository validation.

The functional filter changes are covered, but both vendor-specific migration classes still begin directly with package declarations, leaving the previously reported license-gate failure outstanding.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1133/Migration.java; openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1133/Migration.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/triggers/impl/FilterEntityImpl.java | Restores exclusion-filter inversion and sanitizes empty entity-specific and default filter values before JsonLogic evaluation. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v1133/MigrationUtil.java | Adds an idempotent workflow-definition migration that removes poisoned values while preserving real filters. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v1133/Migration.java | Initializes workflow infrastructure and invokes the filter sanitizer during the MySQL data migration. |
| openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v1133/Migration.java | Mirrors the workflow-filter sanitation hook for PostgreSQL upgrades. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/WorkflowDefinitionResourceIT.java | Verifies exclusion behavior and fail-open handling against the end-to-end workflow path. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Workflow entity event] --> B[Resolve entity-specific or default filter]
  B --> C{Filter value poisoned?}
  C -->|Yes| D[Treat as no filter]
  C -->|No| E[Evaluate JsonLogic]
  D --> F[Trigger workflow]
  E --> G{Matches exclusion filter?}
  G -->|Yes| H[Skip workflow]
  G -->|No or evaluation error| F
  I[v1.13.3 migration] --> J[Load event-based workflows]
  J --> K[Remove poisoned map entries]
  K --> L[Persist cleaned definitions]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["test(governance): flip test\_EntitySpecif..."](https://github.com/open-metadata/openmetadata/commit/1178de91ec7306c1a10318a62d39c2782dc27b77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48295376)</sub>

**Context used:**

- Knowledge Base — [Governance Workflows and Applications in OpenMetadata Service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-workflows-apps.md)
- Knowledge Base — [Bootstrap SQL and the Database Migration Runner](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/bootstrap-migrations.md)

<!-- /greptile_comment -->