### PR TITLE
fix(ui): infer multiple selection from field type

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/render-field-element.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/render-field-element.tsx
@@ -49,10 +49,20 @@ const AUTOCOMPLETE_FIELD_TYPES = new Set<FieldTypes>([
   FieldTypes.DOMAIN_SELECT,
 ]);
 
+const MULTIPLE_SELECTION_FIELD_TYPES = new Set<FieldTypes>([
+  FieldTypes.MULTI_SELECT,
+  FieldTypes.USER_MULTI_SELECT,
+]);
+
 const isMultipleSelection = (
+  type: FieldTypes,
   value: string | string[],
   props: FieldPropsMap
 ) => {
+  if (MULTIPLE_SELECTION_FIELD_TYPES.has(type)) {
+    return true;
+  }
+
   if (typeof props.multiple === 'boolean') {
     return props.multiple;
   }
@@ -119,7 +129,7 @@ export const renderFieldElement = (
   const selectItems = getItems(props);
 
   if (AUTOCOMPLETE_FIELD_TYPES.has(type)) {
-    const multiple = isMultipleSelection(field.value, props);
+    const multiple = isMultipleSelection(type, field.value, props);
     const selectedAutocompleteItems = getSelectedItems(field.value);
 
     const handleInsert = (key: Key) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx
@@ -834,7 +834,6 @@ const TestCaseFormBody: FC<TestCaseFormBodyProps> = ({
     props: {
       'data-testid': 'dimensionColumns',
       isDisabled: !selectedTableFqn,
-      multiple: true,
       options: dimensionColumnOptions,
     },
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.test.tsx
@@ -163,6 +163,29 @@ describe('TestDefinitionFormBody', () => {
     expect(screen.getByText('Something went wrong')).toBeInTheDocument();
   });
 
+  it('allows selecting multiple supported data types without an initial value', async () => {
+    render(<Harness />);
+
+    const input = document.querySelector('input[id="root/supportedDataTypes"]');
+
+    expect(input).toBeInTheDocument();
+
+    fireEvent.mouseDown(input!);
+    fireEvent.focus(input!);
+    fireEvent.change(input!, { target: { value: 'NUMBER' } });
+    fireEvent.click(await screen.findByRole('option', { name: 'NUMBER' }));
+
+    fireEvent.change(input!, { target: { value: 'VARCHAR' } });
+    fireEvent.click(await screen.findByRole('option', { name: 'VARCHAR' }));
+
+    await waitFor(() => {
+      expect(formRef?.getValues('supportedDataTypes')).toEqual([
+        { id: 'NUMBER', label: 'NUMBER' },
+        { id: 'VARCHAR', label: 'VARCHAR' },
+      ]);
+    });
+  });
+
   describe('supportedDataTypes conditional required', () => {
     it('flags supportedDataTypes required when testPlatforms includes OpenMetadata and it is empty', async () => {
       render(<Harness />);


### PR DESCRIPTION
### Describe your changes:

Fixes #30747

Related: open-metadata/openmetadata-collate#5404
Regression source: open-metadata/OpenMetadata#26951

The shared form renderer inferred autocomplete multiplicity only from the optional `multiple` prop or the current value shape. A new `MULTI_SELECT` field starts without a value, so it was incorrectly rendered as single-select unless each caller supplied `multiple: true`.

This change makes `MULTI_SELECT` and `USER_MULTI_SELECT` authoritative multi-select field types. Callers no longer need a redundant prop, and the Test Definition form regression test verifies that two supported data types can be selected from an initially empty field.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small shared form-renderer correction.

#
### Tests:

#### Use cases covered

- A new Test Definition can select `NUMBER` and then `VARCHAR` without losing the first value.
- Multi-select behavior comes from `FieldTypes.MULTI_SELECT` rather than caller-specific props.

#### Unit tests

- [x] Added regression coverage in `TestDefinitionFormBody.test.tsx`.
- `TestDefinitionFormBody.test.tsx`: 12/12 tests passed.
- Focused coverage execution completed, but the linked core-components package was excluded from Jest instrumentation, so no percentage is claimed.

#### Backend integration tests

- [x] Not applicable — no backend API changes.

#### Ingestion integration tests

- [x] Not applicable — no ingestion changes.

#### Playwright (UI) tests

- Covered by the related Collate E2E update in open-metadata/openmetadata-collate#5404.

#### Manual testing performed

- Not performed. The regression test drives the real form interaction and verifies both selected values in form state.

#
### UI screen recording / screenshots:

Not applicable — behavior-only fix with no visual layout or styling change.

#
### Checklist:

- [x] I have read the contributing guidelines.
- [x] No schema or migration changes are required.
- [x] Added a test covering the exact regression scenario.
- [x] ESLint and Prettier pass for all changed UI files.
- [x] Shared core-components TypeScript check passes.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects shared autocomplete multiplicity inference and removes a now-redundant caller override.
- Treats `MULTI_SELECT` and `USER_MULTI_SELECT` field types as inherently multi-select.
- Removes the explicit `multiple` property from the dimension-columns field.
- Adds regression coverage for selecting multiple supported data types from an initially empty field.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/form-field/render-field-element.tsx | Makes multi-select field types authoritative when determining autocomplete selection behavior. |
| openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TestCaseFormBody.tsx | Removes a redundant multiplicity property from the dimension-columns field. |
| openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionForm/TestDefinitionFormBody.test.tsx | Verifies that two supported data types remain selected when the field starts without a value. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into ui/fix-form-mul..."](https://github.com/open-metadata/openmetadata/commit/80b4a1e6c5031a1b61d6f13bc5b1e74c1424d63d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48962732)</sub>

<!-- /greptile_comment -->