### PR TITLE
Fixes #30319: recover Oracle view definitions when the bulk LONG fetch truncates

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
@@ -122,7 +122,9 @@ class OracleSource(CommonDbSourceService):
         super().__init__(config, metadata)
         dialect = self.engine.dialect
         dialect.table_prefix = get_table_prefix_from_connection(self.service_connection)
-        if getattr(self.service_connection, "preserveIdentifierCase", False):
+        preserve_identifier_case = getattr(self.service_connection, "preserveIdentifierCase", False)
+        dialect.preserve_identifier_case = preserve_identifier_case
+        if preserve_identifier_case:
             dialect.normalize_name = types.MethodType(normalize_name, dialect)
             dialect.denormalize_name = types.MethodType(denormalize_name, dialect)
             dialect.get_table_comment = types.MethodType(get_table_comment_preserve_case, dialect)

--- a/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
@@ -123,7 +123,7 @@ class OracleSource(CommonDbSourceService):
         dialect = self.engine.dialect
         dialect.table_prefix = get_table_prefix_from_connection(self.service_connection)
         preserve_identifier_case = getattr(self.service_connection, "preserveIdentifierCase", False)
-        dialect.preserve_identifier_case = preserve_identifier_case
+        dialect.preserve_identifier_case = preserve_identifier_case  # type: ignore
         if preserve_identifier_case:
             dialect.normalize_name = types.MethodType(normalize_name, dialect)
             dialect.denormalize_name = types.MethodType(denormalize_name, dialect)

--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -98,6 +98,32 @@ WHERE u.oracle_maintained = 'N'
 )
 
 
+# Fallback for the bulk view-definition fetch. DBA_VIEWS.TEXT / DBA_MVIEWS.QUERY
+# are LONG columns, and in Oracle thick mode a value larger than OCI's fetch
+# buffer aborts the whole array fetch (ORA-01406), leaving every view definition
+# empty. This lists view and materialized-view names only, with no LONG column,
+# so it always succeeds. Each definition is then read one at a time below.
+# https://github.com/open-metadata/OpenMetadata/issues/30319
+ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES = textwrap.dedent(
+    """
+SELECT v.owner AS "owner", v.view_name AS "name", 'VIEW' AS "object_type"
+FROM {prefix}_VIEWS v
+JOIN {prefix}_USERS u
+    ON v.owner = u.username
+WHERE u.oracle_maintained = 'N'
+UNION ALL
+SELECT m.owner AS "owner", m.mview_name AS "name", 'MATERIALIZED_VIEW' AS "object_type"
+FROM {prefix}_MVIEWS m
+JOIN {prefix}_USERS u
+    ON m.owner = u.username
+WHERE u.oracle_maintained = 'N'
+"""
+)
+
+# GET_DDL returns a CLOB, read through a locator rather than an inline LONG
+# buffer, so it is immune to the ORA-01406 truncation the fallback works around.
+ORACLE_GET_VIEW_DEFINITION_BY_NAME = "SELECT DBMS_METADATA.GET_DDL(:object_type, :name, :owner) AS view_ddl FROM dual"
+
 GET_VIEW_NAMES = textwrap.dedent(
     """
 SELECT view_name FROM {prefix}_VIEWS WHERE owner = :owner

--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -120,8 +120,24 @@ WHERE u.oracle_maintained = 'N'
 """
 )
 
