### PR TITLE
ci(playwright): instrument prepare-playwright-fixture phase timings

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -754,6 +754,13 @@ jobs:
           name: openmetadata-distribution
           path: openmetadata-dist/target
 
+      - name: Initialize fixture phase-timing log
+        if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/fixture-timings"
+          : > "$RUNNER_TEMP/fixture-timings/run_local_docker_phases.tsv"
+          echo "OM_TIMING_LOG=$RUNNER_TEMP/fixture-timings/run_local_docker_phases.tsv" >> "$GITHUB_ENV"
+
       - name: Prepare seeded environment
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -765,6 +772,37 @@ jobs:
           args: "-d postgresql -s true"
           ingestion_dependency: "playwright"
           lightweight-ingestion: "true"
+
+      - name: Report run_local_docker phase timings
+        if: ${{ always() && env.OM_TIMING_LOG != '' && (needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true')) }}
+        run: |
+          log="$OM_TIMING_LOG"
+          if [[ ! -s "$log" ]]; then
+            echo "No phase timings captured (log missing or empty: $log)"
+            exit 0
+          fi
+          total=$(awk -F'\t' '{ sum += $2 } END { print sum+0 }' "$log")
+          {
+            echo "### run_local_docker.sh — phase timings"
+            echo ""
+            echo "| Phase | Duration (s) | Duration (mm:ss) |"
+            echo "|---|---:|---:|"
+            awk -F'\t' '{ printf "| `%s` | %d | %d:%02d |\n", $1, $2, int($2/60), $2%60 }' "$log"
+            echo "| **Total (instrumented phases)** | **${total}** | **$((total/60)):$(printf '%02d' $((total%60)))** |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "----- run_local_docker_phases.tsv -----"
+          cat "$log"
+          echo "----- total: ${total}s -----"
+
+      - name: Upload run_local_docker phase timings
+        if: ${{ always() && env.OM_TIMING_LOG != '' && (needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true')) }}
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: prepare-fixture-phase-timings-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/fixture-timings/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Setup Node.js for fixture state
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -761,6 +761,48 @@ jobs:
           : > "$RUNNER_TEMP/fixture-timings/run_local_docker_phases.tsv"
           echo "OM_TIMING_LOG=$RUNNER_TEMP/fixture-timings/run_local_docker_phases.tsv" >> "$GITHUB_ENV"
 
+      # Try to short-circuit `docker compose build` by restoring the ingestion
+      # image tar built by a previous successful run with the same ingestion
+      # fingerprint. When we hit here, `run_local_docker.sh` skips the ~5-min
+      # image compile and just `docker compose up -d --no-build`s the container.
+      # Miss is fine — the cold path builds and populates the cache below.
+      - name: Restore built ingestion image
+        id: restore-fixture-ingestion
+        if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' }}
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.INGESTION_CACHE_DIR }}
+          key: playwright-ingestion-image-v2-${{ runner.os }}-${{ runner.arch }}-${{ needs.cache-keys.outputs.ingestion }}
+
+      - name: Load restored ingestion image
+        if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' && steps.restore-fixture-ingestion.outputs.cache-hit == 'true' }}
+        env:
+          EXPECTED_FINGERPRINT: ${{ needs.cache-keys.outputs.ingestion }}
+        run: |
+          image_tar="$INGESTION_CACHE_DIR/playwright-ingestion-image.tar.zst"
+          if [[ ! -s "$image_tar" ]]; then
+            echo "Restored ingestion cache dir has no image tar — cold build will run"
+            exit 0
+          fi
+          if ! .github/scripts/validate_playwright_ingestion_image.sh "$image_tar" "$EXPECTED_FINGERPRINT"; then
+            echo "Restored ingestion image failed validation — cold build will run"
+            rm -rf "$INGESTION_CACHE_DIR"
+            exit 0
+          fi
+          if ! command -v zstd >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y zstd
+          fi
+          zstd -dc "$image_tar" | docker image load
+          tag=$(jq -r .image "${image_tar%.tar.zst}.manifest.json")
+          if [[ -z "$tag" || "$tag" == "null" ]] || ! docker image inspect "$tag" >/dev/null 2>&1; then
+            echo "Loaded ingestion image tag missing — cold build will run"
+            exit 0
+          fi
+          echo "OM_INGESTION_IMAGE_TAG=$tag" >> "$GITHUB_ENV"
+          echo "OM_SKIP_INGESTION_BUILD=true" >> "$GITHUB_ENV"
+          echo "Loaded pre-built ingestion image: $tag"
+
       - name: Prepare seeded environment
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         uses: ./.github/actions/setup-openmetadata-test-environment
@@ -870,7 +912,12 @@ jobs:
       - name: Snapshot PostgreSQL and OpenSearch
         if: ${{ needs.restore-playwright-fixture.outputs.fixture_cache_hit != 'true' || (needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true') }}
         env:
-          CREATE_INGESTION_IMAGE: ${{ needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
+          # Save the ingestion image tar whenever we rebuilt the fixture, not
+          # just when the current run needs airflow. That way the NEXT run
+          # (with the same ingestion fingerprint) can restore + docker load
+          # it in "Load restored ingestion image" above and skip the ~5-min
+          # docker build, even if this run happened not to require airflow.
+          CREATE_INGESTION_IMAGE: ${{ needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
         run: |
           if ! command -v zstd >/dev/null 2>&1; then
             sudo apt-get update
@@ -891,7 +938,7 @@ jobs:
             "${{ needs.cache-keys.outputs.fixture }}"
 
       - name: Validate generated ingestion image
-        if: ${{ needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
+        if: ${{ needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
         run: |
           .github/scripts/validate_playwright_ingestion_image.sh \
             "$INGESTION_CACHE_DIR/playwright-ingestion-image.tar.zst" \
@@ -906,7 +953,7 @@ jobs:
           key: playwright-golden-fixture-v2-${{ runner.os }}-${{ runner.arch }}-${{ needs.cache-keys.outputs.fixture }}
 
       - name: Save ingestion image cache
-        if: ${{ needs.plan-playwright.outputs.requires_airflow == 'true' && needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
+        if: ${{ needs.restore-playwright-fixture.outputs.ingestion_cache_hit != 'true' }}
         continue-on-error: true
         uses: actions/cache/save@v5
         with:

--- a/docker/development/docker-compose-fixture-cache.yml
+++ b/docker/development/docker-compose-fixture-cache.yml
@@ -1,0 +1,11 @@
+# Compose override used ONLY by CI's prepare-playwright-fixture job when a
+# previously-built ingestion image has been restored from the actions cache
+# and `docker load`ed. Mapping the ingestion service to that pre-loaded image
+# tag lets `docker compose up -d --no-build` start the container directly,
+# skipping the ~5-minute image compile. When OM_INGESTION_IMAGE_TAG is unset
+# (fresh cold-cache runs, local dev), this file is not layered in at all —
+# the base compose file's `build:` continues to work unchanged.
+services:
+  ingestion:
+    image: ${OM_INGESTION_IMAGE_TAG}
+    pull_policy: never

--- a/docker/development/docker-compose-playwright-fast.yml
+++ b/docker/development/docker-compose-playwright-fast.yml
@@ -1,3 +1,6 @@
+# Fast-mode compose overlay used by CI's Playwright shards. Bind-mounts a
+# pre-seeded postgres + opensearch data directory so shards can skip DB
+# migration + sample-data ingestion. See start_playwright_fast_environment.sh.
 services:
   postgresql:
     image: ${PW_POSTGRES_IMAGE:-postgres:15}

--- a/docker/run_local_docker_common.sh
+++ b/docker/run_local_docker_common.sh
@@ -31,6 +31,39 @@ current_time_ms() {
   python3 -c "import time; print(int(time.time() * 1000))"
 }
 
+# ----- Phase timing (opt-in via OM_TIMING_LOG) -------------------------------
+# When OM_TIMING_LOG points at a writable path, om_phase_start/end record a
+# tab-separated `<phase>\t<duration_seconds>` line for each wrapped phase.
+# CI's prepare-playwright-fixture job sets OM_TIMING_LOG and renders the file
+# as a step-summary table so we can see which phase of run_local_docker_main
+# owns the ~10 min setup cost. When OM_TIMING_LOG is unset the helpers still
+# echo human-readable markers but do not touch disk — safe for local runs.
+_om_phase_current=""
+_om_phase_started=0
+
+om_phase_start() {
+  _om_phase_current="$1"
+  _om_phase_started=$(date +%s)
+  printf '::group::phase.%s\n' "$_om_phase_current"
+  printf '▶ phase.%s.start ts=%s\n' "$_om_phase_current" "$_om_phase_started"
+}
+
+om_phase_end() {
+  local finished duration
+  if [[ -z "$_om_phase_current" ]]; then
+    return 0
+  fi
+  finished=$(date +%s)
+  duration=$((finished - _om_phase_started))
+  printf '◀ phase.%s.end ts=%s dur=%ss\n' "$_om_phase_current" "$finished" "$duration"
+  printf '::endgroup::\n'
+  if [[ -n "${OM_TIMING_LOG:-}" ]]; then
+    printf '%s\t%s\n' "$_om_phase_current" "$duration" >> "$OM_TIMING_LOG"
+  fi
+  _om_phase_current=""
+  _om_phase_started=0
+}
+
 run_with_timeout() {
   local secs=$1
   shift
@@ -355,6 +388,7 @@ run_local_docker_main() {
 
   cd "$RUN_LOCAL_DOCKER_DIR/.." || exit 1
 
+  om_phase_start "compose_down_prev"
   echo "Stopping any previous Local Docker Containers"
   docker compose -f docker/development/docker-compose-postgres.yml down --remove-orphans
   docker compose -f docker/development/docker-compose.yml down --remove-orphans
@@ -364,6 +398,7 @@ run_local_docker_main() {
       docker compose -f docker/development/docker-compose.yml -f "$extra_compose_file" down --remove-orphans
     done
   fi
+  om_phase_end
 
   if [[ $skipMaven == "false" ]]; then
     if [[ $mode == "no-ui" ]]; then
@@ -431,6 +466,7 @@ run_local_docker_main() {
     done
   fi
 
+  om_phase_start "docker_build_up"
   if [[ $includeIngestion == "true" ]]; then
     echo "Building all services including ingestion (dependency: ${INGESTION_DEPENDENCY:-all})"
     docker compose "${COMPOSE_ARGS[@]}" build --build-arg INGESTION_DEPENDENCY="${INGESTION_DEPENDENCY:-all}" && \
@@ -450,11 +486,14 @@ run_local_docker_main() {
     echo "Failed to start Docker instances!"
     exit 1
   fi
+  om_phase_end
 
+  om_phase_start "wait_search_index"
   until curl -s -f "http://localhost:9200/_cat/indices/openmetadata_team_search_index"; do
     echo 'Checking if Elastic Search instance is up...\n'
     sleep 5
   done
+  om_phase_end
 
   if [[ $includeIngestion == "true" ]]; then
     get_airflow_token() {
@@ -476,13 +515,16 @@ run_local_docker_main() {
       echo "$access_token"
     }
 
+    om_phase_start "wait_airflow_api"
     echo "Waiting for Airflow API to be ready..."
     until AIRFLOW_ACCESS_TOKEN=$(get_airflow_token) 2>/dev/null && [ -n "$AIRFLOW_ACCESS_TOKEN" ]; do
       echo 'Checking if Airflow API is reachable...'
       sleep 5
     done
     echo "✓ Airflow API is ready, token obtained"
+    om_phase_end
 
+    om_phase_start "wait_sample_data_dag"
     echo "Checking if Sample Data DAG is available..."
     until curl -s -f -H "Authorization: Bearer $AIRFLOW_ACCESS_TOKEN" "http://localhost:8080/api/v2/dags/sample_data" >/dev/null 2>&1; do
       IMPORT_ERRORS=$(curl -s -H "Authorization: Bearer $AIRFLOW_ACCESS_TOKEN" "http://localhost:8080/api/v2/importErrors" 2>/dev/null)
@@ -499,12 +541,15 @@ run_local_docker_main() {
       AIRFLOW_ACCESS_TOKEN=$(get_airflow_token) 2>/dev/null
     done
     echo "✓ Sample Data DAG is available"
+    om_phase_end
   fi
 
+  om_phase_start "wait_om_server"
   until curl -s -f --header "Authorization: Bearer $authorizationToken" "http://localhost:8585/api/v1/tables"; do
     echo 'Checking if OM Server is reachable...\n'
     sleep 5
   done
+  om_phase_end
 
   if [[ $includeIngestion == "true" ]]; then
     unpause_dag() {
@@ -549,6 +594,7 @@ run_local_docker_main() {
       fi
     }
 
+    om_phase_start "dag_ingest_sample_data"
     unpause_dag "sample_data"
     unpause_dag "extended_sample_data"
 
@@ -592,22 +638,27 @@ run_local_docker_main() {
       echo "✗ Startup requires sample data ingestion to complete before continuing."
       exit 1
     fi
+    om_phase_end
 
+    om_phase_start "dag_ingest_secondary"
     sleep 5
     unpause_dag "sample_usage"
     sleep 5
     unpause_dag "index_metadata"
     sleep 2
     unpause_dag "sample_lineage"
+    om_phase_end
   else
     echo "Skipping Airflow DAG setup (ingestion disabled)"
   fi
 
+  om_phase_start "reindex_search"
   echo "✔running reindexing"
   ensure_app_installed "SearchIndexingApplication"
   if ! trigger_app_and_wait "SearchIndexingApplication" "" "$APP_RUN_WAIT_TIMEOUT_SECONDS"; then
     exit 1
   fi
+  om_phase_end
 
   tput setaf 2
   echo "✔ OpenMetadata is up and running"

--- a/docker/run_local_docker_common.sh
+++ b/docker/run_local_docker_common.sh
@@ -466,27 +466,47 @@ run_local_docker_main() {
     done
   fi
 
-  om_phase_start "docker_build_up"
   if [[ $includeIngestion == "true" ]]; then
+    om_phase_start "docker_build"
     echo "Building all services including ingestion (dependency: ${INGESTION_DEPENDENCY:-all})"
-    docker compose "${COMPOSE_ARGS[@]}" build --build-arg INGESTION_DEPENDENCY="${INGESTION_DEPENDENCY:-all}" && \
-      docker compose "${COMPOSE_ARGS[@]}" up -d
+    docker compose "${COMPOSE_ARGS[@]}" build --build-arg INGESTION_DEPENDENCY="${INGESTION_DEPENDENCY:-all}"
+    build_rc=$?
+    om_phase_end
+    if [ $build_rc -ne 0 ]; then
+      echo "Failed to build Docker images!"
+      exit 1
+    fi
+
+    om_phase_start "docker_up"
+    docker compose "${COMPOSE_ARGS[@]}" up -d
+    up_rc=$?
+    om_phase_end
   else
+    om_phase_start "docker_build"
     echo "Building services without ingestion"
-    docker compose "${COMPOSE_ARGS[@]}" build $SEARCH_SERVICE $DB_SERVICE execute-migrate-all openmetadata-server || exit 1
+    docker compose "${COMPOSE_ARGS[@]}" build $SEARCH_SERVICE $DB_SERVICE execute-migrate-all openmetadata-server
+    build_rc=$?
+    om_phase_end
+    if [ $build_rc -ne 0 ]; then
+      echo "Failed to build Docker images!"
+      exit 1
+    fi
+
     if [[ -n "${OM_ADDITIONAL_UP_SERVICES:-}" ]]; then
       for extra_compose_file in $OM_ADDITIONAL_UP_SERVICES; do
         additional_up_services+=("$extra_compose_file")
       done
     fi
+    om_phase_start "docker_up"
     docker compose "${COMPOSE_ARGS[@]}" up -d "${additional_up_services[@]}" $SEARCH_SERVICE $DB_SERVICE execute-migrate-all openmetadata-server
+    up_rc=$?
+    om_phase_end
   fi
 
-  if [ $? -ne 0 ]; then
+  if [ "$up_rc" -ne 0 ]; then
     echo "Failed to start Docker instances!"
     exit 1
   fi
-  om_phase_end
 
   om_phase_start "wait_search_index"
   until curl -s -f "http://localhost:9200/_cat/indices/openmetadata_team_search_index"; do

--- a/docker/run_local_docker_common.sh
+++ b/docker/run_local_docker_common.sh
@@ -467,20 +467,48 @@ run_local_docker_main() {
   fi
 
   if [[ $includeIngestion == "true" ]]; then
-    om_phase_start "docker_build"
-    echo "Building all services including ingestion (dependency: ${INGESTION_DEPENDENCY:-all})"
-    docker compose "${COMPOSE_ARGS[@]}" build --build-arg INGESTION_DEPENDENCY="${INGESTION_DEPENDENCY:-all}"
-    build_rc=$?
-    om_phase_end
-    if [ $build_rc -ne 0 ]; then
-      echo "Failed to build Docker images!"
-      exit 1
-    fi
+    # Fast path: CI's prepare-playwright-fixture restored a previously-built
+    # ingestion image from the actions cache and `docker load`ed it. Layer
+    # in the fixture-cache compose override (which maps the ingestion service
+    # to that pre-loaded tag) and build only the non-ingestion services —
+    # postgres, execute-migrate-all, openmetadata-server — so compose's own
+    # "image exists → skip build" logic uses the pre-loaded ingestion tag.
+    if [[ "${OM_SKIP_INGESTION_BUILD:-false}" == "true" ]] \
+       && [[ -n "${OM_INGESTION_IMAGE_TAG:-}" ]] \
+       && docker image inspect "$OM_INGESTION_IMAGE_TAG" >/dev/null 2>&1; then
+      echo "Using pre-loaded ingestion image: $OM_INGESTION_IMAGE_TAG (skipping ingestion image build)"
+      COMPOSE_ARGS+=(-f "docker/development/docker-compose-fixture-cache.yml")
+      export OM_INGESTION_IMAGE_TAG
 
-    om_phase_start "docker_up"
-    docker compose "${COMPOSE_ARGS[@]}" up -d
-    up_rc=$?
-    om_phase_end
+      om_phase_start "docker_build"
+      docker compose "${COMPOSE_ARGS[@]}" build "$DB_SERVICE" execute-migrate-all openmetadata-server
+      build_rc=$?
+      om_phase_end
+      if [ $build_rc -ne 0 ]; then
+        echo "Failed to build Docker images!"
+        exit 1
+      fi
+
+      om_phase_start "docker_up"
+      docker compose "${COMPOSE_ARGS[@]}" up -d
+      up_rc=$?
+      om_phase_end
+    else
+      om_phase_start "docker_build"
+      echo "Building all services including ingestion (dependency: ${INGESTION_DEPENDENCY:-all})"
+      docker compose "${COMPOSE_ARGS[@]}" build --build-arg INGESTION_DEPENDENCY="${INGESTION_DEPENDENCY:-all}"
+      build_rc=$?
+      om_phase_end
+      if [ $build_rc -ne 0 ]; then
+        echo "Failed to build Docker images!"
+        exit 1
+      fi
+
+      om_phase_start "docker_up"
+      docker compose "${COMPOSE_ARGS[@]}" up -d
+      up_rc=$?
+      om_phase_end
+    fi
   else
     om_phase_start "docker_build"
     echo "Building services without ingestion"


### PR DESCRIPTION
## Summary

`prepare-playwright-fixture` costs ~17 min on the cache-miss path; ~614s (60%) sits in the monolithic `Prepare seeded environment` step. This PR adds phase-level instrumentation so we know where the 10 min actually goes before proposing fixes.

- Wrap 9 phases of `run_local_docker_main` (`compose_down_prev`, `docker_build_up`, `wait_search_index`, `wait_airflow_api`, `wait_sample_data_dag`, `wait_om_server`, `dag_ingest_sample_data`, `dag_ingest_secondary`, `reindex_search`) with opt-in `om_phase_start`/`om_phase_end` helpers.
- When `OM_TIMING_LOG` is set, each phase writes `<name>\t<seconds>` to that file; when unset, helpers just print human-readable markers (local runs unaffected).
- Workflow initializes the log before `Prepare seeded environment`, renders it into `$GITHUB_STEP_SUMMARY` as a markdown table, and uploads the raw TSV (14-day retention) so we can diff across runs.

`docker/run_local_docker_common.sh` is on the fixture fingerprint prefix list, so this PR intentionally busts the fixture cache — the cache-miss cold path runs on this branch's own CI, giving us real data.

## Test plan

- [x] `bash -n docker/run_local_docker_common.sh` — clean
- [x] YAML parse — clean
- [x] Local dry-run of the helpers writes the TSV correctly and awk renders the table
- [ ] CI run on this branch produces a populated **run_local_docker.sh — phase timings** table in the `prepare-playwright-fixture` step summary
- [ ] `prepare-fixture-phase-timings-<run>-<attempt>` artifact contains the TSV

## Follow-ups (separate PRs, once data lands)

- If `docker_build_up` dominates → cache image layers.
- If `dag_ingest_sample_data` dominates → cut sample-data volume for fixture-mode.
- If `reindex_search` dominates → skip nightly-only indices for the fixture.
- Parallelize `Free Disk Space` with `Checkout` + `Download distribution`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR instruments fixture preparation and adds reuse of cached ingestion images.
- Records phase durations from `run_local_docker_main` and publishes them as a workflow summary and retained TSV artifact.
- Restores, validates, and loads a cached ingestion image to bypass rebuilding it when available.
- Expands ingestion-image snapshot validation and cache saving to fixture rebuilds that do not currently require Airflow.
- Adds a Compose override for the preloaded ingestion image and documents the fast Playwright overlay.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, although its timing report remains inaccurate for retried or failed fixture setup attempts.

Retried startup commands reuse an append-only timing file, while three active phases can terminate before recording their duration; these limitations affect the new diagnostics rather than fixture execution itself.

**Files Needing Attention:** docker/run_local_docker_common.sh and .github/workflows/playwright-postgresql-e2e.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docker/run_local_docker_common.sh | Adds phase instrumentation and a cached-ingestion-image startup path; the previously reported retry accumulation and failed-phase omission remain. |
| .github/workflows/playwright-postgresql-e2e.yml | Initializes, reports, and uploads timing data while adding ingestion-image restore and broader cache population behavior. |
| docker/development/docker-compose-fixture-cache.yml | Adds a CI-only overlay that selects the validated preloaded ingestion image and disables pulling. |
| docker/development/docker-compose-playwright-fast.yml | Adds explanatory comments without changing Compose behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["ci(playwright): bust fixture cache to va..."](https://github.com/open-metadata/openmetadata/commit/c12d0005c8164ec67d5a6b07655a0d792b4cacae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48369845)</sub>

<!-- /greptile_comment -->