### PR TITLE
fix(intake-forms): backend cherry-pick of #30614 onto 1.13

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.3/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.3/mysql/postDataMigrationSQLScript.sql
@@ -1,0 +1,28 @@
+-- Backfill IntakeForm formFields from the legacy requiredFields representation.
+-- requiredFields is only trusted when it is actually an array, and only object
+-- entries are carried over, so a JSON null or scalar left by an older write can
+-- never turn into a malformed formFields array.
+UPDATE intake_form_entity AS intake_form
+SET json = JSON_SET(
+    json,
+    '$.formFields',
+    COALESCE(
+        (
+            SELECT JSON_ARRAYAGG(
+                JSON_SET(required_field.field_json, '$.required', CAST('true' AS JSON))
+            )
+            FROM JSON_TABLE(
+                CASE
+                    WHEN JSON_TYPE(JSON_EXTRACT(intake_form.json, '$.requiredFields')) = 'ARRAY'
+                        THEN JSON_EXTRACT(intake_form.json, '$.requiredFields')
+                    ELSE JSON_ARRAY()
+                END,
+                '$[*]' COLUMNS (field_json JSON PATH '$')
+            ) AS required_field
+            WHERE JSON_TYPE(required_field.field_json) = 'OBJECT'
+        ),
+        JSON_ARRAY()
+    )
+)
+WHERE JSON_CONTAINS_PATH(json, 'one', '$.requiredFields')
+  AND NOT JSON_CONTAINS_PATH(json, 'one', '$.formFields');

--- a/bootstrap/sql/migrations/native/1.13.3/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.3/postgres/postDataMigrationSQLScript.sql
@@ -1,0 +1,26 @@
+-- Backfill IntakeForm formFields from the legacy requiredFields representation.
+-- requiredFields is only trusted when it is actually an array: jsonb_array_elements
+-- raises "cannot extract elements from a scalar" on a JSON null or scalar value,
+-- which would abort the whole upgrade for one malformed row. Non-object entries
+-- are skipped for the same reason.
+UPDATE intake_form_entity
+SET json = jsonb_set(
+    json,
+    '{formFields}',
+    COALESCE(
+        (
+            SELECT jsonb_agg(required_field.field_json || '{"required": true}'::jsonb)
+            FROM jsonb_array_elements(
+                CASE
+                    WHEN jsonb_typeof(json -> 'requiredFields') = 'array'
+                        THEN json -> 'requiredFields'
+                    ELSE '[]'::jsonb
+                END
+            ) AS required_field(field_json)
+            WHERE jsonb_typeof(required_field.field_json) = 'object'
+        ),
+        '[]'::jsonb
+    )
+)
+WHERE jsonb_exists(json, 'requiredFields')
+  AND NOT jsonb_exists(json, 'formFields');

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IntakeFormResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IntakeFormResourceIT.java
@@ -13,6 +13,7 @@
 package org.openmetadata.it.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,6 +50,7 @@ import org.openmetadata.schema.entity.data.GlossaryTerm;
 import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.entity.governance.IntakeForm;
+import org.openmetadata.schema.entity.governance.IntakeFormField;
 import org.openmetadata.schema.entity.governance.IntakeFormRequiredField;
 import org.openmetadata.schema.entity.governance.IntakeFormRequiredField.FieldKind;
 import org.openmetadata.schema.entity.teams.User;
