### PR TITLE
ci: group merge-queue dequeue failures by workflow run

### DIFF
--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -74,8 +74,8 @@ jobs:
                   }
                 }
               }' --jq '.data.repository.pullRequest.timelineItems.nodes[0]
-                       | select(.beforeCommit != null)
-                       | "\(.reason)\t\(.beforeCommit.oid)\t\(.createdAt)"' > event.tsv || true
+                       | select(.reason != null)
+                       | "\(.reason)\t\(.beforeCommit.oid // "")\t\(.createdAt)"' > event.tsv || true
 
             if [ -s event.tsv ]; then
               {
@@ -91,7 +91,7 @@ jobs:
           echo "No RemovedFromMergeQueueEvent found for PR #$PR — nothing to report."
 
       - name: Comment the checks that caused the dequeue
-        if: ${{ steps.event.outputs.sha != '' }}
+        if: ${{ steps.event.outputs.reason != '' }}
         shell: bash
         env:
           REASON: ${{ steps.event.outputs.reason }}
@@ -101,44 +101,54 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC2016  # the jq filter must not expand
 
-          gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
-            --jq '.check_runs[]
-                  | select(.conclusion != null and .conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")
-                  | "\(.html_url)\t\(.name)"' > failures.tsv
-
-          # Only a required check can dequeue an entry; the rest failed alongside it.
-          gh api "repos/$GH_REPO/rules/branches/$BASE_REF" \
-            --jq '.[] | select(.type == "required_status_checks")
-                  | .parameters.required_status_checks[].context' > required.txt || true
-
-          blocked=$(cut -f2 failures.tsv | grep -xFf required.txt \
-            | awk '{ out = out (out ? ", " : "") "`" $0 "`" } END { print out }' || true)
-
-          : > runs.md
-          cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
-            run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
-            # Matrix jobs carry every parameter; the first one is the shard id.
-            jobs=$(grep -F "$run/job/" failures.tsv | cut -f2 \
-                   | sed 's/ (\([^,)]*\)[^)]*)/ (\1)/' \
-                   | awk '{ out = out (out ? ", " : "") $0 } END { print out }')
-            echo "- [$run_name]($run) — $jobs" >> runs.md
-          done
-
-          {
-            echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
-            echo
-            if [ -s runs.md ]; then
-              if [ -n "$blocked" ]; then
-                echo "Blocked the queue: $blocked"
-              else
-                echo "No required check failed — the entry may have timed out, or been dequeued while a required check was still pending."
-              fi
+          # An entry removed while still queued was never built, so it has no
+          # merge-group commit and nothing ever ran against it.
+          if [ -z "$SHA" ]; then
+            {
+              echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
               echo
-              cat runs.md
-            else
-              echo "No failing check on merge-queue commit \`${SHA:0:7}\` — removed by hand, invalidated by an entry ahead in the queue, or a required check timed out."
-            fi
-          } > body.md
+              echo "The entry left the queue before it was built, so no checks ran against it."
+            } > body.md
+          else
+            gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
+              --jq '.check_runs[]
+                    | select(.conclusion != null and .conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")
+                    | "\(.html_url)\t\(.name)"' > failures.tsv
+
+            # Only a required check can dequeue an entry; the rest failed alongside it.
+            gh api "repos/$GH_REPO/rules/branches/$BASE_REF" \
+              --jq '.[] | select(.type == "required_status_checks")
+                    | .parameters.required_status_checks[].context' > required.txt || true
+
+            blocked=$(cut -f2 failures.tsv | grep -xFf required.txt \
+              | awk '{ out = out (out ? ", " : "") "`" $0 "`" } END { print out }' || true)
+
+            : > runs.md
+            cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
+              run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
+              # Matrix jobs carry every parameter; the first one is the shard id.
+              jobs=$(grep -F "$run/job/" failures.tsv | cut -f2 \
+                     | sed 's/ (\([^,)]*\)[^)]*)/ (\1)/' \
+                     | awk '{ out = out (out ? ", " : "") $0 } END { print out }')
+              echo "- [$run_name]($run) — $jobs" >> runs.md
+            done
+
+            {
+              echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
+              echo
+              if [ -s runs.md ]; then
+                if [ -n "$blocked" ]; then
+                  echo "Blocked the queue: $blocked"
+                else
+                  echo "No required check failed — the entry may have timed out, or been dequeued while a required check was still pending."
+                fi
+                echo
+                cat runs.md
+              else
+                echo "No failing check on merge-queue commit \`${SHA:0:7}\` — invalidated by an entry ahead in the queue, or a required check timed out."
+              fi
+            } > body.md
+          fi
 
           if [ "$DRY_RUN" = "true" ]; then
             cat body.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/merge-queue-dequeue-report.yml
+++ b/.github/workflows/merge-queue-dequeue-report.yml
@@ -45,6 +45,7 @@ jobs:
       OWNER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
       PR: ${{ github.event.number || inputs.pr }}
+      BASE_REF: ${{ github.event.repository.default_branch }}
       DRY_RUN: ${{ inputs.dry_run == true || vars.MQ_REPORT_DRY_RUN == 'true' }}
     steps:
       - name: Resolve the dequeue event
@@ -103,15 +104,37 @@ jobs:
           gh api "repos/$GH_REPO/commits/$SHA/check-runs?per_page=100" --paginate \
             --jq '.check_runs[]
                   | select(.conclusion != null and .conclusion != "success" and .conclusion != "neutral" and .conclusion != "skipped")
-                  | "- [\(.name)](\(.html_url)) — `\(.conclusion)`"' > failures.md
+                  | "\(.html_url)\t\(.name)"' > failures.tsv
+
+          # Only a required check can dequeue an entry; the rest failed alongside it.
+          gh api "repos/$GH_REPO/rules/branches/$BASE_REF" \
+            --jq '.[] | select(.type == "required_status_checks")
+                  | .parameters.required_status_checks[].context' > required.txt || true
+
+          blocked=$(cut -f2 failures.tsv | grep -xFf required.txt \
+            | awk '{ out = out (out ? ", " : "") "`" $0 "`" } END { print out }' || true)
+
+          : > runs.md
+          cut -f1 failures.tsv | sed 's#/job/.*##' | sort -u | while read -r run; do
+            run_name=$(gh api "repos/$GH_REPO/actions/runs/${run##*/}" --jq '.name')
+            # Matrix jobs carry every parameter; the first one is the shard id.
+            jobs=$(grep -F "$run/job/" failures.tsv | cut -f2 \
+                   | sed 's/ (\([^,)]*\)[^)]*)/ (\1)/' \
+                   | awk '{ out = out (out ? ", " : "") $0 } END { print out }')
+            echo "- [$run_name]($run) — $jobs" >> runs.md
+          done
 
           {
             echo "### 🚦 Removed from the merge queue — \`$REASON\` ($CREATED)"
             echo
-            if [ -s failures.md ]; then
-              echo "These checks failed on merge-queue commit \`${SHA:0:7}\`:"
+            if [ -s runs.md ]; then
+              if [ -n "$blocked" ]; then
+                echo "Blocked the queue: $blocked"
+              else
+                echo "No required check failed — the entry may have timed out, or been dequeued while a required check was still pending."
+              fi
               echo
-              cat failures.md
+              cat runs.md
             else
               echo "No failing check on merge-queue commit \`${SHA:0:7}\` — removed by hand, invalidated by an entry ahead in the queue, or a required check timed out."
             fi


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

<!-- TODO: link an issue before marking ready for review. -->

Follow-up to #30752, which reports why a PR was kicked out of the merge queue. That version
emitted one deep link per failing check run, which has two problems visible in real data:

- **Redundant links.** PR #30594's six failing jobs all live in a single workflow run — six
  clicks, one destination.
- **Cause and symptom presented as peers.** Only a *required* check can dequeue an entry. On
  #30707, five checks failed but only `playwright-summary` is required; two of the others come
  from an entirely different workflow run and blocked nothing. Listing all five identically
  recreates the "which of these actually matters?" problem #30752 set out to remove.

#
### Type of change:
- [x] Improvement

#
### High-level design:

Name the required check that blocked the queue, then give **one link per failing workflow run**
with its failing job names inline as text. Job names are the diagnostic payload — `chromium-04`
through `chromium-17` scattered across shards reads as flake, `ingestion-01` alone reads as a
regression — but they cost nothing as text, whereas as links they were the redundancy.

Required contexts come from `GET /repos/{owner}/{repo}/rules/branches/{default_branch}`, resolved
from the branch rather than a hardcoded ruleset id, so it tracks whatever the ruleset becomes.

Matrix job names are truncated to their first parameter: raw names are
`playwright-ci-postgresql (chromium-17, chromium-17.json, 3, chromium, false)`, and six of those
is unreadable. The first parameter is the shard id, which is the part that identifies the failure.

Degradation is deliberate. If the rules lookup fails or no required check failed — a timeout, or
a dequeue while a required check was still pending — the runs are still listed, under a line
saying no required check failed, rather than an empty "Blocked the queue" label.

Cost is two extra API calls: one for the rules, one per distinct failing run (1–2 in practice).

**Second commit — dequeues with no merge-group commit.** Observed live after #30752 shipped: PR
#30583 sat `QUEUED` for 15 minutes and was removed manually before GitHub ever built it, so its
`RemovedFromMergeQueueEvent` has `beforeCommit: null`. The `select(.beforeCommit != null)` filter
dropped the event, the resolve step exhausted its retries, and the comment step skipped.

Silence is the right *outcome* there — nothing ran, so there is nothing to report — but it was
reached by the wrong route. The comment step keyed on `sha != ''`, which cannot distinguish "the
entry was never built" from "the event could not be resolved at all". Both produced a green run
with a skipped step, so a genuine resolution failure would have been invisible.

Now the event resolves on `reason` and carries an empty `sha` when there is no commit. The comment
states plainly that nothing ran, and a skipped step means only that the event could not be
resolved.

#
### Tests:

#### Use cases covered
- Failures spread across several workflow runs → one line per run, blocking check named
- Failures concentrated in one run (six shards) → one line, no link repetition
- No failing check on the commit → existing fallback text, unchanged
- Required contexts unresolvable → runs still listed, no blocker claimed
- Dequeued before the entry was built (no merge-group commit) → reason reported, no check list

#### Unit tests
Not applicable — CI workflow.

#### Backend integration tests
Not applicable — no backend changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
Not applicable — no UI changes.

#### Manual testing performed
The step body was run verbatim against real dequeue commits, and `actionlint` passes clean.

    PR 30707 (two runs)
      Blocked the queue: `playwright-summary`
      - [Postgresql PR Playwright E2E Tests](.../runs/30577609429) — playwright-summary,
        playwright-ci-postgresql (ingestion-01), playwright-ci-postgresql (chromium-19)
      - [PostgreSQL PR RDF E2E Tests](.../runs/30577609516) — Playwright RDF (Knowledge Graph +
        Ontology), RDF Playwright execution

    PR 30594 (one run, six shards)
      Blocked the queue: `playwright-summary`
      - [Postgresql PR Playwright E2E Tests](.../runs/30460268124) — playwright-summary,
        playwright-ci-postgresql (ingestion-01), playwright-ci-postgresql (chromium-17),
        playwright-ci-postgresql (chromium-15), playwright-ci-postgresql (chromium-14),
        playwright-ci-postgresql (chromium-04)

    Commit with no failing check -> unchanged fallback text
    Unresolvable rules ref       -> runs listed, "No required check failed" line

    Real no-commit event (PR 30583, reason=manual, beforeCommit=null):
      ### 🚦 Removed from the merge queue — `manual` (2026-07-31T12:31:04Z)
      The entry left the queue before it was built, so no checks ran against it.

#30752's trigger is no longer unverified: a real dequeue of PR #30706 at 11:11:02Z produced a
`pull_request_target` run 4s later that posted its report at 11:11:13Z, and three `merged`
dequeues correctly skipped the job. This PR changes the message body and the no-commit path; the
trigger itself is unchanged.

Known limitation, unchanged by this PR: replaying an old dequeue via `workflow_dispatch` reads
check runs as they are *now*, so checks re-run green since the dequeue will not appear. The live
path runs seconds after the event and is unaffected.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — pending the linked issue
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — pending
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates merge-queue dequeue reporting to identify required blockers and consolidate failed jobs by workflow run.
- Resolves required checks from the default branch’s rules.
- Produces one diagnostic line per failing workflow run.
- Handles dequeues that occur before a merge-group commit is built.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because a failed non-job check can still terminate dequeue reporting before any comment is posted.

The workflow continues to derive an Actions run ID from every failed check’s URL without verifying that the URL represents an Actions job; a non-job check URL therefore causes the unhandled API lookup to fail under strict shell error handling.

**Files Needing Attention:** .github/workflows/merge-queue-dequeue-report.yml
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/merge-queue-dequeue-report.yml | Expands dequeue-event handling and restructures failed-check output around required contexts and workflow-run grouping. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: report dequeues that happened before..."](https://github.com/open-metadata/openmetadata/commit/b9684370032f943dfc8b16c8d2b8a811bf1b257e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49023295)</sub>

<!-- /greptile_comment -->