### PR TITLE
Fixes 30744: mark MCP create_lineage as destructive

### DIFF
--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -702,7 +702,7 @@
       "title": "Create Lineage",
       "annotations": {
         "readOnlyHint": false,
-        "destructiveHint": false,
+        "destructiveHint": true,
         "openWorldHint": false
       },
       "description": "This tool can be used to create lineage between two assets. It takes the source and target asset details and creates a lineage relationship between them.",


### PR DESCRIPTION
### Describe your changes:

Fixes #30744

`create_lineage` had `readOnlyHint: false` and `destructiveHint: false`, so it carried neither applicable annotation hint. It writes to the catalog, so it is now `destructiveHint: true`, matching every other `create_*` tool in `tools.json`.

Why it matters: Anthropic's Connectors Directory review requires every tool to have a `title` plus the applicable `readOnlyHint` or `destructiveHint` — a missing hint is a rejection reason. In MCP clients the hint also drives whether a call needs per-call confirmation.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — one-line JSON change.

#
### Tests:

#### Use cases covered
- MCP clients now prompt for confirmation before `create_lineage` runs, consistent with the other write tools.

#### Unit tests
Not applicable — data-file annotation change, no logic touched. No existing test asserts on `create_lineage` annotations.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Validated `tools.json` parses and that all 24 tools now carry a `title` plus an applicable hint — zero gaps remaining.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the `create_lineage` MCP tool annotation so clients can treat its lineage-edge upsert as a destructive operation requiring confirmation.
- Changes `destructiveHint` from `false` to `true`.
- Aligns `create_lineage` with the other state-changing `create_*` tools.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The updated hint accurately reflects the lineage tool's state-changing upsert behavior and does not violate existing loading or annotation contracts.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-mcp/src/main/resources/json/data/mcp/tools.json | Correctly marks the lineage-creation tool as destructive because creating an existing edge can overwrite its stored relationship details. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mcp): mark create\_lineage as destruc..."](https://github.com/open-metadata/openmetadata/commit/b8c3f55ad80a153f413b0e65bc7b2304a9430f32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48970024)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata MCP Server](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-mcp.md)

<!-- /greptile_comment -->