@@ -80,9 +82,16 @@ import org.openmetadata.sdk.network.RequestOptions;
 public class IntakeFormResourceIT {
 
   private static final String INTAKE_FORMS_PATH = "/v1/governance/intakeForms";
+  private static final Double INITIAL_ENTITY_VERSION = 0.1;
+  private static final String FORM_FIELDS_FIELD = "formFields";
+  private static final String INTAKE_FORM_ENTITY_TYPE = "intakeForm";
   private static final String RISK_PROPERTY = "intakeRiskAssessment";
   private static final String DOMAIN_OWNER_PROPERTY = "intakeDomainOwner";
+  private static final String DOMAIN_AUDIENCE_PROPERTY = "intakeDomainAudience";
+  private static final String DOMAIN_SOURCE_PROPERTY = "intakeDomainSource";
   private static final String GLOSSARY_TERM_STEWARD_PROPERTY = "intakeTermSteward";
+  private static final String GLOSSARY_TERM_AUDIENCE_PROPERTY = "intakeTermAudience";
+  private static final String GLOSSARY_TERM_SOURCE_PROPERTY = "intakeTermSource";
   private static final String DP_STEWARD_REF_PROPERTY = "intakeStewardUserRef";
   private static final String DP_STEWARDS_REF_LIST_PROPERTY = "intakeStewardsList";
   private static final String DP_PRIORITY_ENUM_PROPERTY = "intakePriorityEnum";
@@ -94,7 +103,11 @@ public class IntakeFormResourceIT {
   static void setupCustomProperties() throws Exception {
     ensureStringCustomProperty("dataProduct", RISK_PROPERTY);
     ensureStringCustomProperty("domain", DOMAIN_OWNER_PROPERTY);
+    ensureStringCustomProperty("domain", DOMAIN_AUDIENCE_PROPERTY);
+    ensureStringCustomProperty("domain", DOMAIN_SOURCE_PROPERTY);
     ensureStringCustomProperty("glossaryTerm", GLOSSARY_TERM_STEWARD_PROPERTY);
+    ensureStringCustomProperty("glossaryTerm", GLOSSARY_TERM_AUDIENCE_PROPERTY);
+    ensureStringCustomProperty("glossaryTerm", GLOSSARY_TERM_SOURCE_PROPERTY);
     ensureEntityReferenceCustomProperty("dataProduct", DP_STEWARD_REF_PROPERTY, "user");
     ensureEntityReferenceListCustomProperty("dataProduct", DP_STEWARDS_REF_LIST_PROPERTY, "user");
     ensureEnumCustomProperty(
@@ -185,6 +198,59 @@ public class IntakeFormResourceIT {
     } finally {
       deleteIntakeForm(created.getId());
     }
+  }
+
+  @Test
+  void intakeForm_updatesKeepIncludedAndRequiredStateIndependentForEveryEntityType(TestNamespace ns)
+      throws Exception {
+    assertSelectionUpdateLifecycle(
+        ns.prefix("dp-selection-update"),
+        TargetEntityType.DATA_PRODUCT,
+        RISK_PROPERTY,
+        DP_COST_INTEGER_PROPERTY,
+        DP_PRIORITY_ENUM_PROPERTY);
+    assertSelectionUpdateLifecycle(
+        ns.prefix("domain-selection-update"),
+        TargetEntityType.DOMAIN,
+        DOMAIN_OWNER_PROPERTY,
+        DOMAIN_AUDIENCE_PROPERTY,
+        DOMAIN_SOURCE_PROPERTY);
+    assertSelectionUpdateLifecycle(
+        ns.prefix("glossary-selection-update"),
+        TargetEntityType.GLOSSARY_TERM,
+        GLOSSARY_TERM_STEWARD_PROPERTY,
+        GLOSSARY_TERM_AUDIENCE_PROPERTY,
+        GLOSSARY_TERM_SOURCE_PROPERTY);
+  }
+
+  @Test
+  void intakeForm_hardDeletePreservesCustomPropertyDefinitions() throws Exception {
+    IntakeForm dataProductForm =
+        createIntakeForm(
+            customPropertyForm(
+                "dataProduct",
+                TargetEntityType.DATA_PRODUCT,
+                customPropertyFormField(RISK_PROPERTY, false)));
+    IntakeForm domainForm =
+        createIntakeForm(
+            customPropertyForm(
+                "domain",
+                TargetEntityType.DOMAIN,
+                customPropertyFormField(DOMAIN_OWNER_PROPERTY, false)));
+    IntakeForm glossaryTermForm =
+        createIntakeForm(
+            customPropertyForm(
+                "glossaryTerm",
+                TargetEntityType.GLOSSARY_TERM,
+                customPropertyFormField(GLOSSARY_TERM_STEWARD_PROPERTY, false)));
+
+    deleteIntakeForm(dataProductForm.getId());
+    deleteIntakeForm(domainForm.getId());
+    deleteIntakeForm(glossaryTermForm.getId());
+
+    assertCustomPropertyExists("dataProduct", RISK_PROPERTY);
+    assertCustomPropertyExists("domain", DOMAIN_OWNER_PROPERTY);
+    assertCustomPropertyExists("glossaryTerm", GLOSSARY_TERM_STEWARD_PROPERTY);
   }
 
   @Test
@@ -467,6 +533,7 @@ public class IntakeFormResourceIT {
           () -> SdkClients.adminClient().dataProducts().create(blocked));
 
       // drop the required field
+      form.setFormFields(List.of());
       form.setRequiredFields(List.of());
       putIntakeForm(toCreate(form));
 
@@ -498,6 +565,51 @@ public class IntakeFormResourceIT {
               () -> SdkClients.adminClient().dataProducts().create(req));
       assertEquals(400, ex.getStatusCode());
       assertTrue(ex.getMessage().contains("Risk Assessment"));
+    } finally {
+      deleteIntakeForm(form.getId());
+    }
+  }
+
+  @Test
+  void dataProduct_create_includesOptionalCustomPropertyWithoutEnforcingIt(TestNamespace ns)
+      throws Exception {
+    Domain domain = createDomain(ns);
+    CreateIntakeForm request =
+        new CreateIntakeForm()
+            .withName(ns.prefix("intake-optional-property"))
+            .withEntityType(TargetEntityType.DATA_PRODUCT)
+            .withEnabled(Boolean.TRUE)
+            .withFormFields(
+                List.of(
+                    new IntakeFormField()
+                        .withFieldPath("extension." + RISK_PROPERTY)
+                        .withFieldLabel("Risk Assessment")
+                        .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+                        .withRequired(false),
+                    new IntakeFormField()
+                        .withFieldPath("dataProductType")
+                        .withFieldLabel("Data Product Type")
+                        .withFieldKind(IntakeFormField.FieldKind.NATIVE)
+                        .withRequired(true)));
+    IntakeForm form = createIntakeForm(request);
+    try {
+      assertEquals(2, form.getFormFields().size());
+      assertEquals(1, form.getRequiredFields().size());
+
+      DataProduct created =
+          SdkClients.adminClient()
+              .dataProducts()
+              .create(
+                  minimalDataProductRequest(ns, domain, "optional-property")
+                      .withDataProductType(DataProductType.DATASET));
+      assertNotNull(created.getId());
+
+      assertThrows(
+          InvalidRequestException.class,
+          () ->
+              SdkClients.adminClient()
+                  .dataProducts()
+                  .create(minimalDataProductRequest(ns, domain, "missing-required-type")));
     } finally {
       deleteIntakeForm(form.getId());
     }
@@ -641,6 +753,43 @@ public class IntakeFormResourceIT {
     }
   }
 
+  @Test
+  void domain_create_includesThreeCustomPropertiesAndEnforcesOnlyRequiredOne(TestNamespace ns)
+      throws Exception {
+    IntakeForm form =
+        createIntakeForm(
+            customPropertySelectionForm(
+                ns.prefix("dom-intake-selection"),
+                TargetEntityType.DOMAIN,
+                DOMAIN_OWNER_PROPERTY,
+                DOMAIN_AUDIENCE_PROPERTY,
+                DOMAIN_SOURCE_PROPERTY));
+    try {
+      assertEquals(3, form.getFormFields().size());
+      assertEquals(1, form.getRequiredFields().size());
+
+      Map<String, Object> extension = new LinkedHashMap<>();
+      extension.put(DOMAIN_OWNER_PROPERTY, "finance-team");
+      Domain created =
+          SdkClients.adminClient()
+              .domains()
+              .create(
+                  minimalDomainRequest(ns, "dom-selection-with-required").withExtension(extension));
+      assertNotNull(created.getId());
+      assertFalse(OBJECT_MAPPER.valueToTree(created.getExtension()).has(DOMAIN_AUDIENCE_PROPERTY));
+      assertFalse(OBJECT_MAPPER.valueToTree(created.getExtension()).has(DOMAIN_SOURCE_PROPERTY));
+
+      assertThrows(
+          InvalidRequestException.class,
+          () ->
+              SdkClients.adminClient()
+                  .domains()
+                  .create(minimalDomainRequest(ns, "dom-selection-missing-required")));
+    } finally {
+      deleteIntakeForm(form.getId());
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // GlossaryTerm — POST, PUT, PATCH matrix
   // ---------------------------------------------------------------------------
@@ -689,6 +838,46 @@ public class IntakeFormResourceIT {
       GlossaryTerm created = SdkClients.adminClient().glossaryTerms().create(req);
       assertNotNull(created.getId());
       assertNotNull(created.getExtension());
+    } finally {
+      deleteIntakeForm(form.getId());
+    }
+  }
+
+  @Test
+  void glossaryTerm_create_includesThreeCustomPropertiesAndEnforcesOnlyRequiredOne(TestNamespace ns)
+      throws Exception {
+    IntakeForm form =
+        createIntakeForm(
+            customPropertySelectionForm(
+                ns.prefix("gt-intake-selection"),
+                TargetEntityType.GLOSSARY_TERM,
+                GLOSSARY_TERM_STEWARD_PROPERTY,
+                GLOSSARY_TERM_AUDIENCE_PROPERTY,
+                GLOSSARY_TERM_SOURCE_PROPERTY));
+    try {
+      assertEquals(3, form.getFormFields().size());
+      assertEquals(1, form.getRequiredFields().size());
+
+      Map<String, Object> extension = new LinkedHashMap<>();
+      extension.put(GLOSSARY_TERM_STEWARD_PROPERTY, "data-stewards@example.com");
+      GlossaryTerm created =
+          SdkClients.adminClient()
+              .glossaryTerms()
+              .create(
+                  minimalGlossaryTermRequest(ns, "gt-selection-with-required")
+                      .withExtension(extension));
+      assertNotNull(created.getId());
+      assertFalse(
+          OBJECT_MAPPER.valueToTree(created.getExtension()).has(GLOSSARY_TERM_AUDIENCE_PROPERTY));
+      assertFalse(
+          OBJECT_MAPPER.valueToTree(created.getExtension()).has(GLOSSARY_TERM_SOURCE_PROPERTY));
+
+      assertThrows(
+          InvalidRequestException.class,
+          () ->
+              SdkClients.adminClient()
+                  .glossaryTerms()
+                  .create(minimalGlossaryTermRequest(ns, "gt-selection-missing-required")));
     } finally {
       deleteIntakeForm(form.getId());
     }
@@ -939,6 +1128,154 @@ public class IntakeFormResourceIT {
           "Expected IntakeForm error mentioning Owner, got: " + ex.getMessage());
     } finally {
       deleteIntakeForm(form.getId());
+    }
+  }
+
+  @Test
+  void deletingRequiredCustomPropertiesPrunesAllIntakeFormsAndEntitiesContinueWorking(
+      TestNamespace ns) throws Exception {
+    String dataProductProperty = uniqueCustomPropertyName("intakeDeletedDataProduct");
+    String domainProperty = uniqueCustomPropertyName("intakeDeletedDomain");
+    String glossaryTermProperty = uniqueCustomPropertyName("intakeDeletedGlossaryTerm");
+    String survivingDataProductProperty = uniqueCustomPropertyName("intakeSurvivingDataProduct");
+    String survivingDomainProperty = uniqueCustomPropertyName("intakeSurvivingDomain");
+    String survivingGlossaryTermProperty = uniqueCustomPropertyName("intakeSurvivingGlossaryTerm");
+    ensureStringCustomProperty("dataProduct", dataProductProperty);
+    ensureStringCustomProperty("domain", domainProperty);
+    ensureStringCustomProperty("glossaryTerm", glossaryTermProperty);
+    ensureStringCustomProperty("dataProduct", survivingDataProductProperty);
+    ensureStringCustomProperty("domain", survivingDomainProperty);
+    ensureStringCustomProperty("glossaryTerm", survivingGlossaryTermProperty);
+
+    Map<String, Object> domainExtension = new LinkedHashMap<>();
+    domainExtension.put(domainProperty, "domain-value");
+    domainExtension.put(survivingDomainProperty, "surviving-domain-value");
+    Domain existingDomain =
+        SdkClients.adminClient()
+            .domains()
+            .create(
+                minimalDomainRequest(ns, "domain-before-property-delete")
+                    .withExtension(domainExtension));
+
+    Map<String, Object> dataProductExtension = new LinkedHashMap<>();
+    dataProductExtension.put(dataProductProperty, "data-product-value");
+    dataProductExtension.put(survivingDataProductProperty, "surviving-data-product-value");
+    DataProduct existingDataProduct =
+        SdkClients.adminClient()
+            .dataProducts()
+            .create(
+                minimalDataProductRequest(ns, existingDomain, "data-product-before-property-delete")
+                    .withExtension(dataProductExtension));
+
+    Map<String, Object> glossaryTermExtension = new LinkedHashMap<>();
+    glossaryTermExtension.put(glossaryTermProperty, "glossary-term-value");
+    glossaryTermExtension.put(survivingGlossaryTermProperty, "surviving-glossary-term-value");
+    GlossaryTerm existingGlossaryTerm =
+        SdkClients.adminClient()
+            .glossaryTerms()
+            .create(
+                minimalGlossaryTermRequest(ns, "glossary-term-before-property-delete")
+                    .withExtension(glossaryTermExtension));
+
+    IntakeForm dataProductForm = null;
+    IntakeForm domainForm = null;
+    IntakeForm glossaryTermForm = null;
+    try {
+      dataProductForm =
+          createIntakeForm(
+              customPropertyForm(
+                  ns.prefix("dp-delete-property"),
+                  TargetEntityType.DATA_PRODUCT,
+                  customPropertyFormField(dataProductProperty, true),
+                  customPropertyFormField(survivingDataProductProperty, false)));
+      domainForm =
+          createIntakeForm(
+              customPropertyForm(
+                  ns.prefix("domain-delete-property"),
+                  TargetEntityType.DOMAIN,
+                  customPropertyFormField(domainProperty, true),
+                  customPropertyFormField(survivingDomainProperty, false)));
+      glossaryTermForm =
+          createIntakeForm(
+              customPropertyForm(
+                  ns.prefix("glossary-delete-property"),
+                  TargetEntityType.GLOSSARY_TERM,
+                  customPropertyFormField(glossaryTermProperty, true),
+                  customPropertyFormField(survivingGlossaryTermProperty, false)));
+
+      long pruneStartTs = System.currentTimeMillis();
+      deleteCustomProperty("dataProduct", dataProductProperty);
+      deleteCustomProperty("domain", domainProperty);
+      deleteCustomProperty("glossaryTerm", glossaryTermProperty);
+
+      assertPruneEmittedChangeEvent(dataProductForm.getId(), pruneStartTs);
+      assertDeletedPropertyPruned(
+          getIntakeFormById(dataProductForm.getId()),
+          dataProductProperty,
+          survivingDataProductProperty);
+      assertDeletedPropertyPruned(
+          getIntakeFormById(domainForm.getId()), domainProperty, survivingDomainProperty);
+      assertDeletedPropertyPruned(
+          getIntakeFormById(glossaryTermForm.getId()),
+          glossaryTermProperty,
+          survivingGlossaryTermProperty);
+
+      DataProduct reloadedDataProduct =
+          SdkClients.adminClient()
+              .dataProducts()
+              .get(existingDataProduct.getId().toString(), "extension");
+      Domain reloadedDomain =
+          SdkClients.adminClient().domains().get(existingDomain.getId().toString(), "extension");
+      GlossaryTerm reloadedGlossaryTerm =
+          SdkClients.adminClient()
+              .glossaryTerms()
+              .get(existingGlossaryTerm.getId().toString(), "extension");
+      assertDeletedAndSurvivingExtensionValues(
+          reloadedDataProduct.getExtension(),
+          dataProductProperty,
+          survivingDataProductProperty,
+          "surviving-data-product-value");
+      assertDeletedAndSurvivingExtensionValues(
+          reloadedDomain.getExtension(),
+          domainProperty,
+          survivingDomainProperty,
+          "surviving-domain-value");
+      assertDeletedAndSurvivingExtensionValues(
+          reloadedGlossaryTerm.getExtension(),
+          glossaryTermProperty,
+          survivingGlossaryTermProperty,
+          "surviving-glossary-term-value");
+
+      assertNotNull(
+          SdkClients.adminClient()
+              .dataProducts()
+              .create(
+                  minimalDataProductRequest(
+                      ns, existingDomain, "data-product-after-property-delete")));
+      assertNotNull(
+          SdkClients.adminClient()
+              .domains()
+              .create(minimalDomainRequest(ns, "domain-after-property-delete")));
+      assertNotNull(
+          SdkClients.adminClient()
+              .glossaryTerms()
+              .create(minimalGlossaryTermRequest(ns, "glossary-term-after-property-delete")));
+    } finally {
+      deleteCustomProperty("dataProduct", dataProductProperty);
+      deleteCustomProperty("domain", domainProperty);
+      deleteCustomProperty("glossaryTerm", glossaryTermProperty);
+      deleteCustomProperty("dataProduct", survivingDataProductProperty);
+      deleteCustomProperty("domain", survivingDomainProperty);
+      deleteCustomProperty("glossaryTerm", survivingGlossaryTermProperty);
+      if (dataProductForm != null) {
+        deleteIntakeForm(dataProductForm.getId());
+      }
+      if (domainForm != null) {
+        deleteIntakeForm(domainForm.getId());
+      }
+      if (glossaryTermForm != null) {
+        deleteIntakeForm(glossaryTermForm.getId());
+      }
     }
   }
 
@@ -1505,6 +1842,121 @@ public class IntakeFormResourceIT {
         .execute(HttpMethod.PUT, "/v1/metadata/types/" + type.getId(), prop, Type.class);
   }
 
+  private static void deleteCustomProperty(String entityType, String propertyName)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Type type = getTypeByName(client, entityType);
+    if (type.getCustomProperties() == null) {
+      return;
+    }
+    int propertyIndex = -1;
+    for (int index = 0; index < type.getCustomProperties().size(); index++) {
+      if (propertyName.equals(type.getCustomProperties().get(index).getName())) {
+        propertyIndex = index;
+        break;
+      }
+    }
+    if (propertyIndex < 0) {
+      return;
+    }
+
+    ArrayNode patch = OBJECT_MAPPER.createArrayNode();
+    ObjectNode testOperation = patch.addObject();
+    testOperation.put("op", "test");
+    testOperation.put("path", "/customProperties/" + propertyIndex + "/name");
+    testOperation.put("value", propertyName);
+    ObjectNode removeOperation = patch.addObject();
+    removeOperation.put("op", "remove");
+    removeOperation.put("path", "/customProperties/" + propertyIndex);
+    patchEntity("/v1/metadata/types/" + type.getId(), patch.toString());
+  }
+
+  private static String uniqueCustomPropertyName(String prefix) {
+    return prefix + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  private static void assertDeletedPropertyPruned(
+      IntakeForm form, String deletedProperty, String survivingProperty) {
+    assertEquals(1, form.getFormFields().size());
+    assertEquals("extension." + survivingProperty, form.getFormFields().get(0).getFieldPath());
+    assertFalse(
+        form.getFormFields().stream()
+            .anyMatch(field -> ("extension." + deletedProperty).equals(field.getFieldPath())));
+    assertTrue(form.getRequiredFields().isEmpty());
+    assertPruneWasVersioned(form, deletedProperty);
+  }
+
+  /**
+   * Change events are emitted by ChangeEventHandler, a REST response filter that only ever sees the
+   * Type request driving this cascade. Without an explicit event the IntakeForm changes version with
+   * nothing for subscribers to consume, so assert one was recorded.
+   */
+  private static void assertPruneEmittedChangeEvent(UUID formId, long sinceTs) throws Exception {
+    ObjectNode events =
+        SdkClients.adminClient()
+            .getHttpClient()
+            .execute(
+                HttpMethod.GET,
+                "/v1/events?entityUpdated=" + INTAKE_FORM_ENTITY_TYPE + "&timestamp=" + sinceTs,
+                null,
+                ObjectNode.class);
+    ArrayNode data = (ArrayNode) events.path("data");
+    boolean emitted = false;
+    for (int i = 0; i < data.size(); i++) {
+      if (formId.toString().equals(data.get(i).path("entityId").asText())) {
+        emitted = true;
+
+        break;
+      }
+    }
+    assertTrue(
+        emitted,
+        "Pruning a custom property must record an "
+            + INTAKE_FORM_ENTITY_TYPE
+            + " change event for form "
+            + formId);
+  }
+
+  /**
+   * The prune must go through the standard update path: storing the mutated form directly would
+   * leave the version untouched, so a client holding a pre-prune copy could PUT it back and still
+   * pass the optimistic-lock check.
+   */
+  private static void assertPruneWasVersioned(IntakeForm form, String deletedProperty) {
+    assertTrue(
+        form.getVersion() > INITIAL_ENTITY_VERSION,
+        "Pruning custom property '"
+            + deletedProperty
+            + "' must increment the IntakeForm version, but it stayed at "
+            + form.getVersion());
+    assertNotNull(form.getUpdatedBy());
+    assertNotNull(form.getChangeDescription());
+    assertTrue(
+        form.getChangeDescription().getFieldsUpdated().stream()
+            .anyMatch(field -> FORM_FIELDS_FIELD.equals(field.getName())),
+        "Pruning must record a '"
+            + FORM_FIELDS_FIELD
+            + "' change, got: "
+            + form.getChangeDescription().getFieldsUpdated());
+  }
+
+  private static void assertDeletedAndSurvivingExtensionValues(
+      Object extension, String deletedProperty, String survivingProperty, String survivingValue) {
+    assertNotNull(extension);
+    ObjectNode extensionNode = OBJECT_MAPPER.valueToTree(extension);
+    assertFalse(extensionNode.has(deletedProperty));
+    assertEquals(survivingValue, extensionNode.path(survivingProperty).asText());
+  }
+
+  private static void assertCustomPropertyExists(String entityType, String propertyName)
+      throws Exception {
+    Type type = getTypeByName(SdkClients.adminClient(), entityType);
+    assertNotNull(type.getCustomProperties());
+    assertTrue(
+        type.getCustomProperties().stream()
+            .anyMatch(property -> propertyName.equals(property.getName())));
+  }
+
   private static Type getTypeByName(OpenMetadataClient client, String name) throws Exception {
     String json =
         client
@@ -1575,6 +2027,7 @@ public class IntakeFormResourceIT {
         .withDescription(form.getDescription())
         .withEntityType(form.getEntityType())
         .withEnabled(form.getEnabled())
+        .withFormFields(form.getFormFields())
         .withRequiredFields(form.getRequiredFields());
   }
 
@@ -1618,6 +2071,94 @@ public class IntakeFormResourceIT {
                     .withFieldKind(kind)));
   }
 
