### PR TITLE
fix(playwright): paginate across pages in GlossaryTermRelationSettings tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -124,6 +124,28 @@ const deleteRelationInUi = async (page: Page, name: string) => {
   }).toPass();
 };
 
+// Parallel test workers can push the table past PAGE_SIZE_BASE, putting the
+// target row on page 2+. Navigate forward page-by-page until the row is
+// visible, so individual CRUD tests remain stable regardless of total count.
+const findRowAcrossPages = async (page: Page, testId: string): Promise<void> => {
+  while (!(await page.getByTestId(testId).isVisible())) {
+    const nextBtn = page.getByRole('button', { name: 'Next Page' }).first();
+    const hasNextPage = (await nextBtn.count()) > 0 && (await nextBtn.isEnabled());
+
+    if (!hasNextPage) {
+      throw new Error(`testId "${testId}" not found on any page`);
+    }
+
+    const nextPageResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/glossaryTermRelationSettings/relationTypes') &&
+        response.request().method() === 'GET'
+    );
+    await nextBtn.click();
+    await nextPageResponse;
+  }
+};
+
 test.describe('Glossary Term Relation Settings', () => {
   test.beforeEach(async ({ page }) => {
     await authenticateAdminPage(page);
@@ -173,6 +195,7 @@ test.describe('Glossary Term Relation Settings', () => {
 
       await goToRelationSettings(page);
 
+      await findRowAcrossPages(page, `edit-${relationName}-btn`);
       await page.getByTestId(`edit-${relationName}-btn`).click();
       await expect(page.getByTestId('relation-type-drawer')).toBeVisible();
 
@@ -221,6 +244,7 @@ test.describe('Glossary Term Relation Settings', () => {
 
       await goToRelationSettings(page);
 
+      await findRowAcrossPages(page, `relation-name-${relationName}`);
       await expect(
         page.getByTestId(`relation-name-${relationName}`)
       ).toBeVisible();
@@ -243,6 +267,7 @@ test.describe('Glossary Term Relation Settings', () => {
   }) => {
     await goToRelationSettings(page);
 
+    await findRowAcrossPages(page, `relation-name-${SYSTEM_DEFINED_RELATION}`);
     await expect(
       page.getByTestId(`relation-name-${SYSTEM_DEFINED_RELATION}`)
     ).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -127,12 +127,24 @@ const deleteRelationInUi = async (page: Page, name: string) => {
 // Parallel test workers can push the table past PAGE_SIZE_BASE, putting the
 // target row on page 2+. Navigate forward page-by-page until the row is
 // visible, so individual CRUD tests remain stable regardless of total count.
+//
+// Uses waitFor (not isVisible) so React has time to flush new rows after each
+// page navigation before we decide whether to advance. isVisible() is
+// instantaneous and would read the stale DOM from the previous page,
+// causing the loop to skip the target and eventually throw.
 const findRowAcrossPages = async (page: Page, testId: string): Promise<void> => {
-  while (!(await page.getByTestId(testId).isVisible())) {
-    const nextBtn = page.getByRole('button', { name: 'Next Page' }).first();
-    const hasNextPage = (await nextBtn.count()) > 0 && (await nextBtn.isEnabled());
+  const target = page.getByTestId(testId);
 
-    if (!hasNextPage) {
+  while (true) {
+    const found = await target
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true, () => false);
+
+    if (found) return;
+
+    const nextBtn = page.getByRole('button', { name: 'Next Page' }).first();
+
+    if ((await nextBtn.count()) === 0 || !(await nextBtn.isEnabled())) {
       throw new Error(`testId "${testId}" not found on any page`);
     }
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -132,13 +132,19 @@ const deleteRelationInUi = async (page: Page, name: string) => {
 // page navigation before we decide whether to advance. isVisible() is
 // instantaneous and would read the stale DOM from the previous page,
 // causing the loop to skip the target and eventually throw.
-const findRowAcrossPages = async (page: Page, testId: string): Promise<void> => {
+const findRowAcrossPages = async (
+  page: Page,
+  testId: string
+): Promise<void> => {
   const target = page.getByTestId(testId);
 
   while (true) {
     const found = await target
       .waitFor({ state: 'visible', timeout: 3_000 })
-      .then(() => true, () => false);
+      .then(
+        () => true,
+        () => false
+      );
 
     if (found) return;
 
@@ -150,7 +156,9 @@ const findRowAcrossPages = async (page: Page, testId: string): Promise<void> => 
 
     const nextPageResponse = page.waitForResponse(
       (response) =>
-        response.url().includes('/glossaryTermRelationSettings/relationTypes') &&
+        response
+          .url()
+          .includes('/glossaryTermRelationSettings/relationTypes') &&
         response.request().method() === 'GET'
     );
     await nextBtn.click();


### PR DESCRIPTION
## Summary
- Parallel test workers accumulate relation types that push the table beyond `PAGE_SIZE_BASE` (15), sending target rows to page 2+
- The `edits`, `deletes`, and `locks system-defined` tests were failing because they only inspected page 1
- Added a `findRowAcrossPages` helper that clicks **Next Page** until the target `data-testid` is visible, then each affected test calls it before interacting with the row

## Test plan
- [ ] `edits a custom relation type and keeps the name immutable` — now navigates to the correct page before clicking the edit button
- [ ] `deletes a custom relation type` — now navigates to the correct page before checking visibility and deleting
- [ ] `locks system-defined relation types from edit and delete` — now navigates to find `relatedTo` before asserting disabled state
- [ ] No other tests changed; `creates` and `paginates` tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a pagination-aware row lookup helper for glossary relation settings tests.
- Waits for each page’s rows to render before advancing.
- Uses the helper before editing, deleting, and checking system-defined relation types.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previous page-traversal race is resolved by waiting for the target locator to become visible after each page transition, and no blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts | The new web-first visibility wait addresses the previously reported rendering race before pagination advances. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/glossary-te..."](https://github.com/open-metadata/openmetadata/commit/9ba4c99c62c96a760e24cda0e9141b7ee7a9fb05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48599537)</sub>

<!-- /greptile_comment -->