### PR TITLE
fix(security): bump libthrift to 0.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,12 +232,13 @@
         <artifactId>angus-mail</artifactId>
         <version>${angus-mail.version}</version>
       </dependency>
-      <!-- CVE-2026-43869: pin to 0.23.0. No Jena release ships the fix yet (6.0.0 still uses 0.22.0).
-           Excluding libthrift breaks RDF tests — Jena's ModelFactory statically references TException. -->
+      <!-- CVE-2026-43869 / CVE-2026-45112 / CVE-2026-48586: pin to 0.24.0. Jena (jena-arq) still ships
+           an older libthrift, so we override transitively. Excluding libthrift breaks RDF tests —
+           Jena's ModelFactory statically references TException, which is unchanged in 0.24.0. -->
       <dependency>
         <groupId>org.apache.thrift</groupId>
         <artifactId>libthrift</artifactId>
-        <version>0.23.0</version>
+        <version>0.24.0</version>
       </dependency>
       <dependency>
         <groupId>org.antlr</groupId>


### PR DESCRIPTION
## Advisory

Snyk `server-dep-scan` flags two high-severity advisories against `org.apache.thrift:libthrift@0.23.0`:

| CVE | Snyk ID | Title | Fixed in |
|---|---|---|---|
| CVE-2026-45112 | SNYK-JAVA-ORGAPACHETHRIFT-18389002 | Allocation of Resources Without Limits or Throttling | 0.24.0 |
| CVE-2026-48586 | SNYK-JAVA-ORGAPACHETHRIFT-18389256 | Improper Handling of Highly Compressed Data (Data Amplification) | 0.24.0 |

Raw scanner path (all consumers route through Jena):
```
openmetadata-service > org.apache.jena:jena-arq@5.6.0 > org.apache.thrift:libthrift@0.23.0
```

## Change

Root `pom.xml` `dependencyManagement` override raised `0.23.0` → `0.24.0` (one minor). This is the same transitive-override pattern already in place for CVE-2026-43869 — libthrift is not a direct dependency; it is forced ahead of the version Jena declares.

**Manifests touched:** `pom.xml` (root) — single managed-version line.

## Verified

- libthrift `0.24.0` exists on Maven Central (`maven-metadata.xml`).
- Reported version `0.23.0` is genuinely below the fix `0.24.0` (coherent advisory, unlike some scanner emissions).
- Only one `libthrift` declaration exists across all poms; the override reaches every transitive consumer.
- `TException` — the sole Jena-referenced symbol called out in the pom comment — is a foundational, stable class present in `0.24.0`.

## NOT tested

- **Did not run the RDF / Jena `ModelFactory` integration tests.** The pom comment warns these break if libthrift is excluded; they were not executed here (no full Maven build in this environment). A maintainer should run the RDF test suite before merge — this is why the PR is a **draft**.
- No local `mvn` build/compile was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)