### PR TITLE
Fixes #30380: keep Hive test connection working when no metastore is selected (backport of #30599)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/hive/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/connection.py
@@ -15,7 +15,7 @@ Source connection handler
 from copy import deepcopy
 from enum import Enum
 from functools import singledispatch
-from typing import Any, Optional
+from typing import Any, Optional, Union
 from urllib.parse import quote_plus
 
 from pydantic import ValidationError
@@ -53,7 +53,10 @@ from metadata.ingestion.source.database.hive.custom_hive_connection import (
     CustomHiveConnection,
 )
 from metadata.utils.constants import THREE_MIN
+from metadata.utils.logger import ingestion_logger
 from metadata.utils.ssl_manager import check_ssl_and_init
+
+logger = ingestion_logger()
 
 HIVE_POSTGRES_SCHEME = "hive+postgres"
 HIVE_MYSQL_SCHEME = "hive+mysql"
@@ -144,6 +147,46 @@ def get_connection(connection: HiveConnection) -> Engine:
     )
 
 
+def get_validated_metastore_connection(
+    metastore_connection: Any,
+) -> Optional[Union[PostgresConnection, MysqlConnection]]:
+    """
+    Return the metastore connection as a validated model, or None when no metastore is configured.
+    """
+    validated = None
+    if isinstance(metastore_connection, (PostgresConnection, MysqlConnection)):
+        validated = metastore_connection
+    # Picking "None" for the metastore in the UI submits an empty object, which the server expands
+    # into a defaults-only payload carrying no hostPort. That means "no metastore", not a broken one.
+    elif isinstance(metastore_connection, dict) and metastore_connection.get(
+        "hostPort"
+    ):
+        validated = _validate_metastore_dict(metastore_connection)
+    return validated
+
+
+def _validate_metastore_dict(
+    metastore_connection: dict,
+) -> Optional[Union[PostgresConnection, MysqlConnection]]:
+    """
+    Validate a raw metastore payload against the supported metastore backends.
+    """
+    validated = None
+    for candidate in (PostgresConnection, MysqlConnection):
+        try:
+            validated = candidate.model_validate(metastore_connection)
+            break
+        except ValidationError:
+            continue
+
+    if validated is None:
+        logger.warning(
+            "Ignoring the Hive metastore connection: it matches neither a Postgres nor a MySQL "
+            "metastore. Falling back to HiveServer2 for metadata extraction."
+        )
+    return validated
+
+
 @singledispatch
 def get_metastore_connection(connection: Any) -> Engine:
     """
@@ -216,24 +259,13 @@ def test_connection(
     of a metadata workflow or during an Automation Workflow
     """
 
-    metastore_conn = service_connection.metastoreConnection
+    metastore_conn = get_validated_metastore_connection(
+        service_connection.metastoreConnection
+    )
 
     if metastore_conn:
