### PR TITLE
fix(java-it): resolve the physical table index in ReindexBenchmarkIT

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ReindexBenchmarkIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ReindexBenchmarkIT.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.openmetadata.it.factories.EntityLoadSpec;
 import org.openmetadata.it.factories.EntityLoadSpec.EntityKind;
 import org.openmetadata.it.factories.SeedData;
+import org.openmetadata.it.search.IndexAliasInspector;
 import org.openmetadata.it.search.ReindexHelpers;
 import org.openmetadata.it.search.SearchAssertions;
 import org.openmetadata.it.server.ServerHandle;
@@ -27,6 +28,7 @@ import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.entity.app.AppRunRecord;
 import org.openmetadata.sdk.fluent.Apps;
+import org.openmetadata.service.Entity;
 
 /**
  * Reindex throughput benchmark — seeds 10k tables, runs reindex three times
@@ -43,7 +45,6 @@ import org.openmetadata.sdk.fluent.Apps;
 @ResourceLock(value = "SEARCH_INDEX_APP", mode = ResourceAccessMode.READ_WRITE)
 class ReindexBenchmarkIT {
 
-  private static final String TABLE_ALIAS = "table_search_index";
   private static final int SEED_TABLES = 10_000;
   private static final int COLUMNS_PER_TABLE = 5;
   private static final int LOAD_WORKERS = 16;
@@ -52,12 +53,18 @@ class ReindexBenchmarkIT {
 
   private static ServerHandle server;
   private static SearchAssertions search;
+  private static String tableAlias;
 
   @BeforeAll
   static void setup() {
     server = OssTestServer.defaultHandle();
     search = new SearchAssertions(server);
     Apps.setDefaultClient(SdkClients.adminClient());
+    // Counts go straight to the engine through the test-support passthrough, which takes the
+    // PHYSICAL index name - a server running with a cluster alias prefixes it
+    // (<alias>_table_search_index), so a hardcoded "table_search_index" 404s there. Same
+    // resolution the sibling scale ITs use.
+    tableAlias = new IndexAliasInspector(server).indexNameFor(Entity.TABLE);
   }
 
   @Test
@@ -86,7 +93,7 @@ class ReindexBenchmarkIT {
       final AppRunRecord run = ReindexHelpers.triggerSearchIndexAndWait(server);
       assertThat(run.getStatus().value()).isIn("success", "completed");
       final long elapsed = System.currentTimeMillis() - start;
-      final long docs = search.count(TABLE_ALIAS);
+      final long docs = search.count(tableAlias);
       final long heap = usedHeap();
       if (i >= warmupRuns) {
         totalMs += elapsed;


### PR DESCRIPTION
`ReindexBenchmarkIT.measureReindexThroughputOverTenKCohort` fails against any server configured with
a cluster alias:

```
SearchClient$SearchClientException: GET /v1/test-support/search/count?index=table_search_index
  via test-support endpoint failed
  at SearchAssertions.count(SearchAssertions.java:30)
  at ReindexBenchmarkIT.measureReindexThroughputOverTenKCohort(ReindexBenchmarkIT.java:89)
Caused by: ApiException (404): HTTP 404: Not Found
```

## Cause

The test counted through a hardcoded `TABLE_ALIAS = "table_search_index"`. `SearchAssertions.count`
reaches the engine through the `/v1/test-support/search` passthrough, and that endpoint proxies the
name straight down — `engineGet("/" + safeName(index) + "/_count")`. It is therefore the **physical**
index name, and a server running with a cluster alias prefixes it: `<alias>_table_search_index`. The
engine returns `index_not_found` and the passthrough hands the 404 back verbatim.

Which is why the failure looks like the test-support resource is missing when it is not: the
resource is registered and answering, it is the index name that does not exist. (The other way to
get a 404 here — `OM_TEST_SUPPORT_SEARCH_ENABLED` unset, so the resource throws on construction and
never registers — takes out *every* path under `/v1/test-support/search`, including
`/cluster-alias`. Useful discriminator when triaging.)

## Fix

Resolve the name from the server, exactly as the sibling scale ITs already do
(`Scale100kEntitiesIT:65`, `ReindexOutageRecoveryIT:68`):

```java
tableAlias = new IndexAliasInspector(server).indexNameFor(Entity.TABLE);
```

`IndexAliasInspector` reads the alias from `/v1/test-support/search/cluster-alias` and applies it via
`IndexMapping`, so this is a no-op where no alias is configured — `indexNameFor` returns
`table_search_index`.

## Scope

`ReindexBenchmarkIT` was the only file left doing this. Suites that pass a *logical* index to the
server's own `/v1/search` API — `SearchResourceIT`, the ranking seeders — are unaffected, because
the server applies the alias itself; only the direct-engine passthrough needs the physical name.

`mvn -o test-compile -pl :openmetadata-integration-tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The integration benchmark now resolves the physical table search-index name through `IndexAliasInspector`, allowing document counts to work with both prefixed cluster aliases and unaliased servers.
- Removes the hardcoded `table_search_index` constant.
- Resolves the table index during test setup using the established sibling-test pattern.
- Uses the resolved physical name for post-reindex document counts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the benchmark now handling aliased and unaliased search clusters consistently.

The new resolution maps `Entity.TABLE` to the configured physical index name and follows the same setup pattern already used by sibling scale integration tests.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ReindexBenchmarkIT.java | Replaces the hardcoded table index with cluster-alias-aware physical index resolution; no actionable defects identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(java-it): resolve the physical table..."](https://github.com/open-metadata/openmetadata/commit/a6b1ebf2bfeab5e85c054d573db29bc4f29fd35f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49013446)</sub>

<!-- /greptile_comment -->