### PR TITLE
fix(ingestion): report what a failed test-connection step actually hit

### DIFF
--- a/ingestion/src/metadata/core/connections/test_connection/aws.py
+++ b/ingestion/src/metadata/core/connections/test_connection/aws.py
@@ -84,33 +84,38 @@ def _clock_skew(error: BaseException) -> bool:
 AWS_ERRORS = ErrorPack(
     when(_clock_skew).diagnose(
         "Request signature expired",
-        fix="The clock where ingestion runs is too far from AWS's (tolerance is about 5 minutes); sync it with NTP.",
+        fix="The clock on the machine ingestion runs on is more than about five minutes away from "
+        "AWS's, so AWS rejected the request as too old. Sync that machine's clock, usually with NTP.",
     ),
     when(aws_code(*_UNKNOWN_KEY)).diagnose(
         "AWS access key not recognized",
-        fix="AWS does not know this awsAccessKeyId - it may be deleted, inactive, or from another "
-        "account or partition. With temporary credentials, the awsSessionToken may also be invalid.",
+        fix="AWS does not recognise the AWS Access Key ID. It may have been deleted or made "
+        "inactive, or it may belong to a different AWS account. If you are using temporary "
+        "credentials, the AWS Session Token may be invalid too.",
     ),
     when(aws_code(*_BAD_SIGNATURE)).diagnose(
         "AWS secret key does not match",
-        fix="The awsSecretAccessKey is wrong for this awsAccessKeyId; re-enter the credential pair.",
+        fix="The AWS Secret Access Key does not go with the AWS Access Key ID. They are issued as a "
+        "pair - re-enter both together.",
     ),
     when(aws_code(*_EXPIRED_TOKEN)).diagnose(
         "AWS session token expired",
-        fix="Temporary credentials have expired; refresh the awsSessionToken.",
+        fix="These are temporary credentials and they have expired. Generate a new AWS Session "
+        "Token and update the connection.",
     ),
     when(Matchers.exception(NoCredentialsError)).diagnose(
         "No AWS credentials found",
-        fix="No credentials were configured or resolvable; set awsAccessKeyId/awsSecretAccessKey "
-        "or make an IAM role available where ingestion runs.",
+        fix="No AWS credentials were found at all. Either fill in AWS Access Key ID and AWS Secret "
+        "Access Key, or attach an IAM role to the machine ingestion runs on.",
     ),
     when(Matchers.exception(NoRegionError)).diagnose(
         "No AWS region configured",
-        fix="Set awsRegion; the client cannot resolve a service endpoint without it.",
+        fix="AWS Region is empty, and it is required - without it there is no way to work out which "
+        "regional AWS endpoint to call.",
     ),
     when(Matchers.exception(EndpointConnectionError)).diagnose(
         "Cannot reach the AWS endpoint",
-        fix="Check awsRegion (and endPointURL when overridden), and that the network allows "
-        "access to the service endpoint from where ingestion runs.",
+        fix="Could not reach the AWS service endpoint. Check AWS Region (and Endpoint URL if you "
+        "overrode it), and that the network lets the machine ingestion runs on reach AWS.",
     ),
 ).including(NETWORK_ERRORS)

--- a/ingestion/src/metadata/core/connections/test_connection/network.py
+++ b/ingestion/src/metadata/core/connections/test_connection/network.py
@@ -60,20 +60,24 @@ def probe_or_fail(host: str, port: int) -> None:
 NETWORK_ERRORS = ErrorPack(
     when(Matchers.exception(socket.gaierror)).diagnose(
         "Host could not be resolved",
-        fix="Check hostPort for typos and that DNS can resolve it from where ingestion runs.",
+        fix="The host name in Host and Port could not be looked up in DNS from the machine "
+        "ingestion runs on. Check it for typos, and if it is an internal name, that this machine "
+        "can resolve it.",
     ),
     when(Matchers.exception(ConnectionRefusedError)).diagnose(
         "Connection refused",
-        fix="The host answered but nothing is listening on that port; check the port in "
-        "hostPort and that the service is running.",
+        fix="The host answered, but nothing is listening on that port. Check the port in Host and "
+        "Port, and that the service is actually running there.",
     ),
     when(Matchers.exception(TimeoutError)).diagnose(
         "Connection timed out",
-        fix="The host did not answer in time; check that a firewall, security group, or "
-        "network ACL allows access to this host and port.",
+        fix="The host never answered. Something in between is most likely dropping the traffic - a "
+        "firewall, a security group, or a network ACL. Check that they allow the machine ingestion "
+        "runs on to reach this host and port.",
     ),
     when(Matchers.exception(NetworkUnreachableError)).diagnose(
         "Cannot reach the host",
-        fix="Check hostPort, the network route, and that the host is online and reachable from where ingestion runs.",
+        fix="Could not open a connection to the address in Host and Port. Check the address, that "
+        "the host is online, and that there is a network route to it from where ingestion runs.",
     ),
 )

