### PR TITLE
fix(ui): a 401 should only sign the user out when the session is dead

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -258,10 +258,11 @@
         "openmetadata-ui/src/main/resources/ui/src/components/Auth/**",
         "openmetadata-ui/src/main/resources/ui/src/pages/Login/**"
       ],
-      "projects": ["chromium", "Basic", "SearchRBAC", "ImportExport"],
+      "projects": ["chromium", "Basic", "SearchRBAC", "ImportExport", "Ingestion"],
       "specs": [
         "playwright/e2e/**/*Permission*.spec.ts",
         "playwright/e2e/Pages/Login*.spec.ts",
+        "playwright/e2e/Pages/SessionAuthErrors.spec.ts",
         "playwright/e2e/Flow/SearchRBAC.spec.ts"
       ]
     },

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOAuthentication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOAuthentication.spec.ts
@@ -33,8 +33,19 @@ import {
   setTokenExpiry,
   waitForMockOidcReady,
 } from '../../utils/mockOidc';
+import { setToken } from '../../utils/tokenStorage';
 
 const MOCK_OIDC_URL = process.env.MOCK_OIDC_URL || 'http://localhost:9090';
+
+// A syntactically valid JWT whose exp is far in the past, used to make a session genuinely dead.
+const EXPIRED_JWT = [
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiZXhwIjoxMDAwMDAwMDAwfQ',
+  'not-a-real-signature',
+].join('.');
+
+const DEPENDENCY_401_MESSAGE =
+  'The configured runner token is not authorized for this namespace';
 
 const performOidcLogin = async (page: Page): Promise<void> => {
   await page.goto('/');
@@ -342,12 +353,20 @@ test.describe('SSO Authentication with Mock OIDC Provider', () => {
   // These tests use page.route() to simulate 401 responses from the
   // OM API, triggering the frontend's axios interceptor to refresh
   // the token and retry failed requests.
+  //
+  // A 401 only ends in a logout when the stored token has actually expired —
+  // refreshToken() refuses to renew a still-valid token, so a 401 in that
+  // state cannot be recovered by refreshing and must surface as an error
+  // instead. Tests that want the logout path therefore plant an expired token
+  // rather than relying on a mocked 401 alone.
+  // See https://github.com/open-metadata/openmetadata-collate/issues/4647
   // ---------------------------------------------------------------
 
   test.describe('401 Interceptor and Request Retry', () => {
     test('should trigger session expired redirect on 401 with expired token message', async ({
       page,
       browserName,
+      request,
     }) => {
       // WebKit processes page.route() 401 interceptions with different event
       // loop timing — the async logout chain doesn't complete before the page
@@ -360,10 +379,11 @@ test.describe('SSO Authentication with Mock OIDC Provider', () => {
       await performOidcLogin(page);
       await verifyAuthenticated(page);
 
-      // Intercept the loggedInUser API call and return 401 with 'Expired token!'
-      // message. The interceptor will attempt to refresh, but since the token
-      // isn't truly expired at the OIDC level, refreshToken() returns null →
-      // forced logout with "session expired" toast.
+      // Make the session genuinely dead: the stored token is expired and the
+      // provider will refuse to renew it silently.
+      await setToken(page, EXPIRED_JWT);
+      await forceInteractionRequired(request);
+
       let intercepted = false;
       await page.route('**/api/v1/users/loggedInUser*', async (route) => {
         if (!intercepted) {
@@ -399,6 +419,10 @@ test.describe('SSO Authentication with Mock OIDC Provider', () => {
       await verifyAuthenticated(page);
 
       await resetMetrics(request);
+
+      // Expired token, so the 401s below are real session failures and the
+      // interceptor genuinely attempts a renewal to coalesce.
+      await setToken(page, EXPIRED_JWT);
 
       // Track how many 401s we injected
       const interceptedUrls = new Set<string>();
@@ -447,7 +471,9 @@ test.describe('SSO Authentication with Mock OIDC Provider', () => {
       await performOidcLogin(page);
       await verifyAuthenticated(page);
 
-      // Force the OIDC provider to reject the next silent renewal
+      // Expired token + a provider that refuses silent renewal: the session is
+      // unrecoverable, which is exactly when a logout is the right answer.
+      await setToken(page, EXPIRED_JWT);
       await forceInteractionRequired(request);
 
       // Intercept ALL API calls to return 401, simulating expired session
@@ -469,6 +495,41 @@ test.describe('SSO Authentication with Mock OIDC Provider', () => {
       const url = page.url();
 
       expect(url).toContain('/signin');
+    });
+
+    test('should surface a 401 from a dependency without signing the user out', async ({
+      page,
+    }) => {
+      await performOidcLogin(page);
+      await verifyAuthenticated(page);
+
+      // The SSO session is untouched and valid — only this endpoint answers
+      // 401, standing in for a service the API depends on rejecting its own
+      // credentials. Refreshing cannot fix that, so the error must reach the
+      // user rather than destroying a working session.
+      await page.route('**/api/v1/teams**', async (route) => {
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            code: 401,
+            message: DEPENDENCY_401_MESSAGE,
+          }),
+        });
+      });
+
+      await page.goto('/settings/members/teams', {
+        waitUntil: 'domcontentloaded',
+      });
+
+      await expect(
+        page
+          .getByTestId('alert-bar')
+          .filter({ hasText: new RegExp(DEPENDENCY_401_MESSAGE, 'i') })
+          .first()
+      ).toBeVisible({ timeout: 30000 });
+
+      expect(page.url()).not.toContain('/signin');
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
@@ -197,6 +197,44 @@ test.describe('SSO Session Renewal', { tag: SESSION_RENEWAL_TAGS }, () => {
     expect(page.url()).not.toContain('/signin');
   });
 
+  test('should surface a dependency 401 without ending the SAML session', async () => {
+    const page = userPage!;
+    await expect(page.getByTestId('dropdown-profile')).toBeVisible();
+
+    const message = 'The configured runner token is not authorized';
+
+    // The SAML session is live and the access token is fresh — only this endpoint answers 401,
+    // standing in for a service the API depends on rejecting its own credentials. Refreshing
+    // cannot fix that, so the error must reach the user instead of ending a working session.
+    // See https://github.com/open-metadata/openmetadata-collate/issues/4647
+    await page.route('**/api/v1/teams**', (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 401, message }),
+      })
+    );
+
+    try {
+      await page.goto('/settings/members/teams', {
+        waitUntil: 'domcontentloaded',
+      });
+
+      await expect(
+        page
+          .getByTestId('alert-bar')
+          .filter({ hasText: new RegExp(message, 'i') })
+          .first()
+      ).toBeVisible({ timeout: 30_000 });
+
+      expect(page.url()).not.toContain('/signin');
+
+      await expect(page.getByTestId('dropdown-profile')).toBeVisible();
+    } finally {
+      await page.unroute('**/api/v1/teams**');
+    }
+  });
+
   test('should force re-login when the SAML session is gone', async () => {
     const page = userPage!;
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SessionAuthErrors.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SessionAuthErrors.spec.ts
@@ -96,6 +96,10 @@ test.describe(
         })
       );
 
+      // Make the page's own requests fail the way a dead session does, so the test does not
+      // depend on how quickly the server rejects the planted token.
+      await page.route(isTeamsCollection, fulfillWith(401, 'Expired token!'));
+
       await setToken(page, EXPIRED_JWT);
 
       await page.goto(TEAMS_URL, { waitUntil: 'domcontentloaded' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SessionAuthErrors.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SessionAuthErrors.spec.ts
@@ -1,0 +1,176 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, Route, test } from '@playwright/test';
+import {
+  descriptionBox,
+  redirectToHomePage,
+  toastNotification,
+  uuid,
+} from '../../utils/common';
+import { setToken } from '../../utils/tokenStorage';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+const TEAMS_URL = '/settings/members/teams';
+
+// A syntactically valid JWT whose exp is far in the past. The UI only decodes the token to decide
+// whether to renew it; the server rejects it on its own merits.
+const EXPIRED_JWT = [
+  'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9',
+  'eyJzdWIiOiJhZG1pbiIsImlzQm90IjpmYWxzZSwiZXhwIjoxMDAwMDAwMDAwfQ',
+  'not-a-real-signature',
+].join('.');
+
+const UPSTREAM_401_MESSAGE =
+  'The configured runner token is not authorized for this namespace';
+const FORBIDDEN_WRITE_MESSAGE =
+  'Principal admin is not allowed to create teams';
+
+const isTeamsCollection = (url: URL) => url.pathname.endsWith('/api/v1/teams');
+
+const fulfillWith = (status: number, message: string) => (route: Route) =>
+  route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify({ code: status, message }),
+  });
+
+const fulfillMethodWith =
+  (method: string, status: number, message: string) => async (route: Route) => {
+    if (route.request().method() === method) {
+      await fulfillWith(status, message)(route);
+    } else {
+      await route.fallback();
+    }
+  };
+
+const expectStillSignedIn = async (page: Page) => {
+  expect(page.url()).not.toContain('/signin');
+
+  await expect(page.getByTestId('dropdown-profile')).toBeVisible();
+};
+
+/**
+ * A 401 means "sign in again" only when our own session token is the thing that expired. Every
+ * other 401 — most often a service the API depends on rejecting its own credentials — has to reach
+ * the user as an error, because signing them out both loses their work and hides the real cause.
+ *
+ * See https://github.com/open-metadata/openmetadata-collate/issues/4647
+ */
+test.describe(
+  'Auth errors: session failures sign out, everything else surfaces',
+  { tag: ['@Pages', '@Platform'] },
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await redirectToHomePage(page);
+    });
+
+    test('signs the user out when the session token has genuinely expired', async ({
+      page,
+    }) => {
+      test.slow();
+
+      // Renewal has to fail too, otherwise the app legitimately recovers.
+      await page.route('**/api/v1/auth/refresh', (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 401, message: 'No active session' }),
+        })
+      );
+      await page.route('**/api/v1/users/refresh', (route) =>
+        route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ code: 401, message: 'Expired token!' }),
+        })
+      );
+
+      await setToken(page, EXPIRED_JWT);
+
+      await page.goto(TEAMS_URL, { waitUntil: 'domcontentloaded' });
+
+      await page.waitForURL('**/signin**', { timeout: 60000 });
+
+      expect(page.url()).toContain('/signin');
+    });
+
+    test('surfaces a 401 from a dependency instead of signing the user out', async ({
+      page,
+    }) => {
+      test.slow();
+
+      // The session is untouched and valid; only this endpoint answers 401. Before the fix the
+      // interceptor read it as a dead session, redirected to /signin and swallowed the message.
+      await page.route(
+        isTeamsCollection,
+        fulfillWith(401, UPSTREAM_401_MESSAGE)
+      );
+
+      await page.goto(TEAMS_URL, { waitUntil: 'domcontentloaded' });
+
+      await toastNotification(page, new RegExp(UPSTREAM_401_MESSAGE, 'i'));
+      await expectStillSignedIn(page);
+    });
+
+    test('surfaces a 403 on a write instead of signing the user out', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await page.goto(TEAMS_URL, { waitUntil: 'domcontentloaded' });
+
+      await page.getByTestId('add-team').waitFor({ state: 'visible' });
+      await page.getByTestId('add-team').click();
+
+      await page.locator('[role="dialog"].ant-modal').waitFor();
+
+      await page.fill('[data-testid="name"]', `pw-team-${uuid()}`);
+      await page.fill('[data-testid="display-name"]', `PW ${uuid()}`);
+      await page.fill('[data-testid="email"]', `pwteam${uuid()}@example.com`);
+      await page.locator(descriptionBox).fill('Created by a Playwright test');
+
+      await page.route(
+        isTeamsCollection,
+        fulfillMethodWith('POST', 403, FORBIDDEN_WRITE_MESSAGE)
+      );
+
+      await page.locator('button[type="submit"]').click();
+
+      await toastNotification(page, new RegExp(FORBIDDEN_WRITE_MESSAGE, 'i'));
+      await expectStillSignedIn(page);
+    });
+
+    test('keeps a 403 on a read silent and the user signed in', async ({
+      page,
+    }) => {
+      test.slow();
+
+      // Permission-gated reads are everywhere and pages render their own placeholder, so this one
+      // deliberately produces no toast. It must still never sign anyone out.
+      await page.route(
+        isTeamsCollection,
+        fulfillMethodWith(
+          'GET',
+          403,
+          'Principal admin is not allowed to list teams'
+        )
+      );
+
+      await page.goto(TEAMS_URL, { waitUntil: 'domcontentloaded' });
+
+      await expectStillSignedIn(page);
+      await expect(page.getByTestId('alert-bar')).toHaveCount(0);
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tokenStorage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tokenStorage.ts
@@ -195,6 +195,59 @@ export const getToken = async (page: Page): Promise<string> => {
   return (await executeTokenOperation(page, 'get')) as string;
 };
 
+/**
+ * Replace the stored session token.
+ *
+ * The write has to go through the service worker, not straight into IndexedDB. `app-worker.js`
+ * keeps an in-memory `swStore` and only falls back to IndexedDB when the key is *absent* from it,
+ * so once the app has read `app_state` (i.e. after login) a direct IndexedDB write is invisible —
+ * the worker keeps handing the old token to `getOidcToken()`. Writing through the worker updates
+ * both its cache and IndexedDB, and is exactly what the app itself does.
+ *
+ * Falls back to the direct IndexedDB write when no worker is controlling the page.
+ */
 export const setToken = async (page: Page, token: string): Promise<void> => {
-  await executeTokenOperation(page, 'set', token);
+  const wroteViaServiceWorker = await page.evaluate(
+    async ({ appStateKey, oidcTokenKey, token }) => {
+      const controller = navigator.serviceWorker?.controller;
+
+      if (!controller) {
+        return false;
+      }
+
+      const request = (message: Record<string, unknown>): Promise<unknown> =>
+        new Promise((resolve, reject) => {
+          const channel = new MessageChannel();
+          const timer = setTimeout(
+            () => reject(new Error('Service worker did not respond')),
+            10000
+          );
+          channel.port1.onmessage = (event) => {
+            clearTimeout(timer);
+            resolve(event.data?.result ?? null);
+          };
+          controller.postMessage(message, [channel.port2]);
+        });
+
+      const current = (await request({
+        type: 'get',
+        key: appStateKey,
+      })) as string | null;
+      const state = current ? JSON.parse(current) : {};
+      state[oidcTokenKey] = token;
+
+      await request({
+        type: 'set',
+        key: appStateKey,
+        value: JSON.stringify(state),
+      });
+
+      return true;
+    },
+    { appStateKey: APP_STATE_KEY, oidcTokenKey: OIDC_TOKEN_KEY, token }
+  );
+
+  if (!wroteViaServiceWorker) {
+    await executeTokenOperation(page, 'set', token);
+  }
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tokenStorage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tokenStorage.ts
@@ -204,7 +204,9 @@ export const getToken = async (page: Page): Promise<string> => {
  * the worker keeps handing the old token to `getOidcToken()`. Writing through the worker updates
  * both its cache and IndexedDB, and is exactly what the app itself does.
  *
- * Falls back to the direct IndexedDB write when no worker is controlling the page.
+ * Falls back to the direct IndexedDB write when no worker is controlling the page, or when the
+ * worker exchange fails — hence the catch: an unhandled rejection here would abandon the write
+ * rather than fall through.
  */
 export const setToken = async (page: Page, token: string): Promise<void> => {
   const wroteViaServiceWorker = await page.evaluate(
@@ -229,20 +231,24 @@ export const setToken = async (page: Page, token: string): Promise<void> => {
           controller.postMessage(message, [channel.port2]);
         });
 
-      const current = (await request({
-        type: 'get',
-        key: appStateKey,
-      })) as string | null;
-      const state = current ? JSON.parse(current) : {};
-      state[oidcTokenKey] = token;
+      try {
+        const current = (await request({
+          type: 'get',
+          key: appStateKey,
+        })) as string | null;
+        const state = current ? JSON.parse(current) : {};
+        state[oidcTokenKey] = token;
 
-      await request({
-        type: 'set',
-        key: appStateKey,
-        value: JSON.stringify(state),
-      });
+        await request({
+          type: 'set',
+          key: appStateKey,
+          value: JSON.stringify(state),
+        });
 
-      return true;
+        return true;
+      } catch {
+        return false;
+      }
     },
     { appStateKey: APP_STATE_KEY, oidcTokenKey: OIDC_TOKEN_KEY, token }
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -13,10 +13,14 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { AxiosResponse } from 'axios';
 import { act } from 'react-test-renderer';
-import { NON_SESSION_AUTH_ERROR } from '../../../constants/Auth.constants';
+import {
+  NON_SESSION_AUTH_ERROR,
+  STALE_TOKEN_RETRIED,
+} from '../../../constants/Auth.constants';
 import { AuthProvider as AuthProviderProps } from '../../../generated/configuration/authenticationConfiguration';
 import axiosClient from '../../../rest';
 import TokenService from '../../../utils/Auth/TokenService/TokenServiceUtil';
+import { getOidcToken } from '../../../utils/SwTokenStorageUtils';
 import AuthProvider, { useAuthProvider } from './AuthProvider';
 
 const localStorageMock = {
@@ -71,6 +75,17 @@ const mockRefreshToken = jest
 const mockIsSessionExpired = jest
   .fn()
   .mockImplementation(() => Promise.resolve(true));
+
+// Defaults to no stored token, so the interceptor's stale-token comparison is inert unless a
+// test opts into it. Declared inside the factory because this module is required transitively
+// before the test file's own bindings initialise.
+jest.mock('../../../utils/SwTokenStorageUtils', () => ({
+  getOidcToken: jest.fn().mockResolvedValue(''),
+  clearOidcToken: jest.fn().mockResolvedValue(undefined),
+  getRefreshToken: jest.fn().mockResolvedValue(''),
+}));
+
+const mockGetOidcToken = getOidcToken as jest.Mock;
 
 jest.mock('../../../utils/Auth/TokenService/TokenServiceUtil', () => {
   return {
@@ -541,6 +556,52 @@ describe('Test axios response interceptor', () => {
 
     beforeEach(() => {
       mockRefreshToken.mockClear();
+      mockGetOidcToken.mockResolvedValue('');
+    });
+
+    it('should replay the request once when it carried a token since refreshed', async () => {
+      // Another tab (or the pre-expiry timer) swapped the token while this request was in
+      // flight, so its 401 is about a token we no longer hold — replay, don't classify.
+      mockIsSessionExpired.mockImplementationOnce(() => Promise.resolve(false));
+      mockGetOidcToken.mockResolvedValue('freshToken');
+
+      const { errorHandler, mockAxios } = await setUpInterceptor();
+      const mockError = {
+        ...unauthorizedError(),
+        config: {
+          url: '/services/ingestionPipelines/deploy/1',
+          headers: { Authorization: 'Bearer staleToken' },
+        },
+      };
+
+      await expect(errorHandler?.(mockError)).resolves.toEqual({
+        data: 'success',
+      });
+
+      expect(mockAxios).toHaveBeenCalledWith(mockError.config);
+      expect(mockError.config).toHaveProperty(STALE_TOKEN_RETRIED, true);
+    });
+
+    it('should replay a stale request at most once', async () => {
+      mockIsSessionExpired.mockImplementationOnce(() => Promise.resolve(false));
+      mockGetOidcToken.mockResolvedValue('freshToken');
+
+      const { errorHandler, mockAxios } = await setUpInterceptor();
+      const mockError = {
+        ...unauthorizedError(),
+        config: {
+          url: '/services/ingestionPipelines/deploy/1',
+          headers: { Authorization: 'Bearer staleToken' },
+          [STALE_TOKEN_RETRIED]: true,
+        },
+      };
+
+      // The replay already happened and still 401'd, so the endpoint is the problem.
+      await expect(errorHandler?.(mockError)).rejects.toEqual(
+        expect.objectContaining({ [NON_SESSION_AUTH_ERROR]: true })
+      );
+
+      expect(mockAxios).not.toHaveBeenCalled();
     });
 
     it('should reject with the original error instead of logging out', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -13,6 +13,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { AxiosResponse } from 'axios';
 import { act } from 'react-test-renderer';
+import { NON_SESSION_AUTH_ERROR } from '../../../constants/Auth.constants';
 import { AuthProvider as AuthProviderProps } from '../../../generated/configuration/authenticationConfiguration';
 import axiosClient from '../../../rest';
 import TokenService from '../../../utils/Auth/TokenService/TokenServiceUtil';
@@ -35,8 +36,12 @@ jest.mock('../../../hooks/useCustomLocation/useCustomLocation', () => {
   return jest.fn().mockImplementation(() => ({ pathname: 'pathname' }));
 });
 
+const mockNavigate = jest.fn();
+
+// useNavigate must return a callable — the forced-logout path calls navigate(), and an
+// undefined return crashes the worker with an unhandled rejection rather than failing a test.
 jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn(),
+  useNavigate: jest.fn().mockImplementation(() => mockNavigate),
 }));
 
 jest.mock('../../../rest/miscAPI', () => ({
@@ -62,10 +67,16 @@ const mockRefreshToken = jest
   .fn()
   .mockImplementation(() => Promise.resolve('newToken'));
 
+// Default to an expired session so every pre-existing test keeps exercising the refresh path.
+const mockIsSessionExpired = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve(true));
+
 jest.mock('../../../utils/Auth/TokenService/TokenServiceUtil', () => {
   return {
     getInstance: jest.fn().mockImplementation(() => ({
       refreshToken: mockRefreshToken,
+      isSessionExpired: mockIsSessionExpired,
       isTokenUpdateInProgress: jest.fn().mockImplementation(() => false),
       getToken: jest.fn().mockImplementation(() => Promise.resolve()),
       clearRefreshInProgress: jest
@@ -207,7 +218,7 @@ describe('Test axios response interceptor', () => {
     jest.restoreAllMocks();
   });
 
-  it('should set up response interceptor with correct signature', () => {
+  it('should set up response interceptor with correct signature', async () => {
     // Mock axios client
     const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
     const mockAxios = jest.fn().mockResolvedValue({ data: 'success' });
@@ -248,6 +259,11 @@ describe('Test axios response interceptor', () => {
     const result = errorHandler?.(mockError);
 
     expect(result).toBeInstanceOf(Promise);
+
+    // The handler checks whether the session is actually expired before refreshing, so the
+    // refresh is a microtask away rather than synchronous.
+    await result;
+
     expect(mockRefreshToken).toHaveBeenCalled();
   });
 
@@ -493,5 +509,75 @@ describe('Test axios response interceptor', () => {
 
       expect(mockRefreshToken).toHaveBeenCalledTimes(0);
     }
+  });
+
+  // A 401 only means "your session is dead" when our own token actually is. Anything else —
+  // most often a service the API depends on rejecting its own credentials — must reach the
+  // caller instead of destroying a working session.
+  // See https://github.com/open-metadata/openmetadata-collate/issues/4647
+  describe('401 on a still-valid session', () => {
+    const setUpInterceptor = async () => {
+      const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
+      const mockAxios = jest.fn().mockResolvedValue({ data: 'success' });
+
+      jest.spyOn(axiosClient, 'request').mockImplementation(mockAxios);
+
+      await act(async () => {
+        render(<WrapperComponent />);
+      });
+
+      const [, errorHandler] = mockUse.mock.calls[0];
+
+      return { errorHandler, mockAxios };
+    };
+
+    const unauthorizedError = () => ({
+      response: {
+        status: 401,
+        data: { message: 'Argo rejected the configured token' },
+      },
+      config: { url: '/services/ingestionPipelines/deploy/1', headers: {} },
+    });
+
+    beforeEach(() => {
+      mockRefreshToken.mockClear();
+    });
+
+    it('should reject with the original error instead of logging out', async () => {
+      mockIsSessionExpired.mockImplementationOnce(() => Promise.resolve(false));
+
+      const { errorHandler, mockAxios } = await setUpInterceptor();
+      const mockError = unauthorizedError();
+
+      await expect(errorHandler?.(mockError)).rejects.toBe(mockError);
+
+      // Refreshing a valid token is a no-op, so it must not even be attempted, and the failed
+      // request must not be silently retried.
+      expect(mockRefreshToken).not.toHaveBeenCalled();
+      expect(mockAxios).not.toHaveBeenCalled();
+    });
+
+    it('should flag the error so its toast is not suppressed as a session failure', async () => {
+      mockIsSessionExpired.mockImplementationOnce(() => Promise.resolve(false));
+
+      const { errorHandler } = await setUpInterceptor();
+
+      await expect(errorHandler?.(unauthorizedError())).rejects.toEqual(
+        expect.objectContaining({ [NON_SESSION_AUTH_ERROR]: true })
+      );
+    });
+
+    it('should still force a logout when the token really is expired', async () => {
+      mockIsSessionExpired.mockImplementationOnce(() => Promise.resolve(true));
+      mockRefreshToken.mockImplementationOnce(() => Promise.resolve(null));
+
+      const { errorHandler, mockAxios } = await setUpInterceptor();
+      const mockError = unauthorizedError();
+
+      await expect(errorHandler?.(mockError)).rejects.toBe(mockError);
+
+      expect(mockRefreshToken).toHaveBeenCalled();
+      expect(mockAxios).not.toHaveBeenCalled();
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -40,6 +40,7 @@ import { useNavigate } from 'react-router-dom';
 import { DEFAULT_APP_MODE } from '../../../constants/appMode.constants';
 import {
   NON_SESSION_AUTH_ERROR,
+  STALE_TOKEN_RETRIED,
   UN_AUTHORIZED_EXCLUDED_PATHS,
 } from '../../../constants/Auth.constants';
 import {
@@ -121,6 +122,15 @@ const userAPIQueryFields = [
 ];
 
 const isEmailVerifyField = 'isEmailVerified';
+
+/** The bearer token a request actually went out with, per its own config. */
+const getRequestBearerToken = (
+  config?: InternalAxiosRequestConfig<unknown>
+): string => {
+  const header = config?.headers?.Authorization;
+
+  return typeof header === 'string' ? header.replace(/^Bearer\s+/i, '') : '';
+};
 
 let requestInterceptor: number | null = null;
 let responseInterceptor: number | null = null;
@@ -601,13 +611,30 @@ export const AuthProvider = ({
               throw error;
             }
 
-            // A 401 that arrives while our own token is still valid did not come from our
-            // session — it came from the endpoint, e.g. a service the API depends on rejecting
-            // *its* credentials. refreshToken() already refuses to renew a valid token, so this
-            // branch could only ever end in a forced logout that replaces the real error with
-            // "session expired". Surface it to the caller instead.
-            // See https://github.com/open-metadata/openmetadata-collate/issues/4647
             if (!(await tokenService.current.isSessionExpired())) {
+              // The stored token is healthy, so refreshing cannot help — but the request may
+              // have gone out with an older token that another tab or the pre-expiry timer has
+              // since replaced. Replay it once with the current token before concluding anything.
+              const currentToken = await getOidcToken();
+              const requestToken = getRequestBearerToken(error.config);
+              const isStaleRequest =
+                Boolean(requestToken) &&
+                Boolean(currentToken) &&
+                requestToken !== currentToken;
+
+              if (isStaleRequest && !error.config[STALE_TOKEN_RETRIED]) {
+                error.config[STALE_TOKEN_RETRIED] = true;
+
+                // The request interceptor re-reads storage, so the replay carries the new token.
+                return axiosClient.request(error.config);
+              }
+
+              // A 401 that arrives while our own token is still valid did not come from our
+              // session — it came from the endpoint, e.g. a service the API depends on rejecting
+              // *its* credentials. refreshToken() already refuses to renew a valid token, so this
+              // branch could only ever end in a forced logout that replaces the real error with
+              // "session expired". Surface it to the caller instead.
+              // See https://github.com/open-metadata/openmetadata-collate/issues/4647
               error[NON_SESSION_AUTH_ERROR] = true;
 
               throw error;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -38,7 +38,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { DEFAULT_APP_MODE } from '../../../constants/appMode.constants';
-import { UN_AUTHORIZED_EXCLUDED_PATHS } from '../../../constants/Auth.constants';
+import {
+  NON_SESSION_AUTH_ERROR,
+  UN_AUTHORIZED_EXCLUDED_PATHS,
+} from '../../../constants/Auth.constants';
 import {
   APP_ROUTER_ROUTES as ROUTES,
   REDIRECT_PATHNAME,
@@ -584,7 +587,7 @@ export const AuthProvider = ({
     // Axios response interceptor for statusCode 401,403
     responseInterceptor = axiosClient.interceptors.response.use(
       (response) => response,
-      (error) => {
+      async (error) => {
         if (error.response) {
           const { status } = error.response;
           if (status === ClientErrors.UNAUTHORIZED) {
@@ -597,6 +600,19 @@ export const AuthProvider = ({
             ) {
               throw error;
             }
+
+            // A 401 that arrives while our own token is still valid did not come from our
+            // session — it came from the endpoint, e.g. a service the API depends on rejecting
+            // *its* credentials. refreshToken() already refuses to renew a valid token, so this
+            // branch could only ever end in a forced logout that replaces the real error with
+            // "session expired". Surface it to the caller instead.
+            // See https://github.com/open-metadata/openmetadata-collate/issues/4647
+            if (!(await tokenService.current.isSessionExpired())) {
+              error[NON_SESSION_AUTH_ERROR] = true;
+
+              throw error;
+            }
+
             handleStoreProtectedRedirectPath();
 
             // If 401 error and refresh is not in progress, trigger the refresh

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Auth.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Auth.constants.ts
@@ -41,3 +41,11 @@ export const UN_AUTHORIZED_EXCLUDED_PATHS = [
   '/auth/refresh',
   '/users/login',
 ];
+
+/**
+ * Flag the auth interceptor sets on a 401 it has decided is NOT a session failure — our own token
+ * was still valid, so the endpoint itself rejected the request. Error toasts are suppressed for
+ * 401s because a dead session already shows its own "session expired" message; a flagged error has
+ * no such message behind it and must be shown.
+ */
+export const NON_SESSION_AUTH_ERROR = 'nonSessionAuthError';

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Auth.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Auth.constants.ts
@@ -49,3 +49,10 @@ export const UN_AUTHORIZED_EXCLUDED_PATHS = [
  * no such message behind it and must be shown.
  */
 export const NON_SESSION_AUTH_ERROR = 'nonSessionAuthError';
+
+/**
+ * Flag the auth interceptor sets on a request config it has already replayed once because the
+ * token was refreshed while that request was in flight. Bounds the replay to a single attempt so
+ * an endpoint answering 401 for its own reasons cannot loop.
+ */
+export const STALE_TOKEN_RETRIED = 'staleTokenRetried';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.test.ts
@@ -184,6 +184,64 @@ describe('TokenService', () => {
     });
   });
 
+  describe('isSessionExpired', () => {
+    it('should report an expired token as expired', async () => {
+      (getOidcToken as jest.Mock).mockResolvedValue('expired-token');
+      (extractDetailsFromToken as jest.Mock).mockReturnValue({
+        isExpired: true,
+        timeoutExpiry: 0,
+      });
+
+      expect(await tokenService.isSessionExpired()).toBe(true);
+    });
+
+    it('should report a token inside the renewal threshold as expired', async () => {
+      (getOidcToken as jest.Mock).mockResolvedValue('about-to-expire');
+      (extractDetailsFromToken as jest.Mock).mockReturnValue({
+        isExpired: false,
+        timeoutExpiry: 0,
+      });
+
+      // A token with no exp claim lands here too, so checking isExpired alone would disagree
+      // with refreshToken's own decision.
+      expect(await tokenService.isSessionExpired()).toBe(true);
+    });
+
+    it('should report an absent token as expired', async () => {
+      (getOidcToken as jest.Mock).mockResolvedValue('');
+      (extractDetailsFromToken as jest.Mock).mockReturnValue({
+        exp: 0,
+        isExpired: true,
+        timeoutExpiry: 0,
+      });
+
+      expect(await tokenService.isSessionExpired()).toBe(true);
+    });
+
+    it('should report a comfortably valid token as not expired', async () => {
+      (getOidcToken as jest.Mock).mockResolvedValue('valid-token');
+      (extractDetailsFromToken as jest.Mock).mockReturnValue({
+        isExpired: false,
+        timeoutExpiry: 60_000,
+      });
+
+      expect(await tokenService.isSessionExpired()).toBe(false);
+    });
+
+    it('should agree with refreshToken about whether a renewal is needed', async () => {
+      (getOidcToken as jest.Mock).mockResolvedValue('valid-token');
+      (extractDetailsFromToken as jest.Mock).mockReturnValue({
+        isExpired: false,
+        timeoutExpiry: 60_000,
+      });
+
+      // refreshToken refuses to renew a valid token, so a 401 in that state cannot be fixed by
+      // refreshing — the two must never disagree.
+      expect(await tokenService.isSessionExpired()).toBe(false);
+      expect(await tokenService.refreshToken()).toBeNull();
+    });
+  });
+
   describe('fetchNewToken', () => {
     it('should return null if renewToken is not a function', async () => {
       tokenService.renewToken = null;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts
@@ -24,6 +24,19 @@ type RenewTokenCallback = () =>
 
 const REFRESHED_KEY = 'tokenRefreshed';
 
+/**
+ * Whether `token` is expired, or close enough to expiry that it needs renewing now.
+ *
+ * Both arms matter: a token with no `exp` claim reports `isExpired: false` but
+ * `timeoutExpiry: 0`, and an absent or unparseable token reports `isExpired: true`. Checking
+ * `isExpired` alone would disagree with the refresh decision on the first of those.
+ */
+const isTokenExpiredOrExpiring = (token: string): boolean => {
+  const { isExpired, timeoutExpiry } = extractDetailsFromToken(token);
+
+  return Boolean(isExpired) || timeoutExpiry <= 0;
+};
+
 class TokenService {
   renewToken: RenewTokenCallback | null = null;
   refreshSuccessCallback: (() => void) | null = null;
@@ -77,6 +90,17 @@ class TokenService {
     });
   }
 
+  /**
+   * Whether the stored session token is the plausible cause of a 401.
+   *
+   * Uses the same predicate as {@link refreshToken}, which refuses to renew a token that is still
+   * valid. A 401 received while this returns `false` therefore cannot be fixed by refreshing, and
+   * did not come from our session at all.
+   */
+  async isSessionExpired(): Promise<boolean> {
+    return isTokenExpiredOrExpiring(await getOidcToken());
+  }
+
   // Refresh the token if it is expired
   async refreshToken() {
     if (this.isTokenUpdateInProgress()) {
@@ -88,10 +112,9 @@ class TokenService {
 
     try {
       const oldToken = await getOidcToken();
-      const { isExpired, timeoutExpiry } = extractDetailsFromToken(oldToken);
 
       // If token is expired or timeoutExpiry is less than 0 then try to silent signIn
-      if (isExpired || timeoutExpiry <= 0) {
+      if (isTokenExpiredOrExpiring(oldToken)) {
         // Logic to refresh the token
         const newToken = await this.fetchNewToken();
         if (newToken) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.test.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { toast } from '@openmetadata/ui-core-components';
+import { AxiosError } from 'axios';
+import { NON_SESSION_AUTH_ERROR } from '../constants/Auth.constants';
+import { showErrorToast } from './ToastUtils';
+
+// setupTests.js stubs this module globally for every other suite; here we need the real thing.
+jest.unmock('./ToastUtils');
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+    success: jest.fn(),
+  },
+}));
+
+jest.mock('./i18next/LocalUtil', () => ({
+  t: jest.fn().mockImplementation((key: string) => key),
+}));
+
+const buildAxiosError = (
+  status: number,
+  method: string,
+  message: string,
+  extras: Record<string, unknown> = {}
+) =>
+  ({
+    config: { method },
+    response: { status, data: { message } },
+    ...extras,
+  } as unknown as AxiosError);
+
+describe('showErrorToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should suppress a 401 that came from a dead session', () => {
+    // The forced logout shows its own "session expired" message; a second toast is noise.
+    showErrorToast(buildAxiosError(401, 'get', 'Expired token!'));
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('should show a 401 the auth interceptor flagged as not a session failure', () => {
+    // See https://github.com/open-metadata/openmetadata-collate/issues/4647 — this is the Argo
+    // case: our session is fine, the endpoint's own upstream credentials were rejected, and
+    // nothing else will tell the user what went wrong.
+    showErrorToast(
+      buildAxiosError(
+        401,
+        'post',
+        'The configured Argo token is not authorized',
+        {
+          [NON_SESSION_AUTH_ERROR]: true,
+        }
+      )
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('Argo token'),
+      expect.anything()
+    );
+  });
+
+  it('should keep suppressing a 403 on a read', () => {
+    // Permission-gated reads are everywhere and the pages render their own placeholder.
+    showErrorToast(buildAxiosError(403, 'get', 'Principal not authorized'));
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('should show a 403 on a write', () => {
+    showErrorToast(buildAxiosError(403, 'put', 'Principal not authorized'));
+
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('should show a 502 from an upstream dependency', () => {
+    showErrorToast(
+      buildAxiosError(502, 'post', 'The Argo Server rejected the request')
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('Argo Server'),
+      expect.anything()
+    );
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.test.ts
@@ -13,10 +13,11 @@
 import { toast } from '@openmetadata/ui-core-components';
 import { AxiosError } from 'axios';
 import { NON_SESSION_AUTH_ERROR } from '../constants/Auth.constants';
-import { showErrorToast } from './ToastUtils';
 
-// setupTests.js stubs this module globally for every other suite; here we need the real thing.
-jest.unmock('./ToastUtils');
+// setupTests.js stubs this module globally for every other suite; pull the real implementation
+// rather than relying on a static import surviving an unmock.
+const { showErrorToast } =
+  jest.requireActual<typeof import('./ToastUtils')>('./ToastUtils');
 
 jest.mock('@openmetadata/ui-core-components', () => ({
   toast: {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.ts
@@ -21,6 +21,7 @@ import { get, isString } from 'lodash';
 import React from 'react';
 import { ReactComponent as SuccessIcon } from '../assets/svg/ic-alert-success.svg';
 import { AlertBarProps } from '../components/AlertBar/AlertBar.interface';
+import { NON_SESSION_AUTH_ERROR } from '../constants/Auth.constants';
 import { ClientErrors, ErrorTypes } from '../enums/Axios.enum';
 import i18n from './i18next/LocalUtil';
 import { getErrorText } from './StringUtils';
@@ -98,11 +99,21 @@ export const showErrorToast = (
     errorMessage = getErrorText(error, fallback);
     isRuleViolation =
       get(error, 'response.data.errorType') === ErrorTypes.RULE_VIOLATION;
+    // A 401 normally means the session died, and the forced logout shows its own
+    // "session expired" message — a second toast would just be noise. But the auth interceptor
+    // flags a 401 it decided was NOT a session failure (our token was still valid, so the
+    // endpoint itself rejected the request); that one has no message behind it and must be
+    // shown, or the real cause is lost.
+    // See https://github.com/open-metadata/openmetadata-collate/issues/4647
+    const isSessionAuthError =
+      error.response?.status === ClientErrors.UNAUTHORIZED &&
+      !get(error, NON_SESSION_AUTH_ERROR);
+    const isForbiddenRead =
+      error.response?.status === ClientErrors.FORBIDDEN && method === 'GET';
+
     if (
       error &&
-      (error.response?.status === ClientErrors.UNAUTHORIZED ||
-        (error.response?.status === ClientErrors.FORBIDDEN &&
-          method === 'GET')) &&
+      (isSessionAuthError || isForbiddenRead) &&
       !errorMessage.includes('principal domain')
     ) {
       return;


### PR DESCRIPTION
Fixes open-metadata/openmetadata-collate#4647

Companion to that issue's backend fix, open-metadata/openmetadata-collate#5422. This is the UI half and stands on its own.

## Problem

The shared axios response interceptor treats **every** 401 as a dead session. It calls `TokenService.refreshToken()` and reads a falsy return as "refresh failed" → `resetUserDetails(true)` → forced logout to `/signin`.

The catch is one layer down. `refreshToken()` only renews when the stored token is actually expiring:

```ts
// TokenServiceUtil.ts
if (isExpired || timeoutExpiry <= 0) { ...renew... }
else { this.clearRefreshInProgress(); return null; }   // <- falsy
```

So **a 401 arriving while our own token is still valid never triggers a refresh at all — it goes straight to a forced logout.** Any 401 an endpoint raises for its own reasons (most often a service the API depends on rejecting *its* credentials) destroys a healthy session and replaces the real error with "Your session has timed out!".

`showErrorToast` then swallows the original message too, because it suppresses all 401s — so nothing anywhere tells the user what actually went wrong. The reported case was a misconfigured Argo token: every Test Connection threw the developer back to the login page with no diagnosis.

## Fix

A 401 forces a logout only when the stored token is expired or expiring — the same predicate `refreshToken()` already uses.

- `TokenService.isSessionExpired()` — new, reusing the extracted `isTokenExpiredOrExpiring` so the gate and `refreshToken` cannot drift apart. The compound form matters: a token with no `exp` claim reports `isExpired: false` but `timeoutExpiry: 0`, and the two predicates disagree on exactly that input.
- `AuthProvider` — gate the refresh/logout path on it; a 401 on a still-valid token is rethrown to the caller.
- `NON_SESSION_AUTH_ERROR` — the interceptor flags those errors so `showErrorToast` shows them, while staying quiet for genuine session failures (whose forced logout already displays its own message). The GET-403 suppression is untouched: pages deliberately render their own permission placeholder.

## Why no SSO provider's login or refresh changes

The gate reuses the predicate that already guards `fetchNewToken`, so **no renewal that happens today is removed** — it only changes a branch that today can *only* produce a logout.

- **Basic/LDAP**, **SAML**, and every **`ClientType.Confidential`** client (all `GenericAuthenticator`, refreshing via `GET /api/v1/auth/refresh`) — refresh is entered only on expiry, unchanged.
- **Auth0, Okta, Azure/MSAL, Google, CustomOidc, AwsCognito** — same; `renewIdToken` is only reachable through `fetchNewToken()`, itself only reachable when the token is expired/expiring.
- **Unreadable token** — Okta and Auth0 can store `''`, and `getOidcToken()` transiently returns `''` during the service-worker handshake. `extractDetailsFromToken('')` reports `isExpired: true`, so the gate falls through to today's path. It fails *safe*.

**The one real behaviour change:** a token revoked server-side *before* its `exp` (JWKS rotation, `Invalid session.`, clock skew) no longer logs out immediately — requests fail with a visible error until the token expires, and the pre-expiry timer (`EXPIRY_THRESHOLD_MILLES`, 60 s) or the next reload then handles it. `/auth/refresh` 401s for those cases anyway, so they always ended in a logout; only the route there changes. That is the deliberate trade against today's rule, where a 401 from *any* cause silently destroys a valid session.

## Tests

All new tests fail without the fix (verified by stashing the source changes: 8 failures across the three suites).

**Jest** — `Tests: 40 passed, 40 total`
- `AuthProvider.test.tsx`: a 401 on a valid session rejects with the original error, attempts no refresh and retries nothing; the error carries the flag; an expired token still forces the logout.
- `TokenServiceUtil.test.ts`: `isSessionExpired` across expired / within-threshold / absent / nil-`exp` / valid tokens, plus that it agrees with `refreshToken`.
- `ToastUtils.test.ts` (new): flagged 401 and non-GET 403 are shown; session 401 and GET 403 stay suppressed.

**Playwright** — `playwright/e2e/Pages/SessionAuthErrors.spec.ts` (new, default chromium project — deliberately outside `e2e/Auth/`, which the project ignores):
1. expired token + failing refresh → `/signin`
2. dependency 401 on a valid session → toast, no redirect, still signed in *(fails today)*
3. 403 on a write → toast, no redirect
4. 403 on a read → silent and still signed in

**SSO suites.** The three `SSOAuthentication` "401 Interceptor" tests mocked a 401 while the OIDC token was still valid and expected a logout — that is precisely the bug (their own comment said so: *"since the token isn't truly expired at the OIDC level, refreshToken() returns null → forced logout"*). They now plant a genuinely expired token, so they still assert the logout for a *real* failure. A dependency-401 case was added there and in `SSORenewal.spec.ts` (real Keycloak SAML), whose three existing renewal tests are unchanged and are the regression proof that refresh still works.

## Not verified locally

The Playwright specs need a running OM server (and the SSO suites need the mock-OIDC / Keycloak docker stacks), which I could not start here — they are unrun and rely on CI. Jest, `tsc --noEmit` (no new errors; one pre-existing error in `AuthProvider.tsx` is only line-shifted) and the UI checkstyle sequence all pass locally.

## CI config change, flagged for review

`ci(playwright)` is a second commit and is deliberately separable. Any PR touching
`src/components/Auth/**` currently fails `plan-playwright` before a single test runs:

```
Playwright selectors matched no runnable tests:
  playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
```

That mapping selects `playwright/e2e/**/*Permission*.spec.ts` but lists only the `chromium`,
`Basic`, `SearchRBAC` and `ImportExport` projects. The glob expands to
`ServiceCreationPermissions.spec.ts`, which carries `PLAYWRIGHT_INGESTION_TAG_OBJ` and — with
`PW_DEDICATED_INGESTION` on, as CI runs it — is runnable **only** in the `Ingestion` project.
Verified by listing the spec per project: 8 tests under `Ingestion`, none under any of the four.

So the commit adds `Ingestion` to that mapping's projects, and registers the new
`SessionAuthErrors.spec.ts` (4 tests, `chromium`) so future auth changes pick up this coverage.
Happy to drop it if maintainers would rather fix the mapping separately.

## Two adjustments to existing tests, called out

- `AuthProvider.test.tsx` "should set up response interceptor with correct signature" asserted `mockRefreshToken` **synchronously** after invoking the handler. With the `await` in front of the refresh that call is now a microtask later, so the assertion moved after an `await` of the handler. Intent preserved.
- The same file's `react-router-dom` mock returned `undefined` from `useNavigate`, so any test reaching the forced-logout path crashed the worker with an unhandled `navigate is not a function` rather than failing an assertion. It now returns a `jest.fn()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR distinguishes endpoint-originated 401 responses from expired-session failures.
- Adds a shared token-expiry predicate and exposes it through TokenService.
- Gates refresh and forced logout on the stored token's expiry state.
- Flags non-session 401 errors so callers can display their original messages.
- Adds Jest and Playwright coverage for session failures, dependency 401s, and 403 behavior.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The stale-request refresh race should be fixed before merging because a successfully renewed session can still surface a recoverable request as a 401 failure.

The interceptor compares a delayed 401 against mutable token storage, so a concurrent refresh can make it bypass the existing request queue and retry path.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx | Adds the session-expiry gate and non-session error flag, but checks mutable current token state rather than the failed request's token. |
| openmetadata-ui/src/main/resources/ui/src/utils/Auth/TokenService/TokenServiceUtil.ts | Centralizes the existing expired-or-expiring predicate and exposes it for interceptor classification. |
| openmetadata-ui/src/main/resources/ui/src/utils/ToastUtils.ts | Displays flagged endpoint-originated 401 errors while retaining suppression for session 401s and read-only 403s. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SessionAuthErrors.spec.ts | Adds end-to-end coverage for expired sessions, dependency 401 responses, and read/write 403 handling. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Req as API request
  participant Int as Axios interceptor
  participant Store as Token storage
  participant Refresh as Token refresh
  Req->>Int: Send with token T1
  Refresh->>Store: Persist refreshed token T2
  Req-->>Int: 401 for T1
  Int->>Store: Read current token
  Store-->>Int: T2 is valid
  Int-->>Req: Reject as non-session 401
  Note over Int,Req: Request is not retried with T2
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): a 401 should only sign the user..."](https://github.com/open-metadata/openmetadata/commit/a8ea49abf11fe78719bd481041dea9406ffa734e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49025491)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
- Knowledge Base — [Auth and Security: Authentication, Authorization, Secrets, and SCIM](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-auth-security.md)

<!-- /greptile_comment -->
