### PR TITLE
Chore(UI): Fix the flakiness in SearchRBAC test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
@@ -127,7 +127,8 @@ for (const entity of searchRBACEntities) {
         entityObj.entityResponseData?.displayName ??
           entityObj.entityResponseData?.name ??
           '',
-        userWithPermissionPage
+        userWithPermissionPage,
+        entity.name
       );
     });
 
@@ -251,7 +252,8 @@ test.describe(`Table Column`, () => {
     await searchForEntityShouldWork(
       column.fullyQualifiedName ?? '',
       column.displayName ?? column.name ?? '',
-      userWithPermissionPage
+      userWithPermissionPage,
+      'Columns'
     );
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
@@ -169,7 +169,8 @@ export const enableDisableSearchRBAC = async (
 export const searchForEntityShouldWork = async (
   fqn: string,
   displayName: string,
-  page: Page
+  page: Page,
+  entityName: string
 ) => {
   // Wait for welcome screen and close it if visible
   const isWelcomeScreenVisible = await page
@@ -191,6 +192,8 @@ export const searchForEntityShouldWork = async (
   await page.getByTestId('searchBox').press('Enter');
   await searchResponse;
 
+  await waitForAllLoadersToDisappear(page);
+  await page.getByRole('menuitem').filter({ hasText: entityName }).click();
   await waitForAllLoadersToDisappear(page);
 
   await expect(


### PR DESCRIPTION
This pull request updates the search RBAC (Role-Based Access Control) Playwright tests to improve reliability and specificity by requiring the entity name to be explicitly provided and used when interacting with the UI. The main changes involve updating the `searchForEntityShouldWork` utility function and its usages to accept and utilize an `entityName` parameter, ensuring the correct entity is selected in the UI during tests.

**Test improvements:**

* Updated the `searchForEntityShouldWork` function in `searchRBAC.ts` to require an `entityName` parameter, and modified the function to select the correct entity in the UI based on this name. [[1]](diffhunk://#diff-5998f41052b6a89ad5ff65520bfa0cb92fa2a8b5767f6082017f8306404ee4ceL172-R173) [[2]](diffhunk://#diff-5998f41052b6a89ad5ff65520bfa0cb92fa2a8b5767f6082017f8306404ee4ceR195-R196)
* Updated all calls to `searchForEntityShouldWork` in `SearchRBAC.spec.ts` to pass the appropriate entity name, ensuring tests are explicit and less prone to flakiness. [[1]](diffhunk://#diff-c6de9c62ba565e010f880ff545cb94b1cdd3d40dd8454a00b15c31d8bad96b41L130-R131) [[2]](diffhunk://#diff-c6de9c62ba565e010f880ff545cb94b1cdd3d40dd8454a00b15c31d8bad96b41L254-R256)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the Search RBAC Playwright flow to select the intended entity category explicitly.
- Adds a required entity-name argument to `searchForEntityShouldWork`.
- Selects the matching Explore menu item before asserting search results.
- Updates entity and table-column test cases with their corresponding category names.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete changed-code defects identified.

The new arguments correspond to the Explore entity-category menu labels, and the helper waits for loading both before and after selecting the requested category.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts | Supplies entity category names to the updated search assertion helper for general entities and columns. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts | Selects the matching Explore entity-type menu item and waits for loading to complete before asserting the result. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix the flakiness in SearchRBAC test"](https://github.com/open-metadata/openmetadata/commit/2642e1cac4ddf98ef84e2244a9b20b99f7c960d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49064627)</sub>

<!-- /greptile_comment -->