### PR TITLE
fix(ci): read the ANTLR archive with whichever tool the host provides (2.0.0-rc1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,15 @@ ANTLR_VERSION_RE := $(subst .,\.,$(ANTLR_VERSION))
 #   3. Pinned, checksum-verified download (macOS, non-Debian images, or a distro
 #      carrying a different ANTLR such as jammy's 4.7.2).
 #
+# The checksum is what makes step 3 trustworthy; the archive check next to it is a
+# second opinion, so it reads the archive with whichever tool the host has rather
+# than insisting on one. Requiring a JDK tool to install a CLI that only needs a
+# JRE to run breaks slim runtime images (e.g. ingestion-base ships
+# default-jre-headless, which has java but no jar) on a download that already
+# verified clean. A tool that is present and rejects the archive still fails the
+# build; only the case where no reader exists falls through to the checksum alone,
+# and such a host has no java either, so it could not run the CLI regardless.
+#
 # The version match in step 2 is exact. A distro shipping a different ANTLR falls
 # through to the download rather than silently generating parsers that the pinned
 # runtimes will reject.
@@ -140,7 +149,11 @@ install_antlr_cli:  ## Install antlr CLI locally
 				--connect-timeout 15 --max-time 60 \
 				--output "$$jar_file" "$$url" \
 				&& printf '%s  %s\n' "$(ANTLR_COMPLETE_JAR_SHA256)" "$$jar_file" | $$sha_check \
-				&& jar tf "$$jar_file" > /dev/null; then \
+				&& { if command -v jar > /dev/null 2>&1; then \
+					jar tf "$$jar_file" > /dev/null; \
+				elif command -v unzip > /dev/null 2>&1; then \
+					unzip -tqq "$$jar_file" > /dev/null; \
+				else :; fi; }; then \
 				break 2; \
 			fi; \
 			echo "ANTLR $(ANTLR_VERSION) download failed from $$url (attempt $$attempt)" >&2; \


### PR DESCRIPTION
Targets `2.0.0-rc1` directly to unblock the release. Same change as #30695 (which targets `main`).

## Problem

`make install_antlr_cli` fails on any image that carries a JRE but not a JDK, which breaks the **Collate local ingestion webserver** image build for 2.0.0-rc1. The download and checksum both succeed; the build dies on the archive check that follows:

```
Distro ANTLR candidate '4.7.2-5' is not 4.9.2; using pinned download.
/tmp/tmp.KRcI3pmOjh: OK          <- pinned SHA-256 verified
/bin/sh: 51: jar: not found      <- actual failure
ANTLR 4.9.2 download failed from https://repo1.maven.org/maven2/... (attempt 1)
...
Failed to download a valid ANTLR 4.9.2 CLI after 3 attempts
make: *** [Makefile:93: install_antlr_cli] Error 1
```

`jar` is a JDK tool. When absent, `jar tf` fails, the enclosing `&&` chain reports the *download* as bad, and the recipe retries three times before giving up — on a payload that verified clean the first time.

The base image installs `default-jre-headless` (`ingestion/Dockerfile:31`): `java` is present, `jar` is not.

`1.13.x` / `1.12.x` are unaffected — they still carry the older three-line recipe.

## Change

Read the archive with whichever tool the host provides, rather than insisting on `jar`:

```make
&& { if   command -v jar   > /dev/null 2>&1; then jar tf "$jar_file" > /dev/null; \
     elif command -v unzip > /dev/null 2>&1; then unzip -tqq "$jar_file" > /dev/null; \
     else :; fi; }
```

| Host | Behaviour |
|---|---|
| JDK present (dev machines, CI runners) | `jar tf` — unchanged |
| JRE + `unzip` (slim runtime images) | `unzip -t` — **check stays active** |
| Neither reader | falls through to the pinned checksum alone |

A reader that is present and **rejects** the archive still fails the build, with no second attempt using the other tool.

The skip branch is not an accepted coverage gap: a host with neither reader has no `java` either (verified — `debian:bookworm-slim` has none of `jar`, `unzip`, `java`), and this recipe's output is a `#!/usr/bin/java -jar` wrapper, so such a host cannot run the CLI regardless.

## Verification

Done in the real affected image, `collate-customers-ingestion:om-2.0.0-rc1-cl-2.0.0-rc1` — Debian 12, `java: openjdk 17.0.20`, `jar: ABSENT`, `unzip: /usr/bin/unzip`, distro `antlr4` candidate `4.7.2-5`.

**Recipe-level, all five branches:**

| Case | Result |
|---|---|
| Baseline (as shipped), no `jar` | `EXIT=2` — reproduces the CI failure exactly |
| No `jar`, `unzip` present | `EXIT=0`; `antlr4` → `ANTLR Parser Generator Version 4.9.2` |
| ↳ which branch ran | `UNZIP-BRANCH-RAN (args: -tqq /tmp/tmp.Wyjo8GsG0w)` — delegating wrapper confirms the real `unzip` ran and passed |
| `unzip` present, rejects | `EXIT=2` — build fails |
| `jar` present, passes | `EXIT=0`; `jar` takes precedence over `unzip` |
| `jar` present, rejects | `EXIT=2` — no fallback to `unzip` |
| Neither reader | `EXIT=0` — checksum alone |

Re-running is idempotent (`ANTLR 4.9.2 already available at /usr/local/bin/antlr4; nothing to do.`).

**Full Docker build, reproducing CI.** Same Dockerfile, same base image, contexts built with `git archive` so they contain tracked files only (as a fresh checkout would), differing by this one change:

```
baseline: #17 [generated 4/5] RUN cd ../OpenMetadata && make install_antlr_cli
          1.700 /bin/sh: 51: jar: not found
          8.073 Failed to download a valid ANTLR 4.9.2 CLI after 3 attempts
          ERROR: ... exit code: 2                        -> BUILD EXIT=1

fixed:    #19 [generated 4/5] RUN cd ../OpenMetadata && make install_antlr_cli
          1.153 Distro ANTLR candidate '4.7.2-5' is not 4.9.2; using pinned download.
          1.842 /tmp/tmp.qkEBCpWkx8: OK
          #19 DONE 2.0s
          #20 [generated 5/5] RUN ... yarn install
          #20 DONE 284.6s                                -> BUILD EXIT=0
```

The fixed build completes the whole `generated` stage, including `yarn run js-antlr`, which uses the installed CLI to generate the parsers the webserver UI imports (`FqnLexer.js`, `FqnParser.js`).

## Follow-up

`main` and `2.0` carry the same line and need the same fix, or 2.0.0 GA breaks identically — tracked in #30695.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes ANTLR CLI installation on JRE-only hosts by validating the downloaded archive with `jar` when available, falling back to `unzip`, and relying on the pinned checksum when neither archive reader exists.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with checksum verification preserved and archive validation correctly using the tools available on the host.

The changed recipe retains the pinned SHA-256 check, propagates failures from either available archive reader, and fixes installation in the affected JRE-plus-unzip image without introducing a concrete failure.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Replaces the unconditional JDK-only archive check with a portable archive-reader fallback while preserving checksum verification and failure on archive rejection. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): read the ANTLR archive with whi..."](https://github.com/open-metadata/openmetadata/commit/54ab5939ac950c620a83a4f4df333832b9eaf1a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48667597)</sub>

<!-- /greptile_comment -->