### PR TITLE
Fixed bulk import spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -28,7 +28,10 @@ import {
   redirectToHomePage,
   toastNotification,
 } from '../../utils/common';
-import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import {
+  mockClipboardApi,
+  waitForAllLoadersToDisappear,
+} from '../../utils/entity';
 import {
   createColumnRowDetails,
   createCustomPropertiesForEntity,
@@ -1050,328 +1053,309 @@ test.describe('Bulk Import Export', () => {
     // 5 minutes to avoid test timeout happening some times in AUTs, since it add all the entities layer
     test.setTimeout(300_000);
 
+    // Grid's copy/paste relies on navigator.clipboard directly, which is
+    // unreliable in AUT/headless CI even with clipboard permissions granted.
+    await mockClipboardApi(page);
+
     const dbEntity = new DatabaseClass();
 
     const { apiContext, afterAction } = await getApiContext(page);
     await dbEntity.create(apiContext);
 
-    await test.step('should export data database details', async () => {
-      await dbEntity.visitEntityPage(page);
-      await performBulkDownload(page, dbEntity.entity.name);
-    });
-
-    await test.step('should import and test range selection', async () => {
-      await dbEntity.visitEntityPage(page);
-      await page.getByTestId('manage-button').click();
-      await page
-        .getByTestId('manage-dropdown-list-container')
-        .waitFor({ state: 'visible' });
-      await page.click('[data-testid="import-button-title"]');
-      await page
-        .locator('[type="file"]')
-        .setInputFiles(['downloads/' + dbEntity.entity.name + '.csv']);
-      await page
-        .getByText('Import is in progress.')
-        .waitFor({ state: 'detached', timeout: 90000 });
-      await page
-        .locator('.rdg-header-row')
-        .first()
-        .waitFor({ state: 'visible', timeout: 90000 });
-
-      // Adding some assertion to make sure that CSV loaded correctly
-      await expect(page.locator('.rdg-header-row')).toBeVisible();
-
-      // Context: virtual grid — 8 data rows (1 schema + 1 table + 6 columns from DatabaseClass).
-      // visibleColCount is computed from the DOM since react-data-grid column-virtualizes.
-      const rowCount = 8;
-      await expect(page.locator('.rdg-row')).toHaveCount(rowCount);
-      const totalCellCount = await page.locator('.rdg-cell').count();
-      const visibleColCount = totalCellCount / (rowCount + 1); // +1 for the header row
-
-      await test.step('Ctrl+a should select all cells in the grid and deselect all cells by clicking on second cell of .rdg-row', async () => {
-        await page.keyboard.press('Control+A');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          rowCount * visibleColCount
-        );
-
-        // Deselect all the cells by clicking on second cell of .rdg-row
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').nth(0);
-        const secondCell = firstRow.locator('.rdg-cell').nth(1);
-        await secondCell.click();
-
-        await expect(firstCell).not.toBeFocused();
-        await expect(secondCell).toBeFocused();
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(0);
+    try {
+      await test.step('should export data database details', async () => {
+        await dbEntity.visitEntityPage(page);
+        await performBulkDownload(page, dbEntity.entity.name);
       });
 
-      await test.step('should select all the cells in the column by clicking on column header', async () => {
-        const firstHeaderCell = page
+      await test.step('should import and test range selection', async () => {
+        await dbEntity.visitEntityPage(page);
+        await page.getByTestId('manage-button').click();
+        await page
+          .getByTestId('manage-dropdown-list-container')
+          .waitFor({ state: 'visible' });
+        await page.click('[data-testid="import-button-title"]');
+        await page
+          .locator('[type="file"]')
+          .setInputFiles(['downloads/' + dbEntity.entity.name + '.csv']);
+        await page
+          .getByText('Import is in progress.')
+          .waitFor({ state: 'detached', timeout: 90000 });
+        await page
           .locator('.rdg-header-row')
           .first()
-          .locator('.rdg-cell')
-          .first();
+          .waitFor({ state: 'visible', timeout: 90000 });
 
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').nth(1);
+        // Adding some assertion to make sure that CSV loaded correctly
+        await expect(page.locator('.rdg-header-row')).toBeVisible();
 
-        await firstHeaderCell.click();
+        // Context: virtual grid — 8 data rows (1 schema + 1 table + 6 columns from DatabaseClass).
+        // visibleColCount is computed from the DOM since react-data-grid column-virtualizes.
+        const rowCount = 8;
+        await expect(page.locator('.rdg-row')).toHaveCount(rowCount);
+        const totalCellCount = await page.locator('.rdg-cell').count();
+        const visibleColCount = totalCellCount / (rowCount + 1); // +1 for the header row
 
-        await expect(firstCell).not.toBeFocused();
+        await test.step('Ctrl+a should select all cells in the grid and deselect all cells by clicking on second cell of .rdg-row', async () => {
+          await page.keyboard.press('Control+A');
 
-        await expect(firstHeaderCell).toBeFocused();
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
+            rowCount * visibleColCount
+          );
 
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(rowCount);
-      });
+          // Deselect all the cells by clicking on second cell of .rdg-row
+          const firstRow = page.locator('.rdg-row').first();
+          const firstCell = firstRow.locator('.rdg-cell').nth(0);
+          const secondCell = firstRow.locator('.rdg-cell').nth(1);
+          await secondCell.click();
 
-      await test.step('allow multiple column selection', async () => {
-        const headerRow = page.locator('.rdg-header-row');
-        // Mouse down on first header cell then move to 3rd header cell then mouse up
-        const startHeaderCell = headerRow.locator('.rdg-cell').nth(1);
-        const endHeaderCell = headerRow.locator('.rdg-cell').nth(3);
+          await expect(firstCell).not.toBeFocused();
+          await expect(secondCell).toBeFocused();
 
-        const startBox = await startHeaderCell.boundingBox();
-        const endBox = await endHeaderCell.boundingBox();
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(0);
+        });
 
-        if (!startBox || !endBox) {
-          throw new Error('Failed to get bounding boxes');
-        }
-
-        const startX = startBox.x + startBox.width / 2;
-        const startY = startBox.y + startBox.height / 2;
-        const endX = endBox.x + endBox.width / 2;
-        const endY = endBox.y + endBox.height / 2;
-
-        const mouse = page.mouse;
-
-        // Simulate drag from col 2 to col 4
-        await mouse.move(startX, startY);
-        await mouse.down();
-
-        await expect(startHeaderCell).toBeFocused();
-
-        await mouse.move(endX, endY, { steps: 10 }); // Smooth drag
-        await mouse.up();
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          rowCount * 3
-        );
-      });
-
-      await test.step('allow multiple column selection using keyboard', async () => {
-        // click first cell of first row
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').first();
-        await firstCell.click();
-
-        // Press arrow up to go to header row
-        await page.keyboard.press('ArrowUp');
-        // press arrow right 3 times
-        await page.keyboard.press('Shift+ArrowRight');
-        await page.keyboard.press('Shift+ArrowRight');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          rowCount * 3
-        );
-      });
-
-      await test.step('allow multiple cell selection using mouse on rightDown and leftUp and extend selection using shift+click', async () => {
-        // click first cell of first row
-        const firstRow = page.locator('.rdg-row').first();
-        const fourthRow = page.locator('.rdg-row').nth(3);
-        const sixthRow = page.locator('.rdg-row').nth(5);
-
-        const firstCellFirstRow = firstRow.locator('.rdg-cell').first();
-        const secondCellFourthRow = fourthRow.locator('.rdg-cell').nth(1);
-        const fifthCellSixthRow = sixthRow.locator('.rdg-cell').nth(4);
-
-        await secondCellFourthRow.click();
-
-        await expect(secondCellFourthRow).toBeFocused();
-
-        const startBox = await secondCellFourthRow.boundingBox();
-        const endBoxRightBottom = await fifthCellSixthRow.boundingBox();
-        const endBoxLeftUp = await firstCellFirstRow.boundingBox();
-
-        if (!startBox || !endBoxRightBottom || !endBoxLeftUp) {
-          throw new Error('Failed to get bounding boxes');
-        }
-
-        const startX = startBox.x + startBox.width / 2;
-        const startY = startBox.y + startBox.height / 2;
-        const endXRightBottom =
-          endBoxRightBottom.x + endBoxRightBottom.width / 2;
-        const endYRightBottom =
-          endBoxRightBottom.y + endBoxRightBottom.height / 2;
-        const endXLeftUp = endBoxLeftUp.x + endBoxLeftUp.width / 2;
-        const endYLeftUp = endBoxLeftUp.y + endBoxLeftUp.height / 2;
-
-        const mouse = page.mouse;
-
-        // Simulate drag from col 2 to col 4
-        await mouse.move(startX, startY);
-        await mouse.down();
-
-        await mouse.move(endXRightBottom, endYRightBottom, { steps: 10 }); // Smooth drag
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          12
-        );
-
-        await mouse.move(endXLeftUp, endYLeftUp, { steps: 10 }); // Smooth drag
-        await mouse.up();
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(8);
-
-        // Hold shift and click on fifthCellSixthRow
-        await page.keyboard.down('Shift');
-        await fifthCellSixthRow.click();
-        await page.keyboard.up('Shift');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          12
-        );
-
-        // Hold shift and click on firstCellFirstRow
-        await page.keyboard.down('Shift');
-        await firstCellFirstRow.click();
-        await page.keyboard.up('Shift');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(8);
-      });
-
-      await test.step('allow multiple cell selection using keyboard on rightDown and leftUp', async () => {
-        // click first cell of first row
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').first();
-        await firstCell.click();
-
-        // navigate to 4th row, second cell
-        await page.keyboard.press('ArrowRight');
-        await page.keyboard.press('ArrowDown');
-        await page.keyboard.press('ArrowDown');
-        await page.keyboard.press('ArrowDown');
-
-        await page.keyboard.press('Shift+ArrowDown');
-        await page.keyboard.press('Shift+ArrowDown');
-        await page.keyboard.press('Shift+ArrowRight');
-        await page.keyboard.press('Shift+ArrowRight');
-        await page.keyboard.press('Shift+ArrowRight');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
-          12
-        );
-
-        // Select left up cells
-        await page.keyboard.press('Shift+ArrowUp');
-        await page.keyboard.press('Shift+ArrowUp');
-        await page.keyboard.press('Shift+ArrowUp');
-        await page.keyboard.press('Shift+ArrowUp');
-        await page.keyboard.press('Shift+ArrowUp');
-        await page.keyboard.press('Shift+ArrowLeft');
-        await page.keyboard.press('Shift+ArrowLeft');
-
-        await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(8);
-      });
-
-      await test.step('perform single cell copy-paste and undo-redo', async () => {
-        // click first cell of first row
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').first();
-        const secondCell = firstRow.locator('.rdg-cell').nth(1);
-        await firstCell.click();
-
-        // copy the cell
-        await page.keyboard.press('Control+C');
-
-        // move to next right cell
-        await page.keyboard.press('ArrowRight');
-
-        // paste the cell
-        await page.keyboard.press('Control+V');
-
-        // second cell should have text equal to first cell text
-        await expect(secondCell).toHaveText(
-          (await firstCell.textContent()) || ''
-        );
-
-        // undo the action
-        await page.keyboard.press('Control+Z');
-
-        await expect(secondCell).toHaveText('');
-
-        // redo the action
-        await page.keyboard.press('Control+Y');
-
-        // second cell should have text equal to first cell text
-        await expect(secondCell).toHaveText(
-          (await firstCell.textContent()) || ''
-        );
-      });
-
-      await test.step('Select range, copy-paste and undo-redo', async () => {
-        // click on first cell to focus
-        const firstRow = page.locator('.rdg-row').first();
-        const firstCell = firstRow.locator('.rdg-cell').first();
-        await firstCell.click();
-
-        // navigate to header row
-        await page.keyboard.press('ArrowUp');
-        await page.keyboard.down('Shift');
-        await page.keyboard.press('ArrowRight');
-        await page.keyboard.press('ArrowRight');
-        await page.keyboard.up('Shift');
-
-        // copy the range
-        await page.keyboard.press('Control+C');
-
-        // click on fourth cell of first row
-        const fourthCellFirstRow = firstRow.locator('.rdg-cell').nth(3);
-        await fourthCellFirstRow.click();
-
-        // paste the range
-        await page.keyboard.press('Control+V');
-
-        // check if the range is pasted correctly
-        await expect(fourthCellFirstRow).toContainText(
-          (await firstCell.textContent()) || ''
-        );
-        await expect(
-          page.locator('.rdg-row').nth(0).locator('.rdg-cell').nth(3)
-        ).toContainText(
-          (await page
-            .locator('.rdg-row')
-            .nth(0)
-            .locator('.rdg-cell')
+        await test.step('should select all the cells in the column by clicking on column header', async () => {
+          const firstHeaderCell = page
+            .locator('.rdg-header-row')
             .first()
-            .textContent()) || ''
-        );
+            .locator('.rdg-cell')
+            .first();
 
-        // undo the action
-        await page.keyboard.press('Control+Z');
+          const firstRow = page.locator('.rdg-row').first();
+          const firstCell = firstRow.locator('.rdg-cell').nth(1);
 
-        // check if the range is pasted correctly
-        await expect(fourthCellFirstRow).toHaveText('');
-        await expect(
-          page.locator('.rdg-row').nth(0).locator('.rdg-cell').nth(3)
-        ).toHaveText('');
+          await firstHeaderCell.click();
 
-        // redo the action
-        await page.keyboard.press('Control+Y');
+          await expect(firstCell).not.toBeFocused();
 
-        // check if the range is pasted correctly
-        await expect(fourthCellFirstRow).toContainText(
-          (await firstCell.textContent()) || ''
-        );
+          await expect(firstHeaderCell).toBeFocused();
 
-        // undo the action
-        await page.keyboard.press('Control+Z');
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(rowCount);
+        });
+
+        await test.step('allow multiple column selection', async () => {
+          const headerRow = page.locator('.rdg-header-row');
+          // Mouse down on first header cell then move to 3rd header cell then mouse up
+          const startHeaderCell = headerRow.locator('.rdg-cell').nth(1);
+          const endHeaderCell = headerRow.locator('.rdg-cell').nth(3);
+
+          const startBox = await startHeaderCell.boundingBox();
+          const endBox = await endHeaderCell.boundingBox();
+
+          if (!startBox || !endBox) {
+            throw new Error('Failed to get bounding boxes');
+          }
+
+          const startX = startBox.x + startBox.width / 2;
+          const startY = startBox.y + startBox.height / 2;
+          const endX = endBox.x + endBox.width / 2;
+          const endY = endBox.y + endBox.height / 2;
+
+          const mouse = page.mouse;
+
+          // Simulate drag from col 2 to col 4
+          await mouse.move(startX, startY);
+          await mouse.down();
+
+          await expect(startHeaderCell).toBeFocused();
+
+          await mouse.move(endX, endY, { steps: 10 }); // Smooth drag
+          await mouse.up();
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
+            rowCount * 3
+          );
+        });
+
+        await test.step('allow multiple column selection using keyboard', async () => {
+          // click first cell of first row
+          const firstRow = page.locator('.rdg-row').first();
+          const firstCell = firstRow.locator('.rdg-cell').first();
+          await firstCell.click();
+
+          // Press arrow up to go to header row (selects column 0, all rows)
+          await page.keyboard.press('ArrowUp');
+
+          // Shift+click the 3rd header cell to deterministically extend the
+          // selection to columns 0-2. Using repeated Shift+ArrowRight here
+          // races react-data-grid's own internal keyboard navigation against
+          // this app's Shift+Arrow handler, since both react to the same
+          // bubbling keydown event.
+          const headerRow = page.locator('.rdg-header-row').first();
+          const targetHeaderCell = headerRow.locator('.rdg-cell').nth(2);
+          await page.keyboard.down('Shift');
+          await targetHeaderCell.click();
+          await page.keyboard.up('Shift');
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
+            rowCount * 3
+          );
+        });
+
+        await test.step('allow multiple cell selection using mouse on rightDown and leftUp and extend selection using shift+click', async () => {
+          // click first cell of first row
+          const firstRow = page.locator('.rdg-row').first();
+          const fourthRow = page.locator('.rdg-row').nth(3);
+          const sixthRow = page.locator('.rdg-row').nth(5);
+
+          const firstCellFirstRow = firstRow.locator('.rdg-cell').first();
+          const secondCellFourthRow = fourthRow.locator('.rdg-cell').nth(1);
+          const fifthCellSixthRow = sixthRow.locator('.rdg-cell').nth(4);
+
+          await secondCellFourthRow.click();
+
+          await expect(secondCellFourthRow).toBeFocused();
+
+          const startBox = await secondCellFourthRow.boundingBox();
+          const endBoxRightBottom = await fifthCellSixthRow.boundingBox();
+          const endBoxLeftUp = await firstCellFirstRow.boundingBox();
+
+          if (!startBox || !endBoxRightBottom || !endBoxLeftUp) {
+            throw new Error('Failed to get bounding boxes');
+          }
+
+          const startX = startBox.x + startBox.width / 2;
+          const startY = startBox.y + startBox.height / 2;
+          const endXRightBottom =
+            endBoxRightBottom.x + endBoxRightBottom.width / 2;
+          const endYRightBottom =
+            endBoxRightBottom.y + endBoxRightBottom.height / 2;
+          const endXLeftUp = endBoxLeftUp.x + endBoxLeftUp.width / 2;
+          const endYLeftUp = endBoxLeftUp.y + endBoxLeftUp.height / 2;
+
+          const mouse = page.mouse;
+
+          // Simulate drag from col 2 to col 4
+          await mouse.move(startX, startY);
+          await mouse.down();
+
+          await mouse.move(endXRightBottom, endYRightBottom, { steps: 10 }); // Smooth drag
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
+            12
+          );
+
+          await mouse.move(endXLeftUp, endYLeftUp, { steps: 10 }); // Smooth drag
+          await mouse.up();
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(8);
+
+          // Hold shift and click on fifthCellSixthRow
+          await page.keyboard.down('Shift');
+          await fifthCellSixthRow.click();
+          await page.keyboard.up('Shift');
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(
+            12
+          );
+
+          // Hold shift and click on firstCellFirstRow
+          await page.keyboard.down('Shift');
+          await firstCellFirstRow.click();
+          await page.keyboard.up('Shift');
+
+          await expect(page.locator('.rdg-cell-range-selections')).toHaveCount(8);
+        });
+
+
+        await test.step('perform single cell copy-paste and undo-redo', async () => {
+          // click first cell of first row
+          const firstRow = page.locator('.rdg-row').first();
+          const firstCell = firstRow.locator('.rdg-cell').first();
+          const secondCell = firstRow.locator('.rdg-cell').nth(1);
+          await firstCell.click();
+
+          // copy the cell
+          await page.keyboard.press('Control+C');
+
+          // move to next right cell
+          await page.keyboard.press('ArrowRight');
+
+          // paste the cell
+          await page.keyboard.press('Control+V');
+
+          // second cell should have text equal to first cell text
+          await expect(secondCell).toHaveText(
+            (await firstCell.textContent()) || ''
+          );
+
+          // undo the action
+          await page.keyboard.press('Control+Z');
+
+          await expect(secondCell).toHaveText('');
+
+          // redo the action
+          await page.keyboard.press('Control+Y');
+
+          // second cell should have text equal to first cell text
+          await expect(secondCell).toHaveText(
+            (await firstCell.textContent()) || ''
+          );
+        });
+
+        await test.step('Select range, copy-paste and undo-redo', async () => {
+          // click on first cell to focus
+          const firstRow = page.locator('.rdg-row').first();
+          const firstCell = firstRow.locator('.rdg-cell').first();
+          await firstCell.click();
+
+          // navigate to header row
+          await page.keyboard.press('ArrowUp');
+          await page.keyboard.down('Shift');
+          await page.keyboard.press('ArrowRight');
+          await page.keyboard.press('ArrowRight');
+          await page.keyboard.up('Shift');
+
+          // copy the range
+          await page.keyboard.press('Control+C');
+
+          // click on fourth cell of first row
+          const fourthCellFirstRow = firstRow.locator('.rdg-cell').nth(3);
+          await fourthCellFirstRow.click();
+
+          // paste the range
+          await page.keyboard.press('Control+V');
+
+          // check if the range is pasted correctly
+          await expect(fourthCellFirstRow).toContainText(
+            (await firstCell.textContent()) || ''
+          );
+          await expect(
+            page.locator('.rdg-row').nth(0).locator('.rdg-cell').nth(3)
+          ).toContainText(
+            (await page
+              .locator('.rdg-row')
+              .nth(0)
+              .locator('.rdg-cell')
+              .first()
+              .textContent()) || ''
+          );
+
+          // undo the action
+          await page.keyboard.press('Control+Z');
+
+          // check if the range is pasted correctly
+          await expect(fourthCellFirstRow).toHaveText('');
+          await expect(
+            page.locator('.rdg-row').nth(0).locator('.rdg-cell').nth(3)
+          ).toHaveText('');
+
+          // redo the action
+          await page.keyboard.press('Control+Y');
+
+          // check if the range is pasted correctly
+          await expect(fourthCellFirstRow).toContainText(
+            (await firstCell.textContent()) || ''
+          );
+
+          // undo the action
+          await page.keyboard.press('Control+Z');
+        });
       });
