### PR TITLE
fix(ui): mark column profile row header

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -43,7 +43,17 @@ jest.mock('@openmetadata/ui-core-components', () => {
         ),
       Head: jest
         .fn()
-        .mockImplementation(({ label }: { label: string }) => <th>{label}</th>),
+        .mockImplementation(
+          ({
+            isRowHeader,
+            label,
+          }: {
+            isRowHeader?: boolean;
+            label: string;
+          }) => (
+            <th data-row-header={isRowHeader ? 'true' : undefined}>{label}</th>
+          )
+        ),
       Body: jest
         .fn()
         .mockImplementation(
@@ -191,6 +201,16 @@ describe('Test ColumnProfileTable component', () => {
       await screen.findByTestId('column-profile-table-container')
     ).toBeInTheDocument();
     expect(await screen.findByTestId('searchbar')).toBeInTheDocument();
+  });
+
+  it('should mark the name column as the row header', async () => {
+    await act(async () => {
+      render(<ColumnProfileTable />, { wrapper: MemoryRouter });
+    });
+
+    expect(
+      await screen.findByRole('columnheader', { name: 'label.name' })
+    ).toHaveAttribute('data-row-header', 'true');
   });
 
   it('should render without crashing even if column is undefined', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx
@@ -483,6 +483,7 @@ const ColumnProfileTable = () => {
                   <Table.Head
                     allowsSorting={col.allowsSorting}
                     id={col.id}
+                    isRowHeader={col.id === 'name'}
                     key={col.id}
                     label={col.name}
                   />


### PR DESCRIPTION
### Describe your changes:

Marks the column name as the row header in the column profile table. This satisfies the React Aria table accessibility contract and prevents the column-profile page from crashing with `A table must have at least one Column with the isRowHeader prop set to true`.

Adds a regression test that verifies the name column is designated as the row header.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Opening the column-profile table provides the required accessible row-header column.

#### Unit tests

- [x] Updated `ColumnProfileTable.test.tsx` with the exact regression scenario.
- Full UI suite: 1,150 suites passed; 13,467 tests passed.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (covered by a focused unit regression test).

#### Manual testing performed

- Verified the production exception and affected route in Sentry.

#
### UI screen recording / screenshots:

Not applicable — no visual change.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have added a test that covers the exact scenario being fixed.
- [x] I have added tests and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents the column-profile table from violating React Aria’s accessibility contract.
- Marks the name column as the table’s row-header column.
- Adds a focused regression test asserting the row-header designation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.tsx | Marks the existing name column as the React Aria row header, preventing table initialization from failing. |
| openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx | Extends the table mock and adds a regression assertion for the name column’s row-header property. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ui/fix-column-p..."](https://github.com/open-metadata/openmetadata/commit/4bfbd8f727d50b292ab3d9aab977ea71c2731eef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48611905)</sub>

<!-- /greptile_comment -->