### PR TITLE
Add view more / less support in the rich comments components

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts
@@ -35,6 +35,7 @@ import {
   getDecodedFqn,
   getEncodedFqn,
   getPermissionErrorText,
+  getTrimmedContent,
   jsonToCSV,
   ordinalize,
   removeAttachmentsWithoutUrl,
@@ -417,6 +418,38 @@ describe('StringUtils', () => {
       expect(getPermissionErrorText('plain error', 'fallback')).toBe(
         'plain error'
       );
+    });
+  });
+
+  describe('getTrimmedContent', () => {
+    it('should trim multi-word content to the limit without a broken last word', () => {
+      const content = 'the quick brown fox jumps over the lazy dog';
+
+      const result = getTrimmedContent(content, 20);
+
+      expect(result.length).toBeLessThanOrEqual(20);
+      // last (potentially broken) word is dropped
+      expect(content.startsWith(result)).toBe(true);
+      expect(result).toBe('the quick brown fox');
+    });
+
+    it('should cap a single space-less token to the limit so see-more truncates', () => {
+      const token = 'Please'.repeat(200);
+
+      const result = getTrimmedContent(token, 350);
+
+      expect(result).toHaveLength(350);
+      expect(result).toBe(token.slice(0, 350));
+      // the returned preview must be shorter than the full token
+      expect(result.length).toBeLessThan(token.length);
+    });
+
+    it('should only consider the first three lines', () => {
+      const content = 'line-one\nline-two\nline-three\nline-four';
+
+      const result = getTrimmedContent(content, 1000);
+
+      expect(result).not.toContain('line-four');
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts
@@ -55,9 +55,7 @@ export const getTrimmedContent = (content: string, limit: number) => {
   const wordsCount = words.length;
 
   if (wordsCount === 1) {
-    // In case of only one word (possibly too long URL)
-    // return the whole word instead of trimming
-    return content.split(' ')[0];
+    return slicedContent;
   }
 
   // Eliminate word at the end to avoid using broken words


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30669 


https://github.com/user-attachments/assets/687c68ef-12bf-4a9b-9785-15d560f54fc7



#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI Utilities:**
    - Updated `getTrimmedContent` in `StringUtils.ts` to properly cap single-word/space-less tokens up to the limit.
    - Added comprehensive unit tests for `getTrimmedContent` covering multi-word trimming, single token capping, and line limits.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates rich-comment preview truncation for long, space-less content.
- Returns the length-capped preview when the sliced content contains a single token.
- Adds unit coverage for multi-word truncation, long single tokens, and the three-line limit.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.ts | Updates single-token preview handling to honor the supplied character limit. |
| openmetadata-ui/src/main/resources/ui/src/utils/StringUtils.test.ts | Adds focused tests for word-boundary, single-token, and line-count truncation behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into issue-30669"](https://github.com/open-metadata/openmetadata/commit/d7d14f0069ebb0469317e8a6aeffd5e902e6f8ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48612096)</sub>

<!-- /greptile_comment -->