### PR TITLE
fix(ingestion): make the AI Governance sample bundle optional

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/ai_governance_sample.py
+++ b/ingestion/src/metadata/ingestion/source/database/ai_governance_sample.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import json
+import traceback
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
@@ -40,6 +41,7 @@ from metadata.generated.schema.type.entityLineage import (
 from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.step import WorkflowFatalError
 from metadata.ingestion.ometa.utils import model_str
+from metadata.utils.logger import ingestion_logger
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -48,6 +50,8 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
     from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+logger = ingestion_logger()
 
 AIGovernanceRequest: TypeAlias = (
     CreateLLMServiceRequest
@@ -95,6 +99,28 @@ class AIGovernanceSampleData:
         self.applications = self._read_json("applications.json")
         self.lineage = self._read_json("lineage.json")
         self._validate_contract()
+
+    @classmethod
+    def load_optional(cls, fixture_folder: Path, metadata: OpenMetadata) -> AIGovernanceSampleData | None:
+        """Build the loader, or return None when the bundle is absent or off-contract.
+
+        `sampleDataFolder` is caller-supplied, and deployments routinely point it at
+        their own pinned copy of the sample data rather than the one shipped here. Such
+        a copy predates this fixture set, or lags a change to `_EXPECTED_COUNTS`, and
+        raising then aborts the whole sample data workflow before any entity is
+        written — including the tables, lineage and test cases that have nothing to do
+        with AI Governance. No other ingestion stage depends on this bundle, so callers
+        that want the rest of the catalog use this instead of the constructor.
+
+        The constructor still raises, so a caller that genuinely requires the bundle
+        keeps the strict signal.
+        """
+        try:
+            return cls(fixture_folder, metadata)
+        except AIGovernanceSampleDataError as exc:
+            logger.warning(f"AI Governance sample data not ingested: {exc}")
+            logger.debug(f"Traceback: {traceback.format_exc()}")
+            return None
 
     def _read_json(self, filename: str) -> Any:
         fixture_path = self.fixture_folder / filename

--- a/ingestion/src/metadata/ingestion/source/database/sample_data.py
+++ b/ingestion/src/metadata/ingestion/source/database/sample_data.py
@@ -927,7 +927,9 @@ class SampleDataSource(Source):  # pylint: disable=too-many-instance-attributes,
             logger.debug(f"Traceback: {traceback.format_exc()}")
             self.has_drive_data = False
 
-        self.ai_governance = AIGovernanceSampleData(
+        # Optional, like the drive bundle above: a sampleDataFolder that predates this
+        # fixture set should cost us the AI Governance showcase, not the whole catalog.
+        self.ai_governance = AIGovernanceSampleData.load_optional(
             Path(sample_data_folder) / "ai_governance",
             metadata,
         )
@@ -984,8 +986,9 @@ class SampleDataSource(Source):  # pylint: disable=too-many-instance-attributes,
         yield from self.process_service_batch()
         yield from self.ingest_data_contracts()
         yield from self.ingest_sagemaker_models()
-        for request in self.ai_governance.iter_requests():
-            yield Either(left=None, right=request)
+        if self.ai_governance is not None:
+            for request in self.ai_governance.iter_requests():
+                yield Either(left=None, right=request)
 
     def ingest_domains(self) -> Iterable[Either[CreateDomainRequest]]:
         """Ingest sample domains"""

--- a/ingestion/tests/unit/test_ai_governance_sample.py
+++ b/ingestion/tests/unit/test_ai_governance_sample.py
@@ -1,0 +1,122 @@
+#  Copyright 2026 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Validate that the AI Governance sample bundle is optional.
+
+`sampleDataFolder` is caller-supplied, so a deployment pointing it at its own pinned
+copy of the sample data may not carry this bundle at all. That must not abort the
+sample data workflow, which ingests tables, lineage and test cases no AI Governance
+fixture is involved in.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from metadata.ingestion.source.database.ai_governance_sample import (
+    AIGovernanceSampleData,
+    AIGovernanceSampleDataError,
+)
+
+FIXTURE_FILES = (
+    "services.json",
+    "llm_models.json",
+    "mcp_servers.json",
+    "applications.json",
+    "lineage.json",
+)
+
+
+@pytest.fixture()
+def metadata():
+    return MagicMock()
+
+
+def write_bundle(folder: Path, **overrides) -> Path:
+    """Write a syntactically valid bundle whose counts are deliberately off-contract."""
+    folder.mkdir(parents=True, exist_ok=True)
+    contents = {
+        "services.json": {"llmServices": [], "mcpServices": []},
+        "llm_models.json": [],
+        "mcp_servers.json": [],
+        "applications.json": {"registered": [], "shadow": []},
+        "lineage.json": [],
+    }
+    contents.update(overrides)
+    for filename, payload in contents.items():
+        (folder / filename).write_text(json.dumps(payload), encoding="utf-8")
+    return folder
+
+
+class TestLoadOptional:
+    """`load_optional` is what the sample data source calls."""
+
+    def test_returns_none_when_the_bundle_is_absent(self, tmp_path, metadata):
+        assert AIGovernanceSampleData.load_optional(tmp_path / "ai_governance", metadata) is None
+
+    def test_returns_none_when_only_some_fixtures_are_present(self, tmp_path, metadata):
+        folder = write_bundle(tmp_path / "ai_governance")
+        (folder / "lineage.json").unlink()
+
+        assert AIGovernanceSampleData.load_optional(folder, metadata) is None
+
+    def test_returns_none_when_the_counts_are_off_contract(self, tmp_path, metadata):
+        """The case that bites downstream: files present, contract moved on."""
+        folder = write_bundle(tmp_path / "ai_governance")
+
+        assert AIGovernanceSampleData.load_optional(folder, metadata) is None
+
+    def test_returns_none_when_a_fixture_is_malformed(self, tmp_path, metadata):
+        folder = write_bundle(tmp_path / "ai_governance")
+        (folder / "llm_models.json").write_text("{not json", encoding="utf-8")
+
+        assert AIGovernanceSampleData.load_optional(folder, metadata) is None
+
+    def test_warns_rather_than_failing_silently(self, tmp_path, metadata, caplog):
+        AIGovernanceSampleData.load_optional(tmp_path / "ai_governance", metadata)
+
+        assert any("AI Governance sample data not ingested" in record.message for record in caplog.records)
+
+
+class TestConstructorStaysStrict:
+    """Callers that genuinely require the bundle keep the hard signal."""
+
+    def test_missing_bundle_raises(self, tmp_path, metadata):
+        with pytest.raises(AIGovernanceSampleDataError, match="Missing required AI Governance sample fixture"):
+            AIGovernanceSampleData(tmp_path / "ai_governance", metadata)
+
+    def test_off_contract_counts_raise(self, tmp_path, metadata):
+        folder = write_bundle(tmp_path / "ai_governance")
+
+        with pytest.raises(AIGovernanceSampleDataError, match="Unexpected AI Governance sample entity counts"):
+            AIGovernanceSampleData(folder, metadata)
+
+    def test_malformed_fixture_raises(self, tmp_path, metadata):
+        folder = write_bundle(tmp_path / "ai_governance")
+        (folder / "services.json").write_text("[", encoding="utf-8")
+
+        with pytest.raises(AIGovernanceSampleDataError, match="Malformed AI Governance sample fixture"):
+            AIGovernanceSampleData(folder, metadata)
+
+
+class TestShippedBundleStaysInContract:
+    """The bundle that ships in this repo must satisfy its own validation, or
+    `load_optional` would skip the showcase in a default install."""
+
+    def test_repo_bundle_loads(self, metadata):
+        folder = Path(__file__).parents[2] / "examples" / "sample_data" / "ai_governance"
+        if not folder.is_dir():
+            pytest.skip(f"sample data bundle not present at {folder}")
+
+        assert AIGovernanceSampleData.load_optional(folder, metadata) is not None


### PR DESCRIPTION
## Problem

`SampleDataSource.__init__` builds `AIGovernanceSampleData` unconditionally, and that loader raises `AIGovernanceSampleDataError` (a `WorkflowFatalError`) when the five fixtures are missing, malformed, or don't match `_EXPECTED_COUNTS` exactly.

`sampleDataFolder` is caller-supplied, and deployments routinely point it at their own pinned copy of the sample data rather than the one shipped here. Any copy taken before #30378 has no `ai_governance/` directory, so the whole workflow now dies before writing a single entity — losing the tables, lineage, profiles and test cases that have nothing to do with AI Governance:

```
Error initializing metadata: Missing required AI Governance sample fixture:
examples/sample_data/ai_governance/services.json
```

Exact-count validation makes this permanent rather than one-off: every future change to `_EXPECTED_COUNTS` breaks each pinned copy again, and there is currently no `connectionOption` or flag to opt out.

## Fix

Add `AIGovernanceSampleData.load_optional`, which degrades to a warning and returns `None`, and call it from `SampleDataSource`. This mirrors how the **drive bundle immediately above it** is already handled (`sample_data.py:919-928` → `except Exception` → `has_drive_data = False`), so it introduces no new pattern to this file.

The constructor keeps raising, so any caller that genuinely requires the bundle still gets the strict signal.

## Verification

9 unit tests in `ingestion/tests/unit/test_ai_governance_sample.py`, all passing. They cover the four ways the bundle goes bad (absent, partially present, off-contract counts, malformed JSON), that a warning is emitted rather than failing silently, that the constructor stays strict, and — importantly — that **the bundle shipped in this repo still satisfies its own validation**, so a default install is unaffected and the showcase is not silently skipped.

Confirmed the tests actually catch the regression: reverting `load_optional` to call the constructor directly fails 5 of the 9. `ruff format --check` and `ruff check` are clean on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Makes the AI Governance sample bundle optional while preserving strict direct construction.
- Adds a warning-and-skip loader for absent, malformed, or off-contract fixtures.
- Guards AI Governance request emission when that loader returns no bundle.
- Adds unit coverage for optional loading, strict construction, warnings, and shipped fixtures.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The optional-loading path needs to normalize all invalid or unreadable fixture failures before this PR is safe to merge.

Valid JSON with an unexpected top-level type, or a fixture that cannot be opened, raises outside the narrow AIGovernanceSampleDataError handler and still aborts SampleDataSource initialization; the added tests also bypass that integration path.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/ai_governance_sample.py, ingestion/tests/unit/test_ai_governance_sample.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/ai_governance_sample.py | Adds optional loading, but non-custom parsing and filesystem exceptions can still escape and abort initialization. |
| ingestion/src/metadata/ingestion/source/database/sample_data.py | Uses the optional loader and correctly guards request emission when the bundle is unavailable. |
| ingestion/tests/unit/test_ai_governance_sample.py | Covers expected custom-error cases but omits invalid top-level JSON shapes, unreadable fixtures, and the SampleDataSource integration path. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Initialize SampleDataSource] --> B[Load AI Governance fixtures]
  B -->|Valid| C[Emit AI Governance requests]
  B -->|AIGovernanceSampleDataError| D[Warn and skip bundle]
  C --> E[Continue workflow]
  D --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ingestion): make the AI Governance s..."](https://github.com/open-metadata/openmetadata/commit/ae3154164ea65b21ab2dbd8e17ab2bc6a6448083) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48643132)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/open-metadata/openmetadata/blob/main/CLAUDE.md))

<!-- /greptile_comment -->