### PR TITLE
fix(playwright): eliminate flakiness in DataContracts and DataContractsSemanticRules specs

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts
@@ -341,8 +341,14 @@ test.describe('Data Contracts', () => {
       });
 
       await test.step('Save contract and validate for semantics', async () => {
-        // save and trigger contract validation
-        await saveAndTriggerDataContractValidation(page, true);
+        // save and trigger contract validation; the utility now polls the API
+        // until the result is terminal before reloading, so the status check
+        // below is reliable even when the backend is slow.
+        const contractData = await saveAndTriggerDataContractValidation(
+          page,
+          true
+        );
+        const contractId = (contractData as { id?: string })?.id;
 
         await expect(
           page.getByTestId('contract-status-card-item-semantics-status')
@@ -370,7 +376,9 @@ test.describe('Data Contracts', () => {
           .getByText('Contract validation trigger successfully.')
           .waitFor({ state: 'visible' });
 
-        await triggerContractValidation(page);
+        // Pass contractId so the utility polls for the terminal state before
+        // returning, making the 'Passed' assertion below reliable.
+        await triggerContractValidation(page, contractId);
         await toastPromise;
 
         await page.reload();
@@ -1100,8 +1108,14 @@ test.describe('Data Contracts', () => {
 
     await expect(page.locator('.semantic-rule-editor-view-only')).toBeVisible();
 
-    // save and trigger contract validation
-    await saveAndTriggerDataContractValidation(page, true);
+    // save and trigger contract validation; the utility now polls the API
+    // until the result is terminal before reloading, so the status check
+    // below is reliable even when the backend is slow.
+    const contractData1104 = await saveAndTriggerDataContractValidation(
+      page,
+      true
+    );
+    const contractId1104 = (contractData1104 as { id?: string })?.id;
 
     await expect(
       page.getByTestId('contract-status-card-item-semantics-status')
@@ -1139,7 +1153,9 @@ test.describe('Data Contracts', () => {
       .getByText('Contract validation trigger successfully.')
       .waitFor({ state: 'visible' });
 
-    await triggerContractValidation(page);
+    // Pass contractId so the utility polls for the terminal state before
+    // returning, making the 'Passed' assertion below reliable.
+    await triggerContractValidation(page, contractId1104);
     await toastPromise;
 
     await page.reload();
@@ -1285,8 +1301,14 @@ test.describe('Data Contracts', () => {
 
     await expect(page.locator('.semantic-rule-editor-view-only')).toBeVisible();
 
-    // save and trigger contract validation
-    await saveAndTriggerDataContractValidation(page, true);
+    // save and trigger contract validation; the utility now polls the API
+    // until the result is terminal before reloading, so the status check
+    // below is reliable even when the backend is slow.
+    const contractData1289 = await saveAndTriggerDataContractValidation(
+      page,
+      true
+    );
+    const contractId1289 = (contractData1289 as { id?: string })?.id;
 
     await expect(
       page.getByTestId('contract-status-card-item-semantics-status')
@@ -1321,7 +1343,9 @@ test.describe('Data Contracts', () => {
       .getByText('Contract validation trigger successfully.')
       .waitFor({ state: 'visible' });
 
-    await triggerContractValidation(page);
+    // Pass contractId so the utility polls for the terminal state before
+    // returning, making the 'Failed' assertion below reliable.
+    await triggerContractValidation(page, contractId1289);
     await toastPromise;
 
     await page.reload();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractsSemanticRules.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractsSemanticRules.spec.ts
@@ -1003,8 +1003,40 @@ test.describe('Data Contracts Semantics Rule Domain', () => {
     const { apiContext, afterAction } = await performAdminLogin(browser);
     domain1 = new Domain();
     domain2 = new Domain();
-    await domain1.create(apiContext);
-    await domain2.create(apiContext);
+
+    // When a test is retried on a new worker the beforeAll re-runs with the
+    // same domain objects (same UUID in data.name). If the first run already
+    // created them the POST returns 409; in that case fetch the existing entity
+    // so responseData is populated and the tests can proceed normally.
+    for (const domain of [domain1, domain2]) {
+      try {
+        await domain.create(apiContext);
+      } catch (err) {
+        if ((err as Error).message?.includes('409')) {
+          const encodedName = encodeURIComponent(
+            domain.data.fullyQualifiedName ?? domain.data.name
+          );
+          const res = await apiContext.get(
+            `/api/v1/domains/name/${encodedName}`
+          );
+          if (res.ok()) {
+            domain.responseData = await res.json();
+          } else {
+            throw err;
+          }
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    await afterAction();
+  });
+
+  test.afterAll('Cleanup domains', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await domain1.delete(apiContext).catch(() => {});
+    await domain2.delete(apiContext).catch(() => {});
     await afterAction();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
@@ -22,6 +22,33 @@ import { getApiContext } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 
+const TERMINAL_CONTRACT_STATUS = /(Aborted|Success|Failed|PartialSuccess|Queued)/;
+
+const pollContractStatus = async (
+  page: Page,
+  contractId: string,
+  timeoutMs = 180_000
+): Promise<void> => {
+  const { apiContext } = await getApiContext(page);
+  await expect
+    .poll(
+      async () => {
+        const contract = await apiContext
+          .get(`/api/v1/dataContracts/${contractId}`)
+          .then((r) => (r.ok() ? r.json() : null))
+          .catch(() => null);
+
+        return contract?.latestResult?.status ?? 'Running';
+      },
+      {
+        message: 'Wait for contract validation to reach terminal state',
+        timeout: timeoutMs,
+        intervals: [3_000, 5_000, 5_000, 10_000, 15_000, 20_000],
+      }
+    )
+    .toEqual(expect.stringMatching(TERMINAL_CONTRACT_STATUS));
+};
+
 export const saveAndTriggerDataContractValidation = async (
   page: Page,
   isContractStatusNotVisible?: boolean
@@ -54,6 +81,13 @@ export const saveAndTriggerDataContractValidation = async (
 
   await page.getByTestId('contract-run-now-button').click();
   await runNowResponse;
+
+  // Poll the API until the validation result reaches a terminal state before
+  // reloading the page. Without this, the UI status check immediately after
+  // the reload is racy: the backend may still be processing the result.
+  if (responseData?.id) {
+    await pollContractStatus(page, responseData.id);
+  }
 
   await page.reload();
 
@@ -541,7 +575,10 @@ export const saveContractAndWait = async (page: Page): Promise<void> => {
   await waitForAllLoadersToDisappear(page);
 };
 
-export const triggerContractValidation = async (page: Page): Promise<void> => {
+export const triggerContractValidation = async (
+  page: Page,
+  contractId?: string
+): Promise<void> => {
   const runNowResponse = page.waitForResponse(
     '/api/v1/dataContracts/*/validate'
   );
@@ -549,6 +586,12 @@ export const triggerContractValidation = async (page: Page): Promise<void> => {
   await openContractActionsDropdown(page);
   await page.getByTestId('contract-run-now-button').click();
   await runNowResponse;
+
+  // If a contractId is supplied, poll until the validation reaches a terminal
+  // state so callers can safely assert on the UI status after a reload.
+  if (contractId) {
+    await pollContractStatus(page, contractId);
+  }
 };
 
 export const exportContractYaml = async (

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts
@@ -22,7 +22,7 @@ import { getApiContext } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 
-const TERMINAL_CONTRACT_STATUS = /(Aborted|Success|Failed|PartialSuccess|Queued)/;
+const TERMINAL_CONTRACT_STATUS = /(Aborted|Success|Failed|PartialSuccess)/;
 
 const pollContractStatus = async (
   page: Page,


### PR DESCRIPTION
## Why

Two nightly runs ([Postgres AUT](https://github.com/open-metadata/openmetadata-nightly/actions/runs/30342046250), [MySQL AUT](https://github.com/open-metadata/openmetadata-nightly/actions/runs/30342040656)) showed intermittent failures in `DataContracts.spec.ts` (File, Pipeline, SearchIndex entities) and `DataContractsSemanticRules.spec.ts` (Validate Domain Rule Is_Set).

**Root cause 1 — timing race in DataContracts.spec.ts**
`/api/v1/dataContracts/*/validate` returns immediately after *triggering* validation; the actual job runs asynchronously in the backend. The original code reloaded the page right after the HTTP response, then asserted on the UI status with only the default 60 s `expect` timeout. When the backend was slow the assertion timed out with _"Timeout 60000ms exceeded while waiting on the predicate"_.

**Root cause 2 — 409 on retry in DataContractsSemanticRules.spec.ts**
`Data Contracts Semantics Rule Domain` had a `beforeAll` but no `afterAll`. On test retry, Playwright can re-run `beforeAll` with the same module-level `domain1`/`domain2` objects (UUID already set from the first run). Calling `domain.create()` again with the same name returned 409, failing the retry instantly (2 ms) in setup before any test body ran.

## Changes

### `playwright/utils/dataContracts.ts`
- Added `pollContractStatus` — polls `GET /api/v1/dataContracts/{id}` on a back-off schedule (`3 s → 5 s → 5 s → 10 s → 15 s → 20 s`, up to 180 s) until `latestResult.status` is terminal (`Aborted | Success | Failed | PartialSuccess | Queued`).
- `saveAndTriggerDataContractValidation`: calls `pollContractStatus` **before** `page.reload()` so the page only reloads once the result is ready.
- `triggerContractValidation`: accepts an optional `contractId`; if provided, polls before returning.

### `playwright/e2e/Pages/DataContracts.spec.ts`
- Three call sites updated (parameterized block, Contains test, Not_Contains test): capture the `contractId` from `saveAndTriggerDataContractValidation` and forward it to `triggerContractValidation` so the second validation round also waits for a terminal state before the reload + assertion.

### `playwright/e2e/Pages/DataContractsSemanticRules.spec.ts`
- `beforeAll` for `Data Contracts Semantics Rule Domain`: wraps each `domain.create()` in try/catch — on 409, fetches the existing entity by FQN and populates `responseData` so the retry proceeds without failing in setup.
- Added `afterAll` to hard-delete both domains after all tests in the block complete.

## Test plan
- [ ] Run `DataContracts.spec.ts` against a slow backend to confirm the polling waits for terminal status before asserting
- [ ] Run `DataContractsSemanticRules.spec.ts > Data Contracts Semantics Rule Domain` with `retries: 1` to confirm a forced retry doesn't 409 in `beforeAll`
- [ ] Confirm domains are cleaned up after the describe block runs

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves the reliability and cleanup behavior of Playwright data-contract tests.
- Polls contract validation status before reloading and asserting UI results.
- Passes contract IDs through repeated validation flows.
- Recovers domain fixtures after retry conflicts and hard-deletes them during teardown.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataContracts.ts | Adds API polling around data-contract validation and optionally applies it to repeated validation triggers. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContracts.spec.ts | Propagates saved contract IDs into subsequent validation calls so assertions wait for validation completion. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/DataContractsSemanticRules.spec.ts | Adds retry recovery for existing domain fixtures and teardown cleanup after the semantic-rules tests. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test as Playwright Test
  participant API as Data Contract API
  participant Job as Validation Job
  participant UI as Contract UI
  Test->>API: Trigger validation
  API->>Job: Start validation
  loop Until terminal status
    Test->>API: GET data contract
    API-->>Test: latestResult.status
  end
  Test->>UI: Reload page
  Test->>UI: Assert validation status
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): remove Queued from term..."](https://github.com/open-metadata/openmetadata/commit/dc346e174ea65284846cae6b0a05ea4fea6b3de5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48297690)</sub>

<!-- /greptile_comment -->