-        if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
-            engine = get_metastore_connection(metastore_conn)
-        elif isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            try:
-                service_connection.metastoreConnection = (
-                    PostgresConnection.model_validate(metastore_conn)
-                )
-            except ValidationError:
-                try:
-                    service_connection.metastoreConnection = (
-                        MysqlConnection.model_validate(metastore_conn)
-                    )
-                except ValidationError:
-                    raise ValueError("Invalid metastore connection")
-            engine = get_metastore_connection(service_connection.metastoreConnection)
+        service_connection.metastoreConnection = metastore_conn
+        engine = get_metastore_connection(metastore_conn)
 
     return test_connection_db_schema_sources(
         metadata=metadata,

--- a/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/metadata.py
@@ -13,9 +13,8 @@ Hive source methods.
 """
 
 import traceback
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
-from pydantic import ValidationError
 from pyhive.sqlalchemy_hive import HiveDialect
 from sqlalchemy import text
 from sqlalchemy.engine.reflection import Inspector
@@ -24,19 +23,16 @@ from metadata.generated.schema.entity.data.table import TableType
 from metadata.generated.schema.entity.services.connections.database.hiveConnection import (
     HiveConnection,
 )
-from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
-    MysqlConnection,
-)
-from metadata.generated.schema.entity.services.connections.database.postgresConnection import (
-    PostgresConnection,
-)
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.common_db_source import CommonDbSourceService
-from metadata.ingestion.source.database.hive.connection import get_metastore_connection
+from metadata.ingestion.source.database.hive.connection import (
+    get_metastore_connection,
+    get_validated_metastore_connection,
+)
 from metadata.ingestion.source.database.hive.utils import (
     get_columns,
     get_table_comment,
@@ -82,40 +78,15 @@ class HiveSource(CommonDbSourceService):
             version = version.replace("-", ".")
         return tuple(map(int, (version.split(".")[:3])))
 
-    def _get_validated_metastore_connection(
-        self,
-    ) -> Optional[Union[PostgresConnection, MysqlConnection]]:
-        """
-        Validate and return the metastore connection if it exists.
-        Handles cases where the connection may be a raw dict that needs validation.
-        """
-        metastore_conn = self.service_connection.metastoreConnection
-
-        if not metastore_conn:
-            return None
-
-        if isinstance(metastore_conn, (PostgresConnection, MysqlConnection)):
-            return metastore_conn
-
-        if isinstance(metastore_conn, dict) and len(metastore_conn) > 0:
-            try:
-                return PostgresConnection.model_validate(metastore_conn)
-            except ValidationError:
-                try:
-                    return MysqlConnection.model_validate(metastore_conn)
-                except ValidationError:
-                    logger.warning("Invalid metastore connection configuration")
-                    return None
-
-        return None
-
     def prepare(self):
         """
         Based on the version of hive update the get_table_names method
         Fetching views in hive server with query "SHOW VIEWS" was possible
         only after hive 2.2.0 version
         """
-        metastore_conn = self._get_validated_metastore_connection()
+        metastore_conn = get_validated_metastore_connection(
+            self.service_connection.metastoreConnection
+        )
 
         if not metastore_conn:
             with self.engine.connect() as conn:

--- a/ingestion/src/metadata/ingestion/source/database/hive/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/hive/utils.py
@@ -168,9 +168,9 @@ def get_table_comment(  # pylint: disable=unused-argument
     )
     try:
         for result in list(cursor):
-            data = result.values()
+            data = tuple(result)
             if data[1] and data[1].strip() == "comment":
-                return {"text": data[2] if data and data[2] else None}
+                return {"text": data[2].strip() if data[2] else None}
     except Exception:
         return {"text": None}
     return {"text": None}

--- a/ingestion/tests/unit/topology/database/test_hive.py
+++ b/ingestion/tests/unit/topology/database/test_hive.py
@@ -61,11 +61,13 @@ from metadata.ingestion.models.custom_pydantic import CustomSecretStr
 from metadata.ingestion.source.database.hive.connection import (
     get_connection,
     get_connection_url,
+    get_validated_metastore_connection,
 )
 from metadata.ingestion.source.database.hive.connection import (
     test_connection as hive_test_connection,
 )
 from metadata.ingestion.source.database.hive.metadata import HiveSource
+from metadata.ingestion.source.database.hive.utils import get_table_comment
 
 mock_hive_config = {
     "source": {
@@ -1080,28 +1082,75 @@ class HiveUnitTest(TestCase):
     @patch(
         "metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources"
     )
-    def test_test_connection_with_invalid_dict_raises_error(self, mock_test_db_schema):
+    @patch(
+        "metadata.ingestion.source.database.hive.connection.get_metastore_connection"
+    )
+    def test_test_connection_with_unrecognized_dict_falls_back_to_hiveserver(
+        self, mock_get_metastore, mock_test_db_schema
+    ):
         """
-        Test test_connection raises ValueError when metastoreConnection dict is invalid
+        Test test_connection ignores a metastoreConnection dict that matches no supported backend
         """
         mock_metadata = Mock()
         mock_engine = Mock()
+        mock_test_db_schema.return_value = Mock()
 
-        invalid_dict = {
+        unrecognized_dict = {
             "type": "InvalidType",
+            "hostPort": "localhost:5432",
             "invalid_field": "invalid_value",
         }
 
         hive_conn = HiveConnection(
             type="Hive",
             hostPort="localhost:10000",
-            metastoreConnection=invalid_dict,
+            metastoreConnection=unrecognized_dict,
         )
 
-        with self.assertRaises(ValueError) as context:
-            hive_test_connection(mock_metadata, mock_engine, hive_conn)
+        hive_test_connection(mock_metadata, mock_engine, hive_conn)
 
-        self.assertEqual(str(context.exception), "Invalid metastore connection")
+        mock_get_metastore.assert_not_called()
+        self.assertEqual(mock_test_db_schema.call_args.kwargs["engine"], mock_engine)
+
+    @patch(
+        "metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources"
+    )
+    @patch(
+        "metadata.ingestion.source.database.hive.connection.get_metastore_connection"
+    )
+    def test_test_connection_with_defaults_only_metastore(
+        self, mock_get_metastore, mock_test_db_schema
+    ):
+        """
+        Test test_connection ignores the defaults-only payload the server derives from a "None" metastore
+        """
+        mock_metadata = Mock()
+        mock_engine = Mock()
+        mock_test_db_schema.return_value = Mock()
+
+        defaults_only_dict = {
+            "type": "Mysql",
+            "scheme": "mysql+pymysql",
+            "supportsMetadataExtraction": True,
+            "supportsDBTExtraction": True,
+            "supportsProfiler": True,
+            "supportsQueryComment": True,
+            "supportsDataDiff": True,
+            "supportsUsageExtraction": True,
+            "supportsLineageExtraction": True,
+            "useSlowLogs": False,
+        }
+
+        hive_conn = HiveConnection(
+            type="Hive",
+            hostPort="localhost:10000",
+            metastoreConnection=defaults_only_dict,
+        )
+
+        hive_test_connection(mock_metadata, mock_engine, hive_conn)
+
+        mock_get_metastore.assert_not_called()
+        self.assertEqual(mock_test_db_schema.call_args.kwargs["engine"], mock_engine)
 
     @patch(
         "metadata.ingestion.source.database.hive.connection.test_connection_db_schema_sources"
@@ -1162,61 +1211,46 @@ class HiveUnitTest(TestCase):
         self.assertEqual(call_kwargs.kwargs["engine"], mock_engine)
 
 
-class HiveSourceMetastoreValidationTest(TestCase):
+class HiveMetastoreValidationTest(TestCase):
     """
-    Test the _get_validated_metastore_connection method in HiveSource
+    Test get_validated_metastore_connection
     """
 
-    @patch(
-        "metadata.ingestion.source.database.common_db_source.CommonDbSourceService.test_connection"
-    )
-    def setUp(self, mock_test_connection):
-        mock_test_connection.return_value = False
-        self.config = OpenMetadataWorkflowConfig.model_validate(mock_hive_config)
-        self.hive = HiveSource.create(
-            mock_hive_config["source"],
-            self.config.workflowConfig.openMetadataServerConfig,
-        )
+    def test_with_none(self):
+        """
+        Test None is returned when metastoreConnection is None
+        """
+        self.assertIsNone(get_validated_metastore_connection(None))
 
-    def test_get_validated_metastore_connection_with_none(self):
+    def test_with_postgres_object(self):
         """
-        Test _get_validated_metastore_connection returns None when metastoreConnection is None
-        """
-        self.hive.service_connection.metastoreConnection = None
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
-
-    def test_get_validated_metastore_connection_with_postgres_object(self):
-        """
-        Test _get_validated_metastore_connection returns PostgresConnection when already validated
+        Test an already validated PostgresConnection is returned as is
         """
         postgres_conn = PostgresConnection(
             username="postgres_user",
             hostPort="localhost:5432",
             database="hive_metastore",
         )
-        self.hive.service_connection.metastoreConnection = postgres_conn
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, PostgresConnection)
-        self.assertEqual(result, postgres_conn)
 
-    def test_get_validated_metastore_connection_with_mysql_object(self):
+        self.assertEqual(
+            get_validated_metastore_connection(postgres_conn), postgres_conn
+        )
+
+    def test_with_mysql_object(self):
         """
-        Test _get_validated_metastore_connection returns MysqlConnection when already validated
+        Test an already validated MysqlConnection is returned as is
         """
         mysql_conn = MysqlConnection(
             username="mysql_user",
             hostPort="localhost:3306",
             databaseSchema="hive_metastore",
         )
-        self.hive.service_connection.metastoreConnection = mysql_conn
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsInstance(result, MysqlConnection)
-        self.assertEqual(result, mysql_conn)
 
-    def test_get_validated_metastore_connection_with_postgres_dict(self):
+        self.assertEqual(get_validated_metastore_connection(mysql_conn), mysql_conn)
+
+    def test_with_postgres_dict(self):
         """
-        Test _get_validated_metastore_connection parses dict as PostgresConnection
+        Test a raw dict is parsed as PostgresConnection
         """
         postgres_dict = {
             "type": "Postgres",
@@ -1224,14 +1258,14 @@ class HiveSourceMetastoreValidationTest(TestCase):
             "hostPort": "localhost:5432",
             "database": "hive_metastore",
         }
-        self.hive.service_connection.metastoreConnection = postgres_dict
-        result = self.hive._get_validated_metastore_connection()
+        result = get_validated_metastore_connection(postgres_dict)
+
         self.assertIsInstance(result, PostgresConnection)
         self.assertEqual(result.username, "postgres_user")
 
-    def test_get_validated_metastore_connection_with_mysql_dict(self):
+    def test_with_mysql_dict(self):
         """
-        Test _get_validated_metastore_connection parses dict as MysqlConnection
+        Test a raw dict is parsed as MysqlConnection
         """
         mysql_dict = {
             "type": "Mysql",
@@ -1239,27 +1273,79 @@ class HiveSourceMetastoreValidationTest(TestCase):
             "hostPort": "localhost:3306",
             "databaseSchema": "hive_metastore",
         }
-        self.hive.service_connection.metastoreConnection = mysql_dict
-        result = self.hive._get_validated_metastore_connection()
+        result = get_validated_metastore_connection(mysql_dict)
+
         self.assertIsInstance(result, MysqlConnection)
         self.assertEqual(result.username, "mysql_user")
 
-    def test_get_validated_metastore_connection_with_empty_dict(self):
+    def test_with_empty_dict(self):
         """
-        Test _get_validated_metastore_connection returns None for empty dict
+        Test None is returned for an empty dict
         """
-        self.hive.service_connection.metastoreConnection = {}
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
+        self.assertIsNone(get_validated_metastore_connection({}))
 
-    def test_get_validated_metastore_connection_with_invalid_dict(self):
+    def test_with_defaults_only_dict(self):
         """
-        Test _get_validated_metastore_connection returns None for invalid dict
+        Test None is returned for the payload the server derives from a "None" metastore
         """
-        invalid_dict = {
+        defaults_only_dict = {
+            "type": "Mysql",
+            "scheme": "mysql+pymysql",
+            "supportsMetadataExtraction": True,
+            "supportsProfiler": True,
+            "useSlowLogs": False,
+        }
+
+        self.assertIsNone(get_validated_metastore_connection(defaults_only_dict))
+
+    def test_with_unrecognized_dict(self):
+        """
+        Test None is returned for a dict matching no supported backend
+        """
+        unrecognized_dict = {
             "type": "InvalidType",
+            "hostPort": "localhost:5432",
             "invalid_field": "invalid_value",
         }
-        self.hive.service_connection.metastoreConnection = invalid_dict
-        result = self.hive._get_validated_metastore_connection()
-        self.assertIsNone(result)
+
+        self.assertIsNone(get_validated_metastore_connection(unrecognized_dict))
+
+
+class HiveTableCommentTest(TestCase):
+    """
+    Test get_table_comment
+    """
+
+    @staticmethod
+    def _connection_returning(rows):
+        connection = Mock()
+        connection.execute.return_value = rows
+
+        return connection
+
+    def test_returns_table_comment(self):
+        """
+        Test the comment row of DESCRIBE FORMATTED is returned, stripped of padding
+        """
+        rows = [
+            ("id", "int", "customer id"),
+            ("", "comment             ", "customer master     "),
+        ]
+
+        result = get_table_comment(
+            Mock(), self._connection_returning(rows), "customers", "sales_db"
+        )
+
+        self.assertEqual(result, {"text": "customer master"})
+
+    def test_returns_none_without_comment(self):
+        """
+        Test None is returned when DESCRIBE FORMATTED has no comment row
+        """
+        rows = [("id", "int", "customer id")]
+
+        result = get_table_comment(
+            Mock(), self._connection_returning(rows), "customers", "sales_db"
+        )
+
+        self.assertEqual(result, {"text": None})

--- a/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java
@@ -14,6 +14,7 @@
 package org.openmetadata.service.secrets.converter;
 
 import java.util.List;
+import java.util.Map;
 import org.openmetadata.schema.services.connections.database.HiveConnection;
 import org.openmetadata.schema.services.connections.database.MysqlConnection;
 import org.openmetadata.schema.services.connections.database.PostgresConnection;
@@ -33,9 +34,20 @@ public class HiveConnectionClassConverter extends ClassConverter {
   public Object convert(Object object) {
     HiveConnection hiveConnection = (HiveConnection) JsonUtils.convertValue(object, this.clazz);
 
-    tryToConvert(hiveConnection.getMetastoreConnection(), CONFIG_SOURCE_CLASSES)
-        .ifPresent(hiveConnection::setMetastoreConnection);
+    if (!isEmptyMap(hiveConnection.getMetastoreConnection())) {
+      tryToConvert(hiveConnection.getMetastoreConnection(), CONFIG_SOURCE_CLASSES)
+          .ifPresent(hiveConnection::setMetastoreConnection);
+    }
 
     return hiveConnection;
+  }
+
+  /**
+   * Selecting "None" for the metastore submits an empty object. Jackson does not enforce JSON
+   * Schema `required`, so converting it would succeed against the first candidate class and persist
+   * a metastore config populated entirely with schema defaults.
+   */
+  private static boolean isEmptyMap(Object object) {
+    return object instanceof Map<?, ?> map && map.isEmpty();
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java
@@ -1,0 +1,80 @@
+package org.openmetadata.service.secrets.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.services.connections.database.HiveConnection;
+import org.openmetadata.schema.services.connections.database.MysqlConnection;
+import org.openmetadata.schema.services.connections.database.PostgresConnection;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class HiveConnectionClassConverterTest {
+
+  private final ClassConverter converter = ClassConverterFactory.getConverter(HiveConnection.class);
+
+  @Test
+  void testConvertsPostgresMetastore() {
+    PostgresConnection metastore =
+        new PostgresConnection()
+            .withHostPort("localhost:5432")
+            .withUsername("postgres_user")
+            .withDatabase("hive_metastore");
+
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(metastore);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(PostgresConnection.class, result.getMetastoreConnection());
+  }
+
+  @Test
+  void testConvertsMysqlMetastore() {
+    MysqlConnection metastore =
+        new MysqlConnection().withHostPort("localhost:3306").withUsername("mysql_user");
+
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(metastore);
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(MysqlConnection.class, result.getMetastoreConnection());
+  }
+
+  /**
+   * Selecting "None" for the metastore submits an empty object. Converting it would match the first
+   * candidate class and persist a metastore config built entirely from schema defaults, which the
+   * ingestion framework then rejects as invalid.
+   */
+  @Test
+  void testEmptyMetastoreIsLeftUntouched() {
+    HiveConnection input =
+        new HiveConnection().withHostPort("localhost:10000").withMetastoreConnection(Map.of());
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertInstanceOf(Map.class, result.getMetastoreConnection());
+    assertEquals(Map.of(), result.getMetastoreConnection());
+  }
+
+  @Test
+  void testNullMetastoreDoesNotThrow() {
+    HiveConnection input = new HiveConnection().withHostPort("localhost:10000");
+    Object rawInput = JsonUtils.readValue(JsonUtils.pojoToJson(input), Object.class);
+
+    HiveConnection result = (HiveConnection) converter.convert(rawInput);
+
+    assertNotNull(result);
+    assertNull(result.getMetastoreConnection());
+  }
+}


### PR DESCRIPTION
Backport of #30599 to `1.13`.

Fixes #30380 — selecting **None** for the Hive Metastore Connection made test connection fail with `Error running automation workflow due to [Invalid metastore connection]`, and ingestion failed the same way since the metadata workflow runs `test_connection` at start. Reported against 1.13.0 and 1.13.1.

## Not a cherry-pick

Hive on `1.13` predates the BaseConnection migration — it still has module-level `get_connection()` / `test_connection()` rather than `HiveConnection(BaseConnection[...])._get_client()`. So `cc5eeb5f` does not apply and this is hand-ported. Two pieces of #30599 have no target here and are deliberately omitted:

- moving engine selection into `_get_client()` — `prepare()` keeps assigning `self.engine`
- registering `engine.dispose` via `_on_close`

The typing modernization is also omitted, since `1.13` is pre-ruff and keeps `Optional[Union[...]]`.

## What is ported

**`HiveConnectionClassConverter`** — verbatim from #30599. Skip the conversion when the metastore is an empty map, so `{}` is no longer inflated into a MySQL config built entirely from schema defaults. Jackson does not enforce JSON Schema `required`, which is why converting an empty map succeeded against the first candidate class.

**`hive/connection.py` + `hive/metadata.py`** — the metastore validation was duplicated across both files with divergent behavior (`metadata.py` warned and fell back, `connection.py` raised). Unified into `get_validated_metastore_connection()`: no `hostPort` means not configured and uses HiveServer2; a `hostPort` that matches no backend warns and falls back rather than failing the run. This also heals services that already persisted the bad config, which the server-side fix alone cannot do.

**`hive/utils.py`** — `get_table_comment` used `Row.values()`, a SQLAlchemy 1.x `LegacyRow` API removed in 2.0. This branch pins `sqlalchemy>=2.0.0,<3`, so the bug is live here too: the `AttributeError` was swallowed by a bare `except`, silently dropping every Hive table comment.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport restores HiveServer2 fallback behavior when no usable metastore is configured.
- Leaves empty Hive metastore maps unconverted by the service-side class converter.
- Centralizes ingestion-side metastore validation and falls back to HiveServer2 for empty or unrecognized configurations.
- Updates Hive table-comment extraction for SQLAlchemy 2 row semantics.
- Adds unit coverage for metastore conversion, validation, fallback behavior, and table comments.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security defects identified.

The service and ingestion changes consistently preserve an unconfigured metastore as absent, retain valid MySQL and Postgres paths, fall back to HiveServer2 for unusable configurations, and correctly adapt comment rows to SQLAlchemy 2 semantics.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/hive/connection.py | Centralizes metastore validation and consistently falls back to the supplied HiveServer2 engine when no supported metastore configuration is available. |
| ingestion/src/metadata/ingestion/source/database/hive/metadata.py | Reuses the shared metastore validator during source preparation while retaining the existing engine-selection behavior. |
| ingestion/src/metadata/ingestion/source/database/hive/utils.py | Uses SQLAlchemy 2-compatible positional row conversion and trims Hive table-comment padding. |
| ingestion/tests/unit/topology/database/test_hive.py | Covers empty, defaults-only, valid, and unrecognized metastore configurations plus table-comment extraction. |
| openmetadata-service/src/main/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverter.java | Prevents an empty metastore map from being inflated into a defaults-only database connection. |
| openmetadata-service/src/test/java/org/openmetadata/service/secrets/converter/HiveConnectionClassConverterTest.java | Verifies conversion of configured metastores and preservation of null or empty metastore selections. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Config[Hive service connection] --> Convert[Service class converter]
  Convert -->|Empty metastore map| Preserve[Preserve empty map]
  Convert -->|Configured metastore| Typed[Convert to MySQL or Postgres]
  Preserve --> Validate[Ingestion metastore validation]
  Typed --> Validate
  Validate -->|Valid metastore| Metastore[Use metastore engine]
  Validate -->|Absent or unrecognized| HiveServer2[Use HiveServer2 engine]
  Metastore --> Extract[Extract Hive metadata]
  HiveServer2 --> Extract
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fixes #30380: keep Hive test connection ..."](https://github.com/open-metadata/openmetadata/commit/341a04e51db4362b9f8f1ea50395b7d03b387c40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48986567)</sub>

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->