--- a/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/looker/connection.py
@@ -139,17 +139,19 @@ LOOKER_ERRORS = ErrorPack(
     # Before the generic 404: a rejected login is itself a 404, on /login.
     when(_login_rejected).diagnose(
         "Authentication failed",
-        fix="Looker rejected the credentials. Check the Client ID and Client Secret.",
+        fix="Looker rejected the credentials. Check Client ID and Client Secret - these are the API3 credentials from the "
+        "user's Looker profile, not a Looker login.",
         doc=API_SDK_DOC,
     ),
     when(Matchers.contains("Required auth credentials not found")).diagnose(
         "Missing credentials",
-        fix="Provide both the Client ID and the Client Secret.",
+        fix="Both Client ID and Client Secret are required, and one of them is empty. Generate an API3 key pair on the "
+        "user's Looker profile page and paste both in.",
         doc=API_SDK_DOC,
     ),
     when(http_status(404, extract=_looker_status)).diagnose(
         "Resource not found",
-        fix="Looker could not find the requested resource. Check that Host Port is the instance URL.",
+        fix="Looker answered, but there is nothing at that address. Check Host and Port is your Looker instance URL.",
     ),
     when(http_status(429, extract=_looker_status)).diagnose(
         "Rate limited by Looker",
@@ -166,7 +168,8 @@ LOOKER_ERRORS = ErrorPack(
         _transport_text("failed to resolve", "name or service not known", "nodename nor servname", "getaddrinfo failed")
     ).diagnose(
         "Host could not be resolved",
-        fix="Check Host Port and that DNS resolves it from where ingestion runs.",
+        fix="The host name in Host and Port could not be looked up in DNS from the machine ingestion runs on. Check it "
+        "for typos.",
     ),
     when(_transport_text("connection refused")).diagnose(
         "Connection refused",
@@ -174,15 +177,18 @@ LOOKER_ERRORS = ErrorPack(
     ),
     when(_transport_text("timed out", "timeout")).diagnose(
         "Connection timed out",
-        fix="The host did not answer in time. Check that the network allows access to this host and port.",
+        fix="The host never answered. Check that a firewall or network ACL allows the machine ingestion runs on to reach "
+        "it.",
     ),
     when(_transport_text("certificate verify failed", "sslerror", "ssl: ")).diagnose(
         "TLS verification failed",
-        fix="The instance's certificate could not be verified from where ingestion runs.",
+        fix="The Looker certificate could not be verified from where ingestion runs. If your network inspects TLS "
+        "traffic, its certificate has to be trusted on that machine.",
     ),
     when(_transport_text("max retries exceeded", "connection aborted", "connection error")).diagnose(
         "Cannot reach the host",
-        fix="Check Host Port and that the instance is reachable from where ingestion runs.",
+        fix="Could not reach the address in Host and Port. Check it for typos, and that the instance is online and "
+        "reachable from where ingestion runs.",
     ),
     # Looker serves this page, with no error document, both for a rejected sign-in
     # and for a host that is not a live instance; the two cannot be told apart.
@@ -196,7 +202,8 @@ LOOKER_ERRORS = ErrorPack(
     # error document, whether or not this pack diagnoses its status.
     when(_foreign_404).diagnose(
         "The host is not serving the Looker API",
-        fix="A server answered but did not return a Looker error. Check that Host Port points at the Looker instance.",
+        fix="Something answered, but it was not Looker - the reply had none of the details a Looker error carries. Check "
+        "Host and Port points at the Looker instance itself, not a proxy or landing page.",
     ),
 )
 # NETWORK_ERRORS not folded in: it matches by type, but the SDK transport

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/connection.py
@@ -110,15 +110,14 @@ POWERBI_ERRORS = ErrorPack(
     # 403 - so the two split on tenant-enablement vs. workspace access.
     when(Matchers.exception(InvalidSourceException)).diagnose(
         "Authentication failed",
-        fix="Could not acquire an OAuth token. Check the Client ID, Client Secret, and Tenant ID, "
-        "and that the app registration is allowed to request the configured scope.",
+        fix="Microsoft Entra would not issue a token. Check Client ID, Client Secret and Tenant ID, and that the app "
+        "registration is allowed to request the scope this connection asks for.",
     ),
     when(http_status(401)).diagnose(
         "Power BI did not authorize the service principal",
-        fix="The token was accepted but Power BI rejected the call (401). In the Fabric admin "
-        "portal enable 'Allow service principals to use Power BI APIs' (and the read-only admin "
-        "APIs setting when Use Admin APIs is on), add the service principal to the allowed "
-        "security group, and grant the app registration the required API permission.",
+        fix="The token was valid, but Power BI itself refused the call. In the Fabric admin portal, turn on 'Allow "
+        "service principals to use Power BI APIs' - plus the read-only admin API setting if Use Admin APIs is on - "
+        "and add this service principal to the security group those settings allow.",
     ),
     when(http_status(403)).diagnose(
         "Insufficient permissions",
@@ -128,13 +127,13 @@ POWERBI_ERRORS = ErrorPack(
     ),
     when(http_status(404)).diagnose(
         "Resource not found",
-        fix="The requested resource was not found (404). Check the API URL and that the configured "
-        "tenant/workspace exists and is visible to the service principal.",
+        fix="Power BI answered, but there is nothing at that address. Check the API URL, and that the workspace exists "
+        "and the service principal has been given access to it.",
     ),
     when(http_status(429)).diagnose(
         "Rate limited by Power BI",
-        fix="Power BI is throttling this service principal (429). Retry once the current window "
-        "has elapsed; the admin APIs throttle per user per time window.",
+        fix="Power BI is rate limiting this service principal. Wait for the current window to pass and try again - the "
+        "admin APIs count requests per user, per window.",
     ),
     # Kept last: authority/instance-discovery failures are MSAL ValueErrors that
     # carry no HTTP status, so a broad substring match here must not shadow a

--- a/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/tableau/connection.py
@@ -93,14 +93,14 @@ def _status_of(error: BaseException) -> int | None:
 TABLEAU_ERRORS = ErrorPack(
     when(http_status(401, extract=_status_of)).diagnose(
         "Authentication failed",
-        fix="Tableau rejected the credentials (401). Check the Personal Access Token name and "
-        "secret (or the username and password) and that it has not expired, and that the Site "
-        "Name matches the site those credentials belong to.",
+        fix="Tableau rejected the credentials. Check the Personal Access Token name and secret - or the username and "
+        "password - and that they have not expired. Also check Site Name is the site those credentials belong to, "
+        "since a token is only valid on its own site.",
     ),
     when(http_status(403, extract=_status_of)).diagnose(
         "Insufficient permissions",
-        fix="The credentials are valid but not authorized for this resource (403). Grant the user "
-        "at least the Viewer site role and read access to the projects to ingest.",
+        fix="The credentials are valid, but this user is not allowed to see what ingestion asked for. Give it at least "
+        "the Viewer site role, and read access to the projects you want ingested.",
     ),
     when(http_status(404, extract=_status_of)).diagnose(
         "Resource not found",
@@ -110,29 +110,30 @@ TABLEAU_ERRORS = ErrorPack(
     ),
     when(Matchers.exception(SSLError)).diagnose(
         "TLS verification failed",
-        fix="The server's certificate could not be verified. Provide the CA certificate under SSL "
-        "Config with Verify SSL set to 'validate', or set Verify SSL to 'ignore' for a "
-        "self-signed certificate.",
+        fix="The server's certificate could not be verified from where ingestion runs. Either paste the CA certificate "
+        "under SSL Config and set Verify SSL to validate, or set Verify SSL to ignore if this Tableau uses a self- "
+        "signed certificate.",
     ),
     when(Matchers.exception(TableauWorkBookException)).diagnose(
         "No workbooks visible",
-        fix="The user is authenticated but no workbook could be read. Grant it access to at least "
-        "one project containing workbooks.",
+        fix="The user signed in, but no workbook was readable. Give it access to at least one project that contains "
+        "workbooks - otherwise there is nothing for ingestion to collect.",
     ),
     when(Matchers.exception(TableauChartsException)).diagnose(
         "No views visible",
-        fix="Workbooks are readable but their views are not. Grant the user the View permission on "
-        "the workbooks to ingest; charts are ingested from workbook views.",
+        fix="Workbooks are readable, but the views inside them are not. Give the user the View "
+        "permission on the workbooks you want ingested - charts come from workbook views, so "
+        "without it no charts will be collected.",
     ),
     when(Matchers.exception(TableauOwnersNotFound)).diagnose(
         "Owner information not available",
-        fix="Owners could not be resolved. Grant the user permission to read users on the site, or "
-        "disable owner ingestion in the service configuration.",
+        fix="Owner details could not be read. Either give the user permission to read users on the site, or turn off "
+        "owner ingestion in the service configuration.",
     ),
     when(Matchers.exception(TableauDataModelsException)).diagnose(
         "Data sources could not be read",
-        fix="The Tableau Metadata API returned no data sources for the workbook. Enable the "
-        "Metadata API on the Tableau instance.",
+        fix="The Tableau Metadata API returned no data sources. It is usually switched off by default - a Tableau "
+        "administrator has to enable it on the server.",
         doc=METADATA_API_DOC,
     ),
     when(Matchers.contains("in incorrect format")).diagnose(

--- a/ingestion/src/metadata/ingestion/source/database/athena/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/athena/connection.py
@@ -93,29 +93,29 @@ def _authorization_error(error: BaseException) -> bool:
 ATHENA_ERRORS = ErrorPack(
     when(_authorization_error).diagnose(
         "Not authorized",
-        fix="Grant the IAM principal the required Athena and Glue permissions "
-        "(e.g. athena:StartQueryExecution, glue:GetDatabases, glue:GetTables).",
+        fix="The AWS identity is missing Athena or Glue permissions. It needs athena:StartQueryExecution to run a query, "
+        "and glue:GetDatabases and glue:GetTables to read the catalog behind it.",
     ),
     when(_all_of("workgroup", "is not found")).diagnose(
         "Workgroup not found",
-        fix="Verify the configured workgroup exists in this account and region.",
+        fix="Athena has no workgroup with the name in Athena Workgroup, in this account and region. Check the name "
+        "and AWS Region.",
     ),
     when(Matchers.contains("output location")).diagnose(
         "Query result location not configured",
-        fix="Set s3StagingDir to an S3 path the principal can write to, or configure a query "
-        "result location on the workgroup.",
+        fix="Athena has nowhere to put query results. Set S3 Staging Directory to an S3 path the AWS identity can write "
+        "to, or set a result location on the workgroup itself.",
     ),
     # Athena raises this before the query runs, when it cannot even reach the bucket.
     when(Matchers.contains("unable to verify/create output bucket")).diagnose(
         "Query result bucket not usable",
-        fix="Athena cannot reach the bucket in s3StagingDir. Check that it exists in awsRegion "
-        "and that the identity has s3:ListBucket and s3:GetBucketLocation on it.",
+        fix="Athena could not reach the bucket in S3 Staging Directory. Check the bucket exists in AWS Region, and that "
+        "the AWS identity has s3:ListBucket and s3:GetBucketLocation on it.",
     ),
     when(Matchers.contains("writing to location")).diagnose(
         "Cannot write query results",
-        fix="Athena could not write results to the staging location. Grant s3:PutObject on "
-        "s3StagingDir, and if the bucket requires encryption, use a workgroup that sets "
-        "server-side encryption on query results.",
+        fix="Athena could not write its results to the staging location. Grant the AWS identity s3:PutObject on S3 "
+        "Staging Directory. If the bucket requires encryption, use a workgroup configured to encrypt query results.",
     ),
 ).including(AWS_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -107,6 +107,32 @@ BIGQUERY_ERRORS = ErrorPack(
         fix="Grant the service account the BigQuery Job User role (bigquery.jobs.create) on the "
         "billing project so it can run queries.",
     ),
+    # BigQuery answers 403 for three unrelated causes and google-api-core raises
+    # Forbidden for all of them, so without these the generic rules below would
+    # tell a user to grant IAM roles for a quota breach or a disabled API -
+    # neither of which a role fixes. Keyed on the message tokens Google's error
+    # bodies carry (reasons quotaExceeded/rateLimitExceeded, accessNotConfigured),
+    # and ordered ahead of the "access denied" rule because a body can carry both
+    # that prefix and the sharper reason.
+    when(Matchers.any_of(Matchers.contains("quota exceeded"), Matchers.contains("exceeded rate limits"))).diagnose(
+        "BigQuery quota exceeded",
+        fix="This is a quota or rate limit, not a permission problem. Retry later, or raise the "
+        "affected BigQuery quota for the billing project in the Google Cloud console.",
+    ),
+    when(Matchers.contains("bigquery api has not been used in project")).diagnose(
+        "BigQuery API is not enabled",
+        fix="The BigQuery API is disabled on this project. Enable it in the Google Cloud console "
+        "for the configured project (and for billingProjectId when it differs), then retry - no "
+        "IAM role grants access to a disabled API.",
+    ),
+    # accessNotConfigured is not BigQuery-specific: with policy tags enabled the
+    # disabled API is Data Catalog, not BigQuery. Name no API the error did not.
+    when(Matchers.contains("has not been used in project")).diagnose(
+        "A required Google Cloud API is not enabled",
+        fix="A Google Cloud API this connector calls is disabled on the project - the error names "
+        "which one (Data Catalog when includePolicyTags is set). Enable it in the Google Cloud "
+        "console, then retry; no IAM role grants access to a disabled API.",
+    ),
     when(Matchers.contains("access denied")).diagnose(
         "Access denied",
         fix="The service account is authenticated but lacks permission for the requested "

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/connection.py
@@ -84,28 +84,28 @@ logger = ingestion_logger()
 BIGQUERY_ERRORS = ErrorPack(
     when(Matchers.exception(InvalidPrivateKeyException)).diagnose(
         "Malformed service account private key",
-        fix="The private key in the GCP credentials could not be parsed as a PEM key. Paste the "
-        "full key from the service account JSON, including the BEGIN/END lines and real newlines.",
+        fix="The private key could not be read. Copy the private_key value straight out of the service account JSON file, "
+        "including the BEGIN and END lines, with its line breaks intact.",
     ),
     when(Matchers.contains("invalid_grant")).diagnose(
         "Invalid service account credentials",
-        fix="The service account key was rejected (invalid_grant). Verify the private key and "
-        "client email are correct and that the key has not been revoked, disabled, or expired.",
+        fix="Google rejected the service account key. Check the private key and client email are the ones from the same "
+        "JSON file, and that the key has not been deleted or disabled and the service account is still active.",
     ),
     when(Matchers.exception(DefaultCredentialsError)).diagnose(
         "Could not determine GCP credentials",
-        fix="No usable credentials were found. Provide a service account key, or configure "
-        "Application Default Credentials (ADC) in the environment where ingestion runs.",
+        fix="No Google Cloud credentials were found. Either paste a service account key into the connection, or set up "
+        "Application Default Credentials on the machine ingestion runs on.",
     ),
     when(Matchers.exception(RefreshError)).diagnose(
         "Failed to obtain a GCP access token",
-        fix="The credentials could not be exchanged for an access token. Check the service "
-        "account key, its client email, and that the account is enabled.",
+        fix="Google would not issue an access token for these credentials. Check the service account key and its client "
+        "email, and that the service account has not been disabled.",
     ),
     when(Matchers.contains("bigquery.jobs.create")).diagnose(
         "Missing permission to run BigQuery jobs",
-        fix="Grant the service account the BigQuery Job User role (bigquery.jobs.create) on the "
-        "billing project so it can run queries.",
+        fix="The service account is not allowed to run queries. Give it the BigQuery Job User role on the billing project "
+        "- that is what grants bigquery.jobs.create.",
     ),
     # BigQuery answers 403 for three unrelated causes and google-api-core raises
     # Forbidden for all of them, so without these the generic rules below would
@@ -121,32 +121,33 @@ BIGQUERY_ERRORS = ErrorPack(
     ),
     when(Matchers.contains("bigquery api has not been used in project")).diagnose(
         "BigQuery API is not enabled",
-        fix="The BigQuery API is disabled on this project. Enable it in the Google Cloud console "
-        "for the configured project (and for billingProjectId when it differs), then retry - no "
-        "IAM role grants access to a disabled API.",
+        fix="The BigQuery API is switched off for this project. Enable it in the Google Cloud console for the project you "
+        "configured - and for Billing Project ID as well if that is a different project. No IAM role grants access to "
+        "a disabled API.",
     ),
     # accessNotConfigured is not BigQuery-specific: with policy tags enabled the
     # disabled API is Data Catalog, not BigQuery. Name no API the error did not.
     when(Matchers.contains("has not been used in project")).diagnose(
         "A required Google Cloud API is not enabled",
-        fix="A Google Cloud API this connector calls is disabled on the project - the error names "
-        "which one (Data Catalog when includePolicyTags is set). Enable it in the Google Cloud "
-        "console, then retry; no IAM role grants access to a disabled API.",
+        fix="A Google Cloud API that ingestion calls is switched off for this project - the error above names which one. "
+        "It is usually Data Catalog, which is only needed when Include Policy Tags is on. Enable it in the Google "
+        "Cloud console; no IAM role grants access to a disabled API.",
     ),
     when(Matchers.contains("access denied")).diagnose(
         "Access denied",
-        fix="The service account is authenticated but lacks permission for the requested "
-        "resource. Grant the appropriate BigQuery role (e.g. BigQuery Data Viewer / Metadata "
-        "Viewer), or, for query history, access to INFORMATION_SCHEMA.JOBS_BY_PROJECT.",
+        fix="The service account signed in but is not allowed to read this resource. Give it a BigQuery role that covers "
+        "it - BigQuery Data Viewer or Metadata Viewer for metadata, and access to INFORMATION_SCHEMA.JOBS_BY_PROJECT "
+        "for query history.",
     ),
     when(Matchers.exception(Forbidden)).diagnose(
         "Permission denied",
-        fix="The service account is authenticated but not authorized. Grant it the BigQuery "
-        "roles needed to read metadata (BigQuery Data Viewer / Metadata Viewer / Job User).",
+        fix="The service account signed in but Google refused the request. Give it the roles ingestion needs on this "
+        "project: BigQuery Data Viewer, BigQuery Metadata Viewer, and BigQuery Job User.",
     ),
     when(Matchers.exception(NotFound)).diagnose(
         "Project or dataset not found",
-        fix="Verify the configured project id (and dataset, if set) exist and that the service account can see them.",
+        fix="Google could not find the project, or a dataset inside it. Check the project id, and the dataset name if you "
+        "set one - Google also reports something the service account cannot see as missing.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -104,31 +104,30 @@ UNRESOLVED_TARGET_TOKEN = "Could not resolve a catalog and schema"
 DATABRICKS_ERRORS = ErrorPack(
     when(Matchers.contains(UNRESOLVED_TARGET_TOKEN)).diagnose(
         "Could not resolve a catalog and schema to probe",
-        fix="The earlier steps found no catalog/schema this user can use. Verify the configured "
-        "catalog and schema exist and that the user has USE CATALOG and USE SCHEMA on them.",
+        fix="The earlier steps found no catalog and schema this user can open, so there was nothing to probe. Check "
+        "Catalog and Database Schema exist, and that the token's user has USE CATALOG and USE SCHEMA on them.",
     ),
     when(Matchers.contains("invalid access token")).diagnose(
         "Authentication failed",
-        fix="Check the access token - the workspace rejected it. Verify the token is valid, "
-        "not expired, and belongs to a user with access to this workspace.",
+        fix="The workspace rejected the access token. Check it was copied whole, has not expired, and belongs to a user "
+        "who can reach this workspace.",
     ),
     when(Matchers.contains("token is expired")).diagnose(
         "Access token expired",
-        fix="The access token has expired. Generate a new token and update the connection.",
+        fix="The access token has expired. Generate a new one in Databricks and paste it into the connection.",
     ),
     # No 403 rule: databricks-sql keeps the status in error.context["http-code"] and
     # Error.__str__ returns only self.message (databricks/sql/exc.py), so no status
     # reaches the text; "Forbidden" appears nowhere in the driver (4.2.6).
     when(Matchers.contains("malformed_request")).diagnose(
         "Invalid HTTP path",
-        fix="The HTTP Path is malformed. Copy it from the SQL warehouse (or cluster) Connection "
-        "Details in Databricks - it must look like /sql/1.0/warehouses/<warehouseId> or "
-        "/sql/1.0/endpoints/<endpointId>.",
+        fix="Databricks did not recognise the value in Http Path. Copy it from the Connection Details tab of the SQL "
+        "warehouse or cluster in Databricks - it looks like /sql/1.0/warehouses/<id>.",
     ),
     when(Matchers.contains("no_such_catalog")).diagnose(
         "Catalog not found",
-        fix="The configured catalog does not exist or is not visible to the token's user. Verify "
-        "the catalog name and that the user has USE CATALOG on it.",
+        fix="Databricks has no catalog with the name in Catalog, or the token's user cannot see it. Check the name, and "
+        "that the user has USE CATALOG on it.",
     ),
     when(Matchers.contains("no_such_schema")).diagnose(
         "Schema not found",
@@ -137,13 +136,13 @@ DATABRICKS_ERRORS = ErrorPack(
     ),
     when(Matchers.contains("table_or_view_not_found")).diagnose(
         "Table or view not found",
-        fix="The referenced table or view does not exist or is not visible to the token's user. "
-        "Verify the object exists and the user has SELECT on it.",
+        fix="The table or view this step read does not exist, or the token's user cannot see it. Check it exists and that "
+        "the user has SELECT on it.",
     ),
     when(Matchers.contains("schema_not_found")).diagnose(
         "Schema not found",
-        fix="The referenced schema does not exist or is not visible. Verify the schema name and "
-        "that the user has USAGE on it.",
+        fix="The schema this step read does not exist, or the token's user cannot see it. Check the name and that the "
+        "user has USAGE on it.",
     ),
     when(
         Matchers.any_of(
@@ -152,13 +151,13 @@ DATABRICKS_ERRORS = ErrorPack(
         )
     ).diagnose(
         "Insufficient privileges",
-        fix="Grant the token's user the privileges the failing step needs (USAGE on the catalog / "
-        "schema and SELECT on the system or information_schema tables it reads).",
+        fix="The token's user is not allowed to read what this step needs. Grant it USAGE on the catalog and schema, and "
+        "SELECT on the system or information_schema tables the step reads.",
     ),
     when(Matchers.contains("does not exist")).diagnose(
         "Object not found",
-        fix="Verify the configured catalog, schema, and HTTP path exist and the token's user is "
-        "authorized to use them.",
+        fix="Databricks could not find something this connection names. Check Catalog, Database Schema and Http Path, and "
+        "that the token's user is allowed to use them.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/glue/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/glue/connection.py
@@ -49,13 +49,13 @@ MAX_DATABASES_TO_PROBE = 10
 GLUE_ERRORS = ErrorPack(
     when(aws_code("AccessDenied", "AccessDeniedException")).diagnose(
         "Not authorized",
-        fix="Grant glue:GetDatabases and glue:GetTables to the identity used, and check any "
-        "Lake Formation permissions on the catalog.",
+        fix="Grant the AWS identity glue:GetDatabases and glue:GetTables. If this catalog is managed by Lake Formation, "
+        "it also needs Lake Formation permissions on the databases and tables.",
     ),
     # Only from GetTables; a GetDatabases listing returns an empty list instead.
     when(aws_code("EntityNotFoundException")).diagnose(
         "Glue database not found",
-        fix="The database disappeared from the catalog while the connection was being tested; re-run the test.",
+        fix="The database was removed from the Glue catalog while this test was running. Run the test again.",
     ),
 ).including(AWS_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/connection.py
@@ -95,7 +95,9 @@ SQLSERVER_ERRORS = ErrorPack(
     # as an auth failure, the only signal available.
     when(Matchers.contains("Cannot open database")).diagnose(
         "Database not found or not accessible",
-        fix="Verify the configured database exists and the login is allowed to open it.",
+        fix="SQL Server would not open the database named in Database. Check the name is spelled "
+        "correctly and exists on this server, and ask a SQL Server administrator to give the "
+        "account in Username access to it.",
     ),
     when(
         Matchers.any_of(
@@ -104,7 +106,9 @@ SQLSERVER_ERRORS = ErrorPack(
         )
     ).diagnose(
         "Authentication failed",
-        fix="Check the username and password, and that the login is allowed to connect.",
+        fix="SQL Server rejected the sign-in. Check Username and Password. If both are correct, the "
+        "account may be disabled or not allowed to sign in to this server - a SQL Server "
+        "administrator can confirm.",
     ),
     # 297's text lacks "permission was denied", so its number is the only signal.
     when(
@@ -114,7 +118,9 @@ SQLSERVER_ERRORS = ErrorPack(
         )
     ).diagnose(
         "Insufficient privileges",
-        fix="Grant the login SELECT on the objects the failing step reads (and VIEW SERVER STATE for query history).",
+        fix="The account signed in but is not allowed to read what this step needs. Ask a SQL "
+        "Server administrator to GRANT SELECT on those objects to it - and GRANT VIEW SERVER STATE "
+        "as well if you want query history collected.",
     ),
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/mysql/connection.py
@@ -77,33 +77,41 @@ if TYPE_CHECKING:
 MYSQL_ERRORS = ErrorPack(
     when(Matchers.errno(1045)).diagnose(  # ER_ACCESS_DENIED_ERROR
         "Authentication failed",
-        fix="Check the username and password, and that this host is allowed to connect.",
+        fix="MySQL rejected the sign-in. Check Username and Password. MySQL also ties an account to "
+        "the machine it connects from, so the account may exist but not be allowed in from where "
+        "ingestion runs.",
     ),
     when(Matchers.errno(1044)).diagnose(  # ER_DBACCESS_DENIED_ERROR
         "No access to the database",
-        fix="Grant the user access to the configured databaseSchema.",
+        fix="The account signed in but cannot use the database named in Database Schema. Ask a "
+        "MySQL administrator to grant it access to that database.",
     ),
     when(Matchers.errno(1049)).diagnose(  # ER_BAD_DB_ERROR
         "Database not found",
-        fix="Verify the configured databaseSchema exists and the user can see it.",
+        fix="MySQL has no database with the name in Database Schema. Check the spelling - on Linux "
+        "servers MySQL database names are case-sensitive.",
     ),
     when(Matchers.errno(1142, 1143)).diagnose(  # ER_TABLEACCESS/COLUMNACCESS_DENIED
         "Query history table not accessible",
-        fix="Grant SELECT on the configured query history table "
-        "(mysql.general_log, or mysql.slow_log when useSlowLogs is set), or query "
-        "usage and lineage won't be collected.",
+        fix="The account cannot read the table MySQL keeps query history in (mysql.general_log, or "
+        "mysql.slow_log when Use Slow Logs is on). Ask an administrator to grant SELECT on it, "
+        "otherwise usage and lineage will not be collected.",
     ),
     when(Matchers.errno(2003)).diagnose(  # CR_CONN_HOST_ERROR (refused / DNS / connect timeout)
         "Cannot reach the MySQL host",
-        fix="Check hostPort, that the server is running, and that the network / IP allow-list permits the connection.",
+        fix="Could not reach MySQL. Check Host and Port, that the server is running, and that no "
+        "firewall or IP allow-list is blocking the machine ingestion runs on.",
     ),
     when(Matchers.errno(2013)).diagnose(  # CR_SERVER_LOST (read timeout / dropped mid-query)
         "Lost connection to MySQL",
-        fix="The server answered but the connection dropped or timed out; check server load and read timeouts.",
+        fix="MySQL accepted the connection and then dropped it. This is usually a server under load "
+        "or a read timeout too short for the query - check the server's load and timeout settings.",
     ),
     when(Matchers.errno(2026)).diagnose(  # CR_SSL_CONNECTION_ERROR
         "TLS/SSL connection error",
-        fix="Check the SSL/TLS configuration and the server certificate.",
+        fix="The encrypted connection to MySQL could not be established. Check the SSL/TLS settings "
+        "on this connection, and that the server's certificate is valid and trusted where "
+        "ingestion runs.",
     ),
     # MySQL 8's default caching_sha2_password won't send the password over a plain
     # connection: it needs TLS or RSA public-key exchange. The server may reject
@@ -111,13 +119,13 @@ MYSQL_ERRORS = ErrorPack(
     # no-errno "Couldn't receive server's public key" - match both.
     when(Matchers.errno(3159)).diagnose(
         "Secure connection required (MySQL 8 caching_sha2_password)",
-        fix="Enable TLS/SSL (or allow public-key retrieval); MySQL 8's default auth "
-        "plugin will not send the password over a plain connection.",
+        fix="MySQL 8 will not send the password over an unencrypted connection. Turn on SSL/TLS for "
+        "this connection, or allow the server's public key to be fetched, and try again.",
     ),
     when(Matchers.contains("Couldn't receive server's public key")).diagnose(
         "Secure connection required (MySQL 8 caching_sha2_password)",
-        fix="Enable TLS/SSL (or allow public-key retrieval); MySQL 8's default auth "
-        "plugin will not send the password over a plain connection.",
+        fix="MySQL 8 will not send the password over an unencrypted connection. Turn on SSL/TLS for "
+        "this connection, or allow the server's public key to be fetched, and try again.",
     ),
 )
 

--- a/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/connection.py
@@ -110,32 +110,42 @@ def _role_not_found(error: BaseException) -> bool:
 POSTGRES_ERRORS = ErrorPack(
     when(Matchers.contains("password authentication failed")).diagnose(
         "Authentication failed",
-        fix="Check the username and password, and that the user is allowed to connect.",
+        fix="PostgreSQL rejected the password for the account in Username. Check Username and Password.",
     ),
+    # Deliberately shares the "Authentication failed" title with the rule above:
+    # under trust/peer auth a missing role is what a wrong username looks like, and
+    # the fix is the same field. Only the remediation differs.
     when(_role_not_found).diagnose(
         "Authentication failed",
-        fix="Check the username - the configured role does not exist on the server.",
+        fix="PostgreSQL has no account with the name in Username. Check the spelling - PostgreSQL "
+        "account names are case-sensitive unless they were created with quotes.",
     ),
     when(Matchers.contains("no pg_hba.conf entry")).diagnose(
-        "Connection not permitted by pg_hba.conf",
-        fix="Add a pg_hba.conf entry for this user and host, and enable SSL if the server requires it.",
+        "The server is not configured to accept this connection",
+        fix="PostgreSQL decides which accounts may connect, from where, and over what kind of "
+        "connection, in a file called pg_hba.conf. It has no rule covering this account and the "
+        "machine ingestion runs on. Ask a PostgreSQL administrator to add one - and turn on SSL "
+        "here if the server's rule requires an encrypted connection.",
     ),
     when(_database_not_found).diagnose(
         "Database not found",
-        fix="Verify the configured database exists and the user is allowed to connect to it.",
+        fix="PostgreSQL has no database with the name in Database. Check the spelling, and that the "
+        "account in Username is allowed to connect to it.",
     ),
     when(_sqlstate("42501")).diagnose(  # insufficient_privilege
         "Insufficient privileges",
-        fix="Grant the user SELECT on the objects the failing step reads.",
+        fix="The account signed in but is not allowed to read what this step needs. Ask a "
+        "PostgreSQL administrator to GRANT SELECT on those objects to it.",
     ),
     # 42P01 (undefined_table) across the test steps can only come from the GetQueries
     # source probe - every other step reads system catalogs that always exist - so it
     # means the configured queryStatementSource is missing, whatever it is named.
     when(_sqlstate("42P01")).diagnose(  # undefined_table
         "Query history source not found",
-        fix="The query history source (queryStatementSource, default pg_stat_statements) does not "
-        "exist. Install/enable it (e.g. the pg_stat_statements extension) or correct the setting, "
-        "or query usage and lineage won't be collected.",
+        fix="The table or view named in Query Statement Source does not exist on this server. It "
+        "defaults to pg_stat_statements, which is a PostgreSQL extension an administrator has to "
+        "enable. Either enable it, or point the setting at whatever this server records query "
+        "history in - without it, usage and lineage will not be collected.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/redshift/connection.py
@@ -282,33 +282,38 @@ _QUERY_HISTORY_PRIVILEGE_TOKEN = "query-history views"
 REDSHIFT_ERRORS = ErrorPack(
     when(Matchers.contains("password authentication failed")).diagnose(
         "Authentication failed",
-        fix="Check the username and password, and that the user is allowed to connect.",
+        fix="Redshift rejected the sign-in. Check Username and Password. If both are correct, the account may not be "
+        "allowed to connect to this cluster.",
     ),
     # No _sqlstate("28000", "28P01") rule: those are connect-phase codes, and libpq
     # reports a failed connection with no PGresult, so .pgcode is None (verified on
     # PostgreSQL 15). The message rule above is what catches auth failures.
     when(_database_not_found).diagnose(
         "Database not found",
-        fix="Verify the configured database exists and the user is allowed to connect to it.",
+        fix="Redshift has no database with the name in Database. Check the spelling, and that the account in Username "
+        "is allowed to connect to it.",
     ),
     # Raised by the GetQueries check when has_table_privilege reports the user lacks
     # SELECT on the query-history views; config-agnostic so it never names a view.
     when(Matchers.contains(_QUERY_HISTORY_PRIVILEGE_TOKEN)).diagnose(
         "Query history not accessible",
-        fix="Grant the user SELECT on the Redshift query-history views (stl_* for Provisioned, "
-        "sys_* for Serverless), or usage and lineage won't be collected.",
+        fix="The account cannot read the views Redshift keeps query history in - stl_* on a Provisioned cluster, sys_* on "
+        "Serverless. Ask a Redshift administrator to grant SELECT on them, otherwise usage and lineage will not be "
+        "collected.",
     ),
     when(_sqlstate("42501")).diagnose(  # insufficient_privilege
         "Insufficient privileges",
-        fix="Grant the user SELECT on the objects the failing step reads.",
+        fix="The account signed in but is not allowed to read what this step needs. Ask a Redshift administrator to "
+        "GRANT SELECT on those objects to it.",
     ),
     # 42P01 (undefined_table) across the test steps can only come from the GetQueries
     # source probe - every other step reads catalogs that always exist - so it means
     # the query-history source view is missing, whatever it is named.
     when(_sqlstate("42P01")).diagnose(  # undefined_table
         "Query history source not found",
-        fix="The Redshift query-history views are not available on this deployment. Verify the "
-        "cluster type (Provisioned vs Serverless), or usage and lineage won't be collected.",
+        fix="The query-history views this step looked for do not exist on this cluster. Provisioned clusters expose stl_* "
+        "views and Serverless exposes sys_* views, so this usually means the cluster is not the type the connection "
+        "assumes. Without them, usage and lineage will not be collected.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/connection.py
@@ -198,22 +198,21 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
         # the fix. Keyed on the message: this path's errno is an accidental 540001.
         when(Matchers.contains("verify the account name is correct")).diagnose(
             "Snowflake rejected the login endpoint request",
-            fix="Snowflake answered 403 before authenticating. Most often the account identifier is "
-            "wrong - use the one from your Snowflake URL (e.g. <org>-<account> or "
-            "<locator>.<region>.<cloud>). If it is correct, check whether a network policy, IP "
-            "allowlist, or proxy is blocking this host.",
+            fix="Snowflake refused the request before it looked at any credentials. Most often the Account identifier is "
+            "wrong - copy it from your Snowflake URL, where it looks like <org>-<account> or "
+            "<locator>.<region>.<cloud>. If it is right, something is blocking this machine: a Snowflake network "
+            "policy, an IP allowlist, or a proxy.",
         ),
         when(Matchers.contains("multi-factor authentication")).diagnose(
             "Multi-factor authentication required",
-            fix="MFA is enforced on this user, and password login cannot satisfy the MFA prompt "
-            "for a non-interactive ingestion. Switch the connection to key-pair authentication "
-            "(set the Private Key field) or a Programmatic Access Token (put the PAT in the "
-            "Password field); do not use the account password.",
+            fix="This user has to complete multi-factor authentication, and there is nobody to answer the prompt during "
+            "an unattended ingestion. Use key-pair authentication instead by filling in Private Key, or put a "
+            "Programmatic Access Token in Password. The account password will not work here.",
         ),
         when(Matchers.contains("is not granted to this user")).diagnose(
             "Role not granted",
-            fix="Grant the configured role to the user, or set a role the user already has "
-            "(e.g. PUBLIC), so the connection can assume it.",
+            fix="The user has not been granted the role named in Role, so the connection cannot assume it. Ask a "
+            "Snowflake administrator to grant it, or set Role to one the user already has - PUBLIC, for example.",
         ),
         when(
             Matchers.any_of(
@@ -222,13 +221,15 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
             )
         ).diagnose(
             "Authentication failed",
-            fix="Check the username and password (or private key) and that the user is allowed to connect.",
+            fix="Snowflake rejected the sign-in. Check Username and Password - or Private Key if you are using key-pair "
+            "authentication - and that the user is allowed to connect.",
         ),
         when(_account_usage_denied(account_usage_schema)).diagnose(
             "Account usage not accessible",
-            fix="Grant the role IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE (or SELECT on the "
-            "snowflake.account_usage views) so query history, tags, and lineage can be read; "
-            "otherwise usage and lineage won't be collected.",
+            fix="Query history, tags and lineage come from Snowflake's ACCOUNT_USAGE views, and this role cannot read "
+            "them. Ask a Snowflake administrator to run GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE to the role, "
+            "or to grant it SELECT on the snowflake.account_usage views. Without that, usage and lineage will not be "
+            "collected.",
         ),
         when(
             Matchers.any_of(
@@ -237,8 +238,8 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
             )
         ).diagnose(
             "Insufficient privileges",
-            fix="Grant the role the privileges the failing step needs (USAGE on the database/schema "
-            "and SELECT on its objects).",
+            fix="The role signed in but is not allowed to read what this step needs. Ask a Snowflake administrator to "
+            "grant it USAGE on the database and schema, and SELECT on the objects inside them.",
         ),
         when(
             Matchers.any_of(
@@ -248,14 +249,15 @@ def _snowflake_errors(account_usage_schema: str | None) -> ErrorPack:
             )
         ).diagnose(
             "Object not found",
-            fix="Verify the configured database, schema, warehouse, and role exist and the role is "
-            "authorized to use them.",
+            fix="Snowflake could not find one of the objects this connection names. Check Database, Schema, Warehouse and "
+            "Role all exist and are spelled correctly. Snowflake also reports an object the role cannot see as "
+            "missing, so a permission gap looks exactly the same.",
         ),
         when(Matchers.contains("no active warehouse")).diagnose(
             "No active warehouse",
-            fix="Set a valid warehouse on the connection - verify the name, since a missing, "
-            "misspelled, or inaccessible warehouse all fail here - and ensure the role has USAGE "
-            "on it, so queries have compute to run on.",
+            fix="No warehouse is active, so there is no compute to run queries on. Set Warehouse and check the name - a "
+            "warehouse that is missing, misspelled, or not granted to this role all fail the same way. The role also "
+            "needs USAGE on it.",
         ),
     ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -106,17 +106,17 @@ TAG_PROBE_COMMAND = "SELECT * FROM information_schema.{catalog_tags,schema_tags,
 UNITY_CATALOG_ERRORS = ErrorPack(
     when(Matchers.exception(Unauthenticated)).diagnose(
         "Authentication failed",
-        fix="The workspace rejected the credentials. Verify the personal access token, OAuth "
-        "client secret, or Azure AD credentials are valid and not expired.",
+        fix="The workspace rejected the credentials. Check whichever you are using - personal access token, OAuth client "
+        "secret, or Azure AD credentials - is correct and has not expired.",
     ),
     when(Matchers.contains("invalid access token")).diagnose(
         "Authentication failed",
-        fix="The workspace rejected the access token. Verify it is valid, not expired, and "
-        "belongs to a user with access to this workspace.",
+        fix="The workspace rejected the access token. Check it was copied whole, has not expired, and belongs to a user "
+        "who can reach this workspace.",
     ),
     when(Matchers.contains("token is expired")).diagnose(
         "Access token expired",
-        fix="The access token has expired. Generate a new token and update the connection.",
+        fix="The access token has expired. Generate a new one in Databricks and paste it into the connection.",
     ),
     when(
         Matchers.any_of(
@@ -126,49 +126,48 @@ UNITY_CATALOG_ERRORS = ErrorPack(
         )
     ).diagnose(
         "Insufficient privileges",
-        fix="Grant the connection's principal the privileges the failing step needs: USE CATALOG "
-        "on the catalog, USE SCHEMA on the schema, and SELECT on its tables.",
+        fix="The account this connection uses is not allowed to read what this step needs. Grant it USE CATALOG on the "
+        "catalog, USE SCHEMA on the schema, and SELECT on the tables inside.",
     ),
     when(Matchers.exception(ResourceDoesNotExist, NotFound)).diagnose(
         "Object not found",
-        fix="The configured catalog or schema does not exist, or is not visible to the "
-        "connection's principal. Verify the names and the USE CATALOG / USE SCHEMA grants.",
+        fix="Unity Catalog could not find the catalog or schema. Check the names in Catalog and Database Schema - an "
+        "object the account has not been granted USE CATALOG or USE SCHEMA on is reported as missing too.",
     ),
     when(Matchers.contains("no_such_catalog")).diagnose(
         "Catalog not found",
-        fix="The configured catalog does not exist or is not visible. Verify the catalog name and "
-        "that the principal has USE CATALOG on it.",
+        fix="Unity Catalog has no catalog with the name in Catalog, or the account cannot see it. Check the name, and "
+        "that the account has USE CATALOG on it.",
     ),
     when(Matchers.contains("no_such_schema")).diagnose(
         "Schema not found",
-        fix="The configured schema does not exist or is not visible. Verify the schema name and "
-        "that the principal has USE SCHEMA on it.",
+        fix="Unity Catalog has no schema with the name in Database Schema, or the account cannot see it. Check the name, "
+        "and that the account has USE SCHEMA on it.",
     ),
     when(Matchers.contains("table_or_view_not_found")).diagnose(
         "Table or view not found",
-        fix="The referenced table or view does not exist or is not visible. Verify the object "
-        "exists and the principal has SELECT on it.",
+        fix="The table or view this step read does not exist, or the account cannot see it. Check it exists and that the "
+        "account has SELECT on it.",
     ),
     when(Matchers.contains("malformed_request")).diagnose(
         "Invalid HTTP path",
-        fix="The HTTP Path is malformed. Copy it from the SQL warehouse (or cluster) Connection "
-        "Details in Databricks - it must look like /sql/1.0/warehouses/<warehouseId>.",
+        fix="Databricks did not recognise the value in Http Path. Copy it from the Connection Details tab of the SQL "
+        "warehouse in Databricks - it looks like /sql/1.0/warehouses/<id>.",
     ),
     when(Matchers.contains("no valid connection settings")).diagnose(
         "SQL warehouse not configured",
-        fix="The GetQueries and GetTags steps open a SQL connection, which needs an HTTP Path. Set "
-        "it to a running SQL warehouse (/sql/1.0/warehouses/<warehouseId>). Metadata ingestion "
-        "works without it, but query-log lineage and tag extraction do not.",
+        fix="These steps open a SQL connection, and that needs Http Path pointing at a running SQL warehouse. Metadata "
+        "ingestion works without it, but query-log lineage and tag extraction will not.",
     ),
     when(Matchers.contains("failed to connect to the database")).diagnose(
         "SQL warehouse not reachable",
-        fix="Could not open a SQL connection over the configured HTTP Path. Verify the SQL "
-        "warehouse is running and the principal can use it, and that the HTTP Path is correct.",
+        fix="Could not open a SQL connection over the path in Http Path. Check the SQL warehouse is running, that the "
+        "path is right, and that the account is allowed to use that warehouse.",
     ),
     when(Matchers.contains("does not exist")).diagnose(
         "Object not found",
-        fix="Verify the configured catalog, schema, and HTTP path exist and the connection's "
-        "principal is authorized to use them.",
+        fix="Unity Catalog could not find something this connection names. Check Catalog, Database Schema and Http Path, "
+        "and that the account is allowed to use them.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/connection.py
@@ -295,41 +295,45 @@ def _db_message(*tokens: str) -> Matcher:
 AIRFLOW_ERRORS = ErrorPack(
     when(http_status(401)).diagnose(
         "Authentication failed",
-        fix="Airflow rejected the credentials. Check the username and password (or token) are correct and not expired.",
+        fix="Airflow rejected the credentials. Check the username and password - or the token, if that is how this "
+        "connection authenticates - and that they have not expired.",
     ),
     when(http_status(403)).diagnose(
         "Access denied",
-        fix="The credentials are valid but lack access. Grant this user permission to read the Airflow REST API.",
+        fix="The credentials are valid, but this user is not allowed to use the Airflow API. Give the account a role that "
+        "can read DAGs - Viewer is usually enough.",
     ),
     when(http_status(404)).diagnose(
         "Endpoint not found",
-        fix="Airflow returned 404 for this URL. Check the Host and Port point to the Airflow web "
-        "server, not a UI or console page.",
+        fix="Airflow answered, but there is nothing at that URL. Check Host and Port point at the Airflow web server "
+        "itself rather than a dashboard or console page in front of it.",
     ),
     when(http_status(429)).diagnose(
         "Rate limited",
-        fix="Airflow (or a gateway in front of it) is throttling the request. Retry in a few "
-        "minutes, or raise the rate limit for the account ingestion uses.",
+        fix="Airflow, or something in front of it, is rate limiting these requests. Wait a few minutes and try again, or "
+        "raise the limit for the account ingestion uses.",
     ),
     # A URL that is not the Airflow REST API (an SSO login page, the marketing
     # site) answers with HTML that fails to decode as JSON.
     when(Matchers.exception(JSONDecodeError)).diagnose(
         "Host is not the Airflow REST API",
-        fix="The host replied with a web page, not the Airflow REST API. Point the Host and Port "
-        "at the Airflow web server and make sure its REST API is enabled.",
+        fix="The host returned a web page rather than API data - usually a login screen or a proxy. Point Host and Port "
+        "at the Airflow web server, and check its REST API is turned on.",
     ),
     when(Matchers.exception(SSLError)).diagnose(
         "TLS verification failed",
-        fix="The server's certificate could not be verified. Check the Host, or uncheck "
-        "'Verify SSL' if you use a self-signed certificate.",
+        fix="The server's certificate could not be verified from where ingestion runs. Check Host and Port, or turn off "
+        "Verify SSL if this Airflow uses a self-signed certificate.",
     ),
     when(Matchers.exception(Timeout)).diagnose(
         "Connection timed out",
-        fix="Airflow did not respond in time. Check the Host and Port and that a firewall allows access to it.",
+        fix="Airflow did not answer in time. Check Host and Port, and that a firewall allows the machine ingestion runs "
+        "on to reach it.",
     ),
     when(Matchers.exception(RequestsConnectionError)).diagnose(
         "Cannot reach the host",
-        fix="Could not reach the host. Check the Host and Port for typos and that it is reachable.",
+        fix="Could not reach the host at all. Check Host and Port for typos, and that the machine ingestion runs on can "
+        "reach it.",
     ),
     # Metadata-DB backend path. MySQL answers a bad login with "Access denied"
     # (1045) and PostgreSQL with "password authentication failed" (28P01). Gated
@@ -337,7 +341,8 @@ AIRFLOW_ERRORS = ErrorPack(
     # mislabeled as a database problem.
     when(_db_message("access denied", "password authentication failed")).diagnose(
         "Database authentication failed",
-        fix="The Airflow metadata database rejected the credentials. Check the database username and password.",
+        fix="This connection reads Airflow's metadata database directly, and the database rejected the sign-in. Check the "
+        "username and password on the database connection, not the Airflow ones.",
     ),
 ).including(NETWORK_ERRORS)
 

--- a/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/dbtcloud/connection.py
@@ -81,8 +81,8 @@ DBTCLOUD_ERRORS = ErrorPack(
     ),
     when(http_status(401, extract=_dbt_status)).diagnose(
         "Authentication failed",
-        fix="dbt Cloud rejected the token. Check the Token is a valid, unexpired service token or "
-        "personal access token.",
+        fix="dbt Cloud rejected the token. Check Token holds a current service token or personal access token, copied "
+        "whole and not expired.",
         doc=TOKENS_DOC,
     ),
     when(http_status(403, extract=_dbt_status)).diagnose(
@@ -97,31 +97,31 @@ DBTCLOUD_ERRORS = ErrorPack(
     ),
     when(http_status(429, extract=_dbt_status)).diagnose(
         "Rate limited",
-        fix="dbt Cloud rate limits the API at 5,000 requests per minute per account and then "
-        "enforces a five-minute cooldown. Retry in five minutes.",
+        fix="dbt Cloud limits the API to 5,000 requests a minute per account, and then makes you wait. Try again in about "
+        "five minutes.",
         doc=RATE_LIMITS_DOC,
     ),
     # A Host that is a valid URL but not the dbt Cloud API (e.g. the marketing site)
     # redirects to an HTML page, which answers 200 and fails to decode.
     when(Matchers.exception(JSONDecodeError)).diagnose(
         "Host is not the dbt Cloud API",
-        fix="Host answered with a response that is not dbt Cloud API JSON. Set it to your dbt "
-        "Cloud access URL, e.g. https://cloud.getdbt.com.",
+        fix="The address in Host returned something that is not the dbt Cloud API. Set it to your dbt Cloud access URL, "
+        "for example https://cloud.getdbt.com.",
     ),
     when(Matchers.exception(SSLError)).diagnose(
         "TLS verification failed",
-        fix="The host's certificate could not be verified. Check Host points at dbt Cloud and that "
-        "any TLS-intercepting proxy is trusted where ingestion runs.",
+        fix="The certificate could not be verified from where ingestion runs. Check Host points at dbt Cloud, and if your "
+        "network inspects TLS traffic, that its certificate is trusted on that machine.",
     ),
     when(Matchers.exception(Timeout)).diagnose(
         "Connection timed out",
-        fix="dbt Cloud did not answer in time. Check that a firewall or network ACL allows egress "
-        "to Host from where ingestion runs.",
+        fix="dbt Cloud did not answer in time. Check that a firewall or network ACL lets the machine ingestion runs on "
+        "reach the address in Host.",
     ),
     when(Matchers.exception(RequestsConnectionError)).diagnose(
         "Cannot reach the host",
-        fix="Check Host for typos and that it resolves from where ingestion runs. dbt Cloud is "
-        "regional - the access URL differs per region.",
+        fix="Could not reach the address in Host. Check it for typos - dbt Cloud is regional, so the access URL is "
+        "different depending on where your account is hosted.",
     ),
 )
 # NETWORK_ERRORS not folded in: the requests-typed rules above already claim every

--- a/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
@@ -54,17 +54,18 @@ if TYPE_CHECKING:
 S3_ERRORS = ErrorPack(
     when(aws_code("NoSuchBucket")).diagnose(
         "Bucket not found",
-        fix="Verify the configured bucketNames exist in this AWS account and region.",
+        fix="No bucket with that name exists in this AWS account and region. Check the spelling in Bucket Names, and "
+        "that AWS Region is the region the buckets are actually in.",
     ),
     when(aws_code("AccessDenied", "AccessDeniedException")).diagnose(
         "Not authorized",
-        fix="Grant s3:ListAllMyBuckets (or s3:ListBucket on the configured buckets) "
-        "and cloudwatch:ListMetrics to the identity used.",
+        fix="Grant the AWS identity s3:ListAllMyBuckets - or s3:ListBucket on just the buckets named in Bucket Names - "
+        "and cloudwatch:ListMetrics.",
     ),
     when(Matchers.exception(EndpointConnectionError)).diagnose(
         "Cannot reach the AWS endpoint",
-        fix="Check awsRegion (and endPointURL for S3-compatible services), and that the "
-        "network allows access to it from where ingestion runs.",
+        fix="Could not reach the S3 endpoint. Check AWS Region, and Endpoint URL if you are pointing at an S3-compatible "
+        "store rather than AWS itself, and that the network lets the machine ingestion runs on reach it.",
     ),
 ).including(AWS_ERRORS)
 

--- a/ingestion/tests/unit/source/database/bigquery/test_connection.py
+++ b/ingestion/tests/unit/source/database/bigquery/test_connection.py
@@ -108,6 +108,42 @@ def test_generic_forbidden_is_permission_denied():
     assert BIGQUERY_ERRORS.classify(error).title == "Permission denied"
 
 
+def test_quota_exceeded_is_not_reported_as_a_permission_problem():
+    # BigQuery answers a quota breach with 403, so it arrives as a Forbidden; the
+    # remediation is a quota bump, not a role grant.
+    error = _ApiError(Forbidden("403 Quota exceeded: Your project exceeded quota for free query bytes scanned"))
+    assert BIGQUERY_ERRORS.classify(error).title == "BigQuery quota exceeded"
+
+
+def test_rate_limit_is_not_reported_as_a_permission_problem():
+    error = Forbidden("403 Exceeded rate limits: too many api requests per user per method")
+    assert BIGQUERY_ERRORS.classify(error).title == "BigQuery quota exceeded"
+
+
+def test_disabled_api_is_not_reported_as_a_permission_problem():
+    # reason=accessNotConfigured, also a 403: no role grants access to a disabled API.
+    error = _ApiError(
+        Forbidden("403 BigQuery API has not been used in project 12345 before or it is disabled. Enable it by visiting")
+    )
+    assert BIGQUERY_ERRORS.classify(error).title == "BigQuery API is not enabled"
+
+
+def test_quota_and_disabled_api_beat_the_access_denied_token():
+    # A 403 body can carry the "Access Denied" prefix and the sharper reason at
+    # once; the reason rules are ordered first so the prefix cannot swallow them.
+    quota = Forbidden("403 Access Denied: Quota exceeded: Your project exceeded quota for free query bytes scanned")
+    assert BIGQUERY_ERRORS.classify(quota).title == "BigQuery quota exceeded"
+    disabled = Forbidden("403 Access Denied: BigQuery API has not been used in project 12345 before or it is disabled")
+    assert BIGQUERY_ERRORS.classify(disabled).title == "BigQuery API is not enabled"
+
+
+def test_other_disabled_google_api_is_not_named_bigquery():
+    # accessNotConfigured is raised for any Google API; with policy tags enabled
+    # the disabled one is Data Catalog, so the diagnosis must not name BigQuery.
+    error = Forbidden("403 Google Cloud Data Catalog API has not been used in project 12345 before or it is disabled")
+    assert BIGQUERY_ERRORS.classify(error).title == "A required Google Cloud API is not enabled"
+
+
 def test_not_found_is_classified():
     error = _ApiError(NotFound("404 Not found: Dataset project:dataset was not found"))
     assert BIGQUERY_ERRORS.classify(error).title == "Project or dataset not found"

--- a/ingestion/tests/unit/source/database/postgres/test_connection.py
+++ b/ingestion/tests/unit/source/database/postgres/test_connection.py
@@ -184,7 +184,11 @@ def test_missing_query_history_source_holds_for_a_custom_source_name():
 
 def test_pg_hba_message_is_classified():
     error = Exception('FATAL: no pg_hba.conf entry for host "1.2.3.4", user "u", SSL off')
-    assert POSTGRES_ERRORS.classify(error).title == "Connection not permitted by pg_hba.conf"
+    diagnosis = POSTGRES_ERRORS.classify(error)
+    assert diagnosis.title == "The server is not configured to accept this connection"
+    # The title no longer names pg_hba.conf, so the remediation has to - it is the
+    # file an administrator must edit, and the user cannot act without knowing it.
+    assert "pg_hba.conf" in diagnosis.remediation
 
 
 def test_network_errors_classify_through_including():

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/grafana.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/grafana.json
@@ -5,8 +5,8 @@
     "steps": [
         {
             "name": "GetDashboards",
-            "description": "Validate authentication credentials",
-            "errorMessage": "Failed to authenticate with Grafana. Please check your credentials.",
+            "description": "List the dashboards available to the user.",
+            "errorMessage": "Failed to fetch dashboards from Grafana. Please validate the Host and Port, and that the service account token is valid and has access to search dashboards.",
             "mandatory": true,
             "shortCircuit": true
         }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/hex.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/hex.json
@@ -5,8 +5,8 @@
     "steps": [
       {
         "name": "GetProjects",
-        "description": "List all the dashboards available to the user",
-        "errorMessage": "Failed to fetch dashboards, please validate the credentials or validate if user has access to fetch dashboards",
+        "description": "List all the projects available to the user",
+        "errorMessage": "Failed to fetch projects, please validate the credentials or validate if user has access to fetch projects",
         "shortCircuit": true,
         "mandatory": true
       }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/lightdash.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/lightdash.json
@@ -6,7 +6,7 @@
       {
         "name": "GetDashboards",
         "description": "List all the dashboards available to the user",
-        "errorMessage": "Failed to fetch orgs, please validate the credentials or validate if user has access to fetch orgs",
+        "errorMessage": "Failed to fetch dashboards, please validate the credentials or validate if user has access to fetch dashboards",
         "shortCircuit": true,
         "mandatory": true
       }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/powerbireportserver.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/powerbireportserver.json
@@ -8,7 +8,8 @@
         "description": "List all the dashboards available to the user",
         "errorMessage": "Failed to fetch dashboards, please validate the credentials or validate if user has access to fetch dashboards",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       }
     ]
   }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/sapS4Hana.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/sapS4Hana.json
@@ -8,7 +8,8 @@
       "description": "Validate that we can properly reach the SAP S/4HANA instance and authenticate with the given credentials.",
       "errorMessage": "Failed to connect to SAP S/4HANA. Please validate the host, port, and credentials.",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "GetDashboards",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/thoughtSpot.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/dashboard/thoughtSpot.json
@@ -8,7 +8,8 @@
         "description": "Validate authentication credentials",
         "errorMessage": "Failed to authenticate with ThoughtSpot. Please check your credentials.",
         "mandatory": true,
-        "shortCircuit": true
+        "shortCircuit": true,
+        "category": "ConnectionGate"
       },
       {
         "name": "GetLiveboards",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/dremio.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/dremio.json
@@ -8,7 +8,8 @@
       "description": "Validate that we can properly reach Dremio Cloud API and authenticate with the given Personal Access Token (PAT).",
       "errorMessage": "Failed to connect to Dremio Cloud. Please validate that your Project ID and Personal Access Token (PAT) are correct, and that the region/API URL is properly configured.",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "GetDatabases",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/epic.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/epic.json
@@ -8,7 +8,8 @@
         "description": "Validate that the Epic FHIR metadata endpoint is reachable.",
         "errorMessage": "Failed to connect to Epic FHIR server, please check the endpoint URL.",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       }
     ]
   }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/informix.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/informix.json
@@ -8,7 +8,8 @@
       "description": "Validate that we can properly reach the Informix database server and authenticate with the given credentials.",
       "errorMessage": "Failed to connect to Informix. Please validate the hostPort, username, password, and serverName (INFORMIXSERVER) credentials.",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "GetSchemas",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/microsoftaccess.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/microsoftaccess.json
@@ -9,7 +9,8 @@
         "description": "Validate that at least one Microsoft Access database file (.accdb or .mdb) exists in the configured location (local path or S3 bucket).",
         "errorMessage": "Failed to find Access database files. Please validate the file path or S3 bucket configuration and ensure at least one .accdb or .mdb file exists.",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       }
     ]
   }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/sapBw4Hana.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/sapBw4Hana.json
@@ -8,7 +8,8 @@
       "description": "Validate that we can connect to the underlying SAP HANA database and authenticate with the given credentials.",
       "errorMessage": "Failed to connect to SAP HANA. Please validate the host, port, username, and password.",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "GetInfoAreas",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/sapsuccessfactors.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/sapsuccessfactors.json
@@ -8,7 +8,8 @@
             "description": "Validate that we can properly reach the SAP SuccessFactors OData API and authenticate with the given credentials by fetching the $metadata endpoint.",
             "errorMessage": "Failed to connect to SAP SuccessFactors. Please validate the base URL, company ID, and credentials.",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         },
         {
             "name": "GetEntities",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/servicenow.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/servicenow.json
@@ -5,21 +5,22 @@
     "steps": [
       {
         "name": "CheckAccess",
-        "description": "Validate that we can properly reach the database and authenticate with the given credentials.",
-        "errorMessage": "Failed to connect to mysql, please validate the credentials",
+        "description": "Validate that we can reach the ServiceNow instance REST API and authenticate with the given credentials.",
+        "errorMessage": "Failed to connect to ServiceNow. Please validate the instance URL and that the credentials are correct and the account is active and not locked out.",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       },
       {
         "name": "GetTables",
-        "description": "List all the schemas available to the user.",
-        "errorMessage": "Failed to fetch schemas, please validate if the user has enough privilege to fetch schemas.",
+        "description": "Read the ServiceNow table dictionary (sys_db_object) to list the tables available to the user.",
+        "errorMessage": "Failed to read the table dictionary (sys_db_object). Please validate that the user has read access to the sys_db_object table.",
         "mandatory": true
       },
       {
         "name": "GetColumns",
-        "description": "From a given schema, list the tables belonging to that schema. If no schema is specified, we'll list the tables of a random schema.",
-        "errorMessage": "Failed to fetch tables, please validate if the user has enough privilege to fetch tables.",
+        "description": "Read the ServiceNow column dictionary (sys_dictionary) to list the columns of the tables to ingest.",
+        "errorMessage": "Failed to read the column dictionary (sys_dictionary). Please validate that the user has read access to the sys_dictionary table.",
         "mandatory": true
       }
     ]

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/ssas.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/ssas.json
@@ -8,7 +8,8 @@
             "description":  "Check if the database is reachable.",
             "errorMessage": "Failed to connect to ssas, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/database/synapse.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/database/synapse.json
@@ -8,7 +8,8 @@
         "description": "Validate that we can properly reach the database and authenticate with the given credentials.",
         "errorMessage": "Failed to connect to synapse, please validate the credentials",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       },
       {
         "name": "GetSchemas",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/metadata/alation.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/metadata/alation.json
@@ -8,7 +8,8 @@
             "description":  "Check if the Alation APIs are reachable with the given credentials.",
             "errorMessage": "Failed to connect to Alation, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         },
         {
             "name": "CheckDbAccess",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/metadata/collibra.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/metadata/collibra.json
@@ -8,7 +8,8 @@
             "description":  "Check if the Collibra APIs are reachable and can fetch glossaries with the given credentials.",
             "errorMessage": "Failed to connect to Collibra or fetch glossaries, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/mlmodel/vertexai.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/mlmodel/vertexai.json
@@ -8,7 +8,8 @@
         "description": "Validate that we can get the instances with the given credentials.",
         "errorMessage": "Failed to get VertexAI models, please validate to the credentials of service account",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/datafactory.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/datafactory.json
@@ -8,7 +8,8 @@
             "description":  "Validate that the API can fetch pipelines.",
             "errorMessage": "Failed to fetch pipelines info please validate the credentials or validate if user has access to fetch pipelines",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         },
         {
             "name": "GetRuns",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/kinesisfirehose.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/kinesisfirehose.json
@@ -8,7 +8,8 @@
             "description": "List all the delivery streams available to the user, user must have access to `firehose:ListDeliveryStreams` permission",
             "errorMessage": "Failed to fetch delivery streams, please validate the AWS credentials or validate if the IAM role has access to `firehose:ListDeliveryStreams`",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/matillion.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/matillion.json
@@ -8,7 +8,8 @@
             "description":  "Check if the instance is reachable to fetch the pipeline details.",
             "errorMessage": "Failed to connect to Matillion, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/mulesoft.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/mulesoft.json
@@ -8,7 +8,8 @@
             "description": "Check if we can successfully list environments from MuleSoft Anypoint Platform.",
             "errorMessage": "Failed to retrieve environments from MuleSoft. Please validate the credentials and API access.",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         },
         {
             "name": "GetApplications",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/sapBw4HanaPipeline.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/sapBw4HanaPipeline.json
@@ -8,7 +8,8 @@
       "description": "Validate that we can connect to the underlying SAP HANA database and authenticate with the given credentials.",
       "errorMessage": "Failed to connect to SAP HANA. Please validate the host, port, username, and password.",
       "shortCircuit": true,
-      "mandatory": true
+      "mandatory": true,
+      "category": "ConnectionGate"
     },
     {
       "name": "GetProcessChains",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/snowplow.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/snowplow.json
@@ -8,7 +8,8 @@
             "description":  "Check if the instance is reachable to fetch the pipeline details.",
             "errorMessage": "Failed to connect to Snowplpow, please validate the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/ssis.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/ssis.json
@@ -8,7 +8,8 @@
             "description": "Check if the database is reachable to fetch the DAG details. Skipped in file-only mode (no databaseConnection configured).",
             "errorMessage": "Failed to connect to SSIS database. If running in file-only mode, databaseConnection is not required.",
             "shortCircuit": false,
-            "mandatory": false
+            "mandatory": false,
+            "category": "ConnectionGate"
         },
         {
             "name": "SSISDBExist",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/stitch.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/stitch.json
@@ -8,7 +8,8 @@
         "description": "Get pipeline sources",
         "errorMessage": "Failed to get all the sources for pipeline",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       },
       {
         "name": "GetDestinations",

--- a/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/wherescape.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/pipeline/wherescape.json
@@ -5,10 +5,11 @@
     "steps": [
         {
             "name": "CheckAccess",
-            "description":  "Check if the database is reachable to fetch the DAG details.",
-            "errorMessage": "Failed to connect to airflow, please validate the credentials",
+            "description":  "Check that the WhereScape metadata database is reachable, to fetch the job and workflow details.",
+            "errorMessage": "Failed to connect to the WhereScape metadata database. Please validate the metadata database connection details and that the user can read the WhereScape repository tables.",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
 
     ]

--- a/openmetadata-service/src/main/resources/json/data/testConnections/security/ranger.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/security/ranger.json
@@ -8,7 +8,8 @@
             "description": "Checks if we can access the ranger service",
             "errorMessage": "Failed to access the ranger service, please check the credentials",
             "shortCircuit": true,
-            "mandatory": true
+            "mandatory": true,
+            "category": "ConnectionGate"
         }
     ]
 }

--- a/openmetadata-service/src/main/resources/json/data/testConnections/storage/adls.json
+++ b/openmetadata-service/src/main/resources/json/data/testConnections/storage/adls.json
@@ -8,7 +8,8 @@
         "description": "List all the containers available to the user in the Storage Account.",
         "errorMessage": "Failed to fetch containers, please validate the credentials if the user has access to list containers in the given Storage Account.",
         "shortCircuit": true,
-        "mandatory": true
+        "mandatory": true,
+        "category": "ConnectionGate"
       }
     ]
   }


### PR DESCRIPTION
## Describe your changes

A review of every user-facing string a connector shows when a test-connection step fails. There are two such surfaces and they don't overlap: the `Diagnosis` produced by a connector `ErrorPack` (17 migrated connectors), and the static `errorMessage` on each step of the `testConnectionDefinition` (the other ~105). `StepResultBuilder` sets `message=None` for migrated connectors, so the static string is dead for those and live for everyone else — which makes the definitions the message most services actually show.

### 1. Step messages that named the wrong service or the wrong step

Found by two sweeps over all 122 definitions (message naming a different connector; message noun contradicting its own step name), after discarding legitimate domain renames (Dremio folders→schemas, Domo datasets→tables, SAP S/4HANA Fiori apps→dashboards, Kinesis Firehose delivery streams→pipelines).

| File | Step | Was |
|---|---|---|
| `database/servicenow.json` | CheckAccess | `Failed to connect to mysql` — ServiceNow is a REST connector |
| `database/servicenow.json` | GetTables / GetColumns | messages shifted one step ("fetch schemas" / "fetch tables") |
| `pipeline/wherescape.json` | CheckAccess | `Failed to connect to airflow` — WhereScape reads its own metadata database |
| `dashboard/lightdash.json` | GetDashboards | `Failed to fetch orgs` |
| `dashboard/hex.json` | GetProjects | `Failed to fetch dashboards` |
| `dashboard/grafana.json` | GetDashboards | a listing failure reported as an authentication failure |

Step `description` fields copy-pasted from the same wrong connector are corrected alongside (ServiceNow's `GetTables` was described as "List all the schemas available to the user"; WhereScape's `CheckAccess` referred to "DAG details").

### 2. BigQuery: 403 for quota and for a disabled API was reported as an IAM problem

`google.api_core.exceptions.Forbidden` is raised for every BigQuery 403, and BigQuery uses 403 for three unrelated causes:

| Reason | Message | Actual fix |
|---|---|---|
| `accessDenied` | `403 Access Denied: Table …` | grant a role — already matched |
| `accessNotConfigured` | `403 BigQuery API has not been used in project <id> before or it is disabled.` | **enable the API** |
| `quotaExceeded` / `rateLimitExceeded` | `403 Quota exceeded: …` | **wait or raise the quota** |

The last two fell to the catch-all and told users to grant IAM roles, which fixes neither. Two details worth review:

- The new rules sit **above** the `contains("access denied")` rule, not merely above the `Forbidden` catch-all — a 403 body can carry the `Access Denied:` prefix *and* the sharper reason, and placed below, the prefix swallowed both.
- `accessNotConfigured` is not BigQuery-specific — with `includePolicyTags` set the disabled API is Data Catalog. So the narrow token keeps the specific title and a broader rule behind it names no API the error did not.

### 3. `ConnectionGate` on the definitions of connectors being migrated

26 definitions whose connectors are migrating to the `@check` framework now mark their gate step. The legacy runner reads `shortCircuit` and ignores `category`, so this is a **no-op until each connector migrates**, after which a failed gate short-circuits the rest instead of reporting several doomed failures. Convention matches the 17 already-migrated definitions: exactly one step, the first `shortCircuit: true` one.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `fix(ingestion): report what a failed test-connection step actually hit`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests

## Tests

5 new cases in `tests/unit/source/database/bigquery/test_connection.py` — quota, rate limit, disabled API, the `Access Denied:`-prefixed forms of both, and a non-BigQuery disabled API. The pre-existing 403/404 cases are kept as regression guards for the reordering.

All 10 classification paths verified against the real `BIGQUERY_ERRORS` pack:

| Error | Diagnosis |
|---|---|
| `403 Quota exceeded: …` | BigQuery quota exceeded |
| `403 Access Denied: Quota exceeded: …` | BigQuery quota exceeded |
| `403 Exceeded rate limits: …` | BigQuery quota exceeded |
| `403 BigQuery API has not been used in project 12345 …` | BigQuery API is not enabled |
| `403 Access Denied: BigQuery API has not been used …` | BigQuery API is not enabled |
| `403 Google Cloud Data Catalog API has not been used …` | A required Google Cloud API is not enabled |
| `403 Access Denied: Table …JOBS_BY_PROJECT` | Access denied *(unchanged)* |
| `403 The caller does not have permission` | Permission denied *(unchanged)* |
| `403 User does not have bigquery.jobs.create permission…` | Missing permission to run BigQuery jobs *(unchanged)* |
| `404 Not found: Dataset …` | Project or dataset not found *(unchanged)* |

All five edited definitions re-parse; `ruff check` and `ruff format --check` clean.

Nothing asserts on the definition strings — the only test over them is `TestConnectionDefinitionResourceIT`, which checks structure plus one hard-coded case (`Mysql` has 5 steps). No step was added, removed, or renamed.

**Note:** `pytest tests/unit/source/database/bigquery/test_connection.py` could not be collected locally — `google.cloud.datacatalog_v1` (the `bigquery` extra) is missing from the dev venv, and collection fails identically on unmodified `main`. The classification table above was produced by importing the same module with only that one dependency stubbed. CI, which installs the extras, will execute the new cases.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR improves user-facing test-connection diagnostics across ingestion connectors.
- Adds specific BigQuery classifications for quota limits and disabled Google Cloud APIs.
- Corrects inaccurate connector and step descriptions in test-connection definitions.
- Marks connection-gate steps for connectors migrating to the check framework.
- Rewords existing connector remediation guidance for clarity and specificity.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/bigquery/connection.py | Adds ordered diagnostic rules that distinguish quota and disabled-API failures from permission failures. |
| ingestion/tests/unit/source/database/bigquery/test_connection.py | Adds regression coverage for quota, rate-limit, disabled-API, and overlapping Access Denied messages. |
| openmetadata-service/src/main/resources/json/data/testConnections/database/servicenow.json | Corrects ServiceNow step descriptions and errors and marks CheckAccess as the connection gate. |
| openmetadata-service/src/main/resources/json/data/testConnections/pipeline/wherescape.json | Replaces Airflow-specific copy with WhereScape metadata-database guidance and marks the gate step. |
| openmetadata-service/src/main/resources/json/data/testConnections/dashboard/grafana.json | Aligns the Grafana failure message with dashboard enumeration rather than authentication alone. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ingestion): finish the plain-languag..."](https://github.com/open-metadata/openmetadata/commit/542868e5d5395e094f9057c6cd45c622692e012b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49017662)</sub>

<!-- /greptile_comment -->