### PR TITLE
fix(e2e): converge SubDomainPagination on search indexing instead of racing it

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts
@@ -15,12 +15,12 @@ import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
 import { Domain } from '../../support/domain/Domain';
 import { SubDomain } from '../../support/domain/SubDomain';
+import { createNewPage, redirectToHomePage } from '../../utils/common';
 import {
-  createNewPage,
-  getApiContext,
-  redirectToHomePage,
-} from '../../utils/common';
-import { createSubDomain, selectDomain } from '../../utils/domain';
+  checkSubDomainCount,
+  createSubDomain,
+  selectDomain,
+} from '../../utils/domain';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { sidebarClick } from '../../utils/sidebar';
 
@@ -29,6 +29,7 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 const domain = new Domain();
 const subDomains: SubDomain[] = [];
 const SUBDOMAIN_COUNT = 60;
+const PAGE_SIZE = 9;
 
 test.describe('SubDomain Pagination', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.slow(true);
@@ -77,16 +78,14 @@ test.describe('SubDomain Pagination', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     await waitForAllLoadersToDisappear(page);
 
     await test.step('Verify subdomain count in tab label', async () => {
-      const subDomainsTab = page.getByTestId('subdomains');
+      await expect(page.getByTestId('subdomains')).toBeVisible();
 
-      await expect(subDomainsTab).toBeVisible();
-
-      await expect(subDomainsTab).toContainText('60');
+      await checkSubDomainCount(page, SUBDOMAIN_COUNT);
     });
 
     await test.step('Navigate to subdomains tab and verify initial data load', async () => {
       const subDomainRes = page.waitForResponse(
-        '/api/v1/search/query?q=&index=domain&from=0&size=9*'
+        `/api/v1/search/query?q=&index=domain&from=0&size=${PAGE_SIZE}*`
       );
       await page.getByTestId('subdomains').click();
       await subDomainRes;
@@ -99,7 +98,7 @@ test.describe('SubDomain Pagination', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       // Verify current page shows page 1
       const tableRows = page.locator('table tbody tr');
 
-      await expect(tableRows).toHaveCount(9);
+      await expect(tableRows).toHaveCount(PAGE_SIZE);
     });
 
     await test.step('Test pagination navigation', async () => {
@@ -116,27 +115,7 @@ test.describe('SubDomain Pagination', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       const subDomain = new SubDomain(domain);
       await createSubDomain(page, subDomain.data);
 
-      await redirectToHomePage(page);
-
-      await sidebarClick(page, SidebarItem.DOMAIN);
-
-      await selectDomain(page, domain.data);
-
-      const subDomainsTab = page.getByTestId('subdomains');
-
-      await expect(subDomainsTab).toContainText('61');
-
-      const { apiContext, afterAction } = await getApiContext(page);
-
-      const response = await apiContext.get(
-        '/api/v1/domains/name/' +
-          encodeURIComponent(`"${domain.data.name}"."NewTestSubDomain"`)
-      );
-      const subDomainData = await response.json();
-      await apiContext.delete(
-        `/api/v1/domains/${subDomainData.id}?hardDelete=true`
-      );
-      await afterAction();
+      await checkSubDomainCount(page, SUBDOMAIN_COUNT + 1);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -411,18 +411,44 @@ export const selectDomain = async (page: Page, domain: Domain['data']) => {
   const searchBox = page
     .getByTestId('page-layout-v1')
     .getByPlaceholder('Search');
+  const domainRow = page.getByTestId(domain.name);
 
   await waitForAllLoadersToDisappear(page);
 
-  await Promise.all([
-    searchBox.fill(domain.name),
-    page.waitForResponse('/api/v1/search/query?q=*&index=domain*'),
-  ]);
+  // The domain listing is search-backed, and search indexing is eventually
+  // consistent — a domain created moments ago can legitimately be missing from
+  // the first query. Retry the search, reloading between attempts, so the row
+  // is only clicked once it is actually there; otherwise the click auto-waits
+  // against a list that will never contain it and burns the test timeout.
+  let hasSearched = false;
+  await expect
+    .poll(
+      async () => {
+        if (hasSearched) {
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+        }
+        hasSearched = true;
 
-  await waitForSearchDebounce(page);
+        await Promise.all([
+          searchBox.fill(domain.name),
+          page.waitForResponse('/api/v1/search/query?q=*&index=domain*'),
+        ]);
+
+        await waitForSearchDebounce(page);
+
+        return domainRow.isVisible();
+      },
+      {
+        message: `Wait for domain "${domain.name}" to appear in the domain listing`,
+        timeout: 60_000,
+        intervals: [2_000, 3_000, 5_000],
+      }
+    )
+    .toBe(true);
 
   await Promise.all([
-    page.getByTestId(domain.name).click(),
+    domainRow.click(),
     page.waitForResponse('/api/v1/domains/name/*'),
   ]);
 
@@ -658,6 +684,44 @@ export const checkDataProductCount = async (page: Page, count: number) => {
         return text?.trim();
       },
       { timeout: 30_000, intervals: [500, 1_000, 2_000] }
+    )
+    .toBe(count.toString());
+};
+
+/**
+ * Asserts the sub-domain tab count, alongside checkAssetsCount and
+ * checkDataProductCount.
+ *
+ * Unlike those two this reloads between attempts. The sub-domain count is
+ * rendered from a search query the domain page issues once, on mount, and
+ * search indexing is eventually consistent — so a render that raced indexing
+ * never refreshes itself and polling the label alone would just re-read a
+ * frozen DOM until the timeout. Reloading re-issues the query.
+ */
+export const checkSubDomainCount = async (page: Page, count: number) => {
+  let shouldReload = false;
+
+  await expect
+    .poll(
+      async () => {
+        if (shouldReload) {
+          await page.reload();
+          await waitForAllLoadersToDisappear(page);
+        }
+        shouldReload = true;
+
+        const text = await page
+          .getByTestId('subdomains')
+          .getByTestId('count')
+          .textContent();
+
+        return text?.trim();
+      },
+      {
+        message: `Wait for the sub-domain tab count to reach ${count}`,
+        timeout: 120_000,
+        intervals: [2_000, 3_000, 5_000],
+      }
     )
     .toBe(count.toString());
 };


### PR DESCRIPTION
## Describe your changes

`SubDomainPagination.spec.ts` has been failing consistently on the `chromium-07` shard of the Postgres E2E lane — including on merge-queue runs against `main`, so it is not specific to any one PR.

**Failing runs (all 2026-07-30):** [30523193756](https://github.com/open-metadata/OpenMetadata/actions/runs/30523193756), [30523192930](https://github.com/open-metadata/OpenMetadata/actions/runs/30523192930), [30519905142](https://github.com/open-metadata/OpenMetadata/actions/runs/30519905142), [30519902499](https://github.com/open-metadata/OpenMetadata/actions/runs/30519902499), [30519901858](https://github.com/open-metadata/OpenMetadata/actions/runs/30519901858), [30518989464](https://github.com/open-metadata/OpenMetadata/actions/runs/30518989464), [30518966596](https://github.com/open-metadata/OpenMetadata/actions/runs/30518966596), [30518934500](https://github.com/open-metadata/OpenMetadata/actions/runs/30518934500), [30518865830](https://github.com/open-metadata/OpenMetadata/actions/runs/30518865830)

```
Error: expect(locator).toContainText(expected) failed
Locator:  getByTestId('subdomains')
Expected substring: "61"
Received string:    "Sub Domains60"
Timeout: 15000ms
  19 × locator resolved to <div data-testid="subdomains" ...>
     - unexpected value "Sub Domains60"
```

### Root cause

Both failure modes are the same defect: the test asserts on state served from Elasticsearch — which is eventually consistent — using assertions that cannot cause a refetch.

The sub-domain tab count comes from `fetchSubDomainsCount` in `DomainDetails.component.tsx`, a `searchQuery` against `SearchIndex.DOMAIN` issued **once**, in a mount-time `useEffect`. `expect(locator).toContainText()` retries the **DOM**, not the fetch. So if that single read lands before the new document is searchable, the label is stuck and the assertion can only burn its timeout.

The server access log from run `30523193756` confirms this precisely:

| time | request |
|---|---|
| `08:21:52` | `POST /api/v1/domains` → **201** (the 61st sub-domain is created) |
| `08:21:52` | count query (`parent.fullyQualifiedName.keyword`, `size=0`) |
| `08:21:58` | count query again, on domain-page mount |
| `08:21:58` → `08:22:14` | **no search query at all** |
| `08:22:14` | `afterAll` recursive delete |

The whole 15 s assertion window elapsed with zero refetches. The create genuinely succeeded (201) — the test simply read a stale index once and then polled a frozen DOM.

The **retry** then failed differently but from the same cause. Playwright re-runs `beforeAll` on retry, so a brand-new domain was created (60 POSTs at `08:22:17`) and `selectDomain` immediately searched for it before it was indexed. The row never appeared, so the click auto-waited to the 180 s test timeout:

```
Test timeout of 180000ms exceeded.
Error: page.waitForResponse: Test timeout of 180000ms exceeded.
  waiting for response "/api/v1/domains/name/*"
  at selectDomain (playwright/utils/domain.ts:426:10)
```

The retry screenshot shows the Domains list with the search box filled but the target domain absent — search returned fuzzy matches on sibling `PW Domain *` fixtures instead.

### Changes

- **`checkSubDomainCount`** — added next to the existing `checkAssetsCount` / `checkDataProductCount`, following their shape (poll the `count` testid, exact `toBe`). Unlike those two it reloads between attempts, because this count is one-shot; reloading is what actually re-issues the query. First attempt does not reload, so the happy path costs nothing.
- **`selectDomain`** — retries the search until the row is visible before clicking, instead of clicking into a list that may not contain it yet. This is the root cause of the retry hang and is latent for every spec that creates a domain and immediately selects it. It also replaces an opaque `waitForResponse` timeout with a clear message.
- Removed the inline cleanup that looked up a hardcoded `"NewTestSubDomain"`. `SubDomain` generates `PW%Subdomain.<uuid>`, so this lookup has 404'd since the test was introduced in #22844 — the DELETE was hitting `/api/v1/domains/undefined`. `afterAll` already deletes the parent with `recursive=true&hardDelete=true`.
- Replaced the magic `9` / `60` / `61` literals with `SUBDOMAIN_COUNT` / `PAGE_SIZE`, and switched the count assertion from a substring match to an exact match on the `count` testid.

Both waits are driven through the UI. No search-index query shapes or field names are duplicated into the test layer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `<subject>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.

## Testing

This is a test-only change; the E2E lane is the verification. Locally verified:

- `eslint` and `prettier --check` clean on both changed files
- `tsc --noEmit -p playwright/tsconfig.json` — zero errors in the changed files
- The `count` testid selector shape (`getByTestId('<tab>').getByTestId('count')`) matches existing usage in `checkAssetsCount`, `checkDataProductCount`, `Container.spec.ts`, and `DomainFilterQueryFilter.spec.ts`

Note the race does not reproduce on an idle local stack — indexing there completes in well under a second, which is why this only surfaces under CI load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Converges the subdomain pagination E2E flow on eventually consistent search-index state.
- Adds reload-based polling for the search-backed subdomain count.
- Retries domain search until the newly indexed domain is visible.
- Replaces pagination literals with named constants and removes obsolete inline child cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SubDomainPagination.spec.ts | Uses named pagination constants, delegates eventual-consistency handling to shared helpers, and relies on recursive parent cleanup. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts | Adds bounded reload-and-poll behavior for domain discovery and search-backed subdomain counts. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test as Playwright Test
  participant UI as Domain UI
  participant API as OpenMetadata API
  participant Search as Search Index
  Test->>API: Create domain or subdomain
  API-->>Test: Creation succeeds
  Test->>UI: Search or read subdomain count
  UI->>Search: Query indexed entities
  alt Entity is indexed
    Search-->>UI: Current result
    UI-->>Test: Target row or expected count
  else Index remains stale
    Search-->>UI: Missing row or stale count
    Test->>UI: Reload and retry
  end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/subdomain-p..."](https://github.com/open-metadata/openmetadata/commit/ea7d08bdbb35bd80aa40703279e9f52c6629d381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48628062)</sub>

<!-- /greptile_comment -->