### PR TITLE
Fixes #30807: restore full blobs for the Sonar nightly checkout

### DIFF
--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -153,8 +153,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.BRANCH_NAME }}
+          # Do not add `filter: blob:none` — Sonar blames via JGit, which cannot
+          # lazily fetch blobs from a promisor remote.
           fetch-depth: 0
-          filter: blob:none
 
       - name: Setup Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Fixes #30807

## What

`py-sonarcloud-nightly` has failed **109 consecutive runs**. No ingestion coverage has reached SonarCloud since **2026-04-13** — the day `filter: blob:none` was added to the `py-combine-coverage` checkout in #27221.

The three test jobs pass; only the Sonar upload fails:

```
INFO  SCM Publisher 2231 source files to be analyzed
INFO  SCM Publisher 0/2231 source files have been analyzed (done)

Caused by: org.eclipse.jgit.errors.MissingObjectException: Missing blob 6db552b5...
	at org.sonar.scm.git.blame.BlobReader.loadText(BlobReader.java:76)
	at org.sonar.scm.git.CompositeBlameCommand.blame(CompositeBlameCommand.java:101)
INFO  EXECUTION FAILURE
```

`filter: blob:none` produces a blobless partial clone: blobs are fetched lazily from the promisor remote. The git CLI implements that protocol; **JGit does not**, and Sonar's blame sensor runs on JGit. It misses on the first blob and throws.

#27221 assumed "commits/trees remain available for blame while blobs are fetched lazily on demand" and applied the filter here "for parity with the PR Sonar jobs". Blame needs blob *contents*, and the PR jobs aren't comparable — each disables blame independently:

| Workflow | `fetch-depth: 0` | `blob:none` | Blame | Result |
|---|---|---|---|---|
| `yarn-coverage` | yes | yes | off via `-Dsonar.scm.disabled=true` | passes |
| `maven-sonar-build` | no (depth 1) | no | off — Sonar skips blame on shallow clones | passes |
| `py-sonarcloud-nightly` | yes | yes | **on** — no `sonar.scm.*` set anywhere | fails |

It is also the only *branch* analysis (`-Dsonar.branch.name=main`), the mode where Sonar runs full-history blame to date its New Code period.

## How

Drop `filter: blob:none` from the `py-combine-coverage` checkout, restoring the config that last worked, plus a comment so it isn't reinstated.

This gives up nothing #27221 actually bought: its savings came from dropping `fetch-depth: 0` on `py-unit-tests` and `py-integration-tests`, which stay unchanged. `py-combine-coverage` is a single job on a 10-minute timeout where the full clone took ~17s.

`-Dsonar.scm.disabled=true` was the alternative, but it would degrade New Code attribution for the ingestion project — the main reason blame runs on a branch analysis.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Restores complete Git blobs for the nightly Python SonarCloud job so JGit can perform SCM blame.
- Removes the blobless partial-clone filter from the full-history checkout.
- Documents why `filter: blob:none` is incompatible with Sonar’s JGit-based blame processing.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and directly restores the repository data required by the nightly SonarCloud analysis.

Removing the blobless checkout filter allows JGit to read source blobs while preserving the existing branch selection and full-history checkout behavior.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/py-sonarcloud-nightly.yml | The checkout now retains full history and materializes blobs required by the downstream Sonar blame analysis; no actionable issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): restore full blobs for the Sona..."](https://github.com/open-metadata/openmetadata/commit/3d0d83776c2c7ef8a98dca12b8a16a1486234174) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49343823)</sub>

<!-- /greptile_comment -->