### PR TITLE
Fixes 30770: tag the ingestion AWS client user agent

### DIFF
--- a/ingestion/src/metadata/clients/aws_client.py
+++ b/ingestion/src/metadata/clients/aws_client.py
@@ -16,12 +16,15 @@ import datetime
 import threading
 from enum import Enum
 from functools import partial
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from typing import Any, Callable, Dict, Optional, Type, TypeVar  # noqa: UP035
 from urllib.parse import parse_qs, urlparse
 
 import boto3
 import botocore.session
 from boto3 import Session
+from botocore.config import Config as BotocoreConfig
 from botocore.credentials import RefreshableCredentials
 from botocore.session import get_session
 from pydantic import BaseModel, Field
@@ -60,6 +63,21 @@ def _get_valid_aws_regions() -> set:
 
 
 VALID_AWS_REGIONS = _get_valid_aws_regions()
+
+_UNKNOWN_VERSION = "unknown"
+
+
+def _ingestion_user_agent_extra() -> str:
+    """Suffix appended to the botocore User-Agent, so that AWS and other S3-compatible
+    endpoints can attribute the requests to OpenMetadata ingestion."""
+    try:
+        resolved_version = pkg_version("openmetadata-ingestion")
+    except PackageNotFoundError:
+        resolved_version = _UNKNOWN_VERSION
+    return f"openmetadata-ingestion/{resolved_version}"
+
+
+BOTO_CONFIG = BotocoreConfig(user_agent_extra=_ingestion_user_agent_extra())
 
 
 class AWSAssumeRoleException(Exception):  # noqa: N818
@@ -211,18 +229,26 @@ class AWSClient:
             logger.debug(f"Getting AWS client for service [{service_name}]")
             session = self.create_session()
             if self.config.endPointURL is not None:
-                return session.client(service_name=service_name, endpoint_url=str(self.config.endPointURL))
-            return session.client(service_name=service_name)
+                return session.client(
+                    service_name=service_name,
+                    endpoint_url=str(self.config.endPointURL),
+                    config=BOTO_CONFIG,
+                )
+            return session.client(service_name=service_name, config=BOTO_CONFIG)
 
         logger.debug(f"Getting AWS default client for service [{service_name}]")
         # initialized with the credentials loaded from running machine
-        return boto3.client(service_name=service_name)
+        return boto3.client(service_name=service_name, config=BOTO_CONFIG)
 
     def get_resource(self, service_name: str) -> Any:
         session = self.create_session()
         if self.config.endPointURL is not None:
-            return session.resource(service_name=service_name, endpoint_url=str(self.config.endPointURL))
-        return session.resource(service_name=service_name)
+            return session.resource(
+                service_name=service_name,
+                endpoint_url=str(self.config.endPointURL),
+                config=BOTO_CONFIG,
+            )
+        return session.resource(service_name=service_name, config=BOTO_CONFIG)
 
     def get_rds_client(self):
         return self.get_client(AWSServices.RDS.value)

--- a/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
+++ b/ingestion/src/metadata/ingestion/source/database/datalake/clients/s3.py
@@ -16,7 +16,7 @@ Datalake S3 Client
 from functools import partial
 from typing import Callable, Iterable, Optional, Set, Tuple  # noqa: UP035
 
-from metadata.clients.aws_client import AWSClient
+from metadata.clients.aws_client import BOTO_CONFIG, AWSClient
 from metadata.generated.schema.entity.services.connections.database.datalake.s3Config import (
     S3Config,
 )
@@ -42,9 +42,10 @@ class DatalakeS3Client(DatalakeBaseClient):
             s3_client = session.client(
                 service_name="s3",
                 endpoint_url=str(config.securityConfig.endPointURL),
+                config=BOTO_CONFIG,
             )
         else:
-            s3_client = session.client(service_name="s3")
+            s3_client = session.client(service_name="s3", config=BOTO_CONFIG)
         return cls(client=s3_client, session=session)
 
     def update_client_database(self, config, database_name: str):

--- a/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
+++ b/ingestion/src/metadata/ingestion/source/storage/s3/connection.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from botocore.exceptions import EndpointConnectionError
 
