### PR TITLE
Cherry-pick #30599 to 2.0: keep Hive test connection working when no metastore is selected

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -16,7 +16,7 @@ Source connection handler
 from copy import deepcopy
 from enum import Enum
 from functools import singledispatch
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import quote_plus
 
 from pydantic import ValidationError
@@ -57,7 +57,10 @@ from metadata.ingestion.source.database.hive.custom_hive_connection import (
     CustomHiveConnection,
 )
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.logger import ingestion_logger
 from metadata.utils.ssl_manager import check_ssl_and_init
+
+logger = ingestion_logger()
 
 HIVE_POSTGRES_SCHEME = "hive+postgres"
 HIVE_MYSQL_SCHEME = "hive+mysql"
@@ -102,6 +105,15 @@ class HiveConnection(BaseConnection[HiveConnectionConfig, Engine]):
     def _get_client(self) -> Engine:
         connection = self.service_connection
 
+        # A configured metastore replaces HiveServer2 entirely: it reads the same catalog from the
+        # metastore database in bulk, so only one of the two engines is ever live.
+        metastore_conn = get_validated_metastore_connection(connection.metastoreConnection)
+        if metastore_conn:
+            connection.metastoreConnection = metastore_conn
+            metastore_engine = get_metastore_connection(metastore_conn)
+            self._on_close(metastore_engine.dispose)
+            return metastore_engine
+
         if connection.auth:
             auth_key = (
                 "auth"
@@ -125,11 +137,13 @@ class HiveConnection(BaseConnection[HiveConnectionConfig, Engine]):
         if hasattr(connection, "useSSL") and connection.useSSL:
             self._connection_arguments_root(connection)["use_ssl"] = True
 
-        return create_generic_db_connection(
+        engine = create_generic_db_connection(
             connection=connection,
             get_connection_url_fn=self.get_connection_url,
             get_connection_args_fn=get_connection_args_common,
         )
+        self._on_close(engine.dispose)
+        return engine
 
     @staticmethod
     def _connection_arguments_root(connection: HiveConnectionConfig) -> dict[str, Any]:
@@ -143,37 +157,58 @@ class HiveConnection(BaseConnection[HiveConnectionConfig, Engine]):
     def test_connection(
         self,
         metadata: OpenMetadata,
-        automation_workflow: Optional[AutomationWorkflow] = None,  # noqa: UP045
-        timeout_seconds: Optional[int] = THREE_MIN,  # noqa: UP045
+        automation_workflow: AutomationWorkflow | None = None,
+        timeout_seconds: int | None = THREE_MIN,
     ) -> TestConnectionResult:
         """
         Test connection. This can be executed either as part
         of a metadata workflow or during an Automation Workflow
         """
-        engine = self.client
-        service_connection = self.service_connection
-        metastore_conn = service_connection.metastoreConnection
-
-        if metastore_conn:
-            if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
-                engine = get_metastore_connection(metastore_conn)
-            elif isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-                try:
-                    service_connection.metastoreConnection = PostgresConnection.model_validate(metastore_conn)
-                except ValidationError:
-                    try:
-                        service_connection.metastoreConnection = MysqlConnection.model_validate(metastore_conn)
-                    except ValidationError:
-                        raise ValueError("Invalid metastore connection")  # noqa: B904
-                engine = get_metastore_connection(service_connection.metastoreConnection)
-
         return test_connection_db_schema_sources(
             metadata=metadata,
-            engine=engine,
-            service_connection=service_connection,
+            engine=self.client,
+            service_connection=self.service_connection,
             automation_workflow=automation_workflow,
             timeout_seconds=timeout_seconds,
         )
+
+
+def get_validated_metastore_connection(
+    metastore_connection: Any,
+) -> PostgresConnection | MysqlConnection | None:
+    """
+    Return the metastore connection as a validated model, or None when no metastore is configured.
+    """
+    validated = None
+    if isinstance(metastore_connection, (PostgresConnection, MysqlConnection)):
+        validated = metastore_connection
+    # Picking "None" for the metastore in the UI submits an empty object, which the server expands
+    # into a defaults-only payload carrying no hostPort. That means "no metastore", not a broken one.
+    elif isinstance(metastore_connection, dict) and metastore_connection.get("hostPort"):
+        validated = _validate_metastore_dict(metastore_connection)
+    return validated
+
+
+def _validate_metastore_dict(
+    metastore_connection: dict[str, Any],
+) -> PostgresConnection | MysqlConnection | None:
+    """
+    Validate a raw metastore payload against the supported metastore backends.
+    """
+    validated = None
+    for candidate in (PostgresConnection, MysqlConnection):
+        try:
+            validated = candidate.model_validate(metastore_connection)
+            break
+        except ValidationError:
+            continue
+
+    if validated is None:
+        logger.warning(
+            "Ignoring the Hive metastore connection: it matches neither a Postgres nor a MySQL "
+            "metastore. Falling back to HiveServer2 for metadata extraction."
+        )
+    return validated
 
 
 @singledispatch
@@ -196,7 +231,7 @@ def _(connection: PostgresConnection):
         HIVE_POSTGRES = HIVE_POSTGRES_SCHEME
 
     class CustomPostgresConnection(PostgresConnection):
-        scheme: Optional[CustomPostgresScheme]  # noqa: UP045
+        scheme: CustomPostgresScheme | None
 
     connection_copy = deepcopy(connection.__dict__)
     connection_copy["scheme"] = CustomPostgresScheme.HIVE_POSTGRES
@@ -222,7 +257,7 @@ def _(connection: MysqlConnection):
         HIVE_MYSQL = HIVE_MYSQL_SCHEME
 
     class CustomMysqlConnection(MysqlConnection):
-        scheme: Optional[CustomMysqlScheme]  # noqa: UP045
+        scheme: CustomMysqlScheme | None
 
     connection_copy = deepcopy(connection.__dict__)
     connection_copy["scheme"] = CustomMysqlScheme.HIVE_MYSQL

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,9 +13,7 @@ Hive source methods.
 """
 
 import traceback
-from typing import Optional, Tuple, Union  # noqa: UP035
 
-from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
 from sqlalchemy import text
 from sqlalchemy.engine.reflection import Inspector
@@ -24,19 +22,15 @@ from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.entity.services.connections.database.hiveConnection import (
     HiveConnection,
 )
-from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
-    MysqlConnection,
-)
-from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
-    PostgresConnection,
-)
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
-from metadata.ingestion.source.database.hive.connection import get_metastore_connection
+from metadata.ingestion.source.database.hive.connection import (
+    get_validated_metastore_connection,
+)
 from metadata.ingestion.source.database.hive.utils import (
     get_columns,
     get_table_comment,
@@ -66,44 +60,17 @@ class HiveSource(CommonDbSourceService):
     service_connection: HiveConnection
 
     @classmethod
-    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: Optional[str] = None):  # noqa: UP045
+    def create(cls, config_dict, metadata: OpenMetadata, pipeline_name: str | None = None):
         config = WorkflowSource.model_validate(config_dict)
         connection: HiveConnection = config.serviceConnection.root.config
         if not isinstance(connection, HiveConnection):
             raise InvalidSourceException(f"Expected HiveConnection, but got {connection}")
         return cls(config, metadata)
 
-    def _parse_version(self, version: str) -> Tuple:  # noqa: UP006
+    def _parse_version(self, version: str) -> tuple:
         if "-" in version:
             version = version.replace("-", ".")
         return tuple(map(int, (version.split(".")[:3])))
-
-    def _get_validated_metastore_connection(
-        self,
-    ) -> Optional[Union[PostgresConnection, MysqlConnection]]:  # noqa: UP007, UP045
-        """
-        Validate and return the metastore connection if it exists.
-        Handles cases where the connection may be a raw dict that needs validation.
-        """
-        metastore_conn = self.service_connection.metastoreConnection
-
-        if not metastore_conn:
-            return None
-
-        if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
-            return metastore_conn
-
-        if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            try:
-                return PostgresConnection.model_validate(metastore_conn)
-            except ValidationError:
-                try:
-                    return MysqlConnection.model_validate(metastore_conn)
-                except ValidationError:
-                    logger.warning("Invalid metastore connection configuration")
-                    return None
-
-        return None
 
     def prepare(self):
         """
@@ -111,9 +78,9 @@ class HiveSource(CommonDbSourceService):
         Fetching views in hive server with query "SHOW VIEWS" was possible
         only after hive 2.2.0 version
         """
-        metastore_conn = self._get_validated_metastore_connection()
-
-        if not metastore_conn:
+        # The engine is owned by HiveConnection, which already picked the metastore engine when one
+        # is configured. Dialect patching only applies to the HiveServer2 engine.
+        if not get_validated_metastore_connection(self.service_connection.metastoreConnection):
             with self.engine.connect() as conn:
                 result = conn.execute(text("SELECT VERSION()")).fetchone()._asdict()
 
@@ -125,14 +92,12 @@ class HiveSource(CommonDbSourceService):
             else:
                 HiveDialect.get_table_names = get_table_names_older_versions
                 HiveDialect.get_view_names = get_view_names_older_versions
-        else:
-            self.engine = get_metastore_connection(metastore_conn)
         self._connection_map = {}  # Lazy init as well
         self._inspector_map = {}
 
     def get_schema_definition(  # pylint: disable=unused-argument
         self, table_type: str, table_name: str, schema_name: str, inspector: Inspector
-    ) -> Optional[str]:  # noqa: UP045
+    ) -> str | None:
         """
         Get the DDL statement or View Definition for a table
         """

--- a/ingestion/src/metadata/ingestion/source/database/hive/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/utils.py
@@ -160,9 +160,9 @@ def get_table_comment(  # pylint: disable=unused-argument
     cursor = connection.execute(text(HIVE_GET_COMMENTS.format(schema_name=schema_name, table_name=table_name)))
     try:
         for result in list(cursor):
-            data = result.values()
+            data = tuple(result)
             if data[1] and data[1].strip() == "comment":
-                return {"text": data[2] if data and data[2] else None}
+                return {"text": data[2].strip() if data[2] else None}
     except Exception:
         return {"text": None}
     return {"text": None}

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -61,7 +61,11 @@ from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.source.database.hive.connection import (
     HiveConnection as HiveConnectionHandler,
 )
+from metadata.ingestion.source.database.hive.connection import (
+    get_validated_metastore_connection,
+)
 from metadata.ingestion.source.database.hive.metadata import HiveSource
+from metadata.ingestion.source.database.hive.utils import get_table_comment
 
 mock_hive_config = {
     "source": {
@@ -940,17 +944,13 @@ class HiveUnitTest(TestCase):
         self.assertEqual(ldap_ssl_connection.password.get_secret_value(), "password")
         self.assertTrue(ldap_ssl_connection.useSSL)
 
-    @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
     @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
-    def test_test_connection_with_postgres_connection_object(self, mock_get_metastore, mock_test_db_schema):
+    def test_get_client_with_postgres_connection_object(self, mock_get_metastore):
         """
-        Test test_connection when metastoreConnection is already a PostgresConnection object
+        Test the client is the metastore engine when metastoreConnection is a PostgresConnection
         """
-        mock_metadata = Mock()
-        mock_engine = Mock()
         mock_metastore_engine = Mock()
         mock_get_metastore.return_value = mock_metastore_engine
-        mock_test_db_schema.return_value = Mock()
 
         postgres_conn = PostgresConnection(
             username="postgres_user",
@@ -964,26 +964,18 @@ class HiveUnitTest(TestCase):
             metastoreConnection=postgres_conn,
         )
 
-        handler = HiveConnectionHandler(hive_conn)
-        handler._client = mock_engine
-        handler.test_connection(mock_metadata)
+        client = HiveConnectionHandler(hive_conn)._get_client()
 
         mock_get_metastore.assert_called_once_with(postgres_conn)
-        mock_test_db_schema.assert_called_once()
-        call_kwargs = mock_test_db_schema.call_args
-        self.assertEqual(call_kwargs.kwargs["engine"], mock_metastore_engine)
+        self.assertEqual(client, mock_metastore_engine)
 
-    @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
     @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
-    def test_test_connection_with_mysql_connection_object(self, mock_get_metastore, mock_test_db_schema):
+    def test_get_client_with_mysql_connection_object(self, mock_get_metastore):
         """
-        Test test_connection when metastoreConnection is already a MysqlConnection object
+        Test the client is the metastore engine when metastoreConnection is a MysqlConnection
         """
-        mock_metadata = Mock()
-        mock_engine = Mock()
         mock_metastore_engine = Mock()
         mock_get_metastore.return_value = mock_metastore_engine
-        mock_test_db_schema.return_value = Mock()
 
         mysql_conn = MysqlConnection(
             username="mysql_user",
@@ -997,26 +989,59 @@ class HiveUnitTest(TestCase):
             metastoreConnection=mysql_conn,
         )
 
-        handler = HiveConnectionHandler(hive_conn)
-        handler._client = mock_engine
-        handler.test_connection(mock_metadata)
+        client = HiveConnectionHandler(hive_conn)._get_client()
 
         mock_get_metastore.assert_called_once_with(mysql_conn)
-        mock_test_db_schema.assert_called_once()
-        call_kwargs = mock_test_db_schema.call_args
-        self.assertEqual(call_kwargs.kwargs["engine"], mock_metastore_engine)
+        self.assertEqual(client, mock_metastore_engine)
 
-    @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
     @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
-    def test_test_connection_with_postgres_dict(self, mock_get_metastore, mock_test_db_schema):
+    def test_close_disposes_metastore_engine(self, mock_get_metastore):
         """
-        Test test_connection when metastoreConnection is a dict that validates as PostgresConnection
+        Test the metastore engine is released by close(), like any client the connection builds
         """
-        mock_metadata = Mock()
-        mock_engine = Mock()
         mock_metastore_engine = Mock()
         mock_get_metastore.return_value = mock_metastore_engine
-        mock_test_db_schema.return_value = Mock()
+
+        hive_conn = HiveConnection(
+            type="Hive",
+            hostPort="localhost:10000",
+            metastoreConnection=MysqlConnection(
+                username="mysql_user",
+                hostPort="localhost:3306",
+                databaseSchema="hive_metastore",
+            ),
+        )
+
+        connection = HiveConnectionHandler(hive_conn)
+        self.assertEqual(connection.client, mock_metastore_engine)
+
+        connection.close()
+
+        mock_metastore_engine.dispose.assert_called_once()
+
+    @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
+    def test_get_client_without_metastore_uses_hiveserver(self, mock_get_metastore):
+        """
+        Test the client is the HiveServer2 engine when no metastore is configured
+        """
+        hive_conn = HiveConnection(
+            type="Hive",
+            hostPort="localhost:10000",
+            metastoreConnection={},
+        )
+
+        client = HiveConnectionHandler(hive_conn)._get_client()
+
+        mock_get_metastore.assert_not_called()
+        self.assertEqual(client.url.drivername, "hive")
+
+    @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
+    def test_get_client_with_postgres_dict(self, mock_get_metastore):
+        """
+        Test the raw dict form is validated and used to build the metastore engine
+        """
+        mock_metastore_engine = Mock()
+        mock_get_metastore.return_value = mock_metastore_engine
 
         postgres_dict = {
             "type": "Postgres",
@@ -1031,24 +1056,19 @@ class HiveUnitTest(TestCase):
             metastoreConnection=postgres_dict,
         )
 
-        handler = HiveConnectionHandler(hive_conn)
-        handler._client = mock_engine
-        handler.test_connection(mock_metadata)
+        client = HiveConnectionHandler(hive_conn)._get_client()
 
         mock_get_metastore.assert_called_once()
-        self.assertIsInstance(hive_conn.metastoreConnection, PostgresConnection)
+        self.assertEqual(client, mock_metastore_engine)
+        self.assertIsInstance(mock_get_metastore.call_args.args[0], PostgresConnection)
 
-    @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
     @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
-    def test_test_connection_with_mysql_dict(self, mock_get_metastore, mock_test_db_schema):
+    def test_get_client_with_mysql_dict(self, mock_get_metastore):
         """
-        Test test_connection when metastoreConnection is a dict that validates as MysqlConnection
+        Test the raw dict form is validated and used to build the metastore engine
         """
-        mock_metadata = Mock()
-        mock_engine = Mock()
         mock_metastore_engine = Mock()
         mock_get_metastore.return_value = mock_metastore_engine
-        mock_test_db_schema.return_value = Mock()
 
         mysql_dict = {
             "type": "Mysql",
@@ -1063,38 +1083,79 @@ class HiveUnitTest(TestCase):
             metastoreConnection=mysql_dict,
         )
 
-        handler = HiveConnectionHandler(hive_conn)
-        handler._client = mock_engine
-        handler.test_connection(mock_metadata)
+        client = HiveConnectionHandler(hive_conn)._get_client()
 
         mock_get_metastore.assert_called_once()
+        self.assertEqual(client, mock_metastore_engine)
+        self.assertIsInstance(mock_get_metastore.call_args.args[0], MysqlConnection)
         self.assertIsInstance(hive_conn.metastoreConnection, MysqlConnection)
 
     @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
-    def test_test_connection_with_invalid_dict_raises_error(self, mock_test_db_schema):
+    @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
+    def test_test_connection_with_unrecognized_dict_falls_back_to_hiveserver(
+        self, mock_get_metastore, mock_test_db_schema
+    ):
         """
-        Test test_connection raises ValueError when metastoreConnection dict is invalid
+        Test test_connection ignores a metastoreConnection dict that matches no supported backend
         """
         mock_metadata = Mock()
         mock_engine = Mock()
+        mock_test_db_schema.return_value = Mock()
 
-        invalid_dict = {
+        unrecognized_dict = {
             "type": "InvalidType",
+            "hostPort": "localhost:5432",
             "invalid_field": "invalid_value",
         }
 
         hive_conn = HiveConnection(
             type="Hive",
             hostPort="localhost:10000",
-            metastoreConnection=invalid_dict,
+            metastoreConnection=unrecognized_dict,
         )
 
         handler = HiveConnectionHandler(hive_conn)
         handler._client = mock_engine
-        with self.assertRaises(ValueError) as context:
-            handler.test_connection(mock_metadata)
+        handler.test_connection(mock_metadata)
 
-        self.assertEqual(str(context.exception), "Invalid metastore connection")
+        mock_get_metastore.assert_not_called()
+        self.assertEqual(mock_test_db_schema.call_args.kwargs["engine"], mock_engine)
+
+    @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
+    @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
+    def test_test_connection_with_defaults_only_metastore(self, mock_get_metastore, mock_test_db_schema):
+        """
+        Test test_connection ignores the defaults-only payload the server derives from a "None" metastore
+        """
+        mock_metadata = Mock()
+        mock_engine = Mock()
+        mock_test_db_schema.return_value = Mock()
+
+        defaults_only_dict = {
+            "type": "Mysql",
+            "scheme": "mysql+pymysql",
+            "supportsMetadataExtraction": True,
+            "supportsDBTExtraction": True,
+            "supportsProfiler": True,
+            "supportsQueryComment": True,
+            "supportsDataDiff": True,
+            "supportsUsageExtraction": True,
+            "supportsLineageExtraction": True,
+            "useSlowLogs": False,
+        }
+
+        hive_conn = HiveConnection(
+            type="Hive",
+            hostPort="localhost:10000",
+            metastoreConnection=defaults_only_dict,
+        )
+
+        handler = HiveConnectionHandler(hive_conn)
+        handler._client = mock_engine
+        handler.test_connection(mock_metadata)
+
+        mock_get_metastore.assert_not_called()
+        self.assertEqual(mock_test_db_schema.call_args.kwargs["engine"], mock_engine)
 
     @patch("metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources")
     @patch("metadata.ingestion.source.database.hive.connection.get_metastore_connection")
@@ -1147,102 +1208,108 @@ class HiveUnitTest(TestCase):
         self.assertEqual(call_kwargs.kwargs["engine"], mock_engine)
 
 
-class HiveSourceMetastoreValidationTest(TestCase):
+class TestGetValidatedMetastoreConnection:
     """
-    Test the _get_validated_metastore_connection method in HiveSource
+    Test get_validated_metastore_connection
     """
 
-    @patch("metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection")
-    def setUp(self, mock_test_connection):
-        mock_test_connection.return_value = False
-        self.config = OpenMetadataWorkflowConfig.model_validate(mock_hive_config)
-        self.hive = HiveSource.create(
-            mock_hive_config["source"],
-            self.config.workflowConfig.openMetadataServerConfig,
-        )
+    def test_with_none(self):
+        assert get_validated_metastore_connection(None) is None
 
-    def test_get_validated_metastore_connection_with_none(self):
-        """
-        Test _get_validated_metastore_connection returns None when metastoreConnection is None
-        """
-        self.hive.service_connection.metastoreConnection = None
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
-
-    def test_get_validated_metastore_connection_with_postgres_object(self):
-        """
-        Test _get_validated_metastore_connection returns PostgresConnection when already validated
-        """
+    def test_with_postgres_object(self):
         postgres_conn = PostgresConnection(
             username="postgres_user",
             hostPort="localhost:5432",
             database="hive_metastore",
         )
-        self.hive.service_connection.metastoreConnection = postgres_conn
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, PostgresConnection)
-        self.assertEqual(result, postgres_conn)
 
-    def test_get_validated_metastore_connection_with_mysql_object(self):
-        """
-        Test _get_validated_metastore_connection returns MysqlConnection when already validated
-        """
+        assert get_validated_metastore_connection(postgres_conn) == postgres_conn
+
+    def test_with_mysql_object(self):
         mysql_conn = MysqlConnection(
             username="mysql_user",
             hostPort="localhost:3306",
             databaseSchema="hive_metastore",
         )
-        self.hive.service_connection.metastoreConnection = mysql_conn
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, MysqlConnection)
-        self.assertEqual(result, mysql_conn)
 
-    def test_get_validated_metastore_connection_with_postgres_dict(self):
-        """
-        Test _get_validated_metastore_connection parses dict as PostgresConnection
-        """
+        assert get_validated_metastore_connection(mysql_conn) == mysql_conn
+
+    def test_with_postgres_dict(self):
         postgres_dict = {
             "type": "Postgres",
             "username": "postgres_user",
             "hostPort": "localhost:5432",
             "database": "hive_metastore",
         }
-        self.hive.service_connection.metastoreConnection = postgres_dict
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, PostgresConnection)
-        self.assertEqual(result.username, "postgres_user")
+        result = get_validated_metastore_connection(postgres_dict)
 
-    def test_get_validated_metastore_connection_with_mysql_dict(self):
-        """
-        Test _get_validated_metastore_connection parses dict as MysqlConnection
-        """
+        assert isinstance(result, PostgresConnection)
+        assert result.username == "postgres_user"
+
+    def test_with_mysql_dict(self):
         mysql_dict = {
             "type": "Mysql",
             "username": "mysql_user",
             "hostPort": "localhost:3306",
             "databaseSchema": "hive_metastore",
         }
-        self.hive.service_connection.metastoreConnection = mysql_dict
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, MysqlConnection)
-        self.assertEqual(result.username, "mysql_user")
+        result = get_validated_metastore_connection(mysql_dict)
 
-    def test_get_validated_metastore_connection_with_empty_dict(self):
-        """
-        Test _get_validated_metastore_connection returns None for empty dict
-        """
-        self.hive.service_connection.metastoreConnection = {}
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
+        assert isinstance(result, MysqlConnection)
+        assert result.username == "mysql_user"
 
-    def test_get_validated_metastore_connection_with_invalid_dict(self):
+    def test_with_empty_dict(self):
+        assert get_validated_metastore_connection({}) is None
+
+    def test_with_defaults_only_dict(self):
         """
-        Test _get_validated_metastore_connection returns None for invalid dict
+        The server derives this payload from a "None" metastore selection; it configures nothing.
         """
-        invalid_dict = {
+        defaults_only_dict = {
+            "type": "Mysql",
+            "scheme": "mysql+pymysql",
+            "supportsMetadataExtraction": True,
+            "supportsProfiler": True,
+            "useSlowLogs": False,
+        }
+
+        assert get_validated_metastore_connection(defaults_only_dict) is None
+
+    def test_with_unrecognized_dict(self):
+        unrecognized_dict = {
             "type": "InvalidType",
+            "hostPort": "localhost:5432",
             "invalid_field": "invalid_value",
         }
-        self.hive.service_connection.metastoreConnection = invalid_dict
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
+
+        assert get_validated_metastore_connection(unrecognized_dict) is None
+
+
+class TestGetTableComment:
+    """
+    Test get_table_comment
+    """
+
+    @staticmethod
+    def _connection_returning(rows):
+        connection = Mock()
+        connection.execute.return_value = rows
+
+        return connection
+
+    def test_returns_table_comment(self):
+        rows = [
+            ("id", "int", "customer id"),
+            ("", "comment             ", "customer master     "),
+        ]
+
+        result = get_table_comment(Mock(), self._connection_returning(rows), "customers", "sales_db")
+
+        assert result == {"text": "customer master"}
+
+    def test_returns_none_without_comment(self):
+        rows = [("id", "int", "customer id")]
+
+        result = get_table_comment(Mock(), self._connection_returning(rows), "customers", "sales_db")
+
+        assert result == {"text": None}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java
@@ -14,6 +14,7 @@
 package org.openmetadata.service.secrets.converter;
 
 import java.util.List;
+import java.util.Map;
 import org.openmetadata.schema.services.connections.database.HiveConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.PostgresConnection;
@@ -33,9 +34,20 @@ public class HiveConnectionClassConverter extends ClassConverter {
   public Object convert(Object object) {
     HiveConnection hiveConnection = (HiveConnection) JsonUtils.convertValue(object, this.clazz);
 
-    tryToConvert(hiveConnection.getMetastoreConnection(), CONFIG_SOURCE_CLASSES)
-        .ifPresent(hiveConnection::setMetastoreConnection);
+    if (!isEmptyMap(hiveConnection.getMetastoreConnection())) {
+      tryToConvert(hiveConnection.getMetastoreConnection(), CONFIG_SOURCE_CLASSES)
+          .ifPresent(hiveConnection::setMetastoreConnection);
+    }
 
     return hiveConnection;
+  }
+
+  /**
+   * Selecting "None" for the metastore submits an empty object. Jackson does not enforce JSON
+   * Schema `required`, so converting it would succeed against the first candidate class and persist
+   * a metastore config populated entirely with schema defaults.
+   */
+  private static boolean isEmptyMap(Object object) {
+    return object instanceof Map<?, ?> map && map.isEmpty();
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java
@@ -1,0 +1,80 @@
+package org.openmetadata.service.secrets.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.services.connections.database.HiveConnection;
+import org.openmetadata.schema.services.connections.database.MysqlConnection;
+import org.openmetadata.schema.services.connections.database.PostgresConnection;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class HiveConnectionClassConverterTest {
+
+  private final ClassConverter converter = ClassConverterFactory.getConverter(HiveConnection.class);
+
+  @Test
+  void testConvertsPostgresMetastore() {
+    PostgresConnection metastore =
+        new PostgresConnection()
+            .withHostPort("localhost:5432")
+            .withUsername("postgres_user")
+            .withDatabase("hive_metastore");
+
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(metastore);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(PostgresConnection.class, result.getMetastoreConnection());
+  }
+
+  @Test
+  void testConvertsMysqlMetastore() {
+    MysqlConnection metastore =
+        new MysqlConnection().withHostPort("localhost:3306").withUsername("mysql_user");
+
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(metastore);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(MysqlConnection.class, result.getMetastoreConnection());
+  }
+
+  /**
+   * Selecting "None" for the metastore submits an empty object. Converting it would match the first
+   * candidate class and persist a metastore config built entirely from schema defaults, which the
+   * ingestion framework then rejects as invalid.
+   */
+  @Test
+  void testEmptyMetastoreIsLeftUntouched() {
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(Map.of());
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, result.getMetastoreConnection());
+    assertEquals(Map.of(), result.getMetastoreConnection());
+  }
+
+  @Test
+  void testNullMetastoreDoesNotThrow() {
+    HiveConnection input = new HiveConnection().withHostPort("localhost:10000");
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertNull(result.getMetastoreConnection());
+  }
+}


### PR DESCRIPTION
Cherry-pick of #30599 onto `2.0`.

Fixes #30380 — selecting **None** for the Hive Metastore Connection made test connection fail with `Error running automation workflow due to [Invalid metastore connection]`, and ingestion failed the same way since the metadata workflow runs `test_connection` at start.

Applied cleanly with no conflicts; the six touched files are byte-identical to `main` after the pick.

See #30599 for the full root-cause write-up. Summary of what it carries:

- **`HiveConnectionClassConverter`** — skip conversion when the metastore is an empty map, so `{}` is no longer inflated into a MySQL config built entirely from schema defaults.
- **`hive/connection.py` + `hive/metadata.py`** — single `get_validated_metastore_connection()` replacing the two divergent copies; engine selection moved into `HiveConnection._get_client()` so `BaseConnection` owns it; `engine.dispose` registered with `_on_close`.
- **`hive/utils.py`** — `get_table_comment` used `Row.values()`, removed in SQLAlchemy 2.0, and the `AttributeError` was swallowed by a bare `except`, silently dropping every Hive table comment on the HiveServer2 path.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR preserves an unconfigured Hive metastore as empty and centralizes metastore engine selection and validation.
- Moves metastore engine selection into `HiveConnection`, with engine disposal registered through the connection lifecycle.
- Reuses one metastore-validation helper for test-connection and metadata-ingestion paths.
- Restores Hive table-comment extraction under SQLAlchemy 2.x by converting result rows to tuples.
- Adds Python and Java regression tests for empty, defaults-only, typed, and raw metastore configurations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code failure identified.

Empty and defaults-only metastore configurations consistently fall back to HiveServer2, valid metastore configurations select the corresponding engine, and connection cleanup remains integrated with the existing lifecycle.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/hive/connection.py | Centralizes metastore validation and engine selection while registering both HiveServer2 and metastore engines for lifecycle cleanup. |
| ingestion/src/metadata/ingestion/source/database/hive/metadata.py | Removes duplicate metastore validation and relies on the connection-owned engine while retaining HiveServer2-specific dialect setup. |
| ingestion/src/metadata/ingestion/source/database/hive/utils.py | Updates table-comment row access for SQLAlchemy 2.x and normalizes padded comment text. |
| openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java | Prevents an empty “None” metastore object from being converted into a defaults-populated database connection. |
| ingestion/tests/unit/topology/database/test_hive.py | Expands regression coverage across engine selection, cleanup, metastore validation, fallback behavior, and comment extraction. |
| openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java | Covers typed Postgres/MySQL conversion and preservation of empty or null metastore selections. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Config[Hive service connection] --> Converter[HiveConnectionClassConverter]
  Converter --> Empty{Metastore empty or lacks hostPort?}
  Empty -->|Yes| HiveServer[Create HiveServer2 engine]
  Empty -->|No| Validate[Validate Postgres or MySQL metastore]
  Validate --> Valid{Valid metastore?}
  Valid -->|Yes| Metastore[Create metastore engine]
  Valid -->|No| HiveServer
  HiveServer --> Client[BaseConnection client]
  Metastore --> Client
  Client --> Test[Test connection]
  Client --> Ingest[Metadata ingestion]
  Client --> Close[Dispose engine on close]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #30380: keep Hive test connection ..."](https://github.com/open-metadata/openmetadata/commit/84f1364d360919331c46ce0aeddb7e5afa16263c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48982130)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)
- Knowledge Base — [Auth and Security: Authentication, Authorization, Secrets, and SCIM](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-auth-security.md)

<!-- /greptile_comment -->