### PR TITLE
ci(playwright): raise chromium lane workers 3 → 4 (experiment)

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -48,6 +48,12 @@ PROJECT_DEPENDENCIES = {
     "DataAssetRulesDisabled": {"DataAssetRulesEnabled"},
 }
 LANE_WORKERS = {
+    # ubuntu-latest is 4 vCPU. Chromium (and its Basic sibling) run playwright
+    # tests that are heavily I/O-bound on the OM API, so 4 workers per shard
+    # overlaps request/response waits with test setup without saturating CPU.
+    # Serial lanes (ingestion, reindex, global-state, …) stay at 1 because
+    # their tests mutate shared server-level state.
+    "chromium": 4,
     "domain-isolation": 1,
     "global-state": 1,
     "import-export": 2,

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -45,6 +45,10 @@ def test_basic_and_chromium_share_the_bounded_common_lane():
 
 def test_full_common_shard_count_is_capped_at_24():
     planner = load_script("build_playwright_shards")
+    # Enough weight that the calculated shard count exceeds COMMON_MAX_SHARDS
+    # regardless of chromium's 4-worker parallelism setting — 100 × 1M ms
+    # forecasts to ~26 shards on the 19-min shard budget × 0.85 efficiency,
+    # which caps at 24.
     units = [
         planner.Unit(
             "chromium",
@@ -52,7 +56,7 @@ def test_full_common_shard_count_is_capped_at_24():
             str(index),
             weight_ms=1_000_000,
         )
-        for index in range(81)
+        for index in range(100)
     ]
     units.append(
         planner.Unit("chromium", "remainder.spec.ts", "remainder", weight_ms=363_055)
@@ -86,11 +90,15 @@ def test_common_assignment_stays_within_the_execution_ceiling():
         for index in range(13)
     ]
 
+    workers = planner.LANE_WORKERS["chromium"]
     shards = planner.assign_lane_within_budget(units, "chromium", "targeted")
 
-    assert len(shards) == 5
+    # 13 × 940k ms at 4 workers packs into 4 shards under the 20-min TARGET_MS
+    # ceiling; the assertion below is what actually matters — LPT must place
+    # every shard's predicted execution under TARGET_MS regardless of count.
+    assert len(shards) == 4
     assert all(
-        planner.predicted_execution_ms(shard, 3) <= planner.TARGET_MS
+        planner.predicted_execution_ms(shard, workers) <= planner.TARGET_MS
         for shard in shards
     )
 
@@ -515,6 +523,12 @@ def test_import_export_runs_in_its_own_lane_with_two_workers():
     assert planner.LANE_WORKERS["import-export"] == 2
     assert planner.lane_bounds("import-export", "full") == (1, 8)
     assert planner.lane_bounds("import-export", "targeted") == (1, 2)
+
+
+def test_chromium_lane_uses_four_playwright_workers():
+    planner = load_script("build_playwright_shards")
+
+    assert planner.LANE_WORKERS["chromium"] == 4
 
 
 def test_source_glob_matching_is_explicit():


### PR DESCRIPTION
## Summary

Chromium shards are heavily I/O-bound on OM API calls; ubuntu-latest is 4 vCPU. Try a 4th playwright worker per shard to pack tests denser and reduce shard count.

**Planner impact:**
- `shard_count = ceil(total_weight / (workers × budget × efficiency))` — 25% drop
- Recent merge_group runs used all 24 chromium shards at ~20 min playwright execution
- Expected: same content packs into **~18 shards** at ~15 min each — 6 fewer runners per batch

**Not touching serial lanes** (ingestion / reindex / global-state / search / search-rbac / domain-isolation) — those mutate shared server state and would race, not parallelize.

## Test plan

- [x] `pytest .github/scripts/tests/test_playwright_ci_planning.py` — 57 passed (2 existing tests updated for the new worker count; assertion intent preserved)
- [ ] `plan-playwright` on merge_queue shows chromium shard count drop (target ~18)
- [ ] Chromium shard `PW_EXECUTION_SECONDS` drops proportionally (~1200s → ~900-1000s)
- [ ] No flake spike in the shadow-gate `Retry-pass signatures` count
- [ ] Individual test durations don't regress (spot-check timing-history diffs)

## Rollback

Single-line revert: change `"chromium": 4` back to `"chromium": 3` (or delete the entry to fall back to the default 3). Two tests would need their assertions re-flipped, but the diff is trivial.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates Chromium Playwright CI planning to use four workers per shard.
- Adds an explicit four-worker configuration for the shared Chromium/Basic lane while preserving single-worker serial lanes.
- Updates shard-planning tests for the resulting capacity and adds coverage for the Chromium worker count.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the planner and Playwright runtime consistently using the new four-worker Chromium configuration.

The Chromium and Basic projects share one worker pool, the generated shard plan passes its worker count into the CI Playwright invocation, and the updated tests preserve the execution-ceiling and shard-cap assertions.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/build_playwright_shards.py | Configures the Chromium lane for four workers, which is propagated consistently through shard sizing, prediction, and workflow execution. |
| .github/scripts/tests/test_playwright_ci_planning.py | Updates capacity expectations for four workers and directly verifies the new Chromium lane configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): raise chromium/basic lan..."](https://github.com/open-metadata/openmetadata/commit/631a05e513b8cdd47b954138ac3d78c204bac607) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48659414)</sub>

<!-- /greptile_comment -->