### PR TITLE
Fixes #30709: fix(ingestion): build a deferred model's schema on first instantiation

### DIFF
--- a/ingestion/src/metadata/ingestion/models/custom_pydantic.py
+++ b/ingestion/src/metadata/ingestion/models/custom_pydantic.py
@@ -37,8 +37,12 @@ SECRET = "secret:"
 JSON_ENCODERS = "json_encoders"
 
 # model_rebuild() deletes __pydantic_core_schema__/__pydantic_validator__/__pydantic_serializer__
-# before regenerating them, so concurrent first uses of the same class can observe the inherited
-# MockValSer or lose the delete race outright ("AttributeError: __pydantic_core_schema__").
+# before regenerating them, and says so itself: "as model_rebuild() isn't thread-safe, concurrent
+# model instantiations can lead to the parent validator being used". Two ways that bites us. A
+# first build only deletes the core schema, since the validator and serializer mocks are skipped
+# by pydantic's isinstance(..., MockValSer) guard, so a racing thread loses the delete outright
+# ("AttributeError: __pydantic_core_schema__"). A force rebuild of an already built class deletes
+# the real objects, so a racing thread falls through the MRO onto PydanticBaseModel's own mocks.
 # Reentrant because building one schema can rebuild the nested models it references.
 _MODEL_REBUILD_LOCK = threading.RLock()
 
@@ -78,11 +82,12 @@ class BaseModel(PydanticBaseModel):
         but a FilterPattern object is required in the generated code.
         """
         # Build the schema of a model the first time one is instantiated. With
-        # defer_build a nested model's schema only ever gets inlined into its parent,
-        # so the class itself keeps the MockValSer it inherits from pydantic.BaseModel.
-        # Serialization fallbacks read type(value).__pydantic_serializer__ straight off
-        # the class, which does not go through MockValSer.__getattr__ and so never
-        # triggers its lazy rebuild; pydantic-core then fails to convert the mock with
+        # defer_build a nested model's schema only ever gets inlined into its parent, so
+        # the class keeps the MockValSer that pydantic put on it in place of a real
+        # serializer (see _mock_val_ser.set_model_mocks). Serialization fallbacks read
+        # type(value).__pydantic_serializer__ straight off the class, which does not go
+        # through MockValSer.__getattr__ and so never triggers its lazy rebuild;
+        # pydantic-core then fails to convert the mock with
         # "'MockValSer' object cannot be converted to 'SchemaSerializer'". Building here
         # keeps the import-time saving, since importing a module instantiates nothing.
         # _parent_namespace_depth=0: forward refs must resolve against the model's own

--- a/ingestion/src/metadata/ingestion/models/custom_pydantic.py
+++ b/ingestion/src/metadata/ingestion/models/custom_pydantic.py
@@ -58,6 +58,20 @@ class BaseModel(PydanticBaseModel):
         This is needed because dict is defined in the JSON schema for the FilterPattern field,
         but a FilterPattern object is required in the generated code.
         """
+        # Build the schema of a model the first time one is instantiated. With
+        # defer_build a nested model's schema only ever gets inlined into its parent,
+        # so the class itself keeps the MockValSer it inherits from pydantic.BaseModel.
+        # Serialization fallbacks read type(value).__pydantic_serializer__ straight off
+        # the class, which does not go through MockValSer.__getattr__ and so never
+        # triggers its lazy rebuild; pydantic-core then fails to convert the mock with
+        # "'MockValSer' object cannot be converted to 'SchemaSerializer'". Building here
+        # keeps the import-time saving, since importing a module instantiates nothing.
+        # _parent_namespace_depth=0: forward refs must resolve against the model's own
+        # module, not against whichever frame happened to instantiate it.
+        cls = type(self)
+        if not cls.__pydantic_complete__:
+            cls.model_rebuild(_parent_namespace_depth=0)
+
         # pylint: disable=import-outside-toplevel
         try:
             if not self.__class__.__name__.endswith("Connection"):