-from metadata.clients.aws_client import AWSClient
+from metadata.clients.aws_client import BOTO_CONFIG, AWSClient
 from metadata.core.connections.test_connection import ErrorPack, Matchers, check, when
 from metadata.core.connections.test_connection.aws import AWS_ERRORS, aws_code
 from metadata.core.connections.test_connection.checks.storage import (
@@ -85,8 +85,8 @@ def get_connection(connection: S3ConnectionConfig) -> S3ObjectStoreClient:
     endpoint_url = str(connection.awsConfig.endPointURL) if connection.awsConfig.endPointURL else None
     kwargs = {"endpoint_url": endpoint_url} if endpoint_url else {}
     return S3ObjectStoreClient(
-        s3_client=session.client(service_name="s3", **kwargs),
-        cloudwatch_client=session.client(service_name="cloudwatch", **kwargs),
+        s3_client=session.client(service_name="s3", config=BOTO_CONFIG, **kwargs),
+        cloudwatch_client=session.client(service_name="cloudwatch", config=BOTO_CONFIG, **kwargs),
         session=session,
     )
 

--- a/ingestion/tests/unit/clients/test_aws_client.py
+++ b/ingestion/tests/unit/clients/test_aws_client.py
@@ -14,7 +14,7 @@ Test AWS Client region validation
 
 import pytest
 
-from metadata.clients.aws_client import VALID_AWS_REGIONS, AWSClient
+from metadata.clients.aws_client import BOTO_CONFIG, VALID_AWS_REGIONS, AWSClient
 from metadata.generated.schema.security.credentials.awsCredentials import AWSCredentials
 
 
@@ -95,3 +95,22 @@ class TestAWSClientRegionValidation:
             config = AWSCredentials(awsRegion=region)
             client = AWSClient(config)
             assert client.config.awsRegion == region
+
+
+class TestAWSClientUserAgent:
+    """Validate the User-Agent suffix carried by the boto3 clients"""
+
+    def test_user_agent_extra_identifies_the_ingestion_package(self):
+        assert BOTO_CONFIG.user_agent_extra.startswith("openmetadata-ingestion/")
+
+    def test_client_appends_the_suffix_to_the_botocore_user_agent(self):
+        config = AWSCredentials(
+            awsRegion="us-east-1",
+            awsAccessKeyId="access-key-id",
+            awsSecretAccessKey="secret-access-key",
+            endPointURL="https://s3.example.com",
+        )
+        client = AWSClient(config).get_s3_client()
+        user_agent = client.meta.config.user_agent
+        assert "Botocore/" in user_agent
+        assert user_agent.endswith(BOTO_CONFIG.user_agent_extra)


### PR DESCRIPTION
### Describe your changes:

Fixes #30770

I worked on appending an `openmetadata-ingestion/<version>` suffix to the User-Agent that botocore sends, because right now every AWS and S3-compatible request the ingestion framework makes is indistinguishable from any other boto3 traffic. Whoever owns the account or the endpoint cannot tell which requests came from OpenMetadata when they are reading access logs, chasing a throttling or 403 problem, or sizing the load a scheduled ingestion puts on a bucket.

The suffix is set through botocore's `user_agent_extra`, which appends to the string botocore builds instead of replacing it, so the existing `Boto3/... Botocore/...` identification is preserved in full. The version is resolved from the installed package metadata and falls back to `unknown` when the distribution is not found, so nothing new can raise at import time. This follows what the repo already does for Databricks in `ingestion/src/metadata/ingestion/source/database/databricks/user_agent.py`.

The shared `BOTO_CONFIG` is applied at every place an S3 client is actually built: `AWSClient.get_client` and `AWSClient.get_resource`, the S3 storage connector in `storage/s3/connection.py`, and the Datalake S3 client in `database/datalake/clients/s3.py`. The last two construct their clients straight off the session rather than through `get_client`, so they would otherwise have been missed. No new config keys, no new dependencies, and no change to what gets ingested.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A. Small change.

#
### Tests:

#### Use cases covered
- An S3 storage ingestion against an AWS endpoint sends a User-Agent whose last token is `openmetadata-ingestion/<version>`, with the botocore-generated portion untouched.
- An S3 storage ingestion against an S3-compatible endpoint configured through `endPointURL` sends the same suffix, and the configured endpoint is still honored.
- A Datalake S3 ingestion sends the same suffix on both the `endPointURL` and the default-endpoint branches.
- The version lookup falls back to `openmetadata-ingestion/unknown` rather than raising when the distribution metadata is not available.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added/updated: `ingestion/tests/unit/clients/test_aws_client.py` (new `TestAWSClientUserAgent`, 2 cases). One asserts the suffix names the ingestion package. The other builds a real S3 client through `AWSClient(...).get_s3_client()` and asserts the resolved `client.meta.config.user_agent` still contains `Botocore/` and ends with the suffix, which is what actually proves the value is appended rather than substituted.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable. Only an outbound header changes; request shapes, required permissions, and ingested output are identical.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Built S3 clients through `AWSClient(...).get_s3_client()` with and without `endPointURL` and printed `client.meta.config.user_agent`, confirming the botocore-generated prefix is intact and the OpenMetadata suffix is the trailing token.
2. Repeated for `AWSClient.get_resource` and for the `config is None` default-credentials branch.
3. Confirmed the version fallback resolves to `openmetadata-ingestion/unknown` instead of raising when the distribution is not installed.
4. Ran `ruff check` and `ruff format --check` with `--config ingestion/pyproject.toml` on the four changed files.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #30770` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema was touched.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.