-# GET_DDL returns a CLOB, read through a locator rather than an inline LONG
-# buffer, so it is immune to the ORA-01406 truncation the fallback works around.
+# Per-view read of the LONG text. Fetching a single row is not an array fetch,
+# so it does not hit the ORA-01406 truncation, and it needs no privileges beyond
+# the bulk read. This is the same source column SQLAlchemy's Oracle dialect uses.
+ORACLE_GET_VIEW_TEXT_BY_NAME = textwrap.dedent(
+    """
+SELECT text FROM {prefix}_VIEWS WHERE owner = :owner AND view_name = :name
+"""
+)
+
+ORACLE_GET_MVIEW_QUERY_BY_NAME = textwrap.dedent(
+    """
+SELECT query FROM {prefix}_MVIEWS WHERE owner = :owner AND mview_name = :name
+"""
+)
+
+# Last resort when the raw text is NULL or still cannot be read. GET_DDL returns
+# a CLOB (read through a locator, immune to the LONG truncation) but needs
+# SELECT_CATALOG_ROLE for objects in other schemas.
 ORACLE_GET_VIEW_DEFINITION_BY_NAME = "SELECT DBMS_METADATA.GET_DDL(:object_type, :name, :owner) AS view_ddl FROM dual"
 
 GET_VIEW_NAMES = textwrap.dedent(

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -19,6 +19,7 @@ import traceback
 from sqlalchemy import sql, text, util
 from sqlalchemy.dialects.oracle.base import FLOAT, INTEGER, INTERVAL, NUMBER, TIMESTAMP
 from sqlalchemy.engine import reflection
+from sqlalchemy.exc import DatabaseError
 from sqlalchemy.sql import sqltypes
 
 from metadata.ingestion.source.database.oracle.queries import (
@@ -27,8 +28,10 @@ from metadata.ingestion.source.database.oracle.queries import (
     ORACLE_CONSTRAINTS,
     ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES,
     ORACLE_GET_COLUMNS,
+    ORACLE_GET_MVIEW_QUERY_BY_NAME,
     ORACLE_GET_TABLE_NAMES,
     ORACLE_GET_VIEW_DEFINITION_BY_NAME,
+    ORACLE_GET_VIEW_TEXT_BY_NAME,
     ORACLE_IDENTITY_TYPE,
     ORACLE_TABLE_COMMENTS,
     ORACLE_TABLE_COMMENTS_PRESERVE_CASE,
@@ -99,7 +102,7 @@ def get_all_view_definitions(self, connection, query):
     DBA_MVIEWS.QUERY. In Oracle thick mode a view whose definition is larger than
     OCI's LONG fetch buffer raises ORA-01406 while the row is being fetched,
     which aborts the whole array fetch and leaves every view without a
-    definition. If the bulk fetch fails, fall back to reading each definition on
+    definition. On that database error, fall back to reading each definition on
     its own so one oversized or failing view cannot blank out the rest.
     See https://github.com/open-metadata/OpenMetadata/issues/30319
     """
@@ -108,11 +111,8 @@ def get_all_view_definitions(self, connection, query):
     try:
         for view in connection.execute(text(query)):
             _store_bulk_view_definition(self, view)
-    except Exception as exc:
-        logger.warning(
-            f"Bulk Oracle view-definition fetch failed ({exc}). Falling back to "
-            "per-view retrieval via DBMS_METADATA.GET_DDL."
-        )
+    except DatabaseError as exc:
+        logger.warning(f"Bulk Oracle view-definition fetch failed ({exc}). Falling back to per-view retrieval.")
         logger.debug(traceback.format_exc())
         _get_view_definitions_individually(self, connection)
 
@@ -147,22 +147,50 @@ def _get_view_definitions_individually(self, connection) -> None:
     # Match the cache-key casing that get_view_definition uses for lookups:
     # lowercased by default, kept verbatim when preserveIdentifierCase is set.
     normalize = (lambda value: value) if getattr(self, "preserve_identifier_case", False) else str.lower
-    view_names = connection.execute(
-        text(ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES.format(prefix=_get_table_prefix(self)))
-    ).fetchall()
+    prefix = _get_table_prefix(self)
+    view_names = connection.execute(text(ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES.format(prefix=prefix))).fetchall()
     for owner, name, object_type in view_names:
         try:
-            definition = connection.execute(
-                text(ORACLE_GET_VIEW_DEFINITION_BY_NAME),
-                {"object_type": object_type, "name": name, "owner": owner},
-            ).scalar()
-            if definition is not None and hasattr(definition, "read"):
-                definition = definition.read()
-            if definition is not None:
-                self.all_view_definitions[(normalize(name), normalize(owner))] = definition
-        except Exception as exc:
+            definition = _fetch_view_definition_by_name(connection, prefix, owner, name, object_type)
+        except DatabaseError as exc:
             logger.warning(f"Could not fetch view definition for {owner}.{name}: {exc}")
             logger.debug(traceback.format_exc())
+            continue
+        if definition:
+            self.all_view_definitions[(normalize(name), normalize(owner))] = definition
+
+
+def _read_scalar(result):
+    """Return a scalar result, materializing a LOB locator to str if needed."""
+    value = result.scalar()
+    return value.read() if value is not None and hasattr(value, "read") else value
+
+
+def _fetch_view_definition_by_name(connection, prefix, owner, name, object_type):
+    """Fetch one view's definition without the bulk LONG array truncation.
+
+    Reads the raw text/query with a single-row query first. A single-row fetch is
+    not an array fetch, so it does not hit ORA-01406, and it needs no privileges
+    beyond the bulk read (this is the same column SQLAlchemy's Oracle dialect
+    reads). Only when the text is NULL or still cannot be read does it fall back
+    to DBMS_METADATA.GET_DDL, mirroring the bulk query's text-else-GET_DDL logic.
+    """
+    is_mview = object_type == "MATERIALIZED_VIEW"
+    text_query = ORACLE_GET_MVIEW_QUERY_BY_NAME if is_mview else ORACLE_GET_VIEW_TEXT_BY_NAME
+    try:
+        raw_text = _read_scalar(
+            connection.execute(text(text_query.format(prefix=prefix)), {"owner": owner, "name": name})
+        )
+        if raw_text:
+            return f"CREATE OR REPLACE VIEW {name} AS {raw_text}"
+    except DatabaseError:
+        logger.debug(f"Single-row text read failed for {owner}.{name}, using GET_DDL")
+    return _read_scalar(
+        connection.execute(
+            text(ORACLE_GET_VIEW_DEFINITION_BY_NAME),
+            {"object_type": object_type, "name": name, "owner": owner},
+        )
+    )
 
 
 def _get_col_type(self, coltype, precision, scale, length, colname):  # pylint: disable=too-many-branches

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -14,6 +14,7 @@ Utils module to define overrided sqlalchamy methods
 
 # pylint: disable=protected-access,unused-argument
 import re
+import traceback
 
 from sqlalchemy import sql, text, util
 from sqlalchemy.dialects.oracle.base import FLOAT, INTEGER, INTERVAL, NUMBER, TIMESTAMP
@@ -24,18 +25,23 @@ from metadata.ingestion.source.database.oracle.queries import (
     GET_MATERIALIZED_VIEW_NAMES,
     GET_VIEW_NAMES,
     ORACLE_CONSTRAINTS,
+    ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES,
     ORACLE_GET_COLUMNS,
     ORACLE_GET_TABLE_NAMES,
+    ORACLE_GET_VIEW_DEFINITION_BY_NAME,
     ORACLE_IDENTITY_TYPE,
     ORACLE_TABLE_COMMENTS,
     ORACLE_TABLE_COMMENTS_PRESERVE_CASE,
     ORACLE_VIEW_DEFINITIONS,
     ORACLE_VIEW_DEFINITIONS_PRESERVE_CASE,
 )
+from metadata.utils.logger import ingestion_logger
 from metadata.utils.sqlalchemy_utils import (
     get_table_comment_wrapper,
     get_view_definition_wrapper,
 )
+
+logger = ingestion_logger()
 
 
 def get_table_prefix_from_connection(service_connection) -> str:
@@ -87,27 +93,76 @@ def get_view_definition(
 @reflection.cache
 def get_all_view_definitions(self, connection, query):
     """
-    Method to fetch view definition of all available views
+    Method to fetch view definition of all available views.
+
+    The bulk query reads the view text from the LONG columns DBA_VIEWS.TEXT /
+    DBA_MVIEWS.QUERY. In Oracle thick mode a view whose definition is larger than
+    OCI's LONG fetch buffer raises ORA-01406 while the row is being fetched,
+    which aborts the whole array fetch and leaves every view without a
+    definition. If the bulk fetch fails, fall back to reading each definition on
+    its own so one oversized or failing view cannot blank out the rest.
+    See https://github.com/open-metadata/OpenMetadata/issues/30319
     """
     self.all_view_definitions = {}
     self.current_db: str = connection.engine.url.database  # type: ignore
-    result = connection.execute(text(query))
-    for view in result:
-        if hasattr(view, "view_def") and hasattr(view, "schema"):
-            view_definition = view.view_def
-            if not view_definition and hasattr(view, "view_ddl"):
-                view_definition = view.view_ddl
-            else:
-                view_definition = f"CREATE OR REPLACE VIEW {view.view_name} AS {view_definition}"
-            self.all_view_definitions[(view.view_name, view.schema)] = view_definition
+    try:
+        for view in connection.execute(text(query)):
+            _store_bulk_view_definition(self, view)
+    except Exception as exc:
+        logger.warning(
+            f"Bulk Oracle view-definition fetch failed ({exc}). Falling back to "
+            "per-view retrieval via DBMS_METADATA.GET_DDL."
+        )
+        logger.debug(traceback.format_exc())
+        _get_view_definitions_individually(self, connection, query)
 
-        elif hasattr(view, "VIEW_DEF") and hasattr(view, "SCHEMA"):
-            view_definition = view.VIEW_DEF
-            if not view_definition and hasattr(view, "VIEW_DDL"):
-                view_definition = view.VIEW_DDL
-            else:
-                view_definition = f"CREATE OR REPLACE VIEW {view.VIEW_NAME} AS {view_definition}"
-            self.all_view_definitions[(view.VIEW_NAME, view.SCHEMA)] = view_definition
+
+def _store_bulk_view_definition(self, view) -> None:
+    """Store one row of the bulk ORACLE_VIEW_DEFINITIONS result. Thin mode
+    returns lowercase attribute names and thick mode uppercase, so both cases
+    are handled.
+    """
+    if hasattr(view, "view_def") and hasattr(view, "schema"):
+        view_definition = view.view_def
+        if not view_definition and hasattr(view, "view_ddl"):
+            view_definition = view.view_ddl
+        else:
+            view_definition = f"CREATE OR REPLACE VIEW {view.view_name} AS {view_definition}"
+        self.all_view_definitions[(view.view_name, view.schema)] = view_definition
+
+    elif hasattr(view, "VIEW_DEF") and hasattr(view, "SCHEMA"):
+        view_definition = view.VIEW_DEF
+        if not view_definition and hasattr(view, "VIEW_DDL"):
+            view_definition = view.VIEW_DDL
+        else:
+            view_definition = f"CREATE OR REPLACE VIEW {view.VIEW_NAME} AS {view_definition}"
+        self.all_view_definitions[(view.VIEW_NAME, view.SCHEMA)] = view_definition
+
+
+def _get_view_definitions_individually(self, connection, query) -> None:
+    """Populate self.all_view_definitions one view at a time. Each fetch is
+    isolated so a view that truncates or errors is skipped instead of aborting
+    the whole run. Used only as the fallback after the bulk fetch fails.
+    """
+    # Match the cache-key casing of the bulk query: the default query LOWER()s
+    # the names, the preserve-identifier-case variant keeps them verbatim.
+    normalize = str.lower if "LOWER(" in query.upper() else (lambda value: value)
+    view_names = connection.execute(
+        text(ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES.format(prefix=_get_table_prefix(self)))
+    ).fetchall()
+    for owner, name, object_type in view_names:
+        try:
+            definition = connection.execute(
+                text(ORACLE_GET_VIEW_DEFINITION_BY_NAME),
+                {"object_type": object_type, "name": name, "owner": owner},
+            ).scalar()
+            if definition is not None and hasattr(definition, "read"):
+                definition = definition.read()
+            if definition is not None:
+                self.all_view_definitions[(normalize(name), normalize(owner))] = definition
+        except Exception as exc:
+            logger.warning(f"Could not fetch view definition for {owner}.{name}: {exc}")
+            logger.debug(traceback.format_exc())
 
 
 def _get_col_type(self, coltype, precision, scale, length, colname):  # pylint: disable=too-many-branches

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -114,7 +114,7 @@ def get_all_view_definitions(self, connection, query):
             "per-view retrieval via DBMS_METADATA.GET_DDL."
         )
         logger.debug(traceback.format_exc())
-        _get_view_definitions_individually(self, connection, query)
+        _get_view_definitions_individually(self, connection)
 
 
 def _store_bulk_view_definition(self, view) -> None:
@@ -139,14 +139,14 @@ def _store_bulk_view_definition(self, view) -> None:
         self.all_view_definitions[(view.VIEW_NAME, view.SCHEMA)] = view_definition
 
 
-def _get_view_definitions_individually(self, connection, query) -> None:
+def _get_view_definitions_individually(self, connection) -> None:
     """Populate self.all_view_definitions one view at a time. Each fetch is
     isolated so a view that truncates or errors is skipped instead of aborting
     the whole run. Used only as the fallback after the bulk fetch fails.
     """
-    # Match the cache-key casing of the bulk query: the default query LOWER()s
-    # the names, the preserve-identifier-case variant keeps them verbatim.
-    normalize = str.lower if "LOWER(" in query.upper() else (lambda value: value)
+    # Match the cache-key casing that get_view_definition uses for lookups:
+    # lowercased by default, kept verbatim when preserveIdentifierCase is set.
+    normalize = (lambda value: value) if getattr(self, "preserve_identifier_case", False) else str.lower
     view_names = connection.execute(
         text(ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES.format(prefix=_get_table_prefix(self)))
     ).fetchall()

--- a/ingestion/tests/unit/topology/database/test_oracle.py
+++ b/ingestion/tests/unit/topology/database/test_oracle.py
@@ -585,7 +585,7 @@ class TestOracleViewDefinitionFallback:
         assert ("big_view", "sam") not in defs
 
     def test_fallback_keeps_native_case_for_preserve_identifier_case(self):
-        """The preserve-identifier-case query has no LOWER(), so fallback keys stay verbatim."""
+        """With preserveIdentifierCase set on the dialect, fallback keys stay verbatim."""
         from sqlalchemy.dialects.oracle.base import OracleDialect
 
         from metadata.ingestion.source.database.oracle.utils import (
@@ -594,12 +594,10 @@ class TestOracleViewDefinitionFallback:
 
         dialect = OracleDialect()
         dialect.table_prefix = "DBA"
+        dialect.preserve_identifier_case = True
         conn = self._make_connection([("Sam", "MyView", "VIEW")])
-        preserve_case_query = (
-            'SELECT v.view_name AS "view_name", v.owner AS "schema", text AS "view_def" FROM DBA_VIEWS v'
-        )
 
-        get_all_view_definitions(dialect, conn, preserve_case_query)
+        get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
 
         assert dialect.all_view_definitions[("MyView", "Sam")] == "CREATE VIEW MyView AS SELECT 1 FROM dual"
 

--- a/ingestion/tests/unit/topology/database/test_oracle.py
+++ b/ingestion/tests/unit/topology/database/test_oracle.py
@@ -528,24 +528,41 @@ class TestOracleViewDefinitionFallback:
             'SELECT LOWER(v.view_name) AS "view_name", LOWER(v.owner) AS "schema", text AS "view_def" FROM DBA_VIEWS v'
         )
 
-    def _make_connection(self, names_rows, failing_ddl_names=()):
+    def _make_connection(self, names_rows, texts=None, ddls=None, fail_text=(), fail_ddl=()):
+        """Mock connection that routes each fallback query to canned results.
+
+        texts/ddls map a view name to the raw text / GET_DDL string it returns
+        (None simulates a NULL text). fail_text / fail_ddl name the views whose
+        single-row text read or GET_DDL raises. The bulk query always truncates.
+        """
         from unittest.mock import MagicMock
 
         from sqlalchemy.exc import DatabaseError
 
+        texts = texts or {}
+        ddls = ddls or {}
+
+        def scalar_result(value):
+            res = MagicMock()
+            res.scalar.return_value = value
+            return res
+
         def execute(clause, params=None):
             sql = str(clause)
-            if "GET_DDL" in sql:  # per-view fallback fetch
+            if "GET_DDL" in sql:  # last-resort per-view GET_DDL
                 name = params["name"]
-                if name in failing_ddl_names:
+                if name in fail_ddl:
                     raise DatabaseError("get_ddl", None, Exception("ORA-31603"))
-                res = MagicMock()
-                res.scalar.return_value = f"CREATE VIEW {name} AS SELECT 1 FROM dual"
-                return res
+                return scalar_result(ddls.get(name))
             if "object_type" in sql:  # names-only fallback listing
                 res = MagicMock()
                 res.fetchall.return_value = names_rows
                 return res
+            if ":name" in sql:  # single-row raw text/query read
+                name = params["name"]
+                if name in fail_text:
+                    raise DatabaseError("text", None, Exception("ORA-01406"))
+                return scalar_result(texts.get(name))
             # the bulk view-definition query with the LONG column -> truncates
             raise DatabaseError(
                 "bulk",
@@ -558,8 +575,8 @@ class TestOracleViewDefinitionFallback:
         conn.engine.url.database = "test_db"
         return conn
 
-    def test_bulk_truncation_falls_back_to_per_view_ddl(self):
-        """A truncating bulk fetch must recover every other view via per-view GET_DDL."""
+    def test_bulk_truncation_recovers_views_via_per_view_fallback(self):
+        """A truncating bulk fetch recovers each view, and one failing view is isolated."""
         from sqlalchemy.dialects.oracle.base import OracleDialect
 
         from metadata.ingestion.source.database.oracle.utils import (
@@ -570,19 +587,28 @@ class TestOracleViewDefinitionFallback:
         dialect.table_prefix = "DBA"
         names_rows = [
             ("SAM", "GOOD_VIEW", "VIEW"),
-            ("SAM", "BIG_VIEW", "VIEW"),
             ("SAM", "MV1", "MATERIALIZED_VIEW"),
+            ("SAM", "NULL_TEXT", "VIEW"),
+            ("SAM", "BAD_VIEW", "VIEW"),
         ]
-        conn = self._make_connection(names_rows, failing_ddl_names=("BIG_VIEW",))
+        conn = self._make_connection(
+            names_rows,
+            texts={"GOOD_VIEW": "SELECT * FROM t", "MV1": "SELECT count(*) FROM t", "NULL_TEXT": None},
+            ddls={"NULL_TEXT": "CREATE FORCE VIEW SAM.NULL_TEXT AS SELECT 1 FROM dual"},
+            fail_text=("BAD_VIEW",),
+            fail_ddl=("BAD_VIEW",),
+        )
 
         get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
 
         defs = dialect.all_view_definitions
-        # The whole run must NOT be blanked by the one truncating/failing view.
-        assert defs[("good_view", "sam")] == "CREATE VIEW GOOD_VIEW AS SELECT 1 FROM dual"
-        assert defs[("mv1", "sam")] == "CREATE VIEW MV1 AS SELECT 1 FROM dual"
-        # The view whose per-view GET_DDL also failed is skipped, not fatal.
-        assert ("big_view", "sam") not in defs
+        # Raw text is the primary source (no extra privileges needed).
+        assert defs[("good_view", "sam")] == "CREATE OR REPLACE VIEW GOOD_VIEW AS SELECT * FROM t"
+        assert defs[("mv1", "sam")] == "CREATE OR REPLACE VIEW MV1 AS SELECT count(*) FROM t"
+        # NULL text falls back to GET_DDL, mirroring the bulk query.
+        assert defs[("null_text", "sam")] == "CREATE FORCE VIEW SAM.NULL_TEXT AS SELECT 1 FROM dual"
+        # A view that fails both reads is skipped, not fatal to the rest.
+        assert ("bad_view", "sam") not in defs
 
     def test_fallback_keeps_native_case_for_preserve_identifier_case(self):
         """With preserveIdentifierCase set on the dialect, fallback keys stay verbatim."""
@@ -595,11 +621,30 @@ class TestOracleViewDefinitionFallback:
         dialect = OracleDialect()
         dialect.table_prefix = "DBA"
         dialect.preserve_identifier_case = True
-        conn = self._make_connection([("Sam", "MyView", "VIEW")])
+        conn = self._make_connection([("Sam", "MyView", "VIEW")], texts={"MyView": "SELECT 1"})
 
         get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
 
-        assert dialect.all_view_definitions[("MyView", "Sam")] == "CREATE VIEW MyView AS SELECT 1 FROM dual"
+        assert dialect.all_view_definitions[("MyView", "Sam")] == "CREATE OR REPLACE VIEW MyView AS SELECT 1"
+
+    def test_non_database_error_is_not_routed_through_fallback(self):
+        """A non-DatabaseError during the bulk read must propagate, not trigger the fallback."""
+        from unittest.mock import MagicMock
+
+        import pytest
+        from sqlalchemy.dialects.oracle.base import OracleDialect
+
+        from metadata.ingestion.source.database.oracle.utils import (
+            get_all_view_definitions,
+        )
+
+        conn = MagicMock()
+        conn.execute.side_effect = ValueError("bug in row handling")
+        conn.engine.url.database = "db"
+        dialect = OracleDialect()
+
+        with pytest.raises(ValueError):
+            get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
 
     def test_successful_bulk_fetch_does_not_trigger_fallback(self):
         """When the bulk fetch succeeds, definitions come from it and no fallback query runs."""
@@ -625,5 +670,5 @@ class TestOracleViewDefinitionFallback:
         get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
 
         assert dialect.all_view_definitions[("v1", "sam")] == "CREATE OR REPLACE VIEW v1 AS SELECT 1 FROM dual"
-        # Only the bulk query executed: no names listing, no per-view GET_DDL.
+        # Only the bulk query executed: no names listing, no per-view reads.
         assert conn.execute.call_count == 1

--- a/ingestion/tests/unit/topology/database/test_oracle.py
+++ b/ingestion/tests/unit/topology/database/test_oracle.py
@@ -509,3 +509,123 @@ class TestOraclePreserveIdentifierCase:
         assert result[0]["name"] == "IDX_DEPARTMENT"
         assert result[0]["column_names"] == ["DeptName"]
         assert result[0]["unique"] is False
+
+
+class TestOracleViewDefinitionFallback:
+    """Issue #30319: in Oracle thick mode (OCI), a view whose LONG definition
+    (DBA_VIEWS.TEXT / DBA_MVIEWS.QUERY) exceeds OCI's bounded fetch buffer raises
+    ORA-01406 / DPI-1037 during the bulk array fetch. That aborts the whole bulk
+    query, so every view's definition ends up empty. The bulk fetch must fall
+    back to per-view retrieval so one oversized/failing view cannot blank the
+    rest.
+    """
+
+    @staticmethod
+    def _bulk_query_lowercase():
+        # Mirrors ORACLE_VIEW_DEFINITIONS: the LOWER() calls mean the cache keys
+        # are lowercased.
+        return (
+            'SELECT LOWER(v.view_name) AS "view_name", LOWER(v.owner) AS "schema", text AS "view_def" FROM DBA_VIEWS v'
+        )
+
+    def _make_connection(self, names_rows, failing_ddl_names=()):
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.exc import DatabaseError
+
+        def execute(clause, params=None):
+            sql = str(clause)
+            if "GET_DDL" in sql:  # per-view fallback fetch
+                name = params["name"]
+                if name in failing_ddl_names:
+                    raise DatabaseError("get_ddl", None, Exception("ORA-31603"))
+                res = MagicMock()
+                res.scalar.return_value = f"CREATE VIEW {name} AS SELECT 1 FROM dual"
+                return res
+            if "object_type" in sql:  # names-only fallback listing
+                res = MagicMock()
+                res.fetchall.return_value = names_rows
+                return res
+            # the bulk view-definition query with the LONG column -> truncates
+            raise DatabaseError(
+                "bulk",
+                None,
+                Exception("DPI-1037: column at array position 13 fetched with error 1406"),
+            )
+
+        conn = MagicMock()
+        conn.execute.side_effect = execute
+        conn.engine.url.database = "test_db"
+        return conn
+
+    def test_bulk_truncation_falls_back_to_per_view_ddl(self):
+        """A truncating bulk fetch must recover every other view via per-view GET_DDL."""
+        from sqlalchemy.dialects.oracle.base import OracleDialect
+
+        from metadata.ingestion.source.database.oracle.utils import (
+            get_all_view_definitions,
+        )
+
+        dialect = OracleDialect()
+        dialect.table_prefix = "DBA"
+        names_rows = [
+            ("SAM", "GOOD_VIEW", "VIEW"),
+            ("SAM", "BIG_VIEW", "VIEW"),
+            ("SAM", "MV1", "MATERIALIZED_VIEW"),
+        ]
+        conn = self._make_connection(names_rows, failing_ddl_names=("BIG_VIEW",))
+
+        get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
+
+        defs = dialect.all_view_definitions
+        # The whole run must NOT be blanked by the one truncating/failing view.
+        assert defs[("good_view", "sam")] == "CREATE VIEW GOOD_VIEW AS SELECT 1 FROM dual"
+        assert defs[("mv1", "sam")] == "CREATE VIEW MV1 AS SELECT 1 FROM dual"
+        # The view whose per-view GET_DDL also failed is skipped, not fatal.
+        assert ("big_view", "sam") not in defs
+
+    def test_fallback_keeps_native_case_for_preserve_identifier_case(self):
+        """The preserve-identifier-case query has no LOWER(), so fallback keys stay verbatim."""
+        from sqlalchemy.dialects.oracle.base import OracleDialect
+
+        from metadata.ingestion.source.database.oracle.utils import (
+            get_all_view_definitions,
+        )
+
+        dialect = OracleDialect()
+        dialect.table_prefix = "DBA"
+        conn = self._make_connection([("Sam", "MyView", "VIEW")])
+        preserve_case_query = (
+            'SELECT v.view_name AS "view_name", v.owner AS "schema", text AS "view_def" FROM DBA_VIEWS v'
+        )
+
+        get_all_view_definitions(dialect, conn, preserve_case_query)
+
+        assert dialect.all_view_definitions[("MyView", "Sam")] == "CREATE VIEW MyView AS SELECT 1 FROM dual"
+
+    def test_successful_bulk_fetch_does_not_trigger_fallback(self):
+        """When the bulk fetch succeeds, definitions come from it and no fallback query runs."""
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.dialects.oracle.base import OracleDialect
+
+        from metadata.ingestion.source.database.oracle.utils import (
+            get_all_view_definitions,
+        )
+
+        class Row:
+            view_name = "v1"
+            schema = "sam"
+            view_def = "SELECT 1 FROM dual"
+            view_ddl = None
+
+        conn = MagicMock()
+        conn.execute.return_value = [Row()]
+        conn.engine.url.database = "db"
+        dialect = OracleDialect()
+
+        get_all_view_definitions(dialect, conn, self._bulk_query_lowercase())
+
+        assert dialect.all_view_definitions[("v1", "sam")] == "CREATE OR REPLACE VIEW v1 AS SELECT 1 FROM dual"
+        # Only the bulk query executed: no names listing, no per-view GET_DDL.
+        assert conn.execute.call_count == 1


### PR DESCRIPTION
### Describe your changes:

Fixes #30319

Oracle view definitions are fetched in bulk by `get_all_view_definitions` (oracle/utils.py), which selects each view's text from the Oracle LONG columns `DBA_VIEWS.TEXT` and `DBA_MVIEWS.QUERY`. In thick mode (Instant Client / OCI) a LONG value is fetched into a bounded buffer, so a view whose definition exceeds that buffer raises `ORA-01406`, surfaced by python-oracledb as `DPI-1037: column at array position N fetched with error 1406`, while the row is being fetched. That error aborts the whole array fetch. Because it was swallowed in `common_db_source.get_schema_definition` and the empty or partial cache was kept, most or all view definitions were ingested empty. The impact is position-based rather than size-based: every view fetched after the first oversized one loses its definition regardless of its own complexity, so a simple view can end up blank while a more complex one is populated, and the ingestion still reports success.

On a `DatabaseError` from the bulk fetch I fall back to `_get_view_definitions_individually`, which lists view and materialized-view names with a LONG-free query and then reads each definition one at a time. The per-view read uses a single-row query against the same `text` / `query` column. A single-row fetch is not an array fetch, so it does not hit the ORA-01406 truncation, and it needs no privileges beyond the bulk read (it is the same column SQLAlchemy's own Oracle dialect reads). Only when the text is NULL or still cannot be read does it fall back to `DBMS_METADATA.GET_DDL` (a CLOB), which mirrors the bulk query's text-else-GET_DDL logic. Each per-view read is isolated, so one oversized or failing view is skipped instead of blanking the run. Only `DatabaseError` triggers the fallback path, so unrelated programming errors surface instead of being masked. The fast bulk path and its output are unchanged for the common case. Scope is the Oracle connector only.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

This is not specific to any single release. Both the pre-#25189 query (plain `text AS view_def`) and the current #25189 query (which added a `DBMS_METADATA.GET_DDL` branch only for the case where the LONG is NULL) select the LONG as the primary value, so both truncate identically. #25189 did not fix this because its GET_DDL branch only fired when the text was NULL, whereas here the text is present but oversized. The fix therefore targets the retrieval path, not the query shape, and applies to current `main`.

Changes:
- `oracle/utils.py`:
  - `get_all_view_definitions` wraps the bulk fetch in `try/except DatabaseError` and delegates row storage to `_store_bulk_view_definition` (behavior unchanged from before). On the database error it calls `_get_view_definitions_individually`.
  - `_get_view_definitions_individually` fetches view and mview names (no LONG column), then reads each definition via `_fetch_view_definition_by_name` inside a per-view `try/except DatabaseError`.
  - `_fetch_view_definition_by_name` reads the raw `text` / `query` with a single-row query first (no array fetch, no extra privileges), and only falls back to `DBMS_METADATA.GET_DDL` when the text is NULL or the single-row read fails.
  - Cache-key casing is derived from an explicit `dialect.preserve_identifier_case` flag (set in `metadata.py`), not by inspecting the query string.
- `oracle/metadata.py`: sets `dialect.preserve_identifier_case`.
- `oracle/queries.py`: `ORACLE_GET_ALL_VIEW_AND_MVIEW_NAMES` (names only), `ORACLE_GET_VIEW_TEXT_BY_NAME` / `ORACLE_GET_MVIEW_QUERY_BY_NAME` (single-row raw text), and `ORACLE_GET_VIEW_DEFINITION_BY_NAME` (per-view GET_DDL last resort).

Design notes: the per-view read mirrors SQLAlchemy's own Oracle dialect (single-row `text`) and the bulk query's text-else-GET_DDL logic, so it stays consistent and needs no privileges the bulk read did not already need. GET_DDL as the primary was rejected because it needs `SELECT_CATALOG_ROLE` for cross-owner objects and would reformat every definition. Dropping the bulk query entirely was rejected because it issues one query per view on every run. The fallback only runs after the bulk fetch fails. Blast radius is the Oracle connector's view-definition path only.

#
### Tests:

#### Use cases covered
- An Oracle thick-mode ingestion where one view's definition exceeds OCI's LONG array-fetch buffer no longer loses every other view's definition. The oversized view and all others are recovered via the per-view single-row read.
- A view whose text is NULL falls back to GET_DDL, mirroring the bulk query.
- A view that fails both the single-row read and GET_DDL is skipped without aborting the rest.
- A non-DatabaseError during the bulk read propagates instead of being masked by the fallback.
- `preserveIdentifierCase` keeps native-case cache keys in the fallback.

#### Unit tests
- [x] Added `TestOracleViewDefinitionFallback` in `ingestion/tests/unit/topology/database/test_oracle.py`: recovers-via-per-view-fallback (raw text, mview, NULL-text to GET_DDL, and failure isolation), non-DatabaseError-propagation, preserve-identifier-case keys, and fast-path-does-not-fall-back.
- Full `tests/unit/topology/database/test_oracle.py` passes (18 tests). ruff format and check clean.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable as automated CI (needs a live Oracle server in thick mode with an oversized view). Verified manually against a containerized Oracle instead (see below).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Reproduced against `gvenzl/oracle-free:23-slim-faststart` in thick mode via Oracle Instant Client. A modern 23ai server fetches LONG dynamically and does not truncate even at 32MB, so the bounded-buffer behavior that certain OCI client/server combinations exhibit was recreated deterministically with a python-oracledb output type handler that fetches the LONG into a bounded buffer:
The buffer is bounded only for array fetches (arraysize > 1), matching the reported "array position" error, so single-row reads stream the LONG normally.
1. With the current bulk query, the array fetch aborts with the exact `DPI-1037: column at array position N fetched with error 1406` and 0 definitions are collected, matching the issue.
2. With the fix's control flow, all 16 view definitions are recovered, including the 156K oversized view, all via the single-row raw text read (0 required GET_DDL, so no extra privileges).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #30319` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable (no schema changes).
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds targeted recovery for Oracle LONG-column failures:
- Falls back from bulk view-definition retrieval to isolated per-view reads.
- Uses raw view text before resorting to `DBMS_METADATA.GET_DDL`.
- Preserves configured identifier casing in fallback cache keys.
- Adds unit coverage for fallback recovery, failure isolation, casing, and the successful bulk path.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until unrelated Oracle database errors are prevented from activating the truncation fallback and producing incomplete definitions.

The bulk path still routes every SQLAlchemy DatabaseError through recovery without validating ORA-01406 or DPI-1037; privilege, connectivity, and other database failures can therefore be swallowed while downstream cache lookups return empty definitions and ingestion continues.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/oracle/utils.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/oracle/utils.py | Adds bulk-fetch recovery, per-view definition retrieval, LOB materialization, cache-key normalization, and isolated fallback handling. |
| ingestion/src/metadata/ingestion/source/database/oracle/queries.py | Adds names-only, single-view LONG, and last-resort GET_DDL query templates. |
| ingestion/src/metadata/ingestion/source/database/oracle/metadata.py | Stores the preserve-identifier-case setting on the Oracle dialect for fallback cache normalization. |
| ingestion/tests/unit/topology/database/test_oracle.py | Adds focused tests for truncation recovery, per-view isolation, casing behavior, exception propagation, and fast-path retention. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Bulk view-definition query] --> B{Fetch succeeds?}
  B -->|Yes| C[Populate definition cache]
  B -->|DatabaseError| D[List view and materialized-view names]
  D --> E[Read each LONG value individually]
  E --> F{Raw text available?}
  F -->|Yes| G[Store normalized definition]
  F -->|No or read fails| H[Try DBMS_METADATA.GET_DDL]
  H --> I{DDL succeeds?}
  I -->|Yes| G
  I -->|No| J[Skip that view]
  G --> K[Continue with next view]
  J --> K
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Suppress basedpyright error for dynamic ..."](https://github.com/open-metadata/openmetadata/commit/0e3d58fe3c55d25da2ad20ba2fafbfe691a7a71f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48851458)</sub>

<!-- /greptile_comment -->