--- a/ingestion/src/metadata/ingestion/models/custom_pydantic.py
+++ b/ingestion/src/metadata/ingestion/models/custom_pydantic.py
@@ -19,6 +19,7 @@ be self-sufficient with only pydantic at import time.
 import json
 import logging
 import os
+import threading
 from typing import Any, Callable, Dict, Literal, Optional, Union  # noqa: UP035
 
 from pydantic import BaseModel as PydanticBaseModel
@@ -34,6 +35,12 @@ logger = logging.getLogger("metadata")
 
 SECRET = "secret:"
 JSON_ENCODERS = "json_encoders"
+
+# model_rebuild() deletes __pydantic_core_schema__/__pydantic_validator__/__pydantic_serializer__
+# before regenerating them, so concurrent first uses of the same class can observe the inherited
+# MockValSer or lose the delete race outright ("AttributeError: __pydantic_core_schema__").
+# Reentrant because building one schema can rebuild the nested models it references.
+_MODEL_REBUILD_LOCK = threading.RLock()
 
 
 class BaseModel(PydanticBaseModel):
@@ -52,6 +59,18 @@ class BaseModel(PydanticBaseModel):
         defer_build=os.environ.get("OM_PYDANTIC_DEFER_BUILD", "true").lower() not in ("0", "false", "no", "off")
     )
 
