### PR TITLE
fix(playwright): stabilize IncidentManager test-suite pipeline trigger (2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -11,6 +11,10 @@
  *  limitations under the License.
  */
 import { APIRequestContext, expect, Page } from '@playwright/test';
+import {
+  PipelineState,
+  PipelineStatus,
+} from '../../src/generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { getEncodedFqn } from '../../src/utils/StringUtils';
 import { SidebarItem } from '../constant/sidebar';
 import { ResponseDataType } from '../support/entity/Entity.interface';
@@ -234,47 +238,164 @@ export const assignIncident = async (data: {
   ).toContainText('Assigned');
 };
 
+// Attempts at 0s, +1s, +2s, +3s — the 6s worst case covers the settling time
+// the previous fixed sleep was guessing at, without paying it on every run.
+const PIPELINE_REQUEST_ATTEMPTS = 4;
+
+// Airflow 3.x accepts a trigger (HTTP 200) even when its dag-processor has not
+// serialized the freshly deployed DAG yet. That trigger produces an empty
+// DagRun that finishes instantly and never writes a pipelineStatus back, so the
+// caller would poll forever. We can't detect the empty run positively — only
+// its absence — so after triggering we wait this long for a genuinely new run
+// to appear; if none does, the DAG was unserialized and we trigger again (by
+// then it is parsed). Real runs surface a status within a few seconds, so this
+// window only ever elapses in the race case.
+const NEW_RUN_APPEARANCE_TIMEOUT = 60_000;
+const NEW_RUN_POLL_INTERVAL = 2_000;
+const TRIGGER_ATTEMPTS = 3;
+
 export const triggerTestSuitePipelineAndWaitForSuccess = async (data: {
   page: Page;
   apiContext: APIRequestContext;
   pipeline: ResponseDataType;
 }) => {
   const { page, apiContext, pipeline } = data;
+  const encodedPipelineFqn = encodeURIComponent(
+    pipeline?.['fullyQualifiedName']
+  );
+
+  // `fetched` separates "the pipeline has not run yet" from "the status read
+  // failed" — both yield no run, but only the former is a safe baseline.
+  const fetchLatestPipelineStatus = async (): Promise<{
+    fetched: boolean;
+    run?: PipelineStatus;
+  }> => {
+    const pipelineStatusResponse = await apiContext.get(
+      `/api/v1/services/ingestionPipelines/${encodedPipelineFqn}/pipelineStatus?limit=1`
+    );
+
+    if (pipelineStatusResponse.ok()) {
+      const body = await pipelineStatusResponse.json();
+      const statuses: PipelineStatus[] = Array.isArray(body?.data)
+        ? body.data
+        : [];
+
+      if (statuses[0]) {
+        return { fetched: true, run: statuses[0] };
+      }
+    }
+
+    const ingestionPipelineResponse = await apiContext.get(
+      `/api/v1/services/ingestionPipelines/name/${encodedPipelineFqn}?fields=pipelineStatuses`
+    );
+
+    if (!ingestionPipelineResponse.ok()) {
+      return { fetched: false };
+    }
+
+    const ingestionPipeline = await ingestionPipelineResponse.json();
+
+    return { fetched: true, run: ingestionPipeline?.pipelineStatuses?.[0] };
+  };
+
+  const requestWithRetry = async (
+    request: () => Promise<Awaited<ReturnType<APIRequestContext['post']>>>
+  ) => {
+    let response = await request();
+
+    for (
+      let attempt = 1;
+      attempt < PIPELINE_REQUEST_ATTEMPTS && !response.ok();
+      attempt++
+    ) {
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded backoff before retrying a rejected request
+      await page.waitForTimeout(1000 * attempt);
+      response = await request();
+    }
+
+    return response;
+  };
+
   const executePipelineRequest = async (
     label: string,
     request: () => Promise<Awaited<ReturnType<APIRequestContext['post']>>>
   ) => {
-    let lastStatus: number | undefined;
-    let lastBody = '';
+    const response = await requestWithRetry(request);
 
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      const response = await request();
+    if (!response.ok()) {
+      throw new Error(
+        `${label} failed for ingestion pipeline ${pipeline?.['id']} (${
+          pipeline?.['fullyQualifiedName']
+        }): HTTP ${response.status()} ${await response.text()}`
+      );
+    }
 
-      if (response.ok()) {
-        return response;
+    return response;
+  };
+
+  const triggerPipeline = () =>
+    apiContext.post(
+      `/api/v1/services/ingestionPipelines/trigger/${pipeline?.['id']}`
+    );
+
+  // Airflow queues the DAG asynchronously, so the previous run's `success`
+  // record stays the latest one for a while after triggering. Remember it here
+  // so the poll below waits for a genuinely new run instead of reading the old
+  // one and letting the caller assert on stale results. A baseline we failed to
+  // read would defeat that, so retry and then fail loudly rather than silently
+  // treating the previous run as new.
+  const fetchBaselineRun = async () => {
+    for (let attempt = 1; attempt <= PIPELINE_REQUEST_ATTEMPTS; attempt++) {
+      const { fetched, run } = await fetchLatestPipelineStatus();
+
+      if (fetched) {
+        return run;
       }
 
-      lastStatus = response.status();
-      lastBody = await response.text();
-
-      if (attempt < 3) {
-        // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded retry for transient pipeline readiness
+      if (attempt < PIPELINE_REQUEST_ATTEMPTS) {
+        // eslint-disable-next-line playwright/no-wait-for-timeout -- bounded backoff before re-reading the baseline status
         await page.waitForTimeout(1000 * attempt);
       }
     }
 
     throw new Error(
-      `${label} failed for ingestion pipeline ${pipeline?.['id']} (${pipeline?.['fullyQualifiedName']}): HTTP ${lastStatus} ${lastBody}`
+      `Unable to read the status baseline for ingestion pipeline ${pipeline?.['id']} (${pipeline?.['fullyQualifiedName']})`
     );
   };
 
-  // eslint-disable-next-line playwright/no-wait-for-timeout -- pipeline deployment settling time
-  await page.waitForTimeout(5000);
-  const response = await apiContext.post(
-    `/api/v1/services/ingestionPipelines/trigger/${pipeline?.['id']}`
-  );
+  const previousRun = await fetchBaselineRun();
+  // Either signal alone is enough: `runId` is optional in the schema, so a
+  // conjunction deadlocks the poll when neither record carries one.
+  const isNewRun = (latestRun: PipelineStatus) =>
+    latestRun.runId !== previousRun?.runId ||
+    (latestRun.timestamp ?? 0) > (previousRun?.timestamp ?? 0);
 
-  if (response.status() !== 200) {
+  // Wait for a genuinely new run to surface after a trigger. Returns false if
+  // none appears within the window, which means the trigger raced an
+  // unserialized DAG and produced an empty run that wrote no status.
+  const waitForNewRunToAppear = async () => {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < NEW_RUN_APPEARANCE_TIMEOUT) {
+      const { run } = await fetchLatestPipelineStatus();
+
+      if (run && isNewRun(run)) {
+        return true;
+      }
+
+      // eslint-disable-next-line playwright/no-wait-for-timeout -- poll for a newly triggered run to be recorded
+      await page.waitForTimeout(NEW_RUN_POLL_INTERVAL);
+    }
+
+    return false;
+  };
+
+  // First trigger. A rejected trigger still means the DAG is not registered, so
+  // re-deploy then trigger; an accepted trigger may still have raced
+  // serialization, which the appearance check below catches.
+  const response = await requestWithRetry(triggerPipeline);
+
+  if (!response.ok()) {
     // re-deploy the pipeline then trigger it
     await executePipelineRequest('Pipeline deploy', () =>
       apiContext.post(
@@ -282,59 +403,49 @@ export const triggerTestSuitePipelineAndWaitForSuccess = async (data: {
       )
     );
 
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- pipeline deployment settling time
-    await page.waitForTimeout(5000);
-
-    await executePipelineRequest('Pipeline trigger', () =>
-      apiContext.post(
-        `/api/v1/services/ingestionPipelines/trigger/${pipeline?.['id']}`
-      )
-    );
+    await executePipelineRequest('Pipeline trigger', triggerPipeline);
   }
 
-  // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for pipeline run to complete
-  await page.waitForTimeout(2000);
+  // Re-trigger until a run actually materializes. The empty-run race only
+  // happens on the first trigger of a freshly deployed DAG; once the
+  // dag-processor has serialized it, a re-trigger runs for real.
+  let runAppeared = await waitForNewRunToAppear();
+
+  for (
+    let attempt = 2;
+    attempt <= TRIGGER_ATTEMPTS && !runAppeared;
+    attempt++
+  ) {
+    await executePipelineRequest('Pipeline trigger', triggerPipeline);
+    runAppeared = await waitForNewRunToAppear();
+  }
+
+  if (!runAppeared) {
+    throw new Error(
+      `No run materialized for ingestion pipeline ${pipeline?.['id']} (${pipeline?.['fullyQualifiedName']}) after ${TRIGGER_ATTEMPTS} triggers; the deployed DAG never produced a run`
+    );
+  }
 
   await expect
     .poll(
       async () => {
-        const pipelineStatusResponse = await apiContext.get(
-          `/api/v1/services/ingestionPipelines/${encodeURIComponent(
-            pipeline?.['fullyQualifiedName']
-          )}/pipelineStatus?limit=1`
-        );
+        const { run: latestRun } = await fetchLatestPipelineStatus();
 
-        if (pipelineStatusResponse.ok()) {
-          const body = await pipelineStatusResponse.json();
-          const statuses = Array.isArray(body?.data) ? body.data : [];
-
-          if (statuses[0]?.pipelineState) {
-            return statuses[0].pipelineState;
-          }
+        if (!latestRun || !isNewRun(latestRun)) {
+          return PipelineState.Queued;
         }
 
-        const ingestionPipelineResponse = await apiContext.get(
-          `/api/v1/services/ingestionPipelines/name/${encodeURIComponent(
-            pipeline?.['fullyQualifiedName']
-          )}?fields=pipelineStatuses`
-        );
-
-        if (!ingestionPipelineResponse.ok()) {
-          return 'running';
-        }
-
-        const ingestionPipeline = await ingestionPipelineResponse.json();
-
-        return (
-          ingestionPipeline?.pipelineStatuses?.[0]?.pipelineState ?? 'running'
-        );
+        return latestRun.pipelineState ?? PipelineState.Queued;
       },
       {
-        // Custom expect message for reporting, optional.
-        message: 'Wait for the pipeline to be successful',
+        message: `Wait for a new run of ingestion pipeline ${
+          pipeline?.['fullyQualifiedName']
+        } to be successful (run recorded before trigger: ${
+          previousRun?.runId ?? 'none'
+        })`,
         timeout: 300_000,
-        intervals: [5_000, 10_000, 15_000],
+        intervals: [2_000, 5_000, 10_000],
       }
     )
-    .toBe('success');
+    .toBe(PipelineState.Success);
 };


### PR DESCRIPTION
Backport of the IncidentManager Playwright flakiness fix to **2.0**. The main-branch PR is #30655; merging there will take time, so this ports the fix directly.

## Problem
`triggerTestSuitePipelineAndWaitForSuccess` (used by IncidentManager E2E setup and re-run steps) timed out at the 300s poll in CI, failing the ingestion lane. Root cause, confirmed on a real Airflow 3.2.2 stack: **Airflow 3.x accepts a trigger (HTTP 200) even before its dag-processor has serialized the freshly deployed DAG.** That trigger creates an empty DagRun that finishes in ~0.03s, runs no task, and never writes a `pipelineStatus` — so the helper polls forever. The prior "retry until the trigger is accepted" assumption does not hold, because the trigger is accepted regardless of serialization state.

## Fix (Playwright helper only)
- Record a status **baseline** before triggering and wait for a run that differs by `runId` **or** newer `timestamp` (avoids asserting on the stale previous run, and avoids a deadlock when `runId` is absent — it is optional in the generated schema).
- After triggering, wait up to 60s for a run to **materialize**; if none does (the empty-run signature, since it writes no status), **re-trigger** up to three times. A run that never materializes now fails loudly instead of hanging.

## Scope
Only `playwright/utils/incidentManager.ts` is ported. The impact-map / CI-lane changes on the main PR are specific to main's test-selection setup (the `ImportExport` lane does not exist on 2.0). 2.0 already runs `IncidentManager.spec.ts` in the **Ingestion** lane, so the fix is exercised as-is.

## Validation
- Deterministically reproduced the empty-DAG race on real Airflow 3.2.2; the re-trigger recovered to success (queued -> running -> success in ~6s).
- Full IncidentManager spec locally: **10/10, 0 flaky.**
- On main (#30655) the same fix ran green in CI: ingestion lane `flaky: 0`, IncidentManager all `attempts=1 ['passed']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR revises the IncidentManager Playwright pipeline helper to:
- capture the previous pipeline-status baseline before triggering;
- retry transient pipeline requests and re-trigger when no new run materializes;
- poll the newly identified run until it succeeds or an explicit timeout is reached.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because current IncidentManager hooks and tests can time out before the new pipeline recovery sequence finishes.

The helper can spend up to three 60-second windows waiting for a run to materialize and then enter a 300-second success poll, while current callers include hooks and tests whose effective budgets are only 180 seconds and a setup hook capped at 420 seconds.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts; openmetadata-ui/src/main/resources/ui/playwright/e2e/IncidentManager.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts | Adds baseline-aware status detection, bounded request retries, empty-run re-triggering, and explicit success polling for IncidentManager pipeline execution. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read previous run baseline] --> B[Trigger pipeline]
  B --> C{New status materializes<br/>within 60 seconds?}
  C -->|No, attempts remain| B
  C -->|No, attempts exhausted| D[Throw no-run error]
  C -->|Yes| E[Poll new run for success]
  E -->|Success| F[Return]
  E -->|300-second timeout| G[Fail assertion]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(playwright): stabilize IncidentManag..."](https://github.com/open-metadata/openmetadata/commit/c505bb30902b9ab0db0fdb9ca125062a849ed813) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48710656)</sub>

<!-- /greptile_comment -->