### PR TITLE
docs(ui)/feat(tooling): Typography + Button mapping guides and typography codemod (Wave 1)

### DIFF
--- a/docs/antd-migration/button.md
+++ b/docs/antd-migration/button.md
@@ -1,0 +1,291 @@
+# antd `Button` → `Button` mapping guide
+
+**Sweep status:** ledger row `Button` (openmetadata-ui 310, collate-ui 43,
+collate-local-webserver 24 — per `docs/antd-migration/LEDGER.md`; also covers
+the `antd/lib/button/button-group` ledger row, 5 usages, all in
+openmetadata-ui)
+**Core component:** `@openmetadata/ui-core-components` →
+`components/base/buttons/button` (react-aria based; also exports
+`ButtonUtility`, `CloseButton`, `SocialButton`; `ButtonGroup`/`ButtonGroupItem`
+live in `components/base/button-group/button-group`)
+**Codemod:** `move-named-imports` (import rewrite) + `antd-button-to-core`
+(prop rewrite, **to be written** — no transform exists yet; this guide is the
+spec for it). Follow the same skip/report conventions as
+`transforms/antd-typography-to-core.js` (leave unmappable elements fully
+untouched, `console.warn` per skip reason, alias the core import when a file
+partially converts).
+
+## Import
+
+| Before | After |
+|---|---|
+| `import { Button } from 'antd';` | `import { Button } from '@openmetadata/ui-core-components';` |
+| `import ButtonGroup from 'antd/lib/button/button-group';` (5 sites, all R1) | `import { ButtonGroup, ButtonGroupItem } from '@openmetadata/ui-core-components';` **only** where the group is genuinely single-select toggle state — see `Button.Group` row below; otherwise replace with a plain flex row of `Button`s |
+
+All non-subpath imports across all three repos use the named form
+`import { Button, ... } from 'antd'` — no default-import or namespace-import
+variants to handle.
+
+## Prop mapping
+
+| antd prop | core equivalent | notes |
+|---|---|---|
+| `type="primary"` | `color="primary"` | direct |
+| `type="default"` | `color="secondary"` | direct |
+| `type="text"` | `color="tertiary"` | direct |
+| `type="link"` | `color="link-gray"` (or `link-color`) | design call per context — no mechanical rule distinguishes the two |
+| `type="dashed"` | — | 0 occurrences anywhere — drop, no mapping needed |
+| `danger` | fold into `color`: `primary`+`danger` → `color="primary-destructive"`, `default`+`danger` → `color="secondary-destructive"`, `text`+`danger` → `color="tertiary-destructive"`, `link`+`danger` → `color="link-destructive"` | **not a rename** — the codemod must read the base `type` first, then branch to the `-destructive` variant; `danger` alone (no explicit `type`) implies antd's default `type="default"` base |
+| `size="small"` | `size="xs"` | approved 2026-07-30 — see Size mapping below |
+| `size="middle"` | `size="sm"` (core's own default) | approved 2026-07-30 — see Size mapping below |
+| `size="large"` | `size="md"` | approved 2026-07-30 — see Size mapping below |
+| `ghost` (boolean modifier) | `color="tertiary"` | approved 2026-07-30 — per-site mapping, no new core variant |
+| `type="ghost"` (string literal) | `color="tertiary"` | approved 2026-07-30 — same as above |
+| `loading` (bare or `={expr}`) | `isLoading` | rename |
+| `disabled` (bare or `={expr}`) | `isDisabled` | rename |
+| `icon={<X/>}` | `iconLeading={<X/>}` | rename; leading is antd's implicit default position |
+| `icon={<Icon component={Svg}/>}` | `iconLeading={Svg}` | the `Icon`/`component` wrapper can be dropped — core accepts the bare `FC<{className}>` |
+| `href` / `target` | `href` / `target` | direct — core auto-swaps the rendered element to `AriaLink` when `href` is present, same effect as antd's button-as-link |
+| `htmlType` | native `type` | **name swap, not a rename — see inversion warning below** |
+| `onClick` / `className` / `autoFocus` | unchanged | native passthrough; any `className` targeting border/shadow must move to `tw:after:outline-*` — see Border-override rule below |
+
+### `htmlType` → `type` inversion warning
+
+Antd's `type` prop is the **visual variant** (`primary`/`default`/`text`/…).
+Core's `type` prop is the **native HTML button type**
+(`submit`/`reset`/`button`, default `'button'`) — i.e. what antd calls
+`htmlType`. These two props occupy the same name on opposite meanings, so a
+naive string-rename script that touches `type` alone will silently produce a
+core `Button` with `type="primary"` (an invalid/no-op native HTML type) and
+no visual variant at all. The codemod must perform **both** rewrites in the
+same pass, on every `<Button>` element:
+
+- antd `type="X"` (visual variant) → core `color="<mapped-X>"`
+- antd `htmlType="Y"` → core `type="Y"` (only if present; core's default
+  `'button'` covers antd's implicit default `htmlType="button"`)
+
+43 (R1) + 7 (R2) + 10 (R3) = 60 `htmlType="submit"` sites; 1 `htmlType="button"`
+(R1, redundant with the default); 0 `htmlType="reset"` anywhere.
+
+### Size mapping — approved 2026-07-30
+
+Core has 6 sizes (`xxs | xs | sm | md | lg | xl`, default `'sm'`) vs antd's 3
+(`small | middle | large`). Approved mapping (2026-07-30, as proposed):
+
+| antd | core size |
+|---|---|
+| `small` | `xs` |
+| `middle` | `sm` |
+| `large` | `md` |
+
+144 (R1) + 13 (R2) + 2 (R3) `size="small"`; 6+0+3 `size="middle"`; 6+0+3
+`size="large"`. Additionally **48 dynamic `size={expr}` expressions** (R1:
+41, R2: 7) cannot be pattern-matched as literals and need manual per-site
+triage regardless of which literal mapping is chosen (example:
+`utils/TestConnectionModalUtils.tsx:957`).
+
+## No direct equivalent — do this instead
+
+| antd usage | replacement pattern |
+|---|---|
+| `shape="circle"` (8 usages: R1 3, R2 5) | Core's icon-only auto-detection (`data-icon-only`) gives a **rounded square, never a true circle** — partial gap. Accept the rounded-square look, or add a `tw:rounded-full` override per site and flag for design review. Example: `components/Entity/EntityLineage/CustomNode.utils.tsx:147` |
+| `shape="round"` (pill, 1 usage) | GAP — no pill variant. Example: `components/ActivityFeed/Reactions/Emoji.tsx:116` |
+| `block` (25 usages, all R1) | `className="tw:w-full"` — mechanical move, but needs visual QA since it's no longer a first-class prop. Example: `components/NotificationBox/NotificationBox.component.tsx:271` |
+| `Button.Group` (5 legacy sites: `ClassificationDetails.tsx:1038`, `GlossaryHeader.component.tsx`, `DataProductsDetailsPage.component.tsx`, `GithubStarCard.component.tsx`, `DomainDetails.component.tsx:1038`) | These group **independent action buttons** (vote/star controls), not single-select toggle state. Core `ButtonGroup`/`ButtonGroupItem` is a react-aria `ToggleButtonGroup` (single-select) — semantic mismatch, not a drop-in. Replace with a plain flex row of `Button`s (`className="tw:flex tw:gap-*"`), one per site, by hand. (5 *already-migrated* core `ButtonGroup` usages exist as precedent in R1 lineage components and 2 in R2 — those are genuine toggle groups and are correct as-is; do not touch) |
+| `ref={...}` (5 live usages) | core `Button` is now `forwardRef`-wrapped — **landed in main** (ui-core-components). `<Button ref={...}>` passes through directly; these 5 call sites are unblocked and safe to convert. Sites: `components/Alerts/DestinationFormItem/TeamAndUserSelectItem/TeamAndUserSelectItem.tsx:238`, `components/common/AvatarCarouselItem/AvatarCarouselItem.tsx:62`, plus 3 more (see gap-check §1.9/§4.6) |
+
+## Before / after examples
+
+**1. `type="text"` + `size="small"` (mechanical)**
+`utils/ClassificationUtils.tsx:170`
+
+```tsx
+// Before
+<Button
+  className="p-0 flex-center"
+  data-testid="edit-button"
+  disabled={disableEditButton}
+  icon={
+    <EditIcon data-testid="editTagDescription" height={14} name="edit" width={14} />
+  }
+  size="small"
+  type="text"
+  onClick={() => (handleEditTagClick ? handleEditTagClick(record) : null)}
+/>
+
+// After (size mapping per the approved 2026-07-30 table)
+<Button
+  className="p-0 flex-center"
+  color="tertiary"
+  data-testid="edit-button"
+  iconLeading={
+    <EditIcon data-testid="editTagDescription" height={14} name="edit" width={14} />
+  }
+  isDisabled={disableEditButton}
+  size="xs"
+  onClick={() => (handleEditTagClick ? handleEditTagClick(record) : null)}
+/>
+```
+
+**2. `danger` fold-in with `type="default"` + `size="small"` (mechanical once branching is written)**
+`components/Settings/Bot/BotDetails/AuthMechanism.tsx:92`
+
+```tsx
+// Before
+<Button
+  danger
+  data-testid="revoke-button"
+  disabled={!hasPermission}
+  size="small"
+  type="default"
+  onClick={onTokenRevoke}
+>
+  ...
+</Button>
+
+// After
+<Button
+  color="secondary-destructive"
+  data-testid="revoke-button"
+  isDisabled={!hasPermission}
+  size="xs"
+  onClick={onTokenRevoke}
+>
+  ...
+</Button>
+```
+
+**3. `block` prop → className move (mechanical, needs visual QA)**
+`components/NotificationBox/NotificationBox.component.tsx:271`
+
+```tsx
+// Before
+<Button block href={viewAllPath} type="link">
+  <span>{t('label.view-entity', { entity: t('label.all-lowercase') })}</span>
+</Button>
+
+// After
+<Button className="tw:w-full" color="link-gray" href={viewAllPath}>
+  <span>{t('label.view-entity', { entity: t('label.all-lowercase') })}</span>
+</Button>
+```
+
+**4. Hand-finish example: `ghost` + `type="primary"` (approved mapping, per-site hand-finish — no codemod)**
+`utils/AdvancedSearchUtils.tsx:64`
+
+```tsx
+// Before — codemod skips this element entirely; `ghost` is not pattern-matched
+<Button
+  ghost
+  className="action action--ADD-RULE"
+  data-testid="advanced-search-add-rule"
+  icon={<PlusOutlined />}
+  type="primary"
+  onClick={props?.onClick}
+>
+  {t('label.add')}
+</Button>
+
+// After — hand-finished using the approved 2026-07-30 ghost mapping
+<Button
+  className="action action--ADD-RULE"
+  color="tertiary"
+  data-testid="advanced-search-add-rule"
+  iconLeading={<PlusOutlined />}
+  onClick={props?.onClick}
+>
+  {t('label.add')}
+</Button>
+```
+
+**5. Hand-finish example: `ref` (forwardRef landed in main — unblocked)**
+`components/common/AvatarCarouselItem/AvatarCarouselItem.tsx:62`
+
+```tsx
+// Before — imperative ref for focus/positioning
+<Button
+  className={classNames('p-0 m-r-xss avatar-item', { active: isActive })}
+  data-testid={`avatar-carousel-item-${avatar.id}`}
+  ref={buttonRef}
+  shape="circle"
+  onClick={handleAvatarClick}
+>
+  <ProfilePicture name={avatar.name ?? ''} width="28" />
+</Button>
+
+// After — ref now passes straight through (core Button is forwardRef-wrapped);
+// `shape="circle"` is still a partial gap (rounded square, not a true circle) —
+// flag that remaining blocker for design review at this site
+```
+
+## Border-override className drift
+
+Core `Button`'s element `outline` is reserved for the **focus ring**; the
+color border lives on `::after` (the `borderAfter` helper), and `::before` is
+reserved for the primary gradient border. Any `className` from the antd
+version that targeted a border, shadow, or ring color on `<Button>` must be
+rewritten to target `tw:after:outline-*` (with state variants, e.g.
+`tw:after:hover:outline-*`) — `tw:outline-*` on a `Button` silently sets the
+*focus* color instead and is a no-op for the visible border. This is the
+general Collate rule (no `tw:ring-*`, ever — see repo styling docs, "Overriding
+a core component's border from Collate") applied specifically to Button; audit
+every `className` carried over during this sweep against it, not just newly
+written ones.
+
+## Hand-finish punch list (do not block the bulk codemod run on these)
+
+- **`ghost` boolean + `type="ghost"`** — 38 combined usages (35 boolean + 3
+  literal) across R1/R3 — approved mapping `color="tertiary"` (2026-07-30),
+  applied per-site by hand (no codemod)
+- **`shape="circle"`** — 8 usages (R1 3, R2 5) — partial gap, rounded square only
+- **`shape="round"`** — 1 usage (R1) — no pill variant
+- **`Button.Group`** — 5 legacy sites (file:line list above) — semantic
+  mismatch with core's single-select `ButtonGroup`, redesign per site as a
+  flex row of `Button`s
+- **`ref`** — 5 live usages — unblocked (ui-core-components `forwardRef`
+  landed in main); convert directly, per-site
+- **`block`** — 25 usages (R1) — mechanical `tw:w-full` move but every site
+  needs visual QA
+- **Border-override className drift** — any carried-over `className`
+  targeting border/shadow/ring must be re-pointed at `tw:after:outline-*`
+- **48 dynamic `size={expr}` sites** — need manual triage independent of
+  which literal size mapping is chosen
+
+## Related decisions (recorded 2026-07-30)
+
+- **Tooltip arrow** stays core-default (no arrow) when that sweep comes.
+- **Space** maps to `Box` (blessed).
+- **Status-colored Tags** migrate to core `Badge`.
+
+## CSS to delete with this sweep
+
+Once a directory's `Button` usages are fully converted, grep for orphaned
+`.ant-btn` overrides before deleting:
+
+```bash
+grep -rn "\.ant-btn" --include="*.less" --include="*.css" src/
+```
+
+Pay particular attention to the `remove-button-default-styling` utility class
+(19 R1 usages on `<Button>`) — it exists specifically to strip antd Button
+chrome and becomes dead weight once every consumer in a directory has moved
+to core `Button` (which has no antd chrome to strip). Confirm with
+grep/knip that no remaining call site in that directory still imports antd
+`Button` before deleting `.ant-btn` selectors or the utility class itself.
+
+**Sweep-PR checklist line:** after each chunked PR, regenerate the ledger
+(`tooling/antd-migration/ledger.mjs`) so the `Button` (and
+`antd/lib/button/button-group`) rows in `docs/antd-migration/LEDGER.md`
+reflect the reduced antd usage count.
+
+## Styling rules (apply in every PR of this sweep)
+
+- Semantic Tailwind tokens only (`tw:bg-primary`, `tw:text-tertiary`) — never
+  raw palette classes or hex.
+- No `tw:ring-*` — Button borders are `::after`-based (`tw:after:outline-*`,
+  see Border-override section above); never reintroduce a ring class. Full
+  rationale: upstream `docs/colors.md` §2.3.1.
+- No string literals — use `t('label.…')` / `t('message.…')`, checking both
+  `collate-ui/src/main/resources/ui/src/locale/languages/en-us.json` and the
+  OpenMetadata submodule's `en-us.json` for an existing key before adding a
+  new one.

--- a/docs/antd-migration/typography.md
+++ b/docs/antd-migration/typography.md
@@ -1,0 +1,210 @@
+# antd `Typography` → `Typography` mapping guide
+
+**Sweep status:** ledger row `Typography` (openmetadata-ui 422, collate-ui 67,
+collate-local-webserver 22 — per `docs/antd-migration/LEDGER.md`)
+**Core component:** `@openmetadata/ui-core-components` →
+`components/foundations/typography` (single flat export, no `.Text`/`.Title`/
+`.Paragraph`/`.Link` namespace)
+**Codemod:** `tooling/antd-codemods/transforms/antd-typography-to-core.js`
+
+## Import
+
+| Before | After |
+|---|---|
+| `import { Typography } from 'antd';` | `import { Typography } from '@openmetadata/ui-core-components';` |
+| `const { Text, Title } = Typography;` (destructured, incl. inside jest mocks) | rewritten in place to the member-expression form, then removed once every covered usage converts |
+| `import { ParagraphProps } from 'antd/lib/typography/Paragraph';` (type-only subpath, 2 files total) | out of scope for this codemod — handle by hand or with `move-named-imports.js` |
+
+## Prop mapping
+
+| antd prop (as used in repo) | core equivalent | notes |
+|---|---|---|
+| `<Typography.Text>` | `<Typography>` (`as="span"` is the default) | mechanical |
+| `<Typography.Paragraph>` | `<Typography as="p">` | mechanical |
+| `<Typography.Link>` | `<Typography as="a">` | mechanical; verify `href`/`target` passthrough at each site |
+| `<Typography.Title level={N}>` | `<Typography as="hN" size={LEVEL_SIZE_MAP[N]}>` | **see LEVEL_SIZE_MAP below — approved 2026-07-30** |
+| `type="secondary"` / `"success"` / `"warning"` / `"danger"` | `color="secondary"` / `"success"` / `"warning"` / `"danger"` | core `color` prop landed in main — safe to run the bulk sweep against `type="..."` sites |
+| `strong` | `weight="bold"` | codemod applies this only for literal `strong`/`strong={true}`; dynamic `strong={expr}` is a skip |
+| `underline` | `className` gets `tw:underline` appended (creates `className` if absent) | mechanical workaround, only when `className` is absent or a plain string literal |
+| `ellipsis` (boolean) | `ellipsis` (boolean) | 1:1, identical shape |
+| `ellipsis={{ rows, tooltip }}` | `ellipsis={{ rows, tooltip }}` | 1:1, identical shape |
+| `className` / `style` / `onClick` / `title` / `data-testid` / any other prop | unchanged | passthrough |
+
+### `LEVEL_SIZE_MAP` — approved 2026-07-30
+
+Antd's `Title` `level` (1–5) has no size concept of its own. This is the
+convention baked into the codemod (see
+`transforms/antd-typography-to-core.js`), **approved as proposed on
+2026-07-30**:
+
+| level | `as` | `size` |
+|---|---|---|
+| 1 | `h1` | `display-sm` |
+| 2 | `h2` | `display-xs` |
+| 3 | `h3` | `text-xl` |
+| 4 | `h4` | `text-lg` |
+| 5 | `h5` | `text-md` |
+
+Level 5 dominates real usage (>70% across all three repos — R1: 45/55, R2:
+11/14, R3: 5/8) and maps to `text-md`, the closest visual match to antd's
+smallest heading variant. A `<Typography.Title>` with no `level` attribute
+uses antd's own default, level 1. `level={expr}` (dynamic, non-literal) is
+always a skip — the size lookup needs a known level at codemod time.
+
+## No direct equivalent — do this instead
+
+| antd usage | replacement pattern |
+|---|---|
+| `copyable` (boolean or object) | HARD GAP — no copy-to-clipboard affordance on core `Typography`. Pair with a `CopyButton`/`ButtonUtility` (clipboard icon) at the call site, or leave as antd pending a feature addition. 2 sites, both `AppLogsViewer/ReindexFailures.component.tsx` (lines 108, 134) |
+| `ellipsis={{ expandable, symbol, onExpand }}` | HARD GAP — show-more/less UX not supported. Hand-migrate with local expand/collapse state, or defer. 1 site: `AppLogsViewer/ReindexFailures.component.tsx:136` |
+| `code` | `as="code"` plus manual styling (no semantic prop). 1 site: `components/Settings/Alerts/AlertsDetails/AlertDetails.component.tsx:109` |
+| `keyboard` | custom `<kbd>` element with manual styling. 1 site: `collate-local-webserver/ui/src/pages/DownloadPage.tsx:163` |
+| dynamic `Title level={expr}` | hand-pick the `as`/`size` pair once the runtime value is known, using the `LEVEL_SIZE_MAP` table above as the starting point |
+| bare `<Typography>` (no sub-component) | codemod deliberately leaves this untouched — antd's bare form renders an `<article>` wrapper with different semantics than core's default `span`; verify the intended element and convert by hand |
+| `mark` / `disabled` / `editable` / `italic` / `delete` | zero real usage across all three repos — out of scope, do not build a mapping |
+
+## Before / after examples
+
+**1. `type="secondary"` → `color` (mechanical, `color` prop landed in main)**
+`utils/EntityVersionUtils.tsx:235`
+
+```tsx
+// Before
+<Typography.Text type="secondary">
+  {t('label.no-parameter-available')}
+</Typography.Text>
+
+// After
+<Typography color="secondary">
+  {t('label.no-parameter-available')}
+</Typography>
+```
+
+**2. `Title level={5}` → `as`/`size` lookup (mechanical, uses `LEVEL_SIZE_MAP`)**
+`collate-local-webserver/ui/src/pages/DownloadPage.tsx:157`
+
+```tsx
+// Before
+<Typography.Title level={5}>Next steps</Typography.Title>
+
+// After
+<Typography as="h5" size="text-md">
+  Next steps
+</Typography>
+```
+
+**3. `strong` + `className` (mechanical)**
+`components/AppBar/Suggestions.tsx:415`
+
+```tsx
+// Before
+<Typography.Text strong className="m-b-sm d-block">
+  {t('label.ai-queries')}
+</Typography.Text>
+
+// After
+<Typography weight="bold" className="m-b-sm d-block">
+  {t('label.ai-queries')}
+</Typography>
+```
+
+**4. Hand-finish / partial-conversion file: `copyable` + `ellipsis.expandable` (hard gaps, `CoreTypography` alias)**
+`components/AppLogsViewer/ReindexFailures.component.tsx:100-140` mixes
+convertible and non-convertible `Typography` usages in the same file. The
+codemod converts what it can and keeps the antd import alive for what it
+can't, aliasing the core import to avoid a name collision:
+
+```tsx
+// Before
+import { Tooltip, Typography } from 'antd';
+...
+<Typography.Text className="font-medium">{text}</Typography.Text>
+...
+<Typography.Text copyable={Boolean(text)}>{text || '-'}</Typography.Text>
+...
+<Typography.Paragraph
+  copyable
+  className="m-b-0"
+  ellipsis={{ rows: 2, expandable: true, symbol: 'more' }}>
+  {text}
+</Typography.Paragraph>
+
+// After (partial conversion)
+import { Tooltip, Typography } from 'antd';
+import { Typography as CoreTypography } from '@openmetadata/ui-core-components';
+...
+<CoreTypography className="font-medium">{text}</CoreTypography>
+...
+{/* copyable has no core equivalent — left on antd Typography, hand-finish: pair with a CopyButton */}
+<Typography.Text copyable={Boolean(text)}>{text || '-'}</Typography.Text>
+...
+{/* ellipsis.expandable has no core equivalent — left on antd Typography, hand-finish */}
+<Typography.Paragraph
+  copyable
+  className="m-b-0"
+  ellipsis={{ rows: 2, expandable: true, symbol: 'more' }}>
+  {text}
+</Typography.Paragraph>
+```
+
+Once every skipped/bare usage in a file is eventually hand-finished (or
+removed), drop the antd `Typography` import and rename `CoreTypography` back
+to plain `Typography`.
+
+## DOM-wrapper visual-QA warning
+
+Core `Typography` **always renders content inside `div.prose`** (or
+`Tooltip` + `div.prose`, when `ellipsis.tooltip` is set) around the `as`
+element — a structural difference from antd's single-element render. CSS
+selectors and flex/grid layouts that expect a single inline element (e.g.
+`.parent > span`, flex children relying on `display: inline`) may break at
+any converted call site. **Every converted call site carries layout-regression
+risk** — run the visual-QA harness (baselines under the collate visual-
+regression project) on the affected pages before merging each sweep PR, not
+just spot-checking a sample.
+
+## Hand-finish punch list (do not block the bulk codemod run on these)
+
+- **`copyable`** — 2 sites (`ReindexFailures.component.tsx:108`, `:134`)
+- **`ellipsis.expandable`** — 1 site (`ReindexFailures.component.tsx:136`)
+- **`code`** — 1 site (`AlertDetails.component.tsx:109`)
+- **`keyboard`** — 1 site (`DownloadPage.tsx:163`)
+- **Dynamic `Title level={expr}`** — flagged by the codemod at runtime via
+  `console.warn(... dynamic-title-level)`; triage per-file, no fixed count
+  captured in the gap-check survey
+- **`strong={expr}` / `underline={expr}` with non-literal values** — codemod
+  skips these (`dynamic-strong` / `dynamic-underline`); resolve the runtime
+  value and hand-convert
+- **`type={expr}`, or `type="..."` outside `secondary`/`success`/`warning`/`danger`** — skipped as `unsupported-type`
+
+## CSS to delete with this sweep
+
+Once a directory's `Typography` usages are fully converted, grep for
+orphaned `.ant-typography` overrides before deleting:
+
+```bash
+grep -rn "\.ant-typography" --include="*.less" --include="*.css" src/
+```
+
+Also check for component-scoped `.less` files whose only purpose was
+overriding antd Typography chrome (e.g. link-color or heading-margin
+resets) — delete once knip/grep confirms no remaining `.ant-typography`
+consumers in that directory. Only delete CSS proven dead by grep/knip, not
+by inspection alone.
+
+**Sweep-PR checklist line:** after each chunked PR, regenerate the ledger
+(`tooling/antd-migration/ledger.mjs`) so the `Typography` row in
+`docs/antd-migration/LEDGER.md` reflects the reduced antd usage count.
+
+## Styling rules (apply in every PR of this sweep)
+
+- Semantic Tailwind tokens only (`tw:text-tertiary`, `tw:bg-primary`) — never
+  raw palette classes or hex, including for the `color`-prop-adjacent
+  `tw:underline`/className workarounds above.
+- No `tw:ring-*` — this component doesn't render a border, but any wrapper
+  `className` added during migration must still follow `border`/`outline`,
+  not `ring` (see upstream `docs/colors.md` §2.3.1).
+- No string literals — use `t('label.…')` / `t('message.…')`, checking both
+  `collate-ui/src/main/resources/ui/src/locale/languages/en-us.json` and the
+  OpenMetadata submodule's `en-us.json` for an existing key before adding a
+  new one.

--- a/tooling/antd-codemods/README.md
+++ b/tooling/antd-codemods/README.md
@@ -16,6 +16,23 @@ pointing the path argument at those repos' `src` folders.
 Files a transform cannot fully convert are left untouched; collect them per
 sweep with the ledger (`tooling/antd-migration/`) and hand-finish.
 
+## `antd-typography-to-core`
+
+Converts antd `Typography` sub-components (`Text`/`Title`/`Paragraph`/`Link`,
+including destructured usages) to the flat core `Typography` component. See
+`docs/antd-migration/typography.md` for the full mapping table.
+
+    npx jscodeshift -t transforms/antd-typography-to-core.js \
+      <path-to-src> --parser=tsx
+
+Only touches files that import `Typography` from `'antd'`. Elements it can't
+mechanically convert (`copyable`, `ellipsis.expandable`, dynamic
+`level`/`strong`/`underline`/`type` expressions, bare `<Typography>`, …) are
+left untouched and reported via `console.warn`; partially-converted files get
+a `CoreTypography`-aliased import alongside the surviving antd one. The
+`Typography.Title` `level` → `size` convention (`LEVEL_SIZE_MAP` in the
+transform) was approved 2026-07-30.
+
 ## Tests
 
     yarn test

--- a/tooling/antd-codemods/__tests__/antd-typography-to-core.test.js
+++ b/tooling/antd-codemods/__tests__/antd-typography-to-core.test.js
@@ -1,0 +1,250 @@
+'use strict';
+const { defineInlineTest } = require('jscodeshift/dist/testUtils');
+const transform = require('../transforms/antd-typography-to-core');
+
+const OPTS = {};
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text data-testid="foo">Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography data-testid="foo">Hi</Typography>;`,
+  'Text basic: converts to bare Typography (span default, no as)'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Paragraph>Hi</Typography.Paragraph>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography as='p'>Hi</Typography>;`,
+  'Paragraph: converts with as="p"'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Link href="/x">Go</Typography.Link>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography as='a' href="/x">Go</Typography>;`,
+  'Link: converts with as="a" and keeps href'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Title level={5}>Hi</Typography.Title>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography as='h5' size='text-md'>Hi</Typography>;`,
+  'Title level=5: maps to h5/text-md (the dominant real-world case)'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Title level={1}>Hi</Typography.Title>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography as='h1' size='display-sm'>Hi</Typography>;`,
+  'Title level=1: maps to h1/display-sm'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Title>Hi</Typography.Title>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography as='h1' size='display-sm'>Hi</Typography>;`,
+  'Title with no level attribute: antd default level 1'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = ({ level }) => <Typography.Title level={level}>Hi</Typography.Title>;`,
+  `import { Typography } from 'antd';\nconst App = ({ level }) => <Typography.Title level={level}>Hi</Typography.Title>;`,
+  'Title with dynamic level={expr}: left untouched, reported as needs-hand-finish'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst { Text, Title } = Typography;\nconst App = () => (\n  <>\n    <Text>Hi</Text>\n    <Title level={3}>Yo</Title>\n  </>\n);`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => (\n  <>\n    <Typography>Hi</Typography>\n    <Typography as='h3' size='text-xl'>Yo</Typography>\n  </>\n);`,
+  'destructured Text/Title: rewrites bare JSX and removes the destructuring declaration'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst { Text: T } = Typography;\nconst App = () => <T>Hi</T>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography>Hi</Typography>;`,
+  'destructured alias (Text: T): rewrites <T> using the aliased local name'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text type="secondary">Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography color='secondary'>Hi</Typography>;`,
+  'type="secondary" becomes color="secondary"'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text type="danger">Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography color='danger'>Hi</Typography>;`,
+  'type="danger" becomes color="danger"'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text strong>Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography weight='bold'>Hi</Typography>;`,
+  '`strong` becomes weight="bold"'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text underline className="tw:text-md">Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography className='tw:text-md tw:underline'>Hi</Typography>;`,
+  '`underline` merges tw:underline into an existing className'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text underline>Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography className='tw:underline'>Hi</Typography>;`,
+  '`underline` creates a className when absent'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text underline className={dynamicClass}>Hi</Typography.Text>;`,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text underline className={dynamicClass}>Hi</Typography.Text>;`,
+  '`underline` with a non-literal className: left untouched, reported'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text ellipsis={{ rows: 2, tooltip: true }}>Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography ellipsis={{ rows: 2, tooltip: true }}>Hi</Typography>;`,
+  'ellipsis={{ rows, tooltip }} passes through unchanged'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography.Text ellipsis>Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography ellipsis>Hi</Typography>;`,
+  'ellipsis boolean passes through unchanged'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => (\n  <>\n    <Typography.Text copyable>Hi</Typography.Text>\n    <Typography.Paragraph>Yo</Typography.Paragraph>\n  </>\n);`,
+  `import { Typography } from 'antd';\nimport { Typography as CoreTypography } from '@openmetadata/ui-core-components';\nconst App = () => (\n  <>\n    <Typography.Text copyable>Hi</Typography.Text>\n    <CoreTypography as='p'>Yo</CoreTypography>\n  </>\n);`,
+  '`copyable`: unsupported prop skips its element; file partially converts using the CoreTypography alias'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from "antd";\nconst App = () => <Typography.Text>Hi</Typography.Text>;`,
+  `import { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography>Hi</Typography>;`,
+  'double-quoted antd import is matched the same as single-quoted'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `/*\n * License header\n */\nimport { Typography } from 'antd';\nconst App = () => <Typography.Text>Hi</Typography.Text>;`,
+  `/*\n * License header\n */\nimport { Typography } from '@openmetadata/ui-core-components';\nconst App = () => <Typography>Hi</Typography>;`,
+  'preserves a license header comment when the antd import is fully removed'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography, Button } from 'antd';\nconst App = () => (\n  <>\n    <Button>Click</Button>\n    <Typography.Text>Hi</Typography.Text>\n  </>\n);`,
+  `import { Button } from 'antd';\nimport { Typography } from '@openmetadata/ui-core-components';\nconst App = () => (\n  <>\n    <Button>Click</Button>\n    <Typography>Hi</Typography>\n  </>\n);`,
+  'multi-component antd import keeps sibling specifiers (Button) on antd'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Card } from '@openmetadata/ui-core-components';\nimport { Typography } from 'antd';\nconst App = () => (\n  <>\n    <Card />\n    <Typography.Text>Hi</Typography.Text>\n  </>\n);`,
+  `import { Card, Typography } from '@openmetadata/ui-core-components';\nconst App = () => (\n  <>\n    <Card />\n    <Typography>Hi</Typography>\n  </>\n);`,
+  'merges into an existing core import when fully converted'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Typography } from 'antd';\nconst App = () => <Typography>Hi</Typography>;`,
+  `import { Typography } from 'antd';\nconst App = () => <Typography>Hi</Typography>;`,
+  'bare <Typography> stays untouched (no-op, import unchanged)'
+);
+
+defineInlineTest(
+  transform,
+  OPTS,
+  `import { Button } from 'antd';\nconst App = () => <Button>Click</Button>;`,
+  `import { Button } from 'antd';\nconst App = () => <Button>Click</Button>;`,
+  'no-op when the file does not import Typography from antd at all'
+);
+
+describe('console.warn reporting', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns with the file path and skip reason for a dynamic Title level', () => {
+    transform(
+      {
+        path: 'src/components/Foo.tsx',
+        source: `import { Typography } from 'antd';\nconst App = ({ level }) => <Typography.Title level={level}>Hi</Typography.Title>;`,
+      },
+      { jscodeshift: require('jscodeshift').withParser('tsx') }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('src/components/Foo.tsx');
+    expect(message).toContain('dynamic-title-level');
+  });
+
+  it('warns for an unsupported prop (copyable)', () => {
+    transform(
+      {
+        path: 'src/components/Bar.tsx',
+        source: `import { Typography } from 'antd';\nconst App = () => <Typography.Text copyable>Hi</Typography.Text>;`,
+      },
+      { jscodeshift: require('jscodeshift').withParser('tsx') }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message] = warnSpy.mock.calls[0];
+    expect(message).toContain('unsupported-prop');
+  });
+
+  it('does not warn when everything converts cleanly', () => {
+    transform(
+      {
+        path: 'src/components/Baz.tsx',
+        source: `import { Typography } from 'antd';\nconst App = () => <Typography.Text>Hi</Typography.Text>;`,
+      },
+      { jscodeshift: require('jscodeshift').withParser('tsx') }
+    );
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tooling/antd-codemods/transforms/antd-typography-to-core.js
+++ b/tooling/antd-codemods/transforms/antd-typography-to-core.js
@@ -1,0 +1,512 @@
+'use strict';
+
+/**
+ * Converts antd `Typography` sub-components to the flat core `Typography`
+ * component from `@openmetadata/ui-core-components`.
+ *
+ * jscodeshift -t transforms/antd-typography-to-core.js <path> --parser=tsx
+ *
+ * See README.md for the full mapping table, the approved `LEVEL_SIZE_MAP`
+ * convention, and the list of constructs this transform deliberately
+ * leaves untouched for hand-finishing.
+ */
+
+// Approved 2026-07-30 (tracked in the antd migration ledger): antd's
+// `Typography.Title` `level` (1-5) has no size concept of its own, so this
+// table is the convention used to pick a core `size` per level.
+// Level 5 dominates real usage (>70% across repos) and maps to 'text-md',
+// the closest visual match to antd's smallest heading variant.
+const LEVEL_SIZE_MAP = {
+  1: 'display-sm',
+  2: 'display-xs',
+  3: 'text-xl',
+  4: 'text-lg',
+  5: 'text-md',
+};
+
+const CORE_MODULE = '@openmetadata/ui-core-components';
+const ANTD_MODULE = 'antd';
+const CORE_LOCAL_ALIAS = 'CoreTypography';
+
+const SUB_COMPONENT_KINDS = ['Text', 'Title', 'Paragraph', 'Link'];
+
+// Props with no equivalent on core Typography at all. Any element using one
+// of these is left completely untouched (still antd) and reported.
+const UNSUPPORTED_PROP_NAMES = [
+  'copyable',
+  'editable',
+  'code',
+  'keyboard',
+  'mark',
+  'delete',
+  'italic',
+  'disabled',
+];
+
+// `ellipsis={{ ... }}` keys with no core equivalent (show-more/less UX).
+const ELLIPSIS_UNSUPPORTED_KEYS = ['expandable', 'symbol', 'onExpand'];
+
+// Sub-component -> the `as` value the core component needs (undefined means
+// "no `as` attribute", i.e. the default `span`, which is Text's antd shape).
+const KIND_TO_AS = {
+  Text: undefined,
+  Paragraph: 'p',
+  Link: 'a',
+};
+
+const ALLOWED_TYPE_VALUES = ['secondary', 'success', 'warning', 'danger'];
+
+function isObjectPropertyLike(node) {
+  return node.type === 'ObjectProperty' || node.type === 'Property';
+}
+
+// Reads the resolved literal value of a JSX attribute, distinguishing a
+// present-but-dynamic value from a present-and-literal one so callers can
+// tell "safe to convert" apart from "must skip and hand-finish".
+function readAttrLiteral(attr) {
+  if (!attr) {
+    return { present: false };
+  }
+  if (attr.value == null) {
+    // `<Foo strong />` — implicit `true`.
+    return { present: true, isLiteral: true, value: true };
+  }
+  if (attr.value.type === 'StringLiteral' || attr.value.type === 'Literal') {
+    return { present: true, isLiteral: true, value: attr.value.value };
+  }
+  if (attr.value.type === 'JSXExpressionContainer') {
+    const expr = attr.value.expression;
+    if (
+      expr.type === 'NumericLiteral' ||
+      expr.type === 'BooleanLiteral' ||
+      expr.type === 'StringLiteral' ||
+      expr.type === 'Literal'
+    ) {
+      return { present: true, isLiteral: true, value: expr.value };
+    }
+    return { present: true, isLiteral: false, expression: expr };
+  }
+  return { present: true, isLiteral: false };
+}
+
+function findAttr(attributes, name) {
+  return attributes.find(
+    (attr) => attr.type === 'JSXAttribute' && attr.name.name === name
+  );
+}
+
+module.exports = function transformer(file, api) {
+  const j = api.jscodeshift;
+  const filePath = (file && file.path) || '<unknown>';
+  const root = j(typeof file === 'string' ? file : file.source);
+
+  const antdImports = root.find(j.ImportDeclaration, {
+    source: { value: ANTD_MODULE },
+  });
+  if (!antdImports.size()) {
+    return file.source;
+  }
+
+  let typographyLocalName = null;
+  let typographyImportPath = null;
+  antdImports.forEach((path) => {
+    path.node.specifiers.forEach((spec) => {
+      if (
+        spec.type === 'ImportSpecifier' &&
+        spec.imported.name === 'Typography'
+      ) {
+        typographyLocalName = spec.local.name;
+        typographyImportPath = path;
+      }
+    });
+  });
+  if (!typographyLocalName) {
+    return file.source;
+  }
+
+  // Destructuring: `const { Text, Title: T } = Typography;`, anywhere in the
+  // file (including inside jest mock factories) — track which local name
+  // maps to which sub-component so bare `<Text>`/`<T>` JSX can be resolved.
+  const destructurings = root
+    .find(j.VariableDeclarator, {
+      init: { type: 'Identifier', name: typographyLocalName },
+    })
+    .filter((path) => path.node.id.type === 'ObjectPattern');
+
+  const localNameToKind = new Map();
+  destructurings.forEach((path) => {
+    path.node.id.properties.forEach((prop) => {
+      if (!isObjectPropertyLike(prop) || !prop.key) {
+        return;
+      }
+      const kind = prop.key.name;
+      if (!SUB_COMPONENT_KINDS.includes(kind) || prop.value.type !== 'Identifier') {
+        return;
+      }
+      localNameToKind.set(prop.value.name, kind);
+    });
+  });
+
+  function classifyElement(node) {
+    const name = node.openingElement.name;
+    if (
+      name.type === 'JSXMemberExpression' &&
+      name.object.type === 'JSXIdentifier' &&
+      name.object.name === typographyLocalName
+    ) {
+      if (SUB_COMPONENT_KINDS.includes(name.property.name)) {
+        return { kind: name.property.name, matchType: 'member' };
+      }
+      return null;
+    }
+    if (name.type === 'JSXIdentifier') {
+      if (name.name === typographyLocalName) {
+        return { kind: 'Bare', matchType: 'bare' };
+      }
+      if (localNameToKind.has(name.name)) {
+        return {
+          kind: localNameToKind.get(name.name),
+          matchType: 'destructured',
+          localName: name.name,
+        };
+      }
+    }
+    return null;
+  }
+
+  // Attempts to convert a single element in place. Returns
+  // `{ skip: false }` on success (attributes already rewritten) or
+  // `{ skip: true, reason }` if the element must stay untouched.
+  function convertElement(elNode, kind) {
+    const opening = elNode.openingElement;
+    const attrs = opening.attributes;
+
+    const hasUnsupported = attrs.some(
+      (attr) =>
+        attr.type === 'JSXAttribute' &&
+        UNSUPPORTED_PROP_NAMES.includes(attr.name.name)
+    );
+    if (hasUnsupported) {
+      return { skip: true, reason: 'unsupported-prop' };
+    }
+
+    const ellipsisAttr = findAttr(attrs, 'ellipsis');
+    if (
+      ellipsisAttr &&
+      ellipsisAttr.value &&
+      ellipsisAttr.value.type === 'JSXExpressionContainer' &&
+      ellipsisAttr.value.expression.type === 'ObjectExpression'
+    ) {
+      const hasBadKey = ellipsisAttr.value.expression.properties.some(
+        (prop) => prop.key && ELLIPSIS_UNSUPPORTED_KEYS.includes(prop.key.name)
+      );
+      if (hasBadKey) {
+        return { skip: true, reason: 'ellipsis-expandable' };
+      }
+    }
+
+    let level = 1;
+    if (kind === 'Title') {
+      const levelAttr = findAttr(attrs, 'level');
+      if (levelAttr) {
+        const lit = readAttrLiteral(levelAttr);
+        if (!lit.isLiteral || typeof lit.value !== 'number') {
+          return { skip: true, reason: 'dynamic-title-level' };
+        }
+        level = lit.value;
+      }
+      if (!LEVEL_SIZE_MAP[level]) {
+        return { skip: true, reason: 'unsupported-title-level' };
+      }
+    }
+
+    const strongAttr = findAttr(attrs, 'strong');
+    let strongResolved = null;
+    if (strongAttr) {
+      const lit = readAttrLiteral(strongAttr);
+      if (!lit.isLiteral || typeof lit.value !== 'boolean') {
+        return { skip: true, reason: 'dynamic-strong' };
+      }
+      strongResolved = lit.value;
+    }
+
+    const underlineAttr = findAttr(attrs, 'underline');
+    let underlineResolved = null;
+    if (underlineAttr) {
+      const lit = readAttrLiteral(underlineAttr);
+      if (!lit.isLiteral || typeof lit.value !== 'boolean') {
+        return { skip: true, reason: 'dynamic-underline' };
+      }
+      underlineResolved = lit.value;
+    }
+
+    const classNameAttr = findAttr(attrs, 'className');
+    if (underlineResolved && classNameAttr) {
+      const isPlainString =
+        classNameAttr.value &&
+        (classNameAttr.value.type === 'StringLiteral' ||
+          classNameAttr.value.type === 'Literal');
+      if (!isPlainString) {
+        return { skip: true, reason: 'dynamic-underline-classname' };
+      }
+    }
+
+    const typeAttr = findAttr(attrs, 'type');
+    let typeValue = null;
+    if (typeAttr) {
+      const lit = readAttrLiteral(typeAttr);
+      if (
+        !lit.isLiteral ||
+        typeof lit.value !== 'string' ||
+        !ALLOWED_TYPE_VALUES.includes(lit.value)
+      ) {
+        return { skip: true, reason: 'unsupported-type' };
+      }
+      typeValue = lit.value;
+    }
+
+    // All checks passed — perform the rewrite.
+    const newAttrs = [];
+    if (kind === 'Title') {
+      newAttrs.push(j.jsxAttribute(j.jsxIdentifier('as'), j.stringLiteral(`h${level}`)));
+      newAttrs.push(
+        j.jsxAttribute(j.jsxIdentifier('size'), j.stringLiteral(LEVEL_SIZE_MAP[level]))
+      );
+    } else if (KIND_TO_AS[kind]) {
+      newAttrs.push(
+        j.jsxAttribute(j.jsxIdentifier('as'), j.stringLiteral(KIND_TO_AS[kind]))
+      );
+    }
+
+    attrs.forEach((attr) => {
+      if (attr.type !== 'JSXAttribute') {
+        newAttrs.push(attr); // JSXSpreadAttribute — pass through
+        return;
+      }
+      const name = attr.name.name;
+      if (['level', 'strong', 'underline', 'type', 'className'].includes(name)) {
+        return; // handled below
+      }
+      newAttrs.push(attr);
+    });
+
+    if (strongResolved === true) {
+      newAttrs.push(j.jsxAttribute(j.jsxIdentifier('weight'), j.stringLiteral('bold')));
+    }
+    if (typeValue) {
+      newAttrs.push(j.jsxAttribute(j.jsxIdentifier('color'), j.stringLiteral(typeValue)));
+    }
+
+    if (classNameAttr) {
+      if (underlineResolved) {
+        const merged = `${classNameAttr.value.value} tw:underline`.trim();
+        newAttrs.push(
+          j.jsxAttribute(j.jsxIdentifier('className'), j.stringLiteral(merged))
+        );
+      } else {
+        newAttrs.push(classNameAttr);
+      }
+    } else if (underlineResolved) {
+      newAttrs.push(
+        j.jsxAttribute(j.jsxIdentifier('className'), j.stringLiteral('tw:underline'))
+      );
+    }
+
+    opening.attributes = newAttrs;
+    return { skip: false };
+  }
+
+  const skips = [];
+  const convertedElements = [];
+  let bareUsageFound = false;
+  const destructuredUsage = new Map(); // localName -> { converted, skipped }
+
+  function recordDestructuredUsage(localName, key) {
+    const usage = destructuredUsage.get(localName) || { converted: 0, skipped: 0 };
+    usage[key] += 1;
+    destructuredUsage.set(localName, usage);
+  }
+
+  root.find(j.JSXElement).forEach((elPath) => {
+    const classification = classifyElement(elPath.node);
+    if (!classification) {
+      return;
+    }
+    if (classification.matchType === 'bare') {
+      bareUsageFound = true;
+      return;
+    }
+    const result = convertElement(elPath.node, classification.kind);
+    if (result.skip) {
+      skips.push({ file: filePath, kind: classification.kind, reason: result.reason });
+      if (classification.matchType === 'destructured') {
+        recordDestructuredUsage(classification.localName, 'skipped');
+      }
+      return;
+    }
+    convertedElements.push(elPath.node);
+    if (classification.matchType === 'destructured') {
+      recordDestructuredUsage(classification.localName, 'converted');
+    }
+  });
+
+  if (skips.length) {
+    const summary = skips
+      .map((s) => `${s.kind}(${s.reason})`)
+      .join(', ');
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[antd-typography-to-core] ${filePath}: needs hand-finish -> ${summary}`
+    );
+  }
+
+  if (!convertedElements.length) {
+    return file.source;
+  }
+
+  const fullyConvertedFile = skips.length === 0 && !bareUsageFound;
+  const finalCoreName = fullyConvertedFile ? 'Typography' : CORE_LOCAL_ALIAS;
+
+  convertedElements.forEach((node) => {
+    node.openingElement.name = j.jsxIdentifier(finalCoreName);
+    if (node.closingElement) {
+      node.closingElement.name = j.jsxIdentifier(finalCoreName);
+    }
+  });
+
+  // Drop destructured properties that are now fully converted (no remaining
+  // skipped usage still needs the antd-bound local name); remove the whole
+  // declaration once its pattern is empty.
+  destructurings.forEach((declaratorPath) => {
+    const pattern = declaratorPath.node.id;
+    pattern.properties = pattern.properties.filter((prop) => {
+      if (!isObjectPropertyLike(prop) || !prop.key) {
+        return true;
+      }
+      if (!SUB_COMPONENT_KINDS.includes(prop.key.name)) {
+        return true;
+      }
+      const localName = prop.value.name;
+      const usage = destructuredUsage.get(localName);
+      if (!usage) {
+        return true; // never referenced in JSX — leave alone
+      }
+      return usage.skipped > 0; // keep only if still needed by a skipped usage
+    });
+
+    if (pattern.properties.length === 0) {
+      const declPath = j(declaratorPath).closest(j.VariableDeclaration);
+      if (declPath.size()) {
+        const declNode = declPath.get().node;
+        if (declNode.declarations.length === 1) {
+          declPath.remove();
+        } else {
+          declNode.declarations = declNode.declarations.filter(
+            (d) => d !== declaratorPath.node
+          );
+        }
+      }
+    }
+  });
+
+  const coreImports = root.find(j.ImportDeclaration, {
+    source: { value: CORE_MODULE },
+  });
+
+  function replaceImportPreservingHeader(path, newDecl) {
+    newDecl.comments = path.node.comments;
+    j(path).replaceWith(newDecl);
+  }
+
+  function removeImportPreservingHeader(path) {
+    const wasFirstStatement = root.get().node.program.body[0] === path.node;
+    const leadingComments = path.node.comments;
+    j(path).remove();
+    if (wasFirstStatement && leadingComments && leadingComments.length) {
+      const [firstStatement] = root.get().node.program.body;
+      if (firstStatement) {
+        firstStatement.comments = [
+          ...leadingComments,
+          ...(firstStatement.comments || []),
+        ];
+      }
+    }
+  }
+
+  if (fullyConvertedFile) {
+    const remainingSpecifiers = typographyImportPath.node.specifiers.filter(
+      (spec) =>
+        !(spec.type === 'ImportSpecifier' && spec.imported.name === 'Typography')
+    );
+
+    const hasCoreTypographyAlready = coreImports
+      .nodes()
+      .some((n) =>
+        n.specifiers.some(
+          (s) =>
+            s.type === 'ImportSpecifier' &&
+            s.imported.name === 'Typography' &&
+            s.local.name === 'Typography'
+        )
+      );
+
+    if (remainingSpecifiers.length) {
+      typographyImportPath.node.specifiers = remainingSpecifiers;
+      if (!hasCoreTypographyAlready) {
+        if (coreImports.size()) {
+          coreImports.at(0).get().node.specifiers.push(
+            j.importSpecifier(j.identifier('Typography'))
+          );
+        } else {
+          const decl = j.importDeclaration(
+            [j.importSpecifier(j.identifier('Typography'))],
+            j.literal(CORE_MODULE)
+          );
+          j(typographyImportPath).insertAfter(decl);
+        }
+      }
+    } else if (!hasCoreTypographyAlready && !coreImports.size()) {
+      const decl = j.importDeclaration(
+        [j.importSpecifier(j.identifier('Typography'))],
+        j.literal(CORE_MODULE)
+      );
+      replaceImportPreservingHeader(typographyImportPath, decl);
+    } else {
+      removeImportPreservingHeader(typographyImportPath);
+      if (!hasCoreTypographyAlready) {
+        coreImports.at(0).get().node.specifiers.push(
+          j.importSpecifier(j.identifier('Typography'))
+        );
+      }
+    }
+  } else {
+    const hasAlias = coreImports
+      .nodes()
+      .some((n) =>
+        n.specifiers.some(
+          (s) =>
+            s.type === 'ImportSpecifier' &&
+            s.imported.name === 'Typography' &&
+            s.local.name === CORE_LOCAL_ALIAS
+        )
+      );
+    if (!hasAlias) {
+      if (coreImports.size()) {
+        coreImports.at(0).get().node.specifiers.push(
+          j.importSpecifier(j.identifier('Typography'), j.identifier(CORE_LOCAL_ALIAS))
+        );
+      } else {
+        const decl = j.importDeclaration(
+          [j.importSpecifier(j.identifier('Typography'), j.identifier(CORE_LOCAL_ALIAS))],
+          j.literal(CORE_MODULE)
+        );
+        j(typographyImportPath).insertAfter(decl);
+      }
+    }
+  }
+
+  return root.toSource({ quote: 'single' });
+};
+
+module.exports.parser = 'tsx';
+module.exports.LEVEL_SIZE_MAP = LEVEL_SIZE_MAP;


### PR DESCRIPTION
## Summary

First Wave 1 artifacts for the AntD → ui-core-components migration (#30565, epic #30570), landing now that Wave 0 (#30560) and the core prerequisites (#30664 forwardRef, #30665 Typography color prop — both in main) are merged.

**Commit 1 — mapping guides** (`docs/antd-migration/typography.md`, `button.md`): the review contracts for the first two sweeps, derived from a three-repo usage survey (~1,160 Typography tags, 1,370 Button instances). All previously-pending design decisions are baked in as approved (2026-07-30):
- Typography `Title level→size`: 5→text-md, 4→text-lg, 3→text-xl, 2→display-xs, 1→display-sm
- Button sizes: small→xs, middle→sm, large→md (dynamic expressions = hand-finish)
- `ghost`/`type="ghost"` → `color="tertiary"` per-site (no new core variant)
- `type="secondary"` → core `color="secondary"` (prop landed in #30665)
Hand-finish punch lists (copyable/expandable/code/keyboard for Typography; Button.Group/ref/shape/border-overrides for Button) are enumerated with file:line.

**Commit 2 — typography codemod** (`tooling/antd-codemods/transforms/antd-typography-to-core.js`): converts Typography.Text/Title/Paragraph/Link (incl. destructured + aliased forms and mocks), maps type→color / strong→weight / underline→className, passes ellipsis through (shapes are identical), and does safe partial conversion — elements with unsupported props stay on antd (aliased `CoreTypography` for converted siblings) with warnings listing what needs hand-finishing. 27 inline tests; full codemod suite 37/37.

## Verification

- `yarn test` in `tooling/antd-codemods`: 2 suites, 37/37 green (10 existing + 27 new).
- Prerequisites verified present in main before authoring (Typography `color` prop, Button `forwardRef`).

Fixes #30720

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds Wave 1 Ant Design migration guidance and a Typography codemod.
- Documents Typography and Button prop, size, styling, and manual-migration mappings.
- Adds a jscodeshift transform for Typography subcomponents, destructured aliases, partial conversions, and import rewriting.
- Adds inline coverage for supported mappings, skipped constructs, imports, and warning behavior.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with one non-blocking codemod robustness issue around choosing a collision-free partial-conversion alias.

The documented mappings and covered transformations are coherent, but partial conversion can generate an invalid or incorrect binding when a target file already uses the hard-coded CoreTypography identifier.

**Files Needing Attention:** tooling/antd-codemods/transforms/antd-typography-to-core.js
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/antd-codemods/transforms/antd-typography-to-core.js | Implements the Typography transformation and partial-conversion import management; the fixed partial-conversion alias can collide with an existing local binding. |
| tooling/antd-codemods/__tests__/antd-typography-to-core.test.js | Covers primary mappings, unsupported cases, import updates, destructuring, aliases, and warning output. |
| docs/antd-migration/typography.md | Defines the approved Typography mapping and manual follow-up contract. |
| docs/antd-migration/button.md | Defines Button mappings and enumerates cases requiring manual migration. |
| tooling/antd-codemods/README.md | Documents invocation and the transform's partial-conversion behavior. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Find antd Typography import] --> B[Classify member and destructured JSX]
  B --> C{Element mechanically supported?}
  C -->|Yes| D[Rewrite props and element to core Typography]
  C -->|No| E[Retain antd element and emit warning]
  D --> F{Any retained antd usage?}
  E --> F
  F -->|No| G[Replace or merge Typography import]
  F -->|Yes| H[Add aliased CoreTypography import]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(tooling): add antd-typography-to-co..."](https://github.com/open-metadata/openmetadata/commit/4881920887140ebf520a0bafdb914df22b49b20b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48741504)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->