+    @classmethod
+    def model_rebuild(cls, *, _parent_namespace_depth: int = 2, **kwargs: Any) -> Optional[bool]:  # noqa: UP045
+        """Rebuild the pydantic-core schema, serialising concurrent builds of the same class."""
+        # Every rebuild funnels through here, including pydantic's own lazy repair from
+        # MockValSer.__getattr__ (see _mock_val_ser.set_model_mocks), which is otherwise unguarded
+        # and races the same way whenever threads first validate a deferred model directly.
+        if _parent_namespace_depth > 0:
+            # This override adds a frame between the caller and pydantic's own parent-frame walk.
+            _parent_namespace_depth += 1
+        with _MODEL_REBUILD_LOCK:
+            return super().model_rebuild(_parent_namespace_depth=_parent_namespace_depth, **kwargs)
+
     def model_post_init(self, context: Any, /):
         """
         This function is used to parse the FilterPattern fields for the Connection classes.
@@ -68,6 +87,7 @@ class BaseModel(PydanticBaseModel):
         # keeps the import-time saving, since importing a module instantiates nothing.
         # _parent_namespace_depth=0: forward refs must resolve against the model's own
         # module, not against whichever frame happened to instantiate it.
+        # Checked before calling so the steady-state path never touches the rebuild lock.
         cls = type(self)
         if not cls.__pydantic_complete__:
             cls.model_rebuild(_parent_namespace_depth=0)

--- a/ingestion/tests/unit/test_generated_models_defer_build.py
+++ b/ingestion/tests/unit/test_generated_models_defer_build.py
@@ -15,6 +15,9 @@ import os
 import pkgutil
 import subprocess
 import sys
+import threading
+
+from pydantic import ConfigDict
 
 import metadata.generated.schema as generated_schema
 from metadata.ingestion.models.custom_pydantic import BaseModel
@@ -148,6 +151,56 @@ def test_deferred_nested_models_are_serializable():
     )
     assert result.returncode == 0, f"serialization probe failed:\n{result.stdout}\n{result.stderr}"
     assert result.stdout.strip().endswith("OK")
+
+
+def _make_deferred_family():
+    """Return (Parent, Nested) deferred models; Nested is only ever built via Parent's schema."""
+
+    class Nested(BaseModel):
+        model_config = ConfigDict(defer_build=True)
+
+        account: str | None = None
+
+    class Parent(BaseModel):
+        model_config = ConfigDict(defer_build=True)
+
+        nested: Nested | None = None
+
+    return Parent, Nested
+
+
+def test_concurrent_first_instantiation_is_safe():
+    """Threads racing a deferred model's first build never observe a half-rebuilt class."""
+    # Covers both rebuild routes at once: the parent is validated directly, so pydantic repairs it
+    # through MockValSer.attempt_rebuild, while the nested class is only ever reached via
+    # model_post_init. The delete-then-rebuild window is a handful of bytecodes, so force frequent
+    # switches instead of relying on the default 5ms interval.
+    original_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    failures = []
+    try:
+        for _ in range(200):
+            parent_model, nested_model = _make_deferred_family()
+            assert parent_model.__pydantic_complete__ is False
+            assert nested_model.__pydantic_complete__ is False
+            barrier = threading.Barrier(8)
+
+            def work(parent: type = parent_model, gate: threading.Barrier = barrier):
+                try:
+                    gate.wait()
+                    parent.model_validate({"nested": {"account": "acct"}}).model_dump()
+                except Exception as exc:
+                    failures.append(repr(exc))
+
+            threads = [threading.Thread(target=work) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+    finally:
+        sys.setswitchinterval(original_interval)
+
+    assert not failures, f"concurrent first instantiation failed {len(failures)}x: {failures[:3]}"
 
 
 def test_defer_build_env_var_disables_it():

--- a/ingestion/tests/unit/test_generated_models_defer_build.py
+++ b/ingestion/tests/unit/test_generated_models_defer_build.py
@@ -42,6 +42,42 @@ assert Table.model_config.get("defer_build") is False, "OM_PYDANTIC_DEFER_BUILD=
 print("OK")
 """
 
+_SERIALIZE_PROBE = """
+import warnings
+
+warnings.filterwarnings("ignore")
+from metadata.generated.schema.entity.services.connections.database.snowflakeConnection import (
+    SnowflakeConnection,
+)
+from metadata.generated.schema.metadataIngestion.workflow import Source
+
+assert SnowflakeConnection.__pydantic_complete__ is False, "connection schema was built eagerly at import"
+
+# Nothing here builds the nested models' own schema: validating Source goes through
+# the members pydantic inlined into the parent. Dumping the parent then falls back to
+# reading the serializer off the nested class, which is where a deferred model that was
+# never built surfaces as a MockValSer.
+source = Source.model_validate(
+    {
+        "type": "snowflake",
+        "serviceName": "test",
+        "serviceConnection": {
+            "config": {
+                "type": "Snowflake",
+                "account": "account",
+                "username": "username",
+                "password": "password",
+                "warehouse": "warehouse",
+            }
+        },
+        "sourceConfig": {"config": {"type": "DatabaseMetadata"}},
+    }
+)
+dumped = source.model_dump()
+assert dumped["serviceConnection"]["config"]["account"] == "account"
+print("OK")
+"""
+
 
 def _collect_generated_model_classes() -> dict:
     """Return {qualified_name: class} for importable generated BaseModel subclasses."""
@@ -95,6 +131,22 @@ def test_generated_models_defer_build_is_enabled():
         env=env,
     )
     assert result.returncode == 0, f"defer_build probe failed:\n{result.stdout}\n{result.stderr}"
+    assert result.stdout.strip().endswith("OK")
+
+
+def test_deferred_nested_models_are_serializable():
+    """Dumping a parent reaches nested models whose own schema was never built."""
+    # Fresh interpreter with the toggle unset, for the same reasons as the probe above:
+    # completeness flips on first use, and this has to assert the default.
+    env = {key: value for key, value in os.environ.items() if key != "OM_PYDANTIC_DEFER_BUILD"}
+    result = subprocess.run(
+        [sys.executable, "-c", _SERIALIZE_PROBE],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, f"serialization probe failed:\n{result.stdout}\n{result.stderr}"
     assert result.stdout.strip().endswith("OK")
 
 


### PR DESCRIPTION
### Describe your changes:

Fixes #30709

`defer_build=True` (#30377) means a nested model's schema only ever gets **inlined into its parent**, so the nested class keeps the `MockValSer` that pydantic puts on it in place of a real serializer (`_mock_val_ser.set_model_mocks`). Pydantic's serialization fallbacks read `type(value).__pydantic_serializer__` straight off the class — a plain attribute lookup that never goes through `MockValSer.__getattr__`, so the lazy rebuild that would normally repair this never fires. pydantic-core then fails to convert the mock:

```
TypeError: 'MockValSer' object cannot be converted to 'SchemaSerializer'
```

That takes out **every Snowflake CLI ingestion**. `MetadataWorkflow._get_source` calls `self.config.source.model_dump()`, and `SnowflakeConnection`, `DatabaseConnection`, `SourceConfig` and `DatabaseServiceMetadataPipeline` are all instantiated there without ever being built, so the workflow dies at init before doing any work.

I build the schema in `model_post_init` when the class is still incomplete. An instantiated model is a used model, and importing a module instantiates nothing, so #30377's import-time saving survives — the deferral just now ends at first use rather than first *direct* use.

`_parent_namespace_depth=0` is deliberate: the default (2) would resolve forward refs against whichever frame happened to instantiate the model instead of against the model's own module.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is following the [convention](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md).
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests.

#
### Verification

Peak RSS over a Snowflake workflow source plus 200 `Table` validate/dump cycles:

| config | `Source.model_dump()` | maxrss |
|---|---|---|
| `main` | **TypeError** | 202 MB |
| this PR | OK | **203 MB** |
| `OM_PYDANTIC_DEFER_BUILD=false` | OK | 305 MB |

So the fix costs ~1 MB and keeps ~100 MB of #30377's win. `Table.__pydantic_complete__` is still `False` after an import-only run, i.e. deferral is intact.

Also checked by hand: `metadata ingest -c <snowflake config>` now gets past init to authentication instead of dying on the dump, and a recursive `Table` → `Column` → `children` validate + `model_dump` + `model_dump_json` round-trips, so rebuilding inside `model_post_init` while the parent's validator is running is not re-entrant-hostile.

`tests/unit/test_generated_models_defer_build.py`, `test_pydantic_v2.py`, `test_workflow_parse.py`, `test_workflow_parse_example_config.py` and `test_filter_pattern.py` pass.

#
### Test gap this closes

The existing guards check buildability (`model_rebuild(force=True)`) and the env toggle, but never dump a parent whose nested child class was never built — which is the entire failure mode, so CI was green while every Snowflake ingestion was broken. The new `test_deferred_nested_models_are_serializable` does exactly that, in a fresh interpreter with the toggle unset. Verified that it fails on `main` with the `TypeError` above.

#
### Note for reviewers

- **Thread safety.** ~~First instantiation from the multithreaded topology/profiler paths can race on `model_rebuild`.~~ Addressed in 7cb62713e6 — the race turned out to be real and pre-existing, see the comment below.
- **Error handling.** I deliberately left the rebuild *outside* the existing `try`, so a genuine build failure raises loudly instead of degrading into the opaque `MockValSer` error. `test_all_generated_models_are_buildable` already guarantees every generated model builds.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Fixes deferred Pydantic model serialization while retaining import-time schema deferral.
- Rebuilds incomplete model schemas on first instantiation.
- Serializes schema rebuilds with a reentrant lock to protect concurrent and nested builds.
- Adds regression coverage for nested serialization, configuration toggling, buildability, and concurrent first use.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/models/custom_pydantic.py | Adds locked schema rebuilding on first model instantiation to make deferred nested models serializable. |
| ingestion/tests/unit/test_generated_models_defer_build.py | Adds behavioral regression tests for nested serialization and concurrent deferred-model initialization. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller
  participant Model as Deferred Model
  participant Lock as Rebuild RLock
  participant Pydantic
  Caller->>Model: First validation/instantiation
  Pydantic->>Model: model_post_init()
  Model->>Model: Check __pydantic_complete__
  alt Schema incomplete
    Model->>Lock: Acquire
    Model->>Pydantic: "model_rebuild(depth=0)"
    Pydantic-->>Model: Validator and serializer ready
    Model->>Lock: Release
  end
  Model-->>Caller: Serializable model instance
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(ingestion): correct where a deferre..."](https://github.com/open-metadata/openmetadata/commit/eb86e90318665f46f98d1f85cda079bc6bbeee1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48686702)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->