### PR TITLE
Fixes 30715: block saving a persona AI context rule with an unfinished condition

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts
@@ -1102,4 +1102,125 @@ test.describe.serial('Persona AI Context', () => {
     await expect(adminPage.getByRole('dialog')).toBeVisible();
     await expect(adminPage.getByText('7 truncated')).toBeVisible();
   });
+
+  // A condition with a field but no value serializes to `{"term":{}}`, which the search engines
+  // reject outright. The emitted filter now drops it, so saving such a rule would silently widen it
+  // to match everything — the editor has to stop that at the source. See issue #30715.
+  test('blocks saving a rule whose condition has no value entered', async ({
+    adminPage,
+  }) => {
+    await mockPersonaContextApi(
+      adminPage,
+      persona.responseData.id as string,
+      []
+    );
+    await openPersonaContext(adminPage);
+
+    await adminPage.getByTestId('empty-add-context-rule').click();
+    await adminPage.getByTestId('context-rule-name').fill('Unfinished filter');
+    await adminPage.getByTestId('add-context-condition').click();
+
+    const condition = adminPage.getByTestId('delete-condition-button');
+    await expect(condition).toHaveCount(1);
+
+    const fieldSelect = adminPage
+      .getByRole('dialog')
+      .locator('.rule--field .ant-select')
+      .first();
+    await fieldSelect.click();
+    await adminPage
+      .locator('.ant-select-dropdown:visible .ant-select-item-option')
+      .filter({ hasText: 'Display Name' })
+      .first()
+      .click();
+
+    let saveRequested = false;
+    await adminPage.route('**/aiContext/rules', async (route) => {
+      saveRequested = true;
+      await route.abort();
+    });
+
+    await adminPage.getByRole('button', { name: 'Save Rule' }).click();
+
+    await expect(
+      adminPage.getByTestId('context-rule-filter-error')
+    ).toBeVisible();
+    await expect(adminPage.getByTestId('form-heading')).toBeVisible();
+    expect(saveRequested).toBe(false);
+  });
+
+  // Guards the other side of the same check: "Empty selects every entity of the configured type" is
+  // documented behaviour, so a rule with no filter at all must stay saveable.
+  test('saves a rule that has no filter conditions at all', async ({
+    adminPage,
+  }) => {
+    await mockPersonaContextApi(
+      adminPage,
+      persona.responseData.id as string,
+      []
+    );
+    await openPersonaContext(adminPage);
+
+    await adminPage.getByTestId('empty-add-context-rule').click();
+    await adminPage.getByTestId('context-rule-name').fill('Every table');
+
+    const createRuleRequest = adminPage.waitForRequest(
+      (request) =>
+        request.url().endsWith('/aiContext/rules') &&
+        request.method() === 'POST'
+    );
+    await adminPage.getByRole('button', { name: 'Save Rule' }).click();
+
+    const createdRule = (await createRuleRequest).postDataJSON() as ContextRule;
+    expect(createdRule).toMatchObject({ name: 'Every table', queryFilter: '' });
+    await expect(
+      adminPage.getByTestId('context-rule-filter-error')
+    ).toBeHidden();
+  });
+
+  // The blank row "Add condition" creates is also unfinished, so it blocks too — and removing it
+  // has to clear the error rather than leave the drawer stuck.
+  test('clears the filter error once the unfinished condition is removed', async ({
+    adminPage,
+  }) => {
+    await mockPersonaContextApi(
+      adminPage,
+      persona.responseData.id as string,
+      []
+    );
+    await openPersonaContext(adminPage);
+
+    await adminPage.getByTestId('empty-add-context-rule').click();
+    await adminPage.getByTestId('context-rule-name').fill('Recovered rule');
+    await adminPage.getByTestId('add-context-condition').click();
+
+    const fieldSelect = adminPage
+      .getByRole('dialog')
+      .locator('.rule--field .ant-select')
+      .first();
+    await fieldSelect.click();
+    await adminPage
+      .locator('.ant-select-dropdown:visible .ant-select-item-option')
+      .filter({ hasText: 'Display Name' })
+      .first()
+      .click();
+    await adminPage.getByRole('button', { name: 'Save Rule' }).click();
+    await expect(
+      adminPage.getByTestId('context-rule-filter-error')
+    ).toBeVisible();
+
+    await adminPage.getByTestId('delete-condition-button').last().click();
+
+    const createRuleRequest = adminPage.waitForRequest(
+      (request) =>
+        request.url().endsWith('/aiContext/rules') &&
+        request.method() === 'POST'
+    );
+    await adminPage.getByRole('button', { name: 'Save Rule' }).click();
+    const recoveredRule = (
+      await createRuleRequest
+    ).postDataJSON() as ContextRule;
+
+    expect(recoveredRule).toMatchObject({ name: 'Recovered rule' });
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx
@@ -153,6 +153,7 @@ export const ContextRuleEditor = ({
     useWatch({ control: form.control, name: 'fullyRendered' }) ?? false;
   const maxAssets = useWatch({ control: form.control, name: 'maxAssets' });
   const queryFilter = useWatch({ control: form.control, name: 'queryFilter' });
+  const [filterIncomplete, setFilterIncomplete] = useState(false);
   const closeDrawerRef = useRef<() => void>(() => undefined);
   const lastResetRuleIdRef = useRef<string>();
   const ruleForResetRef = useRef(rule);
@@ -238,6 +239,11 @@ export const ContextRuleEditor = ({
 
   const handleSubmit = useCallback(
     async (data: ContextRule) => {
+      // An unfinished condition contributes nothing to the emitted filter, so saving it would
+      // silently widen the rule to match everything. Make the user finish or remove it.
+      if (filterIncomplete) {
+        return;
+      }
       await onSubmit({
         ...data,
         description: data.description || undefined,
@@ -249,7 +255,7 @@ export const ContextRuleEditor = ({
       });
       closeDrawerRef.current();
     },
-    [onSubmit]
+    [filterIncomplete, onSubmit]
   );
 
   const handleDismiss = useCallback(() => {
@@ -404,7 +410,16 @@ export const ContextRuleEditor = ({
               shouldDirty: true,
             });
           }}
+          onValidityChange={(isValid) => setFilterIncomplete(!isValid)}
         />
+        {filterIncomplete && (
+          <Typography
+            className="tw:mt-1.5 tw:text-error-primary"
+            data-testid="context-rule-filter-error"
+            size="text-sm">
+            {t('message.persona-context-rule-filter-incomplete')}
+          </Typography>
+        )}
         <Alert
           className="tw:mt-3 tw:items-center! tw:gap-2.5 tw:px-3.5 tw:py-2.75 tw:**:data-[testid=alert-icon]:self-center"
           data-testid="context-rule-match-preview"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx
@@ -27,6 +27,7 @@ interface RuleQueryBuilderFieldProps {
   queryFilter?: string;
   readonly?: boolean;
   onChange: (queryFilter: string, filterJsonTree?: string) => void;
+  onValidityChange?: (isValid: boolean) => void;
 }
 
 export const RuleQueryBuilderField = ({
@@ -35,6 +36,7 @@ export const RuleQueryBuilderField = ({
   queryFilter,
   readonly,
   onChange,
+  onValidityChange,
 }: RuleQueryBuilderFieldProps) => {
   const { t } = useTranslation();
   const [queryActions, setQueryActions] = useState<Actions>();
@@ -62,6 +64,7 @@ export const RuleQueryBuilderField = ({
         tree={tree}
         value={queryFilter ?? ''}
         onChange={handleChange}
+        onValidityChange={onValidityChange}
       />
       {!readonly && (
         <Button

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
@@ -75,6 +75,7 @@ const QueryBuilderWidgetV1: FC<{
   label?: string;
   showCountPreview?: boolean;
   tree?: JsonTree;
+  onValidityChange?: (isValid: boolean) => void;
 }> = ({
   onChange,
   entityType = EntityType.ALL,
@@ -215,6 +216,10 @@ const QueryBuilderWidgetV1: FC<{
 
   const handleChange = (nTree: ImmutableTree, nConfig: Config) => {
     onTreeUpdate(nTree, nConfig);
+    // nConfig is the config react-awesome-query-builder has already extended, which isValidTree
+    // needs. A condition the user started but has not finished reads as invalid, letting the caller
+    // block the save instead of silently dropping the condition from the emitted filter.
+    props.onValidityChange?.(QbUtils.isValidTree(nTree, nConfig));
 
     if (outputType === SearchOutputType.ElasticSearch) {
       const data = elasticSearchFormat(nTree, config) ?? '';

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "لم يتم إنشاء السياق بعد",
     "persona-context-restore-confirmation": "استعادة سياق الذكاء الاصطناعي إلى الإصدار v{{version}}؟ سيؤدي هذا إلى إنشاء إصدار جديد بقواعد وإعدادات ذلك الإصدار.",
     "persona-context-rule-deleted": "تم حذف قاعدة سياق الذكاء الاصطناعي.",
+    "persona-context-rule-filter-incomplete": "أكمل الشرط غير المكتمل أو احذفه قبل الحفظ. يتم تجاهل الشرط غير المكتمل، مما يوسّع هذه القاعدة لتطابق كل شيء.",
     "persona-context-rule-saved": "تم حفظ قاعدة سياق الذكاء الاصطناعي.",
     "persona-context-rule-subtitle": "حدد البيانات الوصفية التي تضيفها هذه القاعدة إلى مستند السياق.",
     "persona-context-rules-count": "القواعد ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Der Kontext wurde noch nicht erstellt",
     "persona-context-restore-confirmation": "KI-Kontext auf v{{version}} wiederherstellen? Dadurch wird eine neue Version mit den Regeln und Einstellungen dieser Version erstellt.",
     "persona-context-rule-deleted": "KI-Kontextregel gelöscht.",
+    "persona-context-rule-filter-incomplete": "Vervollständigen oder entfernen Sie die unvollständige Bedingung vor dem Speichern. Eine unvollständige Bedingung wird ignoriert, wodurch diese Regel auf alles zutreffen würde.",
     "persona-context-rule-saved": "KI-Kontextregel gespeichert.",
     "persona-context-rule-subtitle": "Wählen Sie die Metadaten aus, die diese Regel dem Kontextdokument hinzufügt.",
     "persona-context-rules-count": "Regeln ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Context has not been generated yet",
     "persona-context-restore-confirmation": "Restore the AI context to v{{version}}? This creates a new version with that version's rules and settings.",
     "persona-context-rule-deleted": "AI context rule deleted.",
+    "persona-context-rule-filter-incomplete": "Finish or remove the unfinished condition before saving. An unfinished condition is ignored, which would widen this rule to match everything.",
     "persona-context-rule-saved": "AI context rule saved.",
     "persona-context-rule-subtitle": "Select the metadata this rule adds to the context document.",
     "persona-context-rules-count": "Rules ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "El contexto aún no se ha generado",
     "persona-context-restore-confirmation": "¿Restaurar el contexto de IA a v{{version}}? Esto crea una nueva versión con las reglas y ajustes de esa versión.",
     "persona-context-rule-deleted": "Regla de contexto de IA eliminada.",
+    "persona-context-rule-filter-incomplete": "Complete o elimine la condición incompleta antes de guardar. Una condición incompleta se ignora, lo que ampliaría esta regla para que coincida con todo.",
     "persona-context-rule-saved": "Regla de contexto de IA guardada.",
     "persona-context-rule-subtitle": "Seleccione los metadatos que esta regla añade al documento de contexto.",
     "persona-context-rules-count": "Reglas ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Le contexte n’a pas encore été généré",
     "persona-context-restore-confirmation": "Restaurer le contexte IA à la v{{version}} ? Cela crée une nouvelle version avec les règles et paramètres de cette version.",
     "persona-context-rule-deleted": "Règle de contexte IA supprimée.",
+    "persona-context-rule-filter-incomplete": "Terminez ou supprimez la condition incomplète avant d'enregistrer. Une condition incomplète est ignorée, ce qui élargirait cette règle à tous les éléments.",
     "persona-context-rule-saved": "Règle de contexte IA enregistrée.",
     "persona-context-rule-subtitle": "Sélectionnez les métadonnées que cette règle ajoute au document de contexte.",
     "persona-context-rules-count": "Règles ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "O contexto aínda non se xerou",
     "persona-context-restore-confirmation": "Restaurar o contexto de IA á v{{version}}? Isto crea unha nova versión coas regras e axustes desa versión.",
     "persona-context-rule-deleted": "Regra de contexto de IA eliminada.",
+    "persona-context-rule-filter-incomplete": "Complete ou elimine a condición incompleta antes de gardar. Unha condición incompleta ignórase, o que ampliaría esta regra para coincidir con todo.",
     "persona-context-rule-saved": "Regra de contexto de IA gardada.",
     "persona-context-rule-subtitle": "Seleccione os metadatos que esta regra engade ao documento de contexto.",
     "persona-context-rules-count": "Regras ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "ההקשר טרם נוצר",
     "persona-context-restore-confirmation": "לשחזר את הקשר ה-AI לגרסה v{{version}}? פעולה זו יוצרת גרסה חדשה עם הכללים וההגדרות של אותה גרסה.",
     "persona-context-rule-deleted": "כלל ההקשר נמחק.",
+    "persona-context-rule-filter-incomplete": "השלימו או הסירו את התנאי הלא גמור לפני השמירה. תנאי לא גמור מתעלמים ממנו, וכך הכלל יורחב ויתאים להכול.",
     "persona-context-rule-saved": "כלל ההקשר נשמר.",
     "persona-context-rule-subtitle": "בחר את המטא-נתונים שכלל זה מוסיף למסמך ההקשר.",
     "persona-context-rules-count": "כללים ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "コンテキストはまだ生成されていません",
     "persona-context-restore-confirmation": "AI コンテキストを v{{version}} に復元しますか？そのバージョンのルールと設定で新しいバージョンが作成されます。",
     "persona-context-rule-deleted": "AI コンテキストルールを削除しました。",
+    "persona-context-rule-filter-incomplete": "保存する前に、未完了の条件を完成させるか削除してください。未完了の条件は無視されるため、このルールがすべてに一致するまで広がってしまいます。",
     "persona-context-rule-saved": "AI コンテキストルールを保存しました。",
     "persona-context-rule-subtitle": "このルールがコンテキストドキュメントに追加するメタデータを選択します。",
     "persona-context-rules-count": "ルール（{{count}}）",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "컨텍스트가 아직 생성되지 않았습니다",
     "persona-context-restore-confirmation": "AI 컨텍스트를 v{{version}}(으)로 복원하시겠습니까? 해당 버전의 규칙과 설정으로 새 버전이 생성됩니다.",
     "persona-context-rule-deleted": "AI 컨텍스트 규칙이 삭제되었습니다.",
+    "persona-context-rule-filter-incomplete": "저장하기 전에 미완성 조건을 완성하거나 제거하세요. 미완성 조건은 무시되므로 이 규칙이 모든 항목과 일치하도록 확대됩니다.",
     "persona-context-rule-saved": "AI 컨텍스트 규칙이 저장되었습니다.",
     "persona-context-rule-subtitle": "이 규칙이 컨텍스트 문서에 추가할 메타데이터를 선택하세요.",
     "persona-context-rules-count": "규칙({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "संदर्भ अद्याप तयार केलेला नाही",
     "persona-context-restore-confirmation": "AI संदर्भ v{{version}} वर पुनर्संचयित करायचा? यामुळे त्या आवृत्तीच्या नियम आणि सेटिंग्जसह नवीन आवृत्ती तयार होते.",
     "persona-context-rule-deleted": "AI संदर्भ नियम हटवला.",
+    "persona-context-rule-filter-incomplete": "जतन करण्यापूर्वी अपूर्ण अट पूर्ण करा किंवा काढून टाका. अपूर्ण अट दुर्लक्षित केली जाते, त्यामुळे हा नियम सर्व गोष्टींशी जुळेल इतका व्यापक होईल.",
     "persona-context-rule-saved": "AI संदर्भ नियम जतन केला.",
     "persona-context-rule-subtitle": "हा नियम संदर्भ दस्तऐवजात जोडणारा मेटाडेटा निवडा.",
     "persona-context-rules-count": "नियम ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Context is nog niet gegenereerd",
     "persona-context-restore-confirmation": "AI-context herstellen naar v{{version}}? Hiermee wordt een nieuwe versie gemaakt met de regels en instellingen van die versie.",
     "persona-context-rule-deleted": "AI-contextregel verwijderd.",
+    "persona-context-rule-filter-incomplete": "Maak de onvolledige voorwaarde af of verwijder deze voordat u opslaat. Een onvolledige voorwaarde wordt genegeerd, waardoor deze regel op alles zou passen.",
     "persona-context-rule-saved": "AI-contextregel opgeslagen.",
     "persona-context-rule-subtitle": "Selecteer de metadata die deze regel toevoegt aan het contextdocument.",
     "persona-context-rules-count": "Regels ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "زمینه هنوز ایجاد نشده است",
     "persona-context-restore-confirmation": "زمینه هوش مصنوعی به نسخه v{{version}} بازیابی شود؟ این کار نسخه جدیدی با قوانین و تنظیمات آن نسخه ایجاد می‌کند.",
     "persona-context-rule-deleted": "قانون زمینه هوش مصنوعی حذف شد.",
+    "persona-context-rule-filter-incomplete": "پیش از ذخیره، شرط ناتمام را کامل یا حذف کنید. شرط ناتمام نادیده گرفته می‌شود و این قانون را چنان گسترده می‌کند که با همه چیز مطابقت کند.",
     "persona-context-rule-saved": "قانون زمینه هوش مصنوعی ذخیره شد.",
     "persona-context-rule-subtitle": "فراداده‌هایی را که این قانون به سند زمینه اضافه می‌کند انتخاب کنید.",
     "persona-context-rules-count": "قوانین ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "O contexto ainda não foi gerado",
     "persona-context-restore-confirmation": "Restaurar o contexto de IA para v{{version}}? Isso cria uma nova versão com as regras e configurações dessa versão.",
     "persona-context-rule-deleted": "Regra de contexto de IA excluída.",
+    "persona-context-rule-filter-incomplete": "Conclua ou remova a condição incompleta antes de salvar. Uma condição incompleta é ignorada, o que ampliaria esta regra para corresponder a tudo.",
     "persona-context-rule-saved": "Regra de contexto de IA salva.",
     "persona-context-rule-subtitle": "Selecione os metadados que esta regra adiciona ao documento de contexto.",
     "persona-context-rules-count": "Regras ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "O contexto ainda não foi gerado",
     "persona-context-restore-confirmation": "Restaurar o contexto de IA para v{{version}}? Isto cria uma nova versão com as regras e definições dessa versão.",
     "persona-context-rule-deleted": "Regra de contexto de IA eliminada.",
+    "persona-context-rule-filter-incomplete": "Conclua ou remova a condição incompleta antes de guardar. Uma condição incompleta é ignorada, o que alargaria esta regra para corresponder a tudo.",
     "persona-context-rule-saved": "Regra de contexto de IA guardada.",
     "persona-context-rule-subtitle": "Selecione os metadados que esta regra adiciona ao documento de contexto.",
     "persona-context-rules-count": "Regras ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Контекст ещё не создан",
     "persona-context-restore-confirmation": "Восстановить контекст ИИ до v{{version}}? Будет создана новая версия с правилами и настройками этой версии.",
     "persona-context-rule-deleted": "Правило контекста ИИ удалено.",
+    "persona-context-rule-filter-incomplete": "Завершите или удалите незаконченное условие перед сохранением. Незаконченное условие игнорируется, из-за чего это правило будет соответствовать всему.",
     "persona-context-rule-saved": "Правило контекста ИИ сохранено.",
     "persona-context-rule-subtitle": "Выберите метаданные, которые это правило добавляет в документ контекста.",
     "persona-context-rules-count": "Правила ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Kontexten har inte genererats ännu",
     "persona-context-restore-confirmation": "Återställa AI-kontexten till v{{version}}? Detta skapar en ny version med den versionens regler och inställningar.",
     "persona-context-rule-deleted": "AI-kontextregeln har tagits bort.",
+    "persona-context-rule-filter-incomplete": "Slutför eller ta bort det ofullständiga villkoret innan du sparar. Ett ofullständigt villkor ignoreras, vilket skulle utöka regeln till att matcha allt.",
     "persona-context-rule-saved": "AI-kontextregeln har sparats.",
     "persona-context-rule-subtitle": "Välj vilka metadata den här regeln lägger till i kontextdokumentet.",
     "persona-context-rules-count": "Regler ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "ยังไม่ได้สร้างบริบท",
     "persona-context-restore-confirmation": "กู้คืนบริบท AI เป็น v{{version}} หรือไม่ การดำเนินการนี้จะสร้างเวอร์ชันใหม่ด้วยกฎและการตั้งค่าของเวอร์ชันนั้น",
     "persona-context-rule-deleted": "ลบกฎบริบท AI แล้ว",
+    "persona-context-rule-filter-incomplete": "กรุณาทำให้เงื่อนไขที่ยังไม่สมบูรณ์ครบถ้วนหรือลบออกก่อนบันทึก เงื่อนไขที่ไม่สมบูรณ์จะถูกละเว้น ซึ่งจะทำให้กฎนี้ตรงกับทุกรายการ",
     "persona-context-rule-saved": "บันทึกกฎบริบท AI แล้ว",
     "persona-context-rule-subtitle": "เลือกเมทาดาทาที่กฎนี้เพิ่มลงในเอกสารบริบท",
     "persona-context-rules-count": "กฎ ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "Bağlam henüz oluşturulmadı",
     "persona-context-restore-confirmation": "AI bağlamı v{{version}} sürümüne geri yüklensin mi? Bu, o sürümün kuralları ve ayarlarıyla yeni bir sürüm oluşturur.",
     "persona-context-rule-deleted": "Yapay zekâ bağlam kuralı silindi.",
+    "persona-context-rule-filter-incomplete": "Kaydetmeden önce tamamlanmamış koşulu tamamlayın veya kaldırın. Tamamlanmamış bir koşul yok sayılır ve bu kural her şeyle eşleşecek şekilde genişler.",
     "persona-context-rule-saved": "Yapay zekâ bağlam kuralı kaydedildi.",
     "persona-context-rule-subtitle": "Bu kuralın bağlam belgesine eklediği meta verileri seçin.",
     "persona-context-rules-count": "Kurallar ({{count}})",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "尚未生成上下文",
     "persona-context-restore-confirmation": "将 AI 上下文恢复到 v{{version}}？这将使用该版本的规则和设置创建一个新版本。",
     "persona-context-rule-deleted": "已删除 AI 上下文规则。",
+    "persona-context-rule-filter-incomplete": "保存前请完成或删除未完成的条件。未完成的条件会被忽略，这将使该规则匹配所有内容。",
     "persona-context-rule-saved": "已保存 AI 上下文规则。",
     "persona-context-rule-subtitle": "选择此规则添加到上下文文档中的元数据。",
     "persona-context-rules-count": "规则（{{count}}）",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -3989,6 +3989,7 @@
     "persona-context-not-generated": "尚未產生上下文",
     "persona-context-restore-confirmation": "要將 AI 上下文還原至 v{{version}} 嗎？這將使用該版本的規則和設定建立新版本。",
     "persona-context-rule-deleted": "已刪除 AI 上下文規則。",
+    "persona-context-rule-filter-incomplete": "儲存前請完成或移除未完成的條件。未完成的條件會被忽略，這會使此規則比對所有內容。",
     "persona-context-rule-saved": "已儲存 AI 上下文規則。",
     "persona-context-rule-subtitle": "選擇此規則新增至上下文文件的中繼資料。",
     "persona-context-rules-count": "規則（{{count}}）",


### PR DESCRIPTION
### Describe your changes:

Relates to #30715. **Stacked on #30716** — base is that PR's branch, so this diff shows only the follow-up. Retarget to `main` once #30716 merges.

#30716 stopped a half-built condition from crashing the search: `{"term":{}}` is rejected outright by both OpenSearch and Elasticsearch, so the emitted `queryFilter` now drops it. That fixes the 500, but leaves a worse-shaped UX bug behind it — dropping the condition *silently on save*. A rule the user built as "tier is ___" persists as **no filter at all**, so it matches everything and pulls the entity cap instead of the handful of assets they picked. Nothing tells them.

So the editor now refuses the save while a condition is unfinished, and says so inline, rather than quietly widening the rule. Either the condition is in, or it is out.

`QueryBuilderWidgetV1` reports tree validity through a new optional `onValidityChange` prop. It uses `QbUtils.isValidTree` with the config react-awesome-query-builder has already extended in its own `onChange` — the same validity RAQB uses internally, so operators with no value (`is_null` and friends) are not false-flagged. Only the persona rule editor opts in; Explore and the other query-builder consumers are untouched.

The backend prune from #30716 stays regardless. It is the safety net, not the UX: rules with `{"term":{}}` are already persisted in `persona.contextDefinition` today and a UI fix does not heal them, and `POST /aiContext/rules` is a public API that must not 500 on bad input.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- Admin picks a field for a condition, leaves the value empty, hits Save → save is blocked, an inline message explains why, and no `POST /aiContext/rules` is fired.
- Admin saves a rule with **no filter conditions at all** → still saves. This is the regression guard, see the note below.
- Admin removes the unfinished condition → the error clears and the rule saves.

#### Unit tests

- [x] Not applicable to the validity check itself — see the honest note below.
- Existing jest suites re-run for regressions: `QueryBuilderElasticsearchFormatUtils`, `AdvancedSearchClassBase`, `RuleQueryBuilderField`, `AdvancedAssetsFilterField`, `QueryBuilderWidget`, `QueryBuilderWidgetV1`, `ContractSemanticFormTab`, and every `PersonaAIContext` suite.

```
Test Suites: 13 passed, 13 total
Tests:       147 passed, 147 total
```

#### Playwright (UI) tests

- [x] Added to `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts`:
  - `blocks saving a rule whose condition has no value entered`
  - `saves a rule that has no filter conditions at all`
  - `clears the filter error once the unfinished condition is removed`

**Why Playwright and not jest — please read before reviewing.** Every jest suite in this repo mocks react-awesome-query-builder wholesale (`jest.mock('@react-awesome-query-builder/antd')` in `QueryBuilderWidgetV1.test.tsx`), so `QbUtils` is a stub there and a unit test would assert nothing about real `isValidTree` behaviour. Building the real config standalone does not work either — OM's `getTreeConfig` output is not complete until RAQB's `<Query>` extends it, so `ConfigUtils.extendConfig` throws on it. Playwright is the only place the real query builder actually runs.

**The second test is the load-bearing one.** `isValidTree` is RAQB's own validity check and I could not verify locally how it treats a tree with no rules. If it reports an empty tree as invalid, this change would block saving every "match everything" rule — which the schema documents as legal ("Empty selects every entity of the configured type") and which would be a worse regression than the bug being fixed. That test exists to fail loudly in CI if that is the case. I have deliberately not run it locally; **please watch that job.** If it goes red, the fix is to gate the check on the tree being non-empty, not to loosen the test.

#### Backend integration tests

- [x] Not applicable (no backend change in this PR).

#### Ingestion integration tests

- [x] Not applicable.

#### Manual testing performed

None — flagged deliberately. The local stack was unavailable, which is exactly why the verification is pushed into the Playwright job rather than asserted here.

Lint and type-check were run:

- `eslint` on the changed spec — 0 errors, 0 warnings.
- `yarn lint:playwright` — 0 errors (280 pre-existing warnings elsewhere in the suite, none in the changed file).
- The changed src files pass the CI organize-imports → eslint → prettier sequence with no diff.
- `tsc --noEmit` reports one error in `QueryBuilderWidgetV1.test.tsx:297`, confirmed pre-existing on the base commit and untouched by this change.

#
### UI screen recording / screenshots:

Not attached — no local stack available to record against. The three Playwright cases document the behaviour end-to-end instead.

#
### i18n

`message.persona-context-rule-filter-incomplete` added and synced with `yarn i18n`. All 19 non-English locales carry a real translation rather than the English placeholder `yarn i18n` inserts. Note `pr-pr` is Persian, not Portuguese.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: recording explained above.
- [x] I have added tests and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents saving unfinished persona AI-context filters.
- Adds query-tree validity reporting to QueryBuilderWidgetV1 and forwards it through RuleQueryBuilderField.
- Blocks persona context-rule submission and displays an inline localized error while the filter is invalid.
- Adds Playwright coverage for unfinished, empty, and subsequently removed conditions.
- Adds the new validation message to all supported locale files.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The validity lifecycle needs to be fixed before merging because valid rules can remain blocked after resets while invalid persisted rules can bypass the guard without an edit.

Validity is retained after the displayed filter is reset, but it is not initialized when an existing filter tree loads, causing both false save rejection and missed validation.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx; openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/ContextRuleEditor.component.tsx | Adds save blocking and inline feedback, but retains stale invalidity across form resets and entity-type changes. |
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx | Forwards the optional validity callback to the shared query-builder widget. |
| openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx | Reports validity only during query-builder changes, leaving initially loaded invalid trees unreported. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/PersonaAIContext.spec.ts | Adds end-to-end coverage for blocking unfinished conditions while preserving empty-rule saves and recovery after deletion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): block saving a persona rule wit..."](https://github.com/open-metadata/openmetadata/commit/4b87fe819b11ed2ebe5cb6b50ad6385f1496cfb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48729019)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->