### PR TITLE
feat(ui-core): add semantic color prop to Typography

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx
@@ -1,0 +1,78 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Typography } from './typography';
+
+describe('Typography', () => {
+  it('applies no color class when color is omitted', () => {
+    render(<Typography>Hello</Typography>);
+
+    const el = screen.getByText('Hello');
+
+    expect(el.className).not.toMatch(
+      /tw:text-(tertiary|error-primary|warning-primary|success-primary)/
+    );
+  });
+
+  it('applies tw:text-tertiary for color="secondary"', () => {
+    render(<Typography color="secondary">Hello</Typography>);
+
+    expect(screen.getByText('Hello')).toHaveClass('tw:text-tertiary');
+  });
+
+  it('applies tw:text-success-primary for color="success"', () => {
+    render(<Typography color="success">Hello</Typography>);
+
+    expect(screen.getByText('Hello')).toHaveClass('tw:text-success-primary');
+  });
+
+  it('applies tw:text-warning-primary for color="warning"', () => {
+    render(<Typography color="warning">Hello</Typography>);
+
+    expect(screen.getByText('Hello')).toHaveClass('tw:text-warning-primary');
+  });
+
+  it('applies tw:text-error-primary for color="danger"', () => {
+    render(<Typography color="danger">Hello</Typography>);
+
+    expect(screen.getByText('Hello')).toHaveClass('tw:text-error-primary');
+  });
+
+  it('still applies a consumer className alongside the color class', () => {
+    render(
+      <Typography className="tw:italic" color="secondary">
+        Hello
+      </Typography>
+    );
+
+    const el = screen.getByText('Hello');
+
+    expect(el).toHaveClass('tw:text-tertiary');
+    expect(el).toHaveClass('tw:italic');
+  });
+
+  it('lets a consumer className override the color class', () => {
+    render(
+      <Typography className="tw:text-tertiary" color="danger">
+        Hello
+      </Typography>
+    );
+
+    const el = screen.getByText('Hello');
+
+    expect(el).toHaveClass('tw:text-tertiary');
+    expect(el.className).not.toMatch(/tw:text-error-primary/);
+  });
+});

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
@@ -45,6 +45,13 @@ type TypographySize =
 
 type TypographyWeight = 'regular' | 'medium' | 'semibold' | 'bold';
 
+/**
+ * Semantic text color, mirroring antd Typography's `type` prop
+ * ("secondary" | "success" | "warning" | "danger") so migrated call sites
+ * have a first-class equivalent instead of a per-site `className` override.
+ */
+type TypographyColor = 'secondary' | 'success' | 'warning' | 'danger';
+
 type EllipsisRows = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 
 type TypographyEllipsis =
@@ -62,6 +69,7 @@ interface TypographyProps extends HTMLAttributes<HTMLElement> {
   className?: string;
   size?: TypographySize;
   weight?: TypographyWeight;
+  color?: TypographyColor;
   ellipsis?: TypographyEllipsis;
 }
 
@@ -92,6 +100,16 @@ const weightClasses: Record<TypographyWeight, string> = {
   bold: 'tw:font-bold',
 };
 
+// Established idiom already in use across core components (see tree.tsx,
+// pagination.tsx, empty-placeholder, form-field) and the existing per-site
+// `className="tw:text-tertiary"` workaround this prop replaces.
+const colorClasses: Record<TypographyColor, string> = {
+  secondary: 'tw:text-tertiary',
+  success: 'tw:text-success-primary',
+  warning: 'tw:text-warning-primary',
+  danger: 'tw:text-error-primary',
+};
+
 export const Typography = (props: TypographyProps) => {
   const {
     as: Component = 'span',
@@ -100,6 +118,7 @@ export const Typography = (props: TypographyProps) => {
     children,
     size,
     weight,
+    color,
     ellipsis,
     style,
     ...otherProps
@@ -107,6 +126,7 @@ export const Typography = (props: TypographyProps) => {
 
   const sizeClass = size ? sizeClasses[size] : undefined;
   const weightClass = weight ? weightClasses[weight] : undefined;
+  const colorClass = color ? colorClasses[color] : undefined;
 
   const ellipsisConfig = typeof ellipsis === 'object' ? ellipsis : undefined;
   const isEllipsis = !!ellipsis;
@@ -124,9 +144,15 @@ export const Typography = (props: TypographyProps) => {
 
   const ellipsisClassName = isEllipsis ? getEllipsisClassName() : undefined;
 
+  // `cx` (twMerge) resolves conflicting classes in favor of whichever is
+  // passed last, so `colorClass` is placed before `className` here: an
+  // explicit consumer `className` text-color utility still wins over the
+  // `color` prop, matching how `className` already overrides `sizeClass`/
+  // `weightClass` above.
   const innerClassName = cx(
     sizeClass,
     weightClass,
+    colorClass,
     className,
     ellipsisClassName
   );
@@ -160,6 +186,7 @@ export const Typography = (props: TypographyProps) => {
 };
 
 export type {
+  TypographyColor,
   TypographyEllipsis,
   TypographyProps,
   TypographyQuoteVariant,


### PR DESCRIPTION
## Summary

Part of the AntD → ui-core-components migration (Wave 1 prep, epic #30570). **Stacked on #30664** (reuses its vitest infra); base auto-retargets to main when that merges.

antd Typography's `type` prop (semantic text color) has no core equivalent — the Typography sweep's gap check found 20 live `type="secondary"` call sites whose only migration target today is a per-site hardcoded className. This adds a first-class prop so the sweep gets a 1:1 mapping, and covers the remaining antd values for future use.

`color?: 'secondary' | 'success' | 'warning' | 'danger'` mapped to existing semantic tokens (no invented names — each verified in current core usage):

| value | token | precedent |
|---|---|---|
| secondary | `tw:text-tertiary` | tree.tsx, pagination.tsx |
| success | `tw:text-success-primary` | existing theme usage |
| warning | `tw:text-warning-primary` | existing theme usage |
| danger | `tw:text-error-primary` | form-field, file-upload |

Omitted prop → behavior unchanged. Consumer `className` composes and can still override (twMerge precedence, documented inline).

## Tests

7 new vitest cases (one per value, omitted-prop no-op, className composition) — written failing first, now green; full package suite 11/11.

Fixes #30663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds semantic text-color support to the ui-core Typography component.
- Introduces a typed `color` prop mapping secondary, success, warning, and danger values to existing Tailwind utilities.
- Preserves consumer `className` precedence through `cx`.
- Adds tests for every semantic value, omitted-color behavior, class composition, and color overrides.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete behavioral, compatibility, or security defects identified.

The semantic values map to fixed existing utility classes, omitted color preserves prior behavior, consumer classes retain precedence, and focused tests cover the new API behavior.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx | Adds a typed semantic color mapping and composes it with existing Typography classes without changing omitted-prop behavior. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx | Covers all supported color values, default behavior, class composition, and consumer color-class precedence. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui-core): add semantic color prop t..."](https://github.com/open-metadata/openmetadata/commit/33f8cda334e77fd7092f4d48db96afc7a897e1b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48405472)</sub>

<!-- /greptile_comment -->