### PR TITLE
Fixes #30541: refresh Redshift IAM credentials per connection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -15,10 +15,13 @@ Source connection handler
 
 from __future__ import annotations
 
+import threading
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 from urllib.parse import quote_plus
 
 from sqlalchemy.engine import Engine
+from sqlalchemy.event import listen
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.sql import text
 
@@ -55,7 +58,10 @@ from metadata.ingestion.connections.builders import (
 )
 from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import SourceConnectionException
-from metadata.ingestion.source.database.redshift.models import RedshiftInstanceType
+from metadata.ingestion.source.database.redshift.models import (
+    RedshiftIamCredential,
+    RedshiftInstanceType,
+)
 from metadata.ingestion.source.database.redshift.queries import (
     REDSHIFT_GET_ALL_RELATIONS,
     REDSHIFT_GET_DATABASE_NAMES,
@@ -112,7 +118,7 @@ def _non_standard_host_hint(host: str) -> str:
     return hint
 
 
-def _get_serverless_iam_credentials(connection: RedshiftConnectionConfig, host: str) -> tuple:
+def _get_serverless_iam_credentials(connection: RedshiftConnectionConfig, host: str) -> RedshiftIamCredential:
     workgroup = connection.workgroupName or _get_serverless_workgroup(host)
     try:
         aws_client = AWSClient(config=connection.authType.awsConfig).get_redshift_serverless_client()
@@ -120,7 +126,11 @@ def _get_serverless_iam_credentials(connection: RedshiftConnectionConfig, host: 
         kwargs = {"workgroupName": workgroup, "dbName": connection.database or "dev"}
 
         response = aws_client.get_credentials(**kwargs)
-        return response["dbUser"], response["dbPassword"]
+        return RedshiftIamCredential(
+            user=response["dbUser"],
+            password=response["dbPassword"],
+            expiration=response.get("expiration"),
+        )
     except Exception as exc:
         hint = "" if connection.workgroupName else _non_standard_host_hint(host)
         raise SourceConnectionException(
@@ -128,7 +138,7 @@ def _get_serverless_iam_credentials(connection: RedshiftConnectionConfig, host: 
         ) from exc
 
 
-def _get_provisioned_iam_credentials(connection: RedshiftConnectionConfig, host: str) -> tuple:
+def _get_provisioned_iam_credentials(connection: RedshiftConnectionConfig, host: str) -> RedshiftIamCredential:
     cluster_identifier = connection.clusterIdentifier or _get_provisioned_cluster_identifier(host)
     try:
         aws_client = AWSClient(config=connection.authType.awsConfig).get_redshift_client()
@@ -142,7 +152,11 @@ def _get_provisioned_iam_credentials(connection: RedshiftConnectionConfig, host:
             kwargs["DbName"] = connection.database
 
         response = aws_client.get_cluster_credentials(**kwargs)
-        return response["DbUser"], response["DbPassword"]
+        return RedshiftIamCredential(
+            user=response["DbUser"],
+            password=response["DbPassword"],
+            expiration=response.get("Expiration"),
+        )
     except Exception as exc:
         hint = "" if connection.clusterIdentifier else _non_standard_host_hint(host)
         raise SourceConnectionException(
@@ -150,7 +164,7 @@ def _get_provisioned_iam_credentials(connection: RedshiftConnectionConfig, host:
         ) from exc
 
 
-def _get_redshift_iam_credentials(connection: RedshiftConnectionConfig) -> tuple:
+def _get_redshift_iam_credentials(connection: RedshiftConnectionConfig) -> RedshiftIamCredential:
     """
     Get temporary credentials for Redshift using IAM authentication.
     An explicit clusterIdentifier or workgroupName on the connection takes
@@ -175,20 +189,96 @@ def _get_redshift_iam_credentials(connection: RedshiftConnectionConfig) -> tuple
     return _get_provisioned_iam_credentials(connection, host)
 
 
+def _is_iam_auth(connection: RedshiftConnectionConfig) -> bool:
+    return (
+        hasattr(connection, "authType")
+        and connection.authType is not None
+        and isinstance(connection.authType, IamAuthConfigurationSource)
+    )
+
+
+REDSHIFT_IAM_CREDENTIAL_DEFAULT_TTL = timedelta(minutes=15)
+REDSHIFT_IAM_CREDENTIAL_REFRESH_THRESHOLD = timedelta(minutes=5)
+
+
+class RedshiftIamCredentialManager:
+    """
+    Caches a Redshift IAM temporary credential and regenerates it before expiry.
+
+    Redshift temporary credentials are short-lived (default ~15 minutes). A long
+    ingestion that opens new pooled connections after the credential expires would
+    otherwise authenticate with a stale credential and fail. The engine shares one
+    manager across all worker threads (each ``do_connect`` calls ``get_credentials``),
+    so the check-and-refresh is serialized to avoid pairing a credential with a
+    stale expiry.
+    """
+
+    def __init__(
+        self,
+        connection: RedshiftConnectionConfig,
+        refresh_threshold: timedelta = REDSHIFT_IAM_CREDENTIAL_REFRESH_THRESHOLD,
+    ):
+        self._connection = connection
+        self._refresh_threshold = refresh_threshold
+        self._credential: RedshiftIamCredential | None = None
+        self._expires_at: datetime | None = None
+        self._lock = threading.Lock()
+
+    def get_credentials(self) -> RedshiftIamCredential:
+        with self._lock:
+            if self._needs_refresh():
+                self._refresh()
+            if self._credential is None:
+                raise SourceConnectionException("Failed to generate Redshift IAM credentials")
+            return self._credential
+
+    def _needs_refresh(self) -> bool:
+        needs_refresh = True
+        if self._credential is not None and self._expires_at is not None:
+            time_left = self._expires_at - datetime.now(timezone.utc)
+            needs_refresh = time_left <= self._refresh_threshold
+        return needs_refresh
+
+    def _refresh(self) -> None:
+        credential = _get_redshift_iam_credentials(self._connection)
+        self._credential = credential
+        self._expires_at = credential.expiration or (datetime.now(timezone.utc) + REDSHIFT_IAM_CREDENTIAL_DEFAULT_TTL)
+
+
+def _build_iam_engine(connection: RedshiftConnectionConfig) -> Engine:
+    """
+    Build a Redshift engine for IAM auth with no credential baked into the URL.
+
+    A ``do_connect`` listener injects a fresh credential from the manager on every
+    connection, so connections opened later in a long ingestion never authenticate
+    with an expired credential.
+    """
+    engine = create_generic_db_connection(
+        connection=connection,
+        get_connection_url_fn=get_redshift_connection_url,
+        get_connection_args_fn=get_connection_args_common,
+    )
+    manager = RedshiftIamCredentialManager(connection)
+
+    def _inject_iam_credentials(_dialect, _conn_rec, _cargs, cparams: dict) -> None:
+        credential = manager.get_credentials()
+        cparams["user"] = credential.user
+        cparams["password"] = credential.password
+
+    listen(engine, "do_connect", _inject_iam_credentials)
+    return engine
+
+
 def get_redshift_connection_url(connection: RedshiftConnectionConfig) -> str:
     """
     Build the Redshift connection URL.
-    Handles both basic auth and IAM auth.
-    """
-    if (
-        hasattr(connection, "authType")
-        and connection.authType
-        and isinstance(connection.authType, IamAuthConfigurationSource)
-    ):
-        username, password = _get_redshift_iam_credentials(connection)
 
+    For IAM auth the URL carries no credential; a ``do_connect`` listener injects a
+    fresh credential per connection (see ``_build_iam_engine``).
+    """
+    if _is_iam_auth(connection):
         url = f"{connection.scheme.value}://"
-        url += f"{quote_plus(username)}:{quote_plus(password)}@"
+        url += f"{quote_plus(connection.username)}@"
         url += connection.hostPort
         url += f"/{connection.database}" if connection.database else ""
 
@@ -389,11 +479,15 @@ class RedshiftChecks:
 
 class RedshiftConnection(BaseConnection[RedshiftConnectionConfig, Engine]):
     def _get_client(self) -> Engine:
-        engine = create_generic_db_connection(
-            connection=self.service_connection,
-            get_connection_url_fn=get_redshift_connection_url,
-            get_connection_args_fn=get_connection_args_common,
-        )
+        connection = self.service_connection
+        if _is_iam_auth(connection):
+            engine = _build_iam_engine(connection)
+        else:
+            engine = create_generic_db_connection(
+                connection=connection,
+                get_connection_url_fn=get_redshift_connection_url,
+                get_connection_args_fn=get_connection_args_common,
+            )
         self._on_close(engine.dispose)
         return engine
 

--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -240,9 +240,24 @@ class RedshiftIamCredentialManager:
         return needs_refresh
 
     def _refresh(self) -> None:
-        credential = _get_redshift_iam_credentials(self._connection)
+        try:
+            credential = _get_redshift_iam_credentials(self._connection)
+        except Exception as exc:
+            # A proactive refresh (fired within the threshold) that fails must not fail
+            # a connection while the current credential is still valid; keep serving it
+            # and retry on the next connection.
+            if self._credential is not None and not self._is_expired():
+                logger.warning(f"Redshift IAM credential refresh failed ({exc}); reusing cached credential")
+                return
+            raise
+        expiration = credential.expiration
+        if expiration is not None and expiration.tzinfo is None:
+            expiration = expiration.replace(tzinfo=timezone.utc)
         self._credential = credential
-        self._expires_at = credential.expiration or (datetime.now(timezone.utc) + REDSHIFT_IAM_CREDENTIAL_DEFAULT_TTL)
+        self._expires_at = expiration or (datetime.now(timezone.utc) + REDSHIFT_IAM_CREDENTIAL_DEFAULT_TTL)
+
+    def _is_expired(self) -> bool:
+        return self._expires_at is None or self._expires_at <= datetime.now(timezone.utc)
 
 
 def _build_iam_engine(connection: RedshiftConnectionConfig) -> Engine:

--- a/ingestion/src/metadata/ingestion/source/database/redshift/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/models.py
@@ -13,6 +13,8 @@ Redshift models
 """
 
 import re
+from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Dict, FrozenSet, List, Optional, Tuple  # noqa: UP035
 
@@ -27,6 +29,20 @@ class RedshiftInstanceType(Enum):
 
     PROVISIONED = "PROVISIONED"
     SERVERLESS = "SERVERLESS"
+
+
+@dataclass(frozen=True)
+class RedshiftIamCredential:
+    """A temporary Redshift IAM credential and the time it expires.
+
+    Returned by GetClusterCredentials (provisioned) and GetCredentials
+    (serverless). ``expiration`` is the API-provided expiry timestamp, or None
+    when the response omits it.
+    """
+
+    user: str
+    password: str
+    expiration: Optional[datetime] = None  # noqa: UP045
 
 
 class RedshiftStoredProcedure(BaseModel):

--- a/ingestion/src/metadata/ingestion/source/database/redshift/models.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/models.py
@@ -13,7 +13,6 @@ Redshift models
 """
 
 import re
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Dict, FrozenSet, List, Optional, Tuple  # noqa: UP035
@@ -31,8 +30,7 @@ class RedshiftInstanceType(Enum):
     SERVERLESS = "SERVERLESS"
 
 
-@dataclass(frozen=True)
-class RedshiftIamCredential:
+class RedshiftIamCredential(BaseModel):
     """A temporary Redshift IAM credential and the time it expires.
 
     Returned by GetClusterCredentials (provisioned) and GetCredentials

--- a/ingestion/tests/unit/source/database/test_redshift_iam.py
+++ b/ingestion/tests/unit/source/database/test_redshift_iam.py
@@ -24,6 +24,8 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 import metadata.ingestion.source.database.redshift.connection as connection_module
 from metadata.generated.schema.entity.services.connections.database.common.iamAuthConfig import (
     IamAuthConfigurationSource,
@@ -34,6 +36,7 @@ from metadata.generated.schema.entity.services.connections.database.redshiftConn
 from metadata.generated.schema.security.credentials.awsCredentials import (
     AWSCredentials,
 )
+from metadata.ingestion.connections.test_connections import SourceConnectionException
 from metadata.ingestion.source.database.redshift.connection import (
     RedshiftIamCredentialManager,
     _build_iam_engine,
@@ -256,7 +259,60 @@ class TestRedshiftIamCredentialManager:
                 return manager.get_credentials()
 
             with ThreadPoolExecutor(max_workers=10) as executor:
-                results = [f.result() for f in [executor.submit(call) for _ in range(10)]]
+                futures = [executor.submit(call) for _ in range(10)]
+                results = [future.result() for future in futures]
 
             assert client.get_cluster_credentials.call_count == 1
             assert all(credential.password == "temp-pw" for credential in results)
+
+    def test_refresh_failure_reuses_still_valid_credential(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.side_effect = [
+                {"DbUser": "IAM:admin", "DbPassword": "pw-1", "Expiration": _future()},
+                Exception("transient AWS error"),
+            ]
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            first = manager.get_credentials()
+            # Within the refresh window but not yet expired: the proactive refresh fires
+            # and fails, and the still-valid cached credential must be reused.
+            manager._expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=2)
+            second = manager.get_credentials()
+
+            assert client.get_cluster_credentials.call_count == 2
+            assert second is first
+
+    def test_refresh_failure_raises_when_credential_expired(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.side_effect = [
+                {"DbUser": "IAM:admin", "DbPassword": "pw-1", "Expiration": _future()},
+                Exception("transient AWS error"),
+            ]
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            manager.get_credentials()
+            manager._expires_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
+            with pytest.raises(SourceConnectionException):
+                manager.get_credentials()
+
+    def test_naive_expiration_is_normalized_to_utc(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.return_value = {
+                "DbUser": "IAM:admin",
+                "DbPassword": "temp-pw",
+                # tz-naive on purpose: the manager must normalize it to UTC
+                "Expiration": datetime.datetime.now() + datetime.timedelta(minutes=14),
+            }
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            manager.get_credentials()
+
+            assert manager._expires_at.tzinfo is not None
+            # _needs_refresh subtracts a tz-aware "now"; this must not raise on a naive input.
+            assert manager._needs_refresh() is False

--- a/ingestion/tests/unit/source/database/test_redshift_iam.py
+++ b/ingestion/tests/unit/source/database/test_redshift_iam.py
@@ -127,8 +127,8 @@ class TestRedshiftIamEngine:
     @patch.object(connection_module, "create_generic_db_connection")
     def test_listener_injects_fresh_credentials_per_connection(self, mock_create, mock_listen, mock_manager):
         mock_manager.return_value.get_credentials.side_effect = [
-            RedshiftIamCredential("IAM:admin", "pw-1", _future()),
-            RedshiftIamCredential("IAM:admin", "pw-2", _future()),
+            RedshiftIamCredential(user="IAM:admin", password="pw-1", expiration=_future()),
+            RedshiftIamCredential(user="IAM:admin", password="pw-2", expiration=_future()),
         ]
 
         _build_iam_engine(_iam_connection(database="mydb"))

--- a/ingestion/tests/unit/source/database/test_redshift_iam.py
+++ b/ingestion/tests/unit/source/database/test_redshift_iam.py
@@ -1,0 +1,262 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Tests for Redshift IAM authentication credential refresh (issue #30541).
+
+Redshift temporary credentials from GetClusterCredentials / GetCredentials expire
+after ~15 minutes. The connector must inject a fresh credential on every new
+connection (via a SQLAlchemy ``do_connect`` listener) instead of baking a single
+credential into the connection URL, so that connections opened later in a long
+ingestion still authenticate successfully.
+"""
+
+import datetime
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import metadata.ingestion.source.database.redshift.connection as connection_module
+from metadata.generated.schema.entity.services.connections.database.common.iamAuthConfig import (
+    IamAuthConfigurationSource,
+)
+from metadata.generated.schema.entity.services.connections.database.redshiftConnection import (
+    RedshiftConnection,
+)
+from metadata.generated.schema.security.credentials.awsCredentials import (
+    AWSCredentials,
+)
+from metadata.ingestion.source.database.redshift.connection import (
+    RedshiftIamCredentialManager,
+    _build_iam_engine,
+)
+from metadata.ingestion.source.database.redshift.models import RedshiftIamCredential
+
+PROVISIONED_HOST = "my-cluster.abc123.us-east-1.redshift.amazonaws.com"
+SERVERLESS_HOST = "my-workgroup.123456789012.us-east-1.redshift-serverless.amazonaws.com"
+USERNAME = "admin"
+REGION = "us-east-1"
+
+
+def _iam_connection(host: str = PROVISIONED_HOST, **kwargs) -> RedshiftConnection:
+    kwargs.setdefault("username", USERNAME)
+    kwargs.setdefault("database", "dev")
+    return RedshiftConnection(
+        hostPort=f"{host}:5439",
+        authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion=REGION)),
+        **kwargs,
+    )
+
+
+def _future(minutes: int = 14) -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(minutes=minutes)
+
+
+class TestRedshiftIamEngine:
+    """The connector wires a per-connection credential-refresh listener for IAM auth."""
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_credentials_are_not_baked_into_url(self, mock_create, mock_listen, mock_manager):
+        connection = _iam_connection(database="mydb")
+
+        _build_iam_engine(connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(connection)
+        assert url == f"redshift+psycopg2://{USERNAME}@{PROVISIONED_HOST}:5439/mydb"
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_url_does_not_call_credentials_api(self, mock_create, mock_listen, mock_manager):
+        with patch.object(connection_module, "AWSClient") as mock_aws_client:
+            connection = _iam_connection(database="mydb")
+
+            _build_iam_engine(connection)
+            url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+            url_fn(connection)
+
+            mock_aws_client.assert_not_called()
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_url_without_database_omits_credentials(self, mock_create, mock_listen, mock_manager):
+        connection = _iam_connection(database="")
+
+        _build_iam_engine(connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(connection)
+        assert url == f"redshift+psycopg2://{USERNAME}@{PROVISIONED_HOST}:5439"
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_username_is_url_encoded(self, mock_create, mock_listen, mock_manager):
+        connection = _iam_connection(username="iam@user/db", database="mydb")
+
+        _build_iam_engine(connection)
+
+        url_fn = mock_create.call_args.kwargs["get_connection_url_fn"]
+        url = url_fn(connection)
+        assert "iam%40user%2Fdb" in url
+        assert "iam@user/db@" not in url
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_do_connect_listener_is_registered(self, mock_create, mock_listen, mock_manager):
+        _build_iam_engine(_iam_connection(database="mydb"))
+
+        event_name = mock_listen.call_args.args[1]
+        assert event_name == "do_connect"
+
+    @patch.object(connection_module, "RedshiftIamCredentialManager")
+    @patch.object(connection_module, "listen")
+    @patch.object(connection_module, "create_generic_db_connection")
+    def test_listener_injects_fresh_credentials_per_connection(self, mock_create, mock_listen, mock_manager):
+        mock_manager.return_value.get_credentials.side_effect = [
+            RedshiftIamCredential("IAM:admin", "pw-1", _future()),
+            RedshiftIamCredential("IAM:admin", "pw-2", _future()),
+        ]
+
+        _build_iam_engine(_iam_connection(database="mydb"))
+        listener = mock_listen.call_args.args[2]
+
+        first_cparams = {}
+        listener(None, None, None, first_cparams)
+        second_cparams = {}
+        listener(None, None, None, second_cparams)
+
+        assert first_cparams["user"] == "IAM:admin"
+        assert first_cparams["password"] == "pw-1"
+        assert second_cparams["password"] == "pw-2"
+        assert mock_manager.return_value.get_credentials.call_count == 2
+
+
+class TestRedshiftIamCredentialManager:
+    """The manager caches a credential and refreshes it before expiry."""
+
+    def test_first_call_fetches_credentials(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.return_value = {
+                "DbUser": "IAM:admin",
+                "DbPassword": "temp-pw",
+                "Expiration": _future(),
+            }
+            mock_aws.return_value.get_redshift_client.return_value = client
+
+            credential = RedshiftIamCredentialManager(_iam_connection()).get_credentials()
+
+            assert credential.user == "IAM:admin"
+            assert credential.password == "temp-pw"
+            assert client.get_cluster_credentials.call_count == 1
+
+    def test_credentials_cached_within_ttl(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.return_value = {
+                "DbUser": "IAM:admin",
+                "DbPassword": "temp-pw",
+                "Expiration": _future(),
+            }
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            manager.get_credentials()
+            manager.get_credentials()
+
+            assert client.get_cluster_credentials.call_count == 1
+
+    def test_credentials_refreshed_after_expiry(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.side_effect = [
+                {"DbUser": "IAM:admin", "DbPassword": "pw-1", "Expiration": _future()},
+                {"DbUser": "IAM:admin", "DbPassword": "pw-2", "Expiration": _future()},
+            ]
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            manager.get_credentials()
+            manager._expires_at = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=1)
+            second = manager.get_credentials()
+
+            assert client.get_cluster_credentials.call_count == 2
+            assert second.password == "pw-2"
+
+    def test_missing_expiration_falls_back_to_default_ttl(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.return_value = {
+                "DbUser": "IAM:admin",
+                "DbPassword": "temp-pw",
+            }
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            manager.get_credentials()
+            manager.get_credentials()
+
+            assert client.get_cluster_credentials.call_count == 1
+            assert manager._expires_at is not None
+
+    def test_serverless_expiration_is_honoured(self):
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_credentials.return_value = {
+                "dbUser": "IAMR:admin",
+                "dbPassword": "serverless-pw",
+                "expiration": _future(),
+            }
+            mock_aws.return_value.get_redshift_serverless_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection(SERVERLESS_HOST))
+
+            credential = manager.get_credentials()
+            manager.get_credentials()
+
+            assert credential.user == "IAMR:admin"
+            assert client.get_credentials.call_count == 1
+
+    def test_concurrent_get_credentials_refreshes_only_once(self):
+        """Many threads hitting a cold manager must trigger a single fetch.
+
+        Each worker thread calls engine.connect() -> the shared do_connect listener
+        -> the shared manager's get_credentials(). Without locking, threads racing on
+        a cold credential each call the credentials API. A slow fetch widens the race
+        window so the assertion is meaningful.
+        """
+
+        def slow_fetch(**_kwargs):
+            time.sleep(0.05)
+            return {"DbUser": "IAM:admin", "DbPassword": "temp-pw", "Expiration": _future()}
+
+        with patch.object(connection_module, "AWSClient") as mock_aws:
+            client = MagicMock()
+            client.get_cluster_credentials.side_effect = slow_fetch
+            mock_aws.return_value.get_redshift_client.return_value = client
+            manager = RedshiftIamCredentialManager(_iam_connection())
+
+            barrier = threading.Barrier(10)
+
+            def call():
+                barrier.wait()
+                return manager.get_credentials()
+
+            with ThreadPoolExecutor(max_workers=10) as executor:
+                results = [f.result() for f in [executor.submit(call) for _ in range(10)]]
+
+            assert client.get_cluster_credentials.call_count == 1
+            assert all(credential.password == "temp-pw" for credential in results)

--- a/ingestion/tests/unit/topology/database/test_redshift_connection.py
+++ b/ingestion/tests/unit/topology/database/test_redshift_connection.py
@@ -81,41 +81,6 @@ class TestGetRedshiftConnectionUrlBasicAuth:
         assert "admin" in url
 
 
-class TestGetRedshiftConnectionUrlIAMAuth:
-    @patch("metadata.ingestion.source.database.redshift.connection._get_redshift_iam_credentials")
-    def test_iam_auth_url_provisioned(self, mock_get_creds):
-        mock_get_creds.return_value = ("IAMUser:admin", "temporary-password-123")
-
-        connection = RedshiftConnection(
-            hostPort=f"{PROVISIONED_HOST}:5439",
-            username="admin",
-            authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion="us-east-1")),
-            database="mydb",
-        )
-        url = get_redshift_connection_url(connection)
-
-        mock_get_creds.assert_called_once_with(connection)
-        assert "redshift+psycopg2://" in url
-        assert "IAMUser" in url
-        assert "temporary-password-123" in url
-        assert f"{PROVISIONED_HOST}:5439" in url
-        assert url.endswith("/mydb")
-
-    @patch("metadata.ingestion.source.database.redshift.connection._get_redshift_iam_credentials")
-    def test_iam_auth_url_no_database(self, mock_get_creds):
-        mock_get_creds.return_value = ("admin", "temp-pass")
-
-        connection = RedshiftConnection(
-            hostPort=f"{PROVISIONED_HOST}:5439",
-            username="admin",
-            authType=IamAuthConfigurationSource(awsConfig=AWSCredentials(awsRegion="us-east-1")),
-            database="",
-        )
-        url = get_redshift_connection_url(connection)
-
-        assert url.endswith(f"{PROVISIONED_HOST}:5439")
-
-
 class TestGetRedshiftIAMCredentials:
     @patch("metadata.ingestion.source.database.redshift.connection.AWSClient")
     def test_provisioned_calls_get_cluster_credentials(self, mock_aws_client_cls):
@@ -133,10 +98,10 @@ class TestGetRedshiftIAMCredentials:
             database="mydb",
         )
 
-        user, password = _get_redshift_iam_credentials(connection)
+        credential = _get_redshift_iam_credentials(connection)
 
-        assert user == "IAM:admin"
-        assert password == "temp-password"
+        assert credential.user == "IAM:admin"
+        assert credential.password == "temp-password"
         mock_client.get_cluster_credentials.assert_called_once_with(
             DbUser="admin",
             ClusterIdentifier="my-cluster",
@@ -181,10 +146,10 @@ class TestGetRedshiftIAMCredentials:
             database="mydb",
         )
 
-        user, password = _get_redshift_iam_credentials(connection)
+        credential = _get_redshift_iam_credentials(connection)
 
-        assert user == "IAMR:admin"
-        assert password == "serverless-temp-password"
+        assert credential.user == "IAMR:admin"
+        assert credential.password == "serverless-temp-password"
         mock_client.get_credentials.assert_called_once_with(
             workgroupName="my-workgroup",
             dbName="mydb",
@@ -276,10 +241,10 @@ class TestExplicitClusterOverrides:
             clusterIdentifier="my-real-cluster",
         )
 
-        user, password = _get_redshift_iam_credentials(connection)
+        credential = _get_redshift_iam_credentials(connection)
 
-        assert user == "IAM:admin"
-        assert password == "temp-password"
+        assert credential.user == "IAM:admin"
+        assert credential.password == "temp-password"
         mock_client.get_cluster_credentials.assert_called_once_with(
             DbUser="admin",
             ClusterIdentifier="my-real-cluster",
@@ -304,10 +269,10 @@ class TestExplicitClusterOverrides:
             workgroupName="my-real-workgroup",
         )
 
-        user, password = _get_redshift_iam_credentials(connection)
+        credential = _get_redshift_iam_credentials(connection)
 
-        assert user == "IAMR:admin"
-        assert password == "serverless-temp-password"
+        assert credential.user == "IAMR:admin"
+        assert credential.password == "serverless-temp-password"
         mock_client.get_credentials.assert_called_once_with(
             workgroupName="my-real-workgroup",
             dbName="mydb",


### PR DESCRIPTION
### Describe your changes:

Fixes #30541

Redshift IAM temporary credentials from `GetClusterCredentials` (provisioned) and `redshift-serverless GetCredentials` (serverless) are short-lived (default ~15 minutes), but the connector fetched them once at engine-build time and baked the returned `user:password` directly into the SQLAlchemy connection URL. That single frozen credential is reused for the engine's whole lifetime, so a long ingestion that opens a new pooled connection after the credential expires (large catalogs, the profiler, reconnects) authenticates with a stale credential and fails partway through with `FATAL: IAM Authentication token has expired`. A short run reuses one still-valid connection and passes, which is why it presents as intermittent.

I build the IAM engine with no credential in the URL and attach a SQLAlchemy `do_connect` listener that injects a fresh credential on every connection, backed by a small `RedshiftIamCredentialManager` that caches the current credential and regenerates it shortly before expiry (keyed off the API's `Expiration` timestamp, with a conservative default-TTL fallback). This is the same class of fix already merged for MySQL RDS IAM in #28730, adapted to Redshift's credentials API. Scope is Redshift only.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

The Redshift IAM path is separate from the shared `builders.py` RDS path: it has its own `get_redshift_connection_url` and credential helpers using the Redshift APIs, not the RDS `generate_db_auth_token` token, so the MySQL #28730 fix did not cover it.

Changes (all inline in the connector, matching the SQLAlchemy-connector convention and CLAUDE.md's "Redshift IAM auth should be in `redshift/connection.py`"):
- `redshift/models.py`: new frozen `RedshiftIamCredential(user, password, expiration)` dataclass.
- `redshift/connection.py`:
  - the three IAM credential helpers now return `RedshiftIamCredential`, carrying the API `Expiration`.
  - `RedshiftIamCredentialManager`: thread-safe, caches the credential and refreshes it within a 5-minute threshold of expiry (Redshift returns a real `Expiration`, so no presigned-URL parsing is needed, unlike MySQL). Falls back to a 15-minute default TTL when the response omits `Expiration`.
  - `_build_iam_engine`: builds the engine with a password-less URL and attaches a `do_connect` listener that injects a fresh `user`/`password` per connection.
  - `get_redshift_connection_url` builds a password-less URL for IAM; `_get_client` routes IAM auth through `_build_iam_engine`.

Alternatives considered: refreshing at the shared `builders.py` layer (would touch Postgres/Greenplum/Timescale and is a separate follow-up), and a full `EngineStrategy` hierarchy like MySQL (overkill for Redshift's two auth types). Blast radius is zero outside the connector: nothing else imports these functions and no other connector uses Redshift's credential APIs.

#
### Tests:

#### Use cases covered
- A long Redshift IAM ingestion (provisioned or serverless) that opens a new pooled connection after the ~15 minute credential TTL keeps authenticating instead of failing with "IAM Authentication token has expired".
- Explicit `clusterIdentifier` / `workgroupName` overrides and PrivateLink/VPC-endpoint hostnames (#28127) continue to work.

#### Unit tests
- [x] Added `ingestion/tests/unit/source/database/test_redshift_iam.py` (mirrors `test_mysql_iam.py`): engine wiring (no credential baked into the URL, `do_connect` listener registered, fresh `user`/`password` injected per connection) and the manager (caches within TTL, refreshes after expiry, default-TTL fallback, serverless expiry, thread-safe single refresh under concurrency).
- [x] Updated `ingestion/tests/unit/topology/database/test_redshift_connection.py` for the new credential return type and password-less IAM URL.
- Full redshift unit suite passes (108 tests incl. the shared `test_iam_token_refresh.py`, confirming the shared RDS path is unaffected). ruff + basedpyright clean.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable as automated CI (needs a live IAM-enabled Redshift cluster); verified manually against a real cluster instead (see below).

#### Manual testing performed
Verified against a live Redshift cluster (provisioned, IAM auth), with the 15-minute credential TTL confirmed via `get-cluster-credentials`:
1. Deterministic (real AWS): the manager returns two distinct temporary passwords across refreshes and caches within the TTL.
2. Live 25-minute repro, real connector code, forcing a new physical connection after expiry:
   - With the fix: the second connection uses a freshly rotated credential and succeeds.
   - Without the fix (current `main`): the second connection reuses the stale credential and fails with `FATAL: IAM Authentication token has expired`.
3. Full `metadata ingest` run through the fixed connector: test connection + database/schema/table extraction succeeded (100% success).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #30541` above.
- [x] For JSON Schema changes: not applicable (no schema changes).
- [x] For UI changes: not applicable.
- [x] I have added unit tests and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refreshes temporary Redshift IAM credentials for each new physical database connection.
- Adds a thread-safe credential manager with expiration-aware caching and refresh-failure handling.
- Registers a SQLAlchemy `do_connect` listener that injects current IAM credentials without embedding passwords in connection URLs.
- Preserves provisioned and serverless Redshift credential flows and adds focused unit coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/redshift/connection.py | Adds expiration-aware IAM credential management and per-connection credential injection for Redshift engines. |
| ingestion/src/metadata/ingestion/source/database/redshift/models.py | Defines the structured Redshift IAM credential response, including its expiration timestamp. |
| ingestion/tests/unit/source/database/test_redshift_iam.py | Covers engine listener wiring, credential caching and refresh, fallback expiration, failure handling, and concurrency. |
| ingestion/tests/unit/topology/database/test_redshift_connection.py | Updates credential-helper assertions for the structured IAM credential return type. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Job as Ingestion Job
    participant Pool as SQLAlchemy Pool
    participant Listener as do_connect Listener
    participant Manager as IAM Credential Manager
    participant AWS as Redshift API
    participant DB as Redshift
    Job->>Pool: Request connection
    Pool->>Listener: Open physical connection
    Listener->>Manager: get_credentials()
    alt Credential absent or near expiry
        Manager->>AWS: Get temporary credentials
        AWS-->>Manager: User, password, expiration
    else Cached credential remains valid
        Manager-->>Manager: Reuse cached credential
    end
    Manager-->>Listener: Current credential
    Listener->>DB: Connect with injected user/password
    DB-->>Job: Authenticated connection
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Make Redshift IAM credential refresh bes..."](https://github.com/open-metadata/openmetadata/commit/02e21956f01001f9dfa27636f09db9a5b81e1ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48567085)</sub>

<!-- /greptile_comment -->