+  private static CreateIntakeForm customPropertySelectionForm(
+      String name,
+      TargetEntityType entityType,
+      String requiredProperty,
+      String firstOptionalProperty,
+      String secondOptionalProperty) {
+    return customPropertyForm(
+        name,
+        entityType,
+        customPropertyFormField(requiredProperty, true),
+        customPropertyFormField(firstOptionalProperty, false),
+        customPropertyFormField(secondOptionalProperty, false));
+  }
+
+  private static CreateIntakeForm customPropertyForm(
+      String name, TargetEntityType entityType, IntakeFormField... formFields) {
+    return new CreateIntakeForm()
+        .withName(name)
+        .withEntityType(entityType)
+        .withEnabled(Boolean.TRUE)
+        .withFormFields(List.of(formFields));
+  }
+
+  private static void assertSelectionUpdateLifecycle(
+      String name,
+      TargetEntityType entityType,
+      String requiredProperty,
+      String removedOptionalProperty,
+      String survivingOptionalProperty)
+      throws Exception {
+    IntakeForm created =
+        createIntakeForm(
+            customPropertySelectionForm(
+                name,
+                entityType,
+                requiredProperty,
+                removedOptionalProperty,
+                survivingOptionalProperty));
+    try {
+      assertEquals(3, created.getFormFields().size());
+      assertEquals(1, created.getRequiredFields().size());
+
+      IntakeForm optionalRemoved =
+          putIntakeForm(
+              customPropertyForm(
+                  name,
+                  entityType,
+                  customPropertyFormField(requiredProperty, true),
+                  customPropertyFormField(survivingOptionalProperty, false)));
+      assertEquals(2, optionalRemoved.getFormFields().size());
+      assertEquals(1, optionalRemoved.getRequiredFields().size());
+      assertFalse(
+          optionalRemoved.getFormFields().stream()
+              .anyMatch(
+                  field -> ("extension." + removedOptionalProperty).equals(field.getFieldPath())));
+
+      IntakeForm requiredChangedToOptional =
+          putIntakeForm(
+              customPropertyForm(
+                  name,
+                  entityType,
+                  customPropertyFormField(requiredProperty, false),
+                  customPropertyFormField(survivingOptionalProperty, false)));
+      assertEquals(2, requiredChangedToOptional.getFormFields().size());
+      assertTrue(requiredChangedToOptional.getRequiredFields().isEmpty());
+
+      IntakeForm formerlyRequiredRemoved =
+          putIntakeForm(
+              customPropertyForm(
+                  name, entityType, customPropertyFormField(survivingOptionalProperty, false)));
+      assertEquals(1, formerlyRequiredRemoved.getFormFields().size());
+      assertEquals(
+          "extension." + survivingOptionalProperty,
+          formerlyRequiredRemoved.getFormFields().get(0).getFieldPath());
+      assertTrue(formerlyRequiredRemoved.getRequiredFields().isEmpty());
+    } finally {
+      deleteIntakeForm(created.getId());
+    }
+  }
+
+  private static IntakeFormField customPropertyFormField(String propertyName, boolean required) {
+    return new IntakeFormField()
+        .withFieldPath("extension." + propertyName)
+        .withFieldLabel(propertyName)
+        .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+        .withRequired(required);
+  }
+
   private static Domain createDomain(TestNamespace ns) {
     String domainName = ns.prefix("intake-test-domain");
     try {
@@ -1631,6 +2172,13 @@ public class IntakeFormResourceIT {
                   .withDescription("Test domain for IntakeForm integration tests")
                   .withDomainType(DomainType.AGGREGATE));
     }
+  }
+
+  private static CreateDomain minimalDomainRequest(TestNamespace ns, String suffix) {
+    return new CreateDomain()
+        .withName(ns.prefix(suffix))
+        .withDescription("IntakeForm integration test domain")
+        .withDomainType(DomainType.AGGREGATE);
   }
 
   private static CreateDataProduct minimalDataProductRequest(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4521,23 +4521,23 @@ public abstract class EntityRepository<T extends EntityInterface> {
               // Delete all the relationships to other entities
               daoCollection.relationshipDAO().deleteAll(id, entityType);
 
-              // Delete all the field relationships to other entities
-              daoCollection
-                  .fieldRelationshipDAO()
-                  .deleteAllByPrefix(entityInterface.getFullyQualifiedName());
+              if (shouldCleanupFqnDependents()) {
+                daoCollection
+                    .fieldRelationshipDAO()
+                    .deleteAllByPrefix(entityInterface.getFullyQualifiedName());
+              }
 
               // Delete all the extensions of entity
               daoCollection.entityExtensionDAO().deleteAll(id);
 
-              // Delete all the tag labels
-              daoCollection
-                  .tagUsageDAO()
-                  .deleteTagLabelsByTargetPrefix(entityInterface.getFullyQualifiedName());
-
-              // when the glossary and tag is deleted, delete its usage
-              daoCollection
-                  .tagUsageDAO()
-                  .deleteTagLabelsByFqn(entityInterface.getFullyQualifiedName());
+              if (shouldCleanupFqnDependents()) {
+                daoCollection
+                    .tagUsageDAO()
+                    .deleteTagLabelsByTargetPrefix(entityInterface.getFullyQualifiedName());
+                daoCollection
+                    .tagUsageDAO()
+                    .deleteTagLabelsByFqn(entityInterface.getFullyQualifiedName());
+              }
               // Delete all the usage data
               daoCollection.usageDAO().delete(id);
 
@@ -4565,6 +4565,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
   }
 
   protected void entitySpecificCleanup(T entityInterface) {}
+
+  protected boolean shouldCleanupFqnDependents() {
+    return true;
+  }
 
   /**
    * Variant of {@link #entitySpecificCleanup(EntityInterface)} that receives the user performing
@@ -6239,7 +6243,7 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // round-trips for an N-entity subtree. Skip them for cascade-covered types and rely on the root
     // cleanup() prefix delete. Types not FQN-nested under their delete root (e.g. flat-FQN teams)
     // keep the per-entity path.
-    if (!descendantsCoveredByAncestorCascade) {
+    if (shouldCleanupFqnDependents() && !descendantsCoveredByAncestorCascade) {
       try (var ignored = phase("bulkHardDeleteFqnDependents")) {
         for (T entity : entities) {
           String fqn = entity.getFullyQualifiedName();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IntakeFormRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IntakeFormRepository.java
@@ -13,6 +13,8 @@
 
 package org.openmetadata.service.jdbi3;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.schema.type.EventType.ENTITY_UPDATED;
 import static org.openmetadata.service.Entity.INTAKE_FORM;
 
 import lombok.extern.slf4j.Slf4j;
@@ -23,11 +25,12 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.resources.governance.IntakeFormResource;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
+import org.openmetadata.service.util.IntakeFormUtil;
 
 @Slf4j
 @Repository
 public class IntakeFormRepository extends EntityRepository<IntakeForm> {
-  private static final String UPDATE_FIELDS = "owners,requiredFields,enabled,entityType";
+  private static final String UPDATE_FIELDS = "owners,formFields,requiredFields,enabled,entityType";
 
   public IntakeFormRepository() {
     super(
@@ -42,7 +45,7 @@ public class IntakeFormRepository extends EntityRepository<IntakeForm> {
 
   @Override
   public void setFields(IntakeForm entity, Fields fields, RelationIncludes relationIncludes) {
-    // No inherited or lazy fields — all state lives on the entity JSON
+    IntakeFormUtil.synchronizeFields(entity);
   }
 
   @Override
@@ -55,17 +58,24 @@ public class IntakeFormRepository extends EntityRepository<IntakeForm> {
     if (entity.getEntityType() == null) {
       throw new IllegalArgumentException("IntakeForm requires entityType");
     }
+    IntakeFormUtil.synchronizeFields(entity);
     ensureUniquePerEntityType(entity, update);
   }
 
   @Override
   public void storeEntity(IntakeForm entity, boolean update) {
+    IntakeFormUtil.synchronizeFields(entity);
     store(entity, update);
   }
 
   @Override
   public void storeRelationships(IntakeForm entity) {
     // No cross-entity relationships for IntakeForm
+  }
+
+  @Override
+  protected boolean shouldCleanupFqnDependents() {
+    return false;
   }
 
   /**
@@ -79,10 +89,36 @@ public class IntakeFormRepository extends EntityRepository<IntakeForm> {
     String json = Entity.getCollectionDAO().intakeFormDAO().findByEntityType(entityType);
     if (json == null) return null;
     IntakeForm form = JsonUtils.readValue(json, IntakeForm.class);
+    IntakeFormUtil.synchronizeFields(form);
     if (Boolean.FALSE.equals(form.getEnabled())) {
       return null;
     }
     return form;
+  }
+
+  /**
+   * Drops a deleted custom property from this entityType's IntakeForm. Routed through the standard
+   * EntityUpdater so the cascade increments the version and produces a changeDescription and change
+   * event — storing directly would leave the version untouched, letting a client PUT a stale copy
+   * past the optimistic-lock check.
+   */
+  public void removeCustomPropertyField(String entityType, String propertyName, String updatedBy) {
+    String json = Entity.getCollectionDAO().intakeFormDAO().findByEntityType(entityType);
+    if (!nullOrEmpty(json)) {
+      IntakeForm original = JsonUtils.readValue(json, IntakeForm.class);
+      IntakeFormUtil.synchronizeFields(original);
+      IntakeForm updated = JsonUtils.deepCopy(original, IntakeForm.class);
+      if (IntakeFormUtil.removeCustomPropertyField(updated, propertyName)) {
+        updated.setUpdatedBy(updatedBy);
+        getUpdater(original, updated, Operation.PATCH, null).update();
+        // Change events are normally emitted by ChangeEventHandler, a REST
+        // response filter. This cascade runs inside the Type update request, so
+        // that filter only ever sees the Type — without this the IntakeForm
+        // silently changes version with no event for subscribers to consume.
+        createAndInsertChangeEvent(
+            original, updated, updated.getChangeDescription(), ENTITY_UPDATED);
+      }
+    }
   }
 
   private void ensureUniquePerEntityType(IntakeForm entity, boolean update) {
@@ -117,6 +153,7 @@ public class IntakeFormRepository extends EntityRepository<IntakeForm> {
     public void entitySpecificUpdate(boolean consolidatingChanges) {
       recordChange("entityType", original.getEntityType(), updated.getEntityType());
       recordChange("enabled", original.getEnabled(), updated.getEnabled());
+      recordChange("formFields", original.getFormFields(), updated.getFormFields());
       recordChange("requiredFields", original.getRequiredFields(), updated.getRequiredFields());
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TypeRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TypeRepository.java
@@ -328,8 +328,16 @@ public class TypeRepository extends EntityRepository<Type> {
 
   /** Handles entity updated from PUT and POST operation. */
   public class TypeUpdater extends EntityUpdater {
+    private final List<CustomProperty> requestedAdditions;
+    private final List<CustomProperty> requestedDeletions;
+    private boolean membershipChangesApplied;
+
     public TypeUpdater(Type original, Type updated, Operation operation) {
       super(original, updated, operation);
+      requestedAdditions =
+          getPropertiesAbsentByName(updated.getCustomProperties(), original.getCustomProperties());
+      requestedDeletions =
+          getPropertiesAbsentByName(original.getCustomProperties(), updated.getCustomProperties());
     }
 
     @Transaction
@@ -345,19 +353,7 @@ public class TypeRepository extends EntityRepository<Type> {
       List<CustomProperty> deleted = new ArrayList<>();
       recordListChange(
           "customProperties", origProperties, updatedProperties, added, deleted, customFieldMatch);
-      // Legacy names from existing data are not re-validated; only newly added ones.
-      for (CustomProperty property : added) {
-        String violations = ValidatorUtil.validate(property);
-        if (violations != null) {
-          throw new IllegalArgumentException(violations);
-        }
-      }
-      for (CustomProperty property : added) {
-        storeCustomProperty(property);
-      }
-      for (CustomProperty property : deleted) {
-        deleteCustomProperty(property);
-      }
+      applyRequestedMembershipChanges();
 
       // Record changes to updated custom properties (only description can be updated)
       for (CustomProperty updateProperty : updatedProperties) {
@@ -374,6 +370,41 @@ public class TypeRepository extends EntityRepository<Type> {
         updateDisplayName(updated, storedProperty, updateProperty);
         updateCustomPropertyConfig(updated, storedProperty, updateProperty);
       }
+    }
+
+    private List<CustomProperty> getPropertiesAbsentByName(
+        List<CustomProperty> candidates, List<CustomProperty> existingProperties) {
+      Set<String> existingNames =
+          listOrEmpty(existingProperties).stream()
+              .map(CustomProperty::getName)
+              .collect(Collectors.toSet());
+      Set<String> collectedNames = new HashSet<>();
+      return listOrEmpty(candidates).stream()
+          .filter(property -> !existingNames.contains(property.getName()))
+          .filter(property -> collectedNames.add(property.getName()))
+          .map(property -> JsonUtils.deepCopy(property, CustomProperty.class))
+          .toList();
+    }
+
+    private void applyRequestedMembershipChanges() {
+      if (membershipChangesApplied) {
+        return;
+      }
+
+      // Legacy names from existing data are not re-validated; only newly added ones.
+      for (CustomProperty property : requestedAdditions) {
+        String violations = ValidatorUtil.validate(property);
+        if (violations != null) {
+          throw new IllegalArgumentException(violations);
+        }
+      }
+      for (CustomProperty property : requestedAdditions) {
+        storeCustomProperty(property);
+      }
+      for (CustomProperty property : requestedDeletions) {
+        deleteCustomProperty(property);
+      }
+      membershipChangesApplied = true;
     }
 
     private void storeCustomProperty(CustomProperty property) {
@@ -417,6 +448,13 @@ public class TypeRepository extends EntityRepository<Type> {
               Relationship.HAS.ordinal());
       // Delete all the data stored in the entity extension for the custom property
       daoCollection.entityExtensionDAO().deleteExtension(customPropertyFQN);
+
+      if (Entity.hasEntityRepository(Entity.INTAKE_FORM)) {
+        IntakeFormRepository intakeFormRepository =
+            (IntakeFormRepository) Entity.getEntityRepository(Entity.INTAKE_FORM);
+        intakeFormRepository.removeCustomPropertyField(
+            updated.getName(), property.getName(), updated.getUpdatedBy());
+      }
 
       // Remove from TypeRegistry cache
       TypeRegistry.instance().removeCustomProperty(updated.getName(), property.getName());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/governance/IntakeFormMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/governance/IntakeFormMapper.java
@@ -16,14 +16,19 @@ package org.openmetadata.service.resources.governance;
 import org.openmetadata.schema.api.governance.CreateIntakeForm;
 import org.openmetadata.schema.entity.governance.IntakeForm;
 import org.openmetadata.service.mapper.EntityMapper;
+import org.openmetadata.service.util.IntakeFormUtil;
 
 public class IntakeFormMapper implements EntityMapper<IntakeForm, CreateIntakeForm> {
   @Override
   public IntakeForm createToEntity(CreateIntakeForm create, String user) {
-    return copy(new IntakeForm(), create, user)
-        .withEntityType(create.getEntityType())
-        .withEnabled(create.getEnabled() == null ? Boolean.TRUE : create.getEnabled())
-        .withRequiredFields(create.getRequiredFields())
-        .withFullyQualifiedName(create.getName());
+    IntakeForm intakeForm =
+        copy(new IntakeForm(), create, user)
+            .withEntityType(create.getEntityType())
+            .withEnabled(create.getEnabled() == null ? Boolean.TRUE : create.getEnabled())
+            .withFormFields(create.getFormFields())
+            .withRequiredFields(create.getRequiredFields())
+            .withFullyQualifiedName(create.getName());
+    IntakeFormUtil.synchronizeFields(intakeForm);
+    return intakeForm;
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/governance/IntakeFormResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/governance/IntakeFormResource.java
@@ -61,14 +61,15 @@ import org.openmetadata.service.security.Authorizer;
 @Tag(
     name = "IntakeForms",
     description =
-        "An IntakeForm declares additional required fields for a governance entity. Required fields "
-            + "are enforced at the API layer, layered on top of the entity's schema-required fields.")
+        "An IntakeForm declares fields shown for a governance entity and which are required. "
+            + "Required fields are enforced at the API layer, layered on top of the entity's "
+            + "schema-required fields.")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 @Collection(name = "intakeForms", order = 5)
 public class IntakeFormResource extends EntityResource<IntakeForm, IntakeFormRepository> {
   public static final String COLLECTION_PATH = "/v1/governance/intakeForms/";
-  static final String FIELDS = "owners,requiredFields";
+  static final String FIELDS = "owners,formFields,requiredFields";
   private final IntakeFormMapper mapper = new IntakeFormMapper();
 
   public IntakeFormResource(Authorizer authorizer, Limits limits) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormUtil.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmetadata.schema.entity.governance.IntakeForm;
+import org.openmetadata.schema.entity.governance.IntakeFormField;
+import org.openmetadata.schema.entity.governance.IntakeFormRequiredField;
+
+public final class IntakeFormUtil {
+
+  private IntakeFormUtil() {}
+
+  public static List<IntakeFormField> getEffectiveFormFields(IntakeForm form) {
+    if (!nullOrEmpty(form.getFormFields()) || nullOrEmpty(form.getRequiredFields())) {
+      return new ArrayList<>(listOrEmpty(form.getFormFields()));
+    }
+    return toFormFields(form.getRequiredFields());
+  }
+
+  public static void synchronizeFields(IntakeForm form) {
+    List<IntakeFormField> formFields = getEffectiveFormFields(form);
+    form.setFormFields(formFields);
+    form.setRequiredFields(toRequiredFields(formFields));
+  }
+
+  public static boolean removeCustomPropertyField(IntakeForm form, String propertyName) {
+    String extensionPath = "extension." + propertyName;
+    List<IntakeFormField> formFields = new ArrayList<>(getEffectiveFormFields(form));
+    boolean removed =
+        formFields.removeIf(
+            field ->
+                extensionPath.equals(field.getFieldPath())
+                    || (IntakeFormField.FieldKind.CUSTOM_PROPERTY.equals(field.getFieldKind())
+                        && propertyName.equals(field.getFieldPath())));
+    if (removed) {
+      form.setFormFields(formFields);
+      form.setRequiredFields(toRequiredFields(formFields));
+    }
+    return removed;
+  }
+
+  private static List<IntakeFormField> toFormFields(List<IntakeFormRequiredField> requiredFields) {
+    return listOrEmpty(requiredFields).stream()
+        .map(
+            field ->
+                new IntakeFormField()
+                    .withFieldPath(field.getFieldPath())
+                    .withFieldLabel(field.getFieldLabel())
+                    .withFieldKind(
+                        field.getFieldKind() == null
+                            ? null
+                            : IntakeFormField.FieldKind.fromValue(field.getFieldKind().value()))
+                    .withRequired(true)
+                    .withErrorMessage(field.getErrorMessage()))
+        .toList();
+  }
+
+  private static List<IntakeFormRequiredField> toRequiredFields(List<IntakeFormField> formFields) {
+    return listOrEmpty(formFields).stream()
+        .filter(field -> Boolean.TRUE.equals(field.getRequired()))
+        .map(
+            field ->
+                new IntakeFormRequiredField()
+                    .withFieldPath(field.getFieldPath())
+                    .withFieldLabel(field.getFieldLabel())
+                    .withFieldKind(
+                        field.getFieldKind() == null
+                            ? null
+                            : IntakeFormRequiredField.FieldKind.fromValue(
+                                field.getFieldKind().value()))
+                    .withErrorMessage(field.getErrorMessage()))
+        .toList();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormValidator.java
@@ -13,7 +13,6 @@
 
 package org.openmetadata.service.util;
 
-import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.entity.governance.IntakeForm;
-import org.openmetadata.schema.entity.governance.IntakeFormRequiredField;
+import org.openmetadata.schema.entity.governance.IntakeFormField;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.IntakeFormRepository;
 import org.slf4j.Logger;
@@ -72,7 +71,8 @@ public final class IntakeFormValidator {
   private static List<String> checkIntakeFormRequiredFields(
       EntityInterface entity, IntakeForm form) {
     List<String> missing = new ArrayList<>();
-    for (IntakeFormRequiredField field : listOrEmpty(form.getRequiredFields())) {
+    for (IntakeFormField field : IntakeFormUtil.getEffectiveFormFields(form)) {
+      if (!Boolean.TRUE.equals(field.getRequired())) continue;
       if (field.getFieldPath() == null || field.getFieldPath().isBlank()) continue;
       if (!isFieldSet(entity, field)) {
         missing.add(
@@ -84,9 +84,9 @@ public final class IntakeFormValidator {
     return missing;
   }
 
-  private static boolean isFieldSet(EntityInterface entity, IntakeFormRequiredField field) {
+  private static boolean isFieldSet(EntityInterface entity, IntakeFormField field) {
     boolean isCustomProperty =
-        IntakeFormRequiredField.FieldKind.CUSTOM_PROPERTY.equals(field.getFieldKind())
+        IntakeFormField.FieldKind.CUSTOM_PROPERTY.equals(field.getFieldKind())
             || field.getFieldPath().startsWith(EXTENSION_PREFIX);
     if (isCustomProperty) {
       return isExtensionFieldSet(entity, field.getFieldPath());

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormUtilTest.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.governance.IntakeForm;
+import org.openmetadata.schema.entity.governance.IntakeFormField;
+import org.openmetadata.schema.entity.governance.IntakeFormRequiredField;
+
+class IntakeFormUtilTest {
+
+  @Test
+  void getEffectiveFormFieldsConvertsLegacyRequiredFields() {
+    IntakeFormRequiredField requiredField =
+        new IntakeFormRequiredField()
+            .withFieldPath("extension.steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormRequiredField.FieldKind.CUSTOM_PROPERTY);
+    IntakeForm intakeForm = new IntakeForm().withRequiredFields(List.of(requiredField));
+
+    List<IntakeFormField> fields = IntakeFormUtil.getEffectiveFormFields(intakeForm);
+
+    assertEquals(1, fields.size());
+    assertEquals("extension.steward", fields.get(0).getFieldPath());
+    assertTrue(fields.get(0).getRequired());
+  }
+
+  @Test
+  void synchronizeFieldsKeepsOptionalFieldsOutOfLegacyRequiredFields() {
+    IntakeFormField optionalField =
+        new IntakeFormField()
+            .withFieldPath("extension.steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(false);
+    IntakeFormField requiredField =
+        new IntakeFormField()
+            .withFieldPath("dataProductType")
+            .withFieldLabel("Data Product Type")
+            .withFieldKind(IntakeFormField.FieldKind.NATIVE)
+            .withRequired(true);
+    IntakeForm intakeForm = new IntakeForm().withFormFields(List.of(optionalField, requiredField));
+
+    IntakeFormUtil.synchronizeFields(intakeForm);
+
+    assertEquals(2, intakeForm.getFormFields().size());
+    assertFalse(intakeForm.getFormFields().get(0).getRequired());
+    assertEquals(1, intakeForm.getRequiredFields().size());
+    assertEquals("dataProductType", intakeForm.getRequiredFields().get(0).getFieldPath());
+  }
+
+  @Test
+  void removeCustomPropertyFieldRemovesIncludedAndRequiredRepresentations() {
+    IntakeFormField requiredField =
+        new IntakeFormField()
+            .withFieldPath("extension.steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(true);
+    IntakeFormField optionalField =
+        new IntakeFormField()
+            .withFieldPath("extension.audience")
+            .withFieldLabel("Audience")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(false);
+    IntakeForm intakeForm = new IntakeForm().withFormFields(List.of(requiredField, optionalField));
+    IntakeFormUtil.synchronizeFields(intakeForm);
+
+    assertTrue(IntakeFormUtil.removeCustomPropertyField(intakeForm, "steward"));
+
+    assertEquals(1, intakeForm.getFormFields().size());
+    assertEquals("extension.audience", intakeForm.getFormFields().get(0).getFieldPath());
+    assertTrue(intakeForm.getRequiredFields().isEmpty());
+  }
+
+  @Test
+  void removeCustomPropertyFieldSupportsLegacyRequiredFields() {
+    IntakeFormRequiredField requiredField =
+        new IntakeFormRequiredField()
+            .withFieldPath("extension.steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormRequiredField.FieldKind.CUSTOM_PROPERTY);
+    IntakeForm intakeForm = new IntakeForm().withRequiredFields(List.of(requiredField));
+
+    assertTrue(IntakeFormUtil.removeCustomPropertyField(intakeForm, "steward"));
+
+    assertTrue(intakeForm.getFormFields().isEmpty());
+    assertTrue(intakeForm.getRequiredFields().isEmpty());
+  }
+
+  @Test
+  void removeCustomPropertyFieldSupportsBareLegacyCustomPropertyPaths() {
+    IntakeFormField requiredField =
+        new IntakeFormField()
+            .withFieldPath("steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(true);
+    IntakeForm intakeForm = new IntakeForm().withFormFields(List.of(requiredField));
+
+    assertTrue(IntakeFormUtil.removeCustomPropertyField(intakeForm, "steward"));
+
+    assertTrue(intakeForm.getFormFields().isEmpty());
+    assertTrue(intakeForm.getRequiredFields().isEmpty());
+  }
+
+  @Test
+  void removeCustomPropertyFieldLeavesUnrelatedFieldsUnchanged() {
+    IntakeFormField requiredField =
+        new IntakeFormField()
+            .withFieldPath("extension.steward")
+            .withFieldLabel("Steward")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(true);
+    IntakeForm intakeForm = new IntakeForm().withFormFields(List.of(requiredField));
+
+    assertFalse(IntakeFormUtil.removeCustomPropertyField(intakeForm, "audience"));
+
+    assertEquals(List.of(requiredField), intakeForm.getFormFields());
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormValidatorTest.java
@@ -34,6 +34,7 @@ import org.openmetadata.schema.api.governance.CreateIntakeForm.TargetEntityType;
 import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.entity.domains.Domain;
 import org.openmetadata.schema.entity.governance.IntakeForm;
+import org.openmetadata.schema.entity.governance.IntakeFormField;
 import org.openmetadata.schema.entity.governance.IntakeFormRequiredField;
 import org.openmetadata.schema.entity.governance.IntakeFormRequiredField.FieldKind;
 import org.openmetadata.service.Entity;
@@ -264,6 +265,34 @@ class IntakeFormValidatorTest {
     when(mockRepo.findEnabledForEntityType(Entity.DATA_PRODUCT)).thenReturn(form);
 
     DataProduct dp = validDataProduct();
+
+    assertDoesNotThrow(() -> IntakeFormValidator.validate(dp, Entity.DATA_PRODUCT));
+  }
+
+  @Test
+  void validate_doesNotEnforceIncludedOptionalField() {
+    IntakeFormField optionalField =
+        new IntakeFormField()
+            .withFieldPath("extension.riskAssessment")
+            .withFieldLabel("Risk Assessment")
+            .withFieldKind(IntakeFormField.FieldKind.CUSTOM_PROPERTY)
+            .withRequired(false);
+    IntakeFormField requiredField =
+        new IntakeFormField()
+            .withFieldPath("dataProductType")
+            .withFieldLabel("Data Product Type")
+            .withFieldKind(IntakeFormField.FieldKind.NATIVE)
+            .withRequired(true);
+    IntakeForm form =
+        new IntakeForm()
+            .withId(UUID.randomUUID())
+            .withName("dataProduct-intake")
+            .withEntityType(TargetEntityType.DATA_PRODUCT)
+            .withEnabled(Boolean.TRUE)
+            .withFormFields(List.of(optionalField, requiredField));
+    when(mockRepo.findEnabledForEntityType(Entity.DATA_PRODUCT)).thenReturn(form);
+
+    DataProduct dp = validDataProduct().withDataProductType(DataProductType.DATASET);
 
     assertDoesNotThrow(() -> IntakeFormValidator.validate(dp, Entity.DATA_PRODUCT));
   }

--- a/openmetadata-spec/src/main/resources/json/schema/api/governance/createIntakeForm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/governance/createIntakeForm.json
@@ -28,13 +28,23 @@
       "type": "boolean",
       "default": true
     },
+    "formFields": {
+      "description": "Fields included in this IntakeForm. Fields with required=true are enforced.",
+      "type": "array",
+      "items": {
+        "$ref": "../../governance/intakeForm.json#/definitions/intakeFormField"
+      },
+      "default": []
+    },
     "requiredFields": {
-      "description": "Additional required fields enforced by this IntakeForm.",
+      "description": "Deprecated compatibility input for required fields. Use formFields instead.",
       "type": "array",
       "items": {
         "$ref": "../../governance/intakeForm.json#/definitions/requiredField"
       },
-      "default": []
+      "default": [],
+      "deprecated": true,
+      "$comment": "@deprecated Use formFields and set required=true on fields that must be populated"
     },
     "owners": {
       "description": "Owners of this IntakeForm configuration.",

--- a/openmetadata-spec/src/main/resources/json/schema/governance/intakeForm.json
+++ b/openmetadata-spec/src/main/resources/json/schema/governance/intakeForm.json
@@ -2,7 +2,7 @@
   "$id": "https://open-metadata.org/schema/governance/intakeForm.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "IntakeForm",
-  "description": "An IntakeForm declares additional required fields that must be populated when creating or updating a governance entity (Data Product, Domain, Glossary Term). These are org-configurable and layer on top of the schema's own required fields. Enforced identically at the API and UI layers so both contracts match.",
+  "description": "An IntakeForm declares the fields shown when creating or updating a governance entity (Data Product, Domain, Glossary Term) and which of those fields are required. Required fields are enforced identically at the API and UI layers so both contracts match.",
   "$comment": "@om-entity-type",
   "type": "object",
   "javaType": "org.openmetadata.schema.entity.governance.IntakeForm",
@@ -41,6 +41,37 @@
       },
       "required": ["fieldPath", "fieldLabel", "fieldKind"],
       "additionalProperties": false
+    },
+    "intakeFormField": {
+      "description": "A field included in this IntakeForm.",
+      "type": "object",
+      "javaType": "org.openmetadata.schema.entity.governance.IntakeFormField",
+      "properties": {
+        "fieldPath": {
+          "description": "Path to the field on the entity. Native paths are simple attribute names (e.g., 'dataProductType'). Custom property paths look like 'extension.<propertyName>'.",
+          "type": "string"
+        },
+        "fieldLabel": {
+          "description": "Human-friendly label used on the intake form UI and in validation error messages.",
+          "type": "string"
+        },
+        "fieldKind": {
+          "description": "Whether a form field refers to a native entity attribute or a custom property defined via the Type system.",
+          "type": "string",
+          "enum": ["native", "customProperty"]
+        },
+        "required": {
+          "description": "Whether this field must have a value before the entity can be created or updated.",
+          "type": "boolean",
+          "default": false
+        },
+        "errorMessage": {
+          "description": "Optional override for the validation error message when a required field is missing.",
+          "type": "string"
+        }
+      },
+      "required": ["fieldPath", "fieldLabel", "fieldKind"],
+      "additionalProperties": false
     }
   },
   "properties": {
@@ -73,13 +104,23 @@
       "type": "boolean",
       "default": true
     },
+    "formFields": {
+      "description": "Fields included in this IntakeForm. Fields with required=true are enforced on top of the schema-required fields.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/intakeFormField"
+      },
+      "default": []
+    },
     "requiredFields": {
-      "description": "Additional required fields enforced by this IntakeForm on top of the schema-required fields.",
+      "description": "Deprecated compatibility view of the required entries in formFields.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/requiredField"
       },
-      "default": []
+      "default": [],
+      "deprecated": true,
+      "$comment": "@deprecated Use formFields and set required=true on fields that must be populated"
     },
     "version": {
       "description": "Metadata version of the entity.",


### PR DESCRIPTION
## Summary

Backend-only cherry-pick of #30614 onto the `1.13` release branch.

**What's included:**
- `bootstrap/sql/migrations/native/1.13.3/mysql/postDataMigrationSQLScript.sql` — backfill `formFields` from legacy `requiredFields` rows
- `bootstrap/sql/migrations/native/1.13.3/postgres/postDataMigrationSQLScript.sql` — same for Postgres
- `openmetadata-spec/.../governance/intakeForm.json` — adds `formFields` array with per-field `required` flag
- `openmetadata-spec/.../api/governance/createIntakeForm.json` — matching schema for create API
- `openmetadata-service/.../util/IntakeFormUtil.java` (**new**) — serialization helper (`getEffectiveFormFields`, `synchronizeFields`, `removeCustomPropertyField`)
- `openmetadata-service/.../util/IntakeFormValidator.java` — guard against non-array `requiredFields`
- `openmetadata-service/.../jdbi3/IntakeFormRepository.java` — hooks `IntakeFormUtil.synchronizeFields` into store/prepare/update; overrides `shouldCleanupFqnDependents` → `false`
- `openmetadata-service/.../jdbi3/TypeRepository.java` — custom-property deletion now cascades to IntakeForm via `IntakeFormRepository.removeCustomPropertyField`; refactored to idempotent `applyRequestedMembershipChanges`
- `openmetadata-service/.../jdbi3/EntityRepository.java` — adds `shouldCleanupFqnDependents()` hook (default `true`) used during hard-delete to skip FQN-scoped cleanup for non-FQN-owning entities
- `openmetadata-service/.../resources/governance/IntakeFormMapper.java` — updated field mappings
- `openmetadata-service/.../resources/governance/IntakeFormResource.java` — resource endpoint updates
- `openmetadata-integration-tests/.../IntakeFormResourceIT.java` — integration tests for the new endpoints
- `openmetadata-service/src/test/...IntakeFormUtilTest.java` (**new**) — unit tests for IntakeFormUtil
- `openmetadata-service/src/test/...IntakeFormValidatorTest.java` — additional validator tests

**What's excluded (UI — API incompatibility with 1.13):**
- All `openmetadata-ui/` files — the UI changes rely on `ui-core-components` APIs (`CustomPropertyTypeBadge`, updated `AddDomainForm` extension fields pattern, etc.) that are not available in 1.13's ui-core-components version.
- All `openmetadata-ui-core-components/` changes.
- `.github/playwright/impact-map.json`.

**1.13 compatibility fix applied:**
`TypeRepository.TypeUpdater` in the original PR added `@Override protected void resetForRetryAttempt()` — this method does not exist in 1.13's `EntityRepository.EntityUpdater` base class. The override was removed; the `membershipChangesApplied` flag it reset is still used correctly via the idempotent `applyRequestedMembershipChanges()` guard.

## Test plan

- [ ] Run `bootstrap/sql/migrations/native/1.13.3/mysql/postDataMigrationSQLScript.sql` against a 1.13 DB; verify `formFields` populated from `requiredFields`
- [ ] Run `bootstrap/sql/migrations/native/1.13.3/postgres/postDataMigrationSQLScript.sql` — same
- [ ] `mvn test -pl openmetadata-service -Dtest="IntakeFormUtilTest,IntakeFormValidatorTest"` passes
- [ ] `mvn test -pl openmetadata-integration-tests -Dtest="IntakeFormResourceIT"` passes against a running 1.13 server
- [ ] Existing IntakeForm API endpoints (`GET /v1/governance/intakeForms`, `POST`, `PUT`, `DELETE`) behave correctly with both old `requiredFields` and new `formFields` payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds optional IntakeForm field selection while retaining legacy required-field compatibility.
- Adds `formFields` schemas and synchronization/validation logic.
- Backfills existing MySQL and PostgreSQL IntakeForms.
- Prunes deleted custom properties from affected forms with versioned change events.
- Avoids FQN-dependent cleanup when hard-deleting IntakeForms.
- Expands unit and integration coverage for selection, validation, deletion, and migration compatibility.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs a fix before merging because canonical-only updates cannot reliably remove all fields from an existing IntakeForm.

An empty formFields update is overwritten from the populated compatibility field during repository preparation, leaving removed fields present and potentially still enforced.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormUtil.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormUtil.java | Adds compatibility synchronization and pruning helpers, but stale requiredFields can prevent canonical formFields from being cleared. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IntakeFormRepository.java | Integrates synchronization, custom-property pruning, versioning, and IntakeForm-specific hard-delete behavior. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TypeRepository.java | Makes custom-property membership side effects idempotent and cascades deletions into IntakeForms. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java | Adds an overridable guard around cleanup of FQN-keyed dependent records. |
| bootstrap/sql/migrations/native/1.13.3/mysql/postDataMigrationSQLScript.sql | Backfills legacy required fields into canonical formFields for MySQL while filtering malformed values. |
| bootstrap/sql/migrations/native/1.13.3/postgres/postDataMigrationSQLScript.sql | Provides the equivalent guarded IntakeForm backfill for PostgreSQL. |
| openmetadata-spec/src/main/resources/json/schema/governance/intakeForm.json | Defines included form fields and preserves requiredFields as a deprecated compatibility view. |
| openmetadata-spec/src/main/resources/json/schema/api/governance/createIntakeForm.json | Extends create/update payloads with canonical formFields while retaining legacy requiredFields input. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Client[Create, PUT, or PATCH IntakeForm] --> Mapper[Mapper / patch application]
  Mapper --> Sync[IntakeFormUtil.synchronizeFields]
  Legacy[Legacy requiredFields] --> Sync
  Migration[1.13.3 SQL backfill] --> Stored[(IntakeForm JSON)]
  Sync --> Stored
  Stored --> Validator[IntakeFormValidator]
  Validator --> Governance[Data Product / Domain / Glossary Term writes]
  TypeDelete[Custom property deletion] --> Prune[removeCustomPropertyField]
  Prune --> Stored
  Prune --> Event[Version and change event]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intake-forms): cherry-pick backend c..."](https://github.com/open-metadata/openmetadata/commit/af342d02ace7c0081248764be6ffe26ef3416122) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48802715)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [openmetadata-spec: JSON Schema specification and multi-language code generation](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-spec.md)
- Knowledge Base — [Bootstrap SQL and the Database Migration Runner](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/bootstrap-migrations.md)
</details>

<!-- /greptile_comment -->