### PR TITLE
ci: surface the cause when a PR is kicked out of the merge queue

### DIFF
--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -96,11 +96,10 @@ jobs:
 
           gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
             --jq '.check_runs[]
-                  | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")
+                  | select(.conclusion != null and .conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")
                   | "- [\(.name)](\(.html_url)) — `\(.conclusion)`"' > failures.md
 
           {
-            echo "<!-- merge-queue-dequeue-report -->"
             echo "### 🚦 Removed from the merge queue — \`$REASON\`"
             echo
             if [ -s failures.md ]; then

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -52,10 +52,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # shellcheck disable=SC2016  # the GraphQL query and jq filter must not expand
 
-          # The timeline entry is written as part of the dequeue, so it may not
-          # be readable the instant the webhook fires.
+          # A PR dequeued before still has an older event, so "an event exists"
+          # cannot mean "this dequeue's event". Require a recent one, wide
+          # enough to absorb runner queueing.
+          CUTOFF=$(date -u -d '30 minutes ago' +%s)
+
+          # The timeline entry may not be readable the instant the webhook fires.
+          # shellcheck disable=SC2016  # the GraphQL query and jq filter must not expand
           for _ in 1 2 3; do
             gh api graphql -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" -f query='
               query($owner: String!, $repo: String!, $pr: Int!) {
@@ -65,6 +69,7 @@ jobs:
                       nodes {
                         ... on RemovedFromMergeQueueEvent {
                           reason
+                          createdAt
                           beforeCommit { oid }
                         }
                       }
@@ -73,16 +78,24 @@ jobs:
                 }
               }' --jq '.data.repository.pullRequest.timelineItems.nodes[0]
                        | select(.beforeCommit != null)
-                       | "reason=\(.reason)\nsha=\(.beforeCommit.oid)"' > event.txt || true
+                       | "\(.reason)\t\(.beforeCommit.oid)\t\(.createdAt)"' > event.tsv || true
 
-            if [ -s event.txt ]; then
-              cat event.txt >> "$GITHUB_OUTPUT"
-              exit 0
+            if [ -s event.tsv ]; then
+              CREATED=$(cut -f3 event.tsv)
+              if [ "$(date -u -d "$CREATED" +%s)" -ge "$CUTOFF" ]; then
+                {
+                  echo "reason=$(cut -f1 event.tsv)"
+                  echo "sha=$(cut -f2 event.tsv)"
+                  echo "created=$CREATED"
+                } >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Newest dequeue event for PR #$PR is from $CREATED — stale, not this dequeue."
             fi
             sleep 5
           done
 
-          echo "No RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
+          echo "No fresh RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
 
       - name: Comment the checks that caused the dequeue
         if: ${{ steps.event.outputs.sha != '' }}
@@ -90,6 +103,7 @@ jobs:
         env:
           REASON: ${{ steps.event.outputs.reason }}
           SHA: ${{ steps.event.outputs.sha }}
+          CREATED: ${{ steps.event.outputs.created }}
         run: |
           set -euo pipefail
           # shellcheck disable=SC2016  # the jq filter must not expand
@@ -100,7 +114,7 @@ jobs:
                   | "- [\(.name)](\(.html_url)) — `\(.conclusion)`"' > failures.md
 
           {
-            echo "### 🚦 Removed from the merge queue — \`$REASON\`"
+            echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
             echo
             if [ -s failures.md ]; then
               echo "These checks failed on merge-queue commit \`${SHA:0:7}\`:"

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -45,6 +45,7 @@ jobs:
       OWNER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
       PR: ${{ github.event.number || inputs.pr }}
+      IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
       DRY_RUN: ${{ inputs.dry_run == true || vars.MQ_REPORT_DRY_RUN == 'true' }}
     steps:
       - name: Resolve the dequeue event
@@ -55,8 +56,13 @@ jobs:
 
           # A PR dequeued before still has an older event, so "an event exists"
           # cannot mean "this dequeue's event". Require a recent one, wide
-          # enough to absorb runner queueing.
-          CUTOFF=$(date -u -d '30 minutes ago' +%s)
+          # enough to absorb runner queueing. A manual dispatch names the PR
+          # outright, so there is no webhook to match an event against.
+          if [ "$IS_DISPATCH" = "true" ]; then
+            CUTOFF=0
+          else
+            CUTOFF=$(date -u -d '30 minutes ago' +%s)
+          fi
 
           # The timeline entry may not be readable the instant the webhook fires.
           # shellcheck disable=SC2016  # the GraphQL query and jq filter must not expand

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -45,7 +45,6 @@ jobs:
       OWNER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
       PR: ${{ github.event.number || inputs.pr }}
-      IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
       DRY_RUN: ${{ inputs.dry_run == true || vars.MQ_REPORT_DRY_RUN == 'true' }}
     steps:
       - name: Resolve the dequeue event
@@ -54,17 +53,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A PR dequeued before still has an older event, so "an event exists"
-          # cannot mean "this dequeue's event". Require a recent one, wide
-          # enough to absorb runner queueing. A manual dispatch names the PR
-          # outright, so there is no webhook to match an event against.
-          if [ "$IS_DISPATCH" = "true" ]; then
-            CUTOFF=0
-          else
-            CUTOFF=$(date -u -d '30 minutes ago' +%s)
-          fi
-
-          # The timeline entry may not be readable the instant the webhook fires.
+          # Only a first-ever dequeue can return an empty list; a repeat dequeue
+          # matches at once, and its createdAt in the comment exposes a stale read.
           # shellcheck disable=SC2016  # the GraphQL query and jq filter must not expand
           for _ in 1 2 3; do
             gh api graphql -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" -f query='
@@ -87,21 +77,17 @@ jobs:
                        | "\(.reason)\t\(.beforeCommit.oid)\t\(.createdAt)"' > event.tsv || true
 
             if [ -s event.tsv ]; then
-              CREATED=$(cut -f3 event.tsv)
-              if [ "$(date -u -d "$CREATED" +%s)" -ge "$CUTOFF" ]; then
-                {
-                  echo "reason=$(cut -f1 event.tsv)"
-                  echo "sha=$(cut -f2 event.tsv)"
-                  echo "created=$CREATED"
-                } >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              echo "Newest dequeue event for PR #$PR is from $CREATED — stale, not this dequeue."
+              {
+                echo "reason=$(cut -f1 event.tsv)"
+                echo "sha=$(cut -f2 event.tsv)"
+                echo "created=$(cut -f3 event.tsv)"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
             fi
             sleep 5
           done
 
-          echo "No fresh RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
+          echo "No RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
 
       - name: Comment the checks that caused the dequeue
         if: ${{ steps.event.outputs.sha != '' }}

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -1,0 +1,123 @@
+#  Copyright 2026 Collate
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# The queue ref is deleted on dequeue; its commit is not, so check runs are
+# read from the commit rather than the branch.
+# Must stay pull_request_target — pull_request gets a read-only token on fork
+# PRs and cannot comment. Safe only while nothing checks out PR code.
+name: Merge Queue Dequeue Report
+
+on:
+  pull_request_target:
+    types: [dequeued]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to report on
+        required: true
+        type: number
+      dry_run:
+        description: Print to the job summary instead of commenting on the PR
+        type: boolean
+        default: true
+
+permissions:
+  checks: read
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: merge-queue-dequeue-report-${{ github.event.number || inputs.pr }}
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Report dequeue cause
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+      PR: ${{ github.event.number || inputs.pr }}
+      DRY_RUN: ${{ inputs.dry_run == true || vars.MQ_REPORT_DRY_RUN == 'true' }}
+    steps:
+      - name: Resolve the dequeue event
+        id: event
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016  # the GraphQL query and jq filter must not expand
+
+          # The timeline entry is written as part of the dequeue, so it may not
+          # be readable the instant the webhook fires.
+          for _ in 1 2 3; do
+            gh api graphql -f owner="$OWNER" -f repo="$REPO" -F pr="$PR" -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
+                      nodes {
+                        ... on RemovedFromMergeQueueEvent {
+                          reason
+                          beforeCommit { oid }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' --jq '.data.repository.pullRequest.timelineItems.nodes[0]
+                       | select(.beforeCommit != null)
+                       | "reason=\(.reason)\nsha=\(.beforeCommit.oid)"' > event.txt || true
+
+            if [ -s event.txt ]; then
+              cat event.txt >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "No RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
+
+      - name: Comment the checks that caused the dequeue
+        if: ${{ steps.event.outputs.sha != '' }}
+        shell: bash
+        env:
+          REASON: ${{ steps.event.outputs.reason }}
+          SHA: ${{ steps.event.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016  # the jq filter must not expand
+
+          gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
+            --jq '.check_runs[]
+                  | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled")
+                  | "- [\(.name)](\(.html_url)) — `\(.conclusion)`"' > failures.md
+
+          {
+            echo "<!-- merge-queue-dequeue-report -->"
+            echo "### 🚦 Removed from the merge queue — \`$REASON\`"
+            echo
+            if [ -s failures.md ]; then
+              echo "These checks failed on merge-queue commit \`${SHA:0:7}\`:"
+              echo
+              cat failures.md
+            else
+              echo "No failing check on merge-queue commit \`${SHA:0:7}\` — removed by hand, invalidated by an entry ahead in the queue, or a required check timed out."
+            fi
+          } > body.md
+
+          if [ "$DRY_RUN" = "true" ]; then
+            cat body.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            gh pr comment "$PR" --body-file body.md
+          fi

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -34,10 +34,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: merge-queue-dequeue-report-${{ github.event.number || inputs.pr }}
-  cancel-in-progress: false
-
 jobs:
   report:
     name: Report dequeue cause


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

<!-- TODO: link an issue before marking ready for review. -->

When a PR fails in the merge queue it is silently dequeued. The checks ran on a
`gh-readonly-queue/main/pr-<N>-<sha>` ref that the PR never references, and that ref is
deleted on dequeue — so the PR timeline shows one grey line and nothing else. Every
PR-facing reporter in this repo is gated to `pull_request_target`
(`java-checkstyle.yml:91`, `py-checkstyle.yml:106`, `ui-checkstyle.yml:310`) or excludes
merge-queue runs outright (`playwright-postgresql-pr-comment.yml:32`), so queue runs
produce no PR output at all. Today the only way to find the failure is to page the Actions
tab filtered by `event:merge_group` and eyeball branch names.

This adds a workflow that comments the cause on the PR, with deep links to the failing
jobs.

#
### Type of change:
- [x] Improvement

#
### High-level design:

The dequeue is recorded on the PR timeline as a `RemovedFromMergeQueueEvent`, which carries
both halves of the answer:

- `reason` — observed values `failed_checks`, `manual`, `merged`
- `beforeCommit` — the merge-group commit

The branch is deleted on dequeue but the commit is not, and all queue checks are attached to
it. So `GET /commits/{sha}/check-runs` returns the failing checks, and each check run's
`html_url` deep-links to the exact job. Two API calls from the PR number alone — no run
listing, no per-workflow subscription, no stored state.

Alternatives rejected:

- **Search `gh run list --event merge_group` for `pr-<N>-*`** — needs a deep, unbounded
  listing (the queue can sit hours deep) and races branch deletion.
- **`workflow_run` fan-out** — requires naming every workflow and emits one comment per
  failing workflow.
- **`check_suite: completed`** — does not fire at all: GitHub suppresses it for check suites
  created by Actions, to prevent recursion.
- **`pull_request` instead of `pull_request_target`** — fork PRs get a read-only
  `GITHUB_TOKEN` regardless of the `permissions:` key, so commenting 403s for external
  contributors (4 of the last 60 merged PRs). `pull_request_target` is safe here because the
  workflow never checks out PR code.

#
### Tests:

#### Use cases covered
- PR dequeued for failing checks → comment lists each failing check with a link to the job
- PR removed from the queue by hand → comment states the reason, plus any failures found
- PR dequeued with no failing check (invalidated by an entry ahead, or a timeout) → comment
  says so rather than showing an empty list
- PR that merged normally → no comment

#### Unit tests
Not applicable — CI workflow.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
The step body was run verbatim against three real dequeues in this repo, and `actionlint`
passes clean on the workflow.

    PR 30613 (reason=failed_checks sha=4d1dd96)
      - playwright-summary                          -> .../runs/30611468850/job/91104770995
      - Playwright RDF (Knowledge Graph + Ontology) -> .../runs/30611468900/job/91101452980
      - RDF Playwright execution                    -> .../runs/30611468900/job/91097238127

    PR 30451 (reason=manual sha=f14790a)
      - playwright-summary                          -> .../runs/30603720876/job/91088875048
      - playwright-ci-postgresql (chromium-18, ...)  -> .../runs/30603720876/job/91084674759

    PR 30599 (reason=merged sha=cc5eeb5)
      - no failing check -> fallback text

Still unverified, and only verifiable after this lands on `main`: that GitHub delivers the
`dequeued` activity type to Actions in this repo, and that the token can comment. Rollout
below covers both.

#
### Rollout

`pull_request_target` always loads the workflow from the base branch, and `workflow_dispatch` only
registers once the file is on the default branch — verified: `gh workflow run` on the feature branch
answers `could not find any workflows named Merge Queue Dequeue Report`. So **nothing about this can
run in CI until it is merged.** Pre-merge verification is limited to the local runs above.

After merge:

1. Replay any past dequeue without touching the PR:
   `gh workflow run "Merge Queue Dequeue Report" -f pr=<N> -f dry_run=true` — output lands in the job
   summary, so nothing is posted to the PR being replayed.
2. Optional kill switch — set repository variable `MQ_REPORT_DRY_RUN=true` to route every run's output
   to the job summary instead of the PR. Unset (the default) means it comments.

To watch it silently against real dequeues for a day before it posts anything, set that variable
before merging.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — pending the linked issue
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — pending
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a GitHub Actions workflow that reports merge-queue dequeue causes.
- Resolves the latest removal event and associated merge-group commit.
- Lists unsuccessful check runs with links to their jobs.
- Posts the report to the pull request or job summary in dry-run mode.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because repeat dequeues can be attributed to an earlier removal event.

The reply from : states that a createdAt cutoff was added, but the current workflow only checks that beforeCommit is non-null and never compares createdAt with an invocation-specific cutoff, so a prior dequeue event can still be reported as the current one.

**Files Needing Attention:** .github/workflows/merge-queue-dequeue-report.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/merge-queue-dequeue-report.yml | Adds the dequeue-reporting workflow, but the previously reported stale-event association remains in the current implementation. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Revert &quot;ci: only accept a dequeue event ..."](https://github.com/open-metadata/openmetadata/commit/6b348b43b2a2cefb808b2218ac9419519f0b89f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48990975)</sub>

<!-- /greptile_comment -->