### PR TITLE
ci(playwright): raise shard timeouts 21m/30m → 25m/35m (hotfix)

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -903,7 +903,12 @@ jobs:
     needs:
       [build, cache-keys, detect-changes, plan-playwright, prepare-playwright-fixture]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Budget breakdown: 20 min planner shard target + up to 25 min playwright
+    # timeout wrapper (line ~1090) + ~5-8 min for setup (env, node, browser,
+    # bundle verify) and teardown/artifact upload. 30 min was tight enough
+    # that slow shards were being cancelled by the job clock while playwright
+    # itself still had time on the inner wrapper; 35 gives real headroom.
+    timeout-minutes: 35
     if: ${{ !cancelled() && needs.build.result == 'success' && needs.detect-changes.result == 'success' && needs.plan-playwright.result == 'success' && needs.prepare-playwright-fixture.result == 'success' }}
     environment: test
     permissions:
@@ -1084,7 +1089,7 @@ jobs:
           jq '{shardId, lane, workers, predictedWorkerMs, predictedExecutionMs, testCount, projects, files: (.files | length)}' "$plan_file"
           started_at=$(date +%s)
           set +e
-          timeout --signal=TERM --kill-after=30s 21m \
+          timeout --signal=TERM --kill-after=30s 25m \
             npx playwright test "${project_args[@]}" "${files[@]}"
           test_exit=$?
           set -e


### PR DESCRIPTION
## Summary

Hotfix — chromium-07 on PR #30681 was TERM'd at exactly `PW_EXECUTION_SECONDS=1260` (21 min), blocking the merge queue: https://github.com/open-metadata/OpenMetadata/actions/runs/30526682203/job/90823511137

The planner budgets shards to a 20 min target and LPT can pack right up against that ceiling. A 21m inner timeout has only 60s of drift room before it kills a shard whose tests are still running fine. Same class of failure as the earlier chromium-09 diagnosis (which hit the 30m job clock).

- **Inner (`timeout ... 21m` on `npx playwright test`) → 25m** — 5m headroom above the 20m planner target, enough to absorb LPT imprecision + per-test retries.
- **Outer (`timeout-minutes: 30`) → 35m** — keeps setup + tests + teardown under the job clock even on slow runners.

Not masking real regressions — plan-playwright's LPT still targets 20m, timing history + shadow gate still catch drift. This just stops the wrappers from firing before the planner's own signal does.

## Test plan

- [x] YAML parses
- [ ] Merge-queue chromium shards stop hitting the 21m timeout mid-test
- [ ] No shard blows past 35m (would indicate a real regression to investigate)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Raises the PostgreSQL Playwright shard’s inner test timeout from 21 to 25 minutes and its GitHub Actions job timeout from 30 to 35 minutes.
- Adds comments documenting the planner, setup, execution, and teardown budget.
- Provides additional headroom for shards approaching the planner’s 20-minute target.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the timeout changes consistently increase execution and job-level headroom.

The Playwright wrapper remains shorter than the enclosing job timeout, and the changed values do not alter test selection, shell input handling, permissions, or artifact behavior.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-postgresql-e2e.yml | The inner and outer timeout increases remain ordered correctly and introduce no actionable workflow defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): raise shard timeouts 21m..."](https://github.com/open-metadata/openmetadata/commit/d7f6d2a186f89f711fc6df41fe4b69de8d824b7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48631862)</sub>

<!-- /greptile_comment -->