### PR TITLE
fix(playwright): paginate across pages in GlossaryTermRelationSettings tests [1.13]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts
@@ -124,6 +124,48 @@ const deleteRelationInUi = async (page: Page, name: string) => {
   }).toPass();
 };
 
+// Parallel test workers can push the table past PAGE_SIZE_BASE, putting the
+// target row on page 2+. Navigate forward page-by-page until the row is
+// visible, so individual CRUD tests remain stable regardless of total count.
+//
+// Uses waitFor (not isVisible) so React has time to flush new rows after each
+// page navigation before we decide whether to advance. isVisible() is
+// instantaneous and would read the stale DOM from the previous page,
+// causing the loop to skip the target and eventually throw.
+const findRowAcrossPages = async (
+  page: Page,
+  testId: string
+): Promise<void> => {
+  const target = page.getByTestId(testId);
+
+  while (true) {
+    const found = await target
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(
+        () => true,
+        () => false
+      );
+
+    if (found) return;
+
+    const nextBtn = page.getByRole('button', { name: 'Next Page' }).first();
+
+    if ((await nextBtn.count()) === 0 || !(await nextBtn.isEnabled())) {
+      throw new Error(`testId "${testId}" not found on any page`);
+    }
+
+    const nextPageResponse = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes('/glossaryTermRelationSettings/relationTypes') &&
+        response.request().method() === 'GET'
+    );
+    await nextBtn.click();
+    await nextPageResponse;
+  }
+};
+
 test.describe('Glossary Term Relation Settings', () => {
   test.beforeEach(async ({ page }) => {
     await authenticateAdminPage(page);
@@ -173,6 +215,7 @@ test.describe('Glossary Term Relation Settings', () => {
 
       await goToRelationSettings(page);
 
+      await findRowAcrossPages(page, `edit-${relationName}-btn`);
       await page.getByTestId(`edit-${relationName}-btn`).click();
       await expect(page.getByTestId('relation-type-drawer')).toBeVisible();
 
@@ -221,6 +264,7 @@ test.describe('Glossary Term Relation Settings', () => {
 
       await goToRelationSettings(page);
 
+      await findRowAcrossPages(page, `relation-name-${relationName}`);
       await expect(
         page.getByTestId(`relation-name-${relationName}`)
       ).toBeVisible();
@@ -243,6 +287,7 @@ test.describe('Glossary Term Relation Settings', () => {
   }) => {
     await goToRelationSettings(page);
 
+    await findRowAcrossPages(page, `relation-name-${SYSTEM_DEFINED_RELATION}`);
     await expect(
       page.getByTestId(`relation-name-${SYSTEM_DEFINED_RELATION}`)
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Backport of #30672 to the `1.13` branch.

- Parallel test workers accumulate relation types that push the table beyond `PAGE_SIZE_BASE` (15), sending target rows to page 2+
- The `edits`, `deletes`, and `locks system-defined` tests were failing because they only inspected page 1
- Added a `findRowAcrossPages` helper that clicks **Next Page** until the target `data-testid` is visible, then each affected test calls it before interacting with the row

## Test plan
- [ ] `edits a custom relation type and keeps the name immutable` — now navigates to the correct page before clicking the edit button
- [ ] `deletes a custom relation type` — now navigates to the correct page before checking visibility and deleting
- [ ] `locks system-defined relation types from edit and delete` — now navigates to find `relatedTo` before asserting disabled state
- [ ] No other tests changed; `creates` and `paginates` tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a Playwright helper that searches paginated glossary relation-type rows and uses it before edit, delete, and system-defined relation assertions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The helper begins from the first page, waits for each pagination response, polls for the requested row while React updates the DOM, and stops cleanly when no further page exists.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryTermRelationSettings.spec.ts | The new helper advances through relation-type pages while synchronizing with API responses, and the affected tests use it before interacting with uniquely identified rows. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): paginate across pages i..."](https://github.com/open-metadata/openmetadata/commit/6f5d1a25f5e614b682176085193b27ec990f2f13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48703821)</sub>

<!-- /greptile_comment -->