### PR TITLE
Fix the ServiceEntity spec failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseClass.ts
@@ -267,20 +267,22 @@ export class DatabaseClass extends EntityClass {
       .getByTestId('owner-label')
       .getByTestId('owner-link')
       .getByTestId(owner);
+    const tableTab = page.getByRole('menuitem', { name: 'Tables' });
 
-    await waitForSearchResult(page, searchTerm, ownerLink);
+    await waitForSearchResult(page, searchTerm, ownerLink, tableTab);
     await expect(ownerLink).toBeVisible();
   }
 
   async verifyDomainChangeInES(page: Page, domains: Domain['responseData'][]) {
     const searchTerm = this.tableResponseData?.['fullyQualifiedName'];
     const entityCard = page.getByTestId(`table-data-card_${searchTerm}`);
+    const tableTab = page.getByRole('menuitem', { name: 'Tables' });
 
     for (const domain of domains) {
       const domainLink = entityCard
         .getByTestId('domain-link')
         .filter({ hasText: domain.displayName });
-      await waitForSearchResult(page, searchTerm, domainLink);
+      await waitForSearchResult(page, searchTerm, domainLink, tableTab);
       await verifyDomainLinkInCard(entityCard, domain);
     }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -877,6 +877,7 @@ export const waitForSearchResult = async (
         }
         await waitForAllLoadersToDisappear(page);
         await tabSelector?.click();
+        await waitForAllLoadersToDisappear(page);
 
         return result.isVisible();
       },

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -850,7 +850,8 @@ export const verifyDomainLinkInCard = async (
 export const waitForSearchResult = async (
   page: Page,
   searchTerm: string,
-  result: Locator
+  result: Locator,
+  tabSelector?: Locator
 ) => {
   let hasSubmittedSearch = false;
 
@@ -875,6 +876,7 @@ export const waitForSearchResult = async (
           hasSubmittedSearch = true;
         }
         await waitForAllLoadersToDisappear(page);
+        await tabSelector?.click();
 
         return result.isVisible();
       },


### PR DESCRIPTION
Fixes #30652
This pull request updates the Playwright test utilities and usage to improve reliability when verifying search results, particularly by ensuring the correct tab is selected before checking for results. The main change is that the `waitForSearchResult` utility now optionally clicks a provided tab selector, and the relevant test methods have been updated to use this feature.

Test utility improvements:

* Modified `waitForSearchResult` in `common.ts` to accept an optional `tabSelector` parameter and click it if provided, ensuring tests interact with the correct UI tab before verifying results. [[1]](diffhunk://#diff-083eec9d4ac00cdb5b7dd06c76abd61667b6f6abdd7cedc2c16a927180127d67L853-R854) [[2]](diffhunk://#diff-083eec9d4ac00cdb5b7dd06c76abd61667b6f6abdd7cedc2c16a927180127d67R879)

Test usage updates:

* Updated `DatabaseClass.ts` methods to pass the "Tables" tab locator to `waitForSearchResult`, improving test accuracy when searching for owners and verifying domain changes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adjusts search-result verification in Playwright tests.
- Adds an optional tab locator to `waitForSearchResult` and clicks it before checking result visibility.
- Passes the Tables tab from database owner and domain propagation checks.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because the tab-triggered search can remain unsynchronized and leave the affected propagation tests flaky.

Clicking the tab schedules asynchronous search and rendering, while the subsequent helper only verifies that no loader exists at that instant; it can therefore inspect stale DOM before the new search starts and repeat the timeout behavior reported previously.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts | Adds optional tab selection, but the post-click loader assertion can complete before the tab-triggered asynchronous search begins rendering. |
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/DatabaseClass.ts | Supplies the Tables tab locator for owner and domain search-result verification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Worked on the comment"](https://github.com/open-metadata/openmetadata/commit/41ccfba9c8d434b41d498c17945b410b01886d54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48317976)</sub>

<!-- /greptile_comment -->