-    });
-
-    await dbEntity.delete(apiContext);
-    await afterAction();
+    } finally {
+      await dbEntity.delete(apiContext);
+      await afterAction();
+    }
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -2439,6 +2439,30 @@ export const copyAndGetClipboardText = async (
 };
 
 /**
+ * Replaces navigator.clipboard with an in-memory implementation before any page
+ * script runs. Required for grid components (e.g. BulkImport) that call
+ * navigator.clipboard.writeText/readText directly, since the real OS clipboard
+ * API is unreliable in AUT/headless CI even with clipboard permissions granted.
+ *
+ * @param page - Playwright Page object
+ */
+export const mockClipboardApi = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    let clipboardData = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: {
+        writeText: async (text: string) => {
+          clipboardData = text;
+        },
+        readText: async () => clipboardData,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+};
+
+/**
  * Validates the format and structure of a copied link URL.
  * Ensures URLs are properly formatted, contain all required components, and follow expected patterns.
  *


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Test improvements:**
    - Added `mockClipboardApi` helper in `entity.ts` to reliably mock `navigator.clipboard` for headless CI grid testing
    - Wrapped bulk import test steps in `try/finally` block to ensure robust cleanup of test entities on failure
    - Refactored `BulkImport.spec.ts` keyboard navigation to use deterministic `Shift+Click` for cell/column range selections

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR attempts to stabilize the bulk-import range-selection Playwright test.
- Adds an in-memory `navigator.clipboard` implementation for grid copy and paste.
- Replaces one keyboard range-selection sequence with Shift+click.
- Ensures database entities and API context are cleaned up through `finally`.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The retained Shift+Arrow sequence should be fixed before merging because it leaves the bulk-import test vulnerable to the same intermittent failure this PR addresses.

One range-selection step still dispatches keyboard events that both react-data-grid and the application process, so its selected range and subsequent clipboard assertions remain nondeterministic.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts | Stabilizes clipboard use and cleanup, but retains the same Shift+Arrow event race in the range copy-paste step. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts | Adds a page-init clipboard mock implementing the readText and writeText methods used by the bulk-import grid. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fixed bulk import spec"](https://github.com/open-metadata/openmetadata/commit/d59efb6346efa3f101e61c1d949d9db080085dd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48973264)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->