### PR TITLE
fix(ui): make the Asset Health widget E2E spec seed its own tables

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AssetHealthWidget.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AssetHealthWidget.spec.ts
@@ -10,34 +10,46 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { TableClass } from '../../support/entity/TableClass';
+import { performAdminLogin } from '../../utils/admin';
 import { redirectToHomePage } from '../../utils/common';
-import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { test } from '../fixtures/pages';
 
-// These specs drive the real app against the demo `sample_data` tables (no seeded
-// fixtures, no response mocking), so coverage is limited to the states sample data
-// actually exhibits: the unconfigured setup-CTA rows + their navigation, and the
-// one sample table that has a real test suite. Exhaustive per-tone, transient,
-// loading and error states are covered by AssetHealthWidget.utils.test.ts.
-
-// sample_data table with no test suite and no contract -> those rows show setup CTAs
-const EMPTY_TABLE_FQN = 'sample_data.ecommerce_db.shopify.fact_sale';
-// the one sample_data table that ships with a native test suite + test cases
-const TEST_SUITE_TABLE_FQN = 'sample_data.ecommerce_db.shopify.dim_address';
-
-const visitTable = async (page: Page, fqn: string) => {
-  await page.goto(`/table/${fqn}`);
-  await waitForAllLoadersToDisappear(page);
-};
+const emptyTable = new TableClass();
+const testSuiteTable = new TableClass();
 
 test.describe('Asset Health widget', () => {
+  test.beforeAll('Create the tables under test', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await emptyTable.create(apiContext);
+    await testSuiteTable.create(apiContext);
+    const testCase = await testSuiteTable.createTestCase(apiContext);
+    await testSuiteTable.addTestCaseResult(
+      apiContext,
+      testCase.fullyQualifiedName,
+      {
+        result: 'Asset health widget fixture',
+        testCaseStatus: 'Success',
+        timestamp: Date.now(),
+      }
+    );
+    await afterAction();
+  });
+
+  test.afterAll('Remove the tables under test', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await emptyTable.delete(apiContext);
+    await testSuiteTable.delete(apiContext);
+    await afterAction();
+  });
+
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
   });
 
   test('renders the widget with all four category rows', async ({ page }) => {
-    await visitTable(page, TEST_SUITE_TABLE_FQN);
+    await testSuiteTable.visitEntityPage(page);
 
     await expect(page.getByTestId('asset-health-widget')).toBeVisible();
     await expect(page.getByTestId('asset-health-row-pipeline')).toBeVisible();
@@ -51,7 +63,7 @@ test.describe('Asset Health widget', () => {
   });
 
   test('shows setup CTAs for unconfigured categories', async ({ page }) => {
-    await visitTable(page, EMPTY_TABLE_FQN);
+    await emptyTable.visitEntityPage(page);
 
     await expect(page.getByTestId('asset-health-widget')).toBeVisible();
     await expect(
@@ -64,7 +76,7 @@ test.describe('Asset Health widget', () => {
   });
 
   test('Add tests CTA navigates to the Profiler tab', async ({ page }) => {
-    await visitTable(page, EMPTY_TABLE_FQN);
+    await emptyTable.visitEntityPage(page);
 
     await page.getByTestId('asset-health-cta-dataQuality').click();
 
@@ -74,7 +86,7 @@ test.describe('Asset Health widget', () => {
   test('Enable observability CTA navigates to the Profiler tab', async ({
     page,
   }) => {
-    await visitTable(page, EMPTY_TABLE_FQN);
+    await emptyTable.visitEntityPage(page);
 
     await page.getByTestId('asset-health-cta-dataObservability').click();
 
@@ -84,25 +96,27 @@ test.describe('Asset Health widget', () => {
   test('Create contract CTA navigates to the Contract tab', async ({
     page,
   }) => {
-    await visitTable(page, EMPTY_TABLE_FQN);
+    await emptyTable.visitEntityPage(page);
 
     await page.getByTestId('asset-health-cta-contract').click();
 
     await expect(page).toHaveURL(/\/table\/.*\/contract/);
   });
 
-  test('reflects a configured test suite via the data observability row', async ({
+  test('replaces the setup CTAs with status badges once tests are configured', async ({
     page,
   }) => {
-    await visitTable(page, TEST_SUITE_TABLE_FQN);
+    await testSuiteTable.visitEntityPage(page);
 
-    // dim_address has a real test suite, so the observability row is driven by
-    // testSuite presence and renders a status badge rather than the setup CTA.
     await expect(
       page.getByTestId('asset-health-row-dataObservability')
     ).toBeVisible();
     await expect(
+      page.getByTestId('asset-health-row-dataQuality')
+    ).toBeVisible();
+    await expect(
       page.getByTestId('asset-health-cta-dataObservability')
     ).toBeHidden();
+    await expect(page.getByTestId('asset-health-cta-dataQuality')).toBeHidden();
   });
 });


### PR DESCRIPTION
Fixes three Asset Health widget specs failing on `main` ([run 30482475429](https://github.com/open-metadata/OpenMetadata/actions/runs/30482475429/job/90687811403)):

```
✘ shows setup CTAs for unconfigured categories
✘ Add tests CTA navigates to the Profiler tab
✘ Enable observability CTA navigates to the Profiler tab
```

## Why

The spec used `sample_data.ecommerce_db.shopify.fact_sale` as its "no test suite, no contract" fixture. `6e5bc803a8` (#30367) added `fact_sale.testSuite` to `ingestion/examples/sample_data/tests/testSuites.json`, and both failing rows are gated on the table's test suite:

| row | CTA renders only when |
|---|---|
| `asset-health-cta-dataQuality` | `!hasTests \|\| summary.total === 0` |
| `asset-health-cta-dataObservability` | `!hasTests` |

`AssetHealthRowItem` renders either the CTA `<button>` or a `<Badge>`, never both — so the testids stopped existing. Deterministic, not flaky.

## What changed

- **The spec creates its own tables** in `beforeAll` and deletes them in `afterAll`, so sample-data drift can't break it again. Re-pointing the constant at another sample table would only reset the timer — that commit took three tables out of eligibility at once.
- **Dropped the local `visitTable` helper** for the existing `TableClass.visitEntityPage(page)`, which adds `encodeURIComponent` and a `waitForResponse` on the table's own fetch, and stays off the search-box path (which would time out on a freshly created, unindexed table).
- **Added the missing assertion** on the data quality row's badge state — the branch that actually broke. It needs a test case *result*, not just a test case, since the execution summary only counts cases that have one.

## Verification

Ran against a local stack built from this branch (`system/version` revision matched `git rev-parse HEAD`):

```
9 passed (38.0s)     # first run, incl. setup + entity-data-setup
12 passed (17.7s)    # --repeat-each=2
```

Temporarily giving the "empty" table a test case reproduced the CI failure on the same testids, confirming the assertions discriminate. `eslint`, `prettier`, `organize-imports` and `tsc` clean; no services left behind after the run.

Test-only change — no UI recording applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes the Asset Health widget E2E suite independent of mutable sample data.
- Creates dedicated empty and test-suite-backed table fixtures.
- Adds a test-case result to exercise configured health badges.
- Uses the shared entity-page navigation helper.
- Deletes the generated fixtures after the suite.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until teardown guarantees that every generated fixture is removed even when an earlier deletion fails.

The first rejected fixture deletion still prevents the second deletion and final cleanup from running, which can leave generated backend state that interferes with later E2E execution.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AssetHealthWidget.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/AssetHealthWidget.spec.ts | Seeds deterministic Asset Health fixtures and expands badge assertions, but the previously reported teardown short-circuit remains outstanding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ui): make the Asset Health widget E2..."](https://github.com/open-metadata/openmetadata/commit/86f274fcf5273a20dce7a4c4596c385496ad3c69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48597587)</sub>

<!-- /greptile_comment -->