### PR TITLE
fix(playwright): stop ExploreTree.spec.ts flaking on the Explore tree's alphabetical service bucket cap

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
@@ -17,7 +17,7 @@ import { SidebarItem } from '../../constant/sidebar';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
 import { TableClass } from '../../support/entity/TableClass';
-import { createNewPage, redirectToHomePage } from '../../utils/common';
+import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import {
   copyAndGetClipboardText,
   testCopyLinkButton,
@@ -55,8 +55,16 @@ test.describe('Explore Tree scenarios', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   test.beforeAll(async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
 
-    table1 = new TableClass();
-    table2 = new TableClass();
+    // Explore tree's service bucket is capped and sorted alphabetically
+    // (ElasticSearchAggregationManager orders by _key ASC), so a name starting
+    // with a digit guarantees these services land within that bucket
+    // regardless of how many other `pw-*` services have accumulated.
+    table1 = new TableClass(undefined, undefined, {
+      name: `0-pw-database-service-${uuid()}`,
+    });
+    table2 = new TableClass(undefined, undefined, {
+      name: `0-pw-database-service-${uuid()}`,
+    });
 
     await table1.create(apiContext);
     await table2.create(apiContext);


### PR DESCRIPTION
Fixes #30766

## Summary
- `ExploreTree.spec.ts` → "Verify Database and Database Schema available in explore tree" intermittently timed out (60s) waiting to click a service row in the Explore tree that never rendered.
- Root cause: the Explore tree's SERVICE bucket (`ExploreTree.tsx`) is fetched unfiltered with `size: 166`, and the backend (`ElasticSearchAggregationManager.buildSingleAgg`) orders that terms aggregation by `_key ASC` — so only the 166 alphabetically-smallest service names for the active serviceType come back. Test-created services use a shared `pw-database-service-<uuid>` prefix, so as CI accumulates more of them, whether a given run's service lands in that slice becomes a matter of uuid luck.
- Fix: give the two `TableClass` instances used by these tree-verification tests an explicit name (`0-pw-database-service-<uuid>`) whose prefix sorts before the shared `pw-*` prefix, guaranteeing inclusion in the first-166 slice — no mocking/filtering, the real tree/bucket flow is still exercised end-to-end.

## Test plan
- [x] Ran locally against a live server (`:8585`): `Verify Database and Database Schema available in explore tree` — was timing out at 57s, now passes in 2.7s.
- [x] Ran the sibling `Verify Database and Database schema after rename` test (reuses `table1`) — still passes, no regression.
- [x] `yarn ui-checkstyle:changed` — clean, no formatting diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the two Explore tree test fixtures to use unique service names prefixed with `0-`, ensuring they sort into the capped alphabetical service bucket and preventing intermittent lookup timeouts.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the fixture-name override matches the existing TableClass constructor contract and introduces no actionable regression.

The changed fixtures remain unique and valid while reliably sorting ahead of the accumulated `pw-*` services in the capped Explore tree bucket.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts | Supplies alphabetically early, UUID-suffixed service names to both TableClass fixtures without changing the tested Explore tree flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(playwright): stop ExploreTree.spec.t..."](https://github.com/open-metadata/openmetadata/commit/6273e66637dde86bd7010e8baee67be716419d6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49045104)</sub>

<!-- /greptile_comment -->