### PR TITLE
fix(ui): only flag genuinely new antd imports in deprecation guard

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.js
+++ b/openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.js
@@ -17,23 +17,43 @@
  *
  * Antd (864 files) and Less (449 files) can't be a blanket error — instead we
  * enforce "no NEW debt": fail if a change ADDS a `.less` file or ADDS an
- * `import … from 'antd'`. Existing usage is untouched and migrates over time.
+ * `import … from 'antd'` specifier that wasn't already imported from that
+ * same module before the change. Existing usage is untouched and migrates
+ * over time.
+ *
+ * The antd check compares full before/after file contents (via `git show`)
+ * rather than raw diff lines. A diff-line scan flags
+ *   - import { Button, Typography } from 'antd'
+ *   + import { Button } from 'antd'
+ * as a "new" import line even though it strictly REMOVES usage (Typography),
+ * and it can't reliably reconstruct multi-line import statements that git's
+ * `-U0` diff splits apart. Parsing the whole file on both sides sidesteps
+ * both problems: for every antd module (`antd`, `antd/es/button`, …) we diff
+ * the *set of imported specifiers* before vs. after, and only fail when the
+ * after-set contains a specifier absent from the before-set (or the module
+ * wasn't imported at all before) — i.e. genuinely new antd debt.
  *
  *   node scripts/tw-deprecation-guard.js              # staged changes (pre-commit)
  *   node scripts/tw-deprecation-guard.js <baseRef>    # vs a base branch (CI)
  */
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 
 const base = process.argv[2];
 const diffArgs = base ? `${base}...HEAD` : '--cached';
 
 function sh(cmd) {
   try {
-    return execSync(cmd, { encoding: 'utf8' });
+    return execSync(cmd, { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
   } catch (e) {
     return e.stdout || '';
   }
 }
+
+// For baseRef mode, diff against the merge-base of <base> and HEAD (matches
+// the three-dot diff semantics already used for `diffArgs`) rather than the
+// tip of <base>, so unrelated commits that landed on the base branch after
+// this branch forked don't get treated as part of the "before" state.
+const mergeBase = base ? sh(`git merge-base ${base} HEAD`).trim() : null;
 
 const C = { red: (s) => `\x1b[31m${s}\x1b[0m`, green: (s) => `\x1b[32m${s}\x1b[0m`, gray: (s) => `\x1b[90m${s}\x1b[0m` };
 
@@ -42,21 +62,121 @@ function newLessFiles() {
   return out.split('\n').map((s) => s.trim()).filter(Boolean);
 }
 
-function newAntdImports() {
-  // Added lines (leading '+') that import from 'antd', across TS/TSX.
-  const out = sh(`git diff ${diffArgs} -U0 -- '*.ts' '*.tsx'`);
-  const hits = [];
-  let file = null;
+// --- antd import comparison -------------------------------------------------
+
+// Matches `import [type] <clause> from 'antd'` and `'antd/<subpath>'`, across
+// multi-line import clauses (the `s` flag lets `.` span newlines).
+const ANTD_IMPORT_RE = /import\s+(?:type\s+)?([^'";]*?)\s+from\s+(['"])(antd(?:\/[^'"]*)?)\2/gs;
+
+function parseClause(clause) {
+  const specifiers = new Set();
+  let rest = clause.trim();
+  const braceMatch = rest.match(/\{([^}]*)\}/s);
+  if (braceMatch) {
+    braceMatch[1]
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      // `Foo as Bar` — the imported name (`Foo`) is what matters, not the
+      // local alias.
+      .forEach((s) => specifiers.add(s.split(/\s+as\s+/)[0].trim()));
+    rest = (rest.slice(0, braceMatch.index) + rest.slice(braceMatch.index + braceMatch[0].length)).trim();
+  }
+  rest = rest.replace(/,\s*$/, '').replace(/^,\s*/, '').trim();
+  if (rest.startsWith('*')) {
+    specifiers.add('*namespace*');
+  } else if (rest) {
+    specifiers.add('*default*');
+  }
+  return specifiers;
+}
+
+// Returns Map<moduleString, { specifiers: Set<string>, statement: string }>
+function parseAntdImports(content) {
+  const map = new Map();
+  if (!content) {
+    return map;
+  }
+  let m;
+  ANTD_IMPORT_RE.lastIndex = 0;
+  while ((m = ANTD_IMPORT_RE.exec(content))) {
+    const moduleName = m[3];
+    const specifiers = parseClause(m[1]);
+    const statement = m[0].replace(/\s+/g, ' ').trim();
+    if (!map.has(moduleName)) {
+      map.set(moduleName, { specifiers: new Set(), statement });
+    }
+    const entry = map.get(moduleName);
+    specifiers.forEach((s) => entry.specifiers.add(s));
+    entry.statement = statement;
+  }
+  return map;
+}
+
+// List of changed .ts/.tsx files, as { before, after } repo-relative paths
+// (they differ only for detected renames).
+function changedTsFiles() {
+  const out = sh(`git diff ${diffArgs} --diff-filter=ACMRT --name-status -- '*.ts' '*.tsx'`);
+  const files = [];
   for (const line of out.split('\n')) {
-    const fileMatch = line.match(/^\+\+\+ b\/(.+)$/);
-    if (fileMatch) {
-      file = fileMatch[1];
-    } else if (
-      line.startsWith('+') &&
-      !line.startsWith('+++') &&
-      /import\s+[^;]*\bfrom\s+['"]antd(?:\/[^'"]*)?['"]/.test(line)
-    ) {
-      hits.push({ file, line: line.slice(1).trim() });
+    if (!line.trim()) {
+      continue;
+    }
+    const parts = line.split('\t');
+    const status = parts[0];
+    if (status.startsWith('R') || status.startsWith('C')) {
+      files.push({ before: parts[1], after: parts[2] });
+    } else {
+      files.push({ before: parts[1], after: parts[1] });
+    }
+  }
+  return files;
+}
+
+function gitShow(objectSpec) {
+  try {
+    return execFileSync('git', ['show', objectSpec], { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 });
+  } catch (e) {
+    // File didn't exist at that ref (e.g. newly added file) — treat as empty.
+    return '';
+  }
+}
+
+function getBeforeContent(path) {
+  if (!path) {
+    return '';
+  }
+  // baseRef mode: "before" is the merge-base. Staged mode: "before" is HEAD.
+  return gitShow(`${base ? mergeBase : 'HEAD'}:${path}`);
+}
+
+function getAfterContent(path) {
+  if (!path) {
+    return '';
+  }
+  // baseRef mode: "after" is HEAD. Staged mode: "after" is the index — the
+  // index object spec has no ref before the colon, just `:path`.
+  return gitShow(base ? `HEAD:${path}` : `:${path}`);
+}
+
+function newAntdImports() {
+  const hits = [];
+  const files = changedTsFiles();
+  for (const { before, after } of files) {
+    const afterContent = getAfterContent(after);
+    const afterMap = parseAntdImports(afterContent);
+    if (afterMap.size === 0) {
+      continue;
+    }
+    const beforeContent = getBeforeContent(before);
+    const beforeMap = parseAntdImports(beforeContent);
+    for (const [moduleName, afterEntry] of afterMap) {
+      const beforeEntry = beforeMap.get(moduleName);
+      const beforeSpecifiers = beforeEntry ? beforeEntry.specifiers : new Set();
+      const isNew = [...afterEntry.specifiers].some((s) => !beforeSpecifiers.has(s));
+      if (isNew) {
+        hits.push({ file: after, line: afterEntry.statement });
+      }
     }
   }
   return hits;
@@ -85,4 +205,8 @@ function main() {
   process.stdout.write(C.green('✔ No new Antd imports or .less files.\n'));
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { parseClause, parseAntdImports, newAntdImports, newLessFiles, main };

--- a/openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.test.js
+++ b/openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.test.js
@@ -1,0 +1,169 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/* Focused checks for the antd + less deprecation guard. Run: node scripts/tw-deprecation-guard.test.js */
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const { parseClause, parseAntdImports } = require('./tw-deprecation-guard');
+
+let pass = 0;
+function check(name, fn) {
+  try {
+    fn();
+    pass++;
+  } catch (e) {
+    process.stderr.write(`\nFAIL: ${name}\n  ${e.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function setEq(actual, expected) {
+  assert.deepStrictEqual([...actual].sort(), [...expected].sort());
+}
+
+// --- parseClause -------------------------------------------------------
+
+check('named specifiers', () => {
+  setEq(parseClause('{ Button, Space }'), ['Button', 'Space']);
+});
+
+check('aliased named specifier keeps the imported name, not the local alias', () => {
+  setEq(parseClause('{ Tag as AntdTag, Tooltip }'), ['Tag', 'Tooltip']);
+});
+
+check('default import', () => {
+  setEq(parseClause('Foo'), ['*default*']);
+});
+
+check('namespace import', () => {
+  setEq(parseClause('* as antd'), ['*namespace*']);
+});
+
+check('default + named combo', () => {
+  setEq(parseClause('Foo, { Bar, Baz }'), ['*default*', 'Bar', 'Baz']);
+});
+
+// --- parseAntdImports ----------------------------------------------------
+
+check('parses a simple named import', () => {
+  const map = parseAntdImports(`import { Button, Space } from 'antd';\n`);
+  assert.ok(map.has('antd'));
+  setEq(map.get('antd').specifiers, ['Button', 'Space']);
+});
+
+check('keys subpath modules separately from the bare module', () => {
+  const map = parseAntdImports(
+    `import { Button } from 'antd';\nimport { ExpandableConfig } from 'antd/lib/table/interface';\n`
+  );
+  setEq(map.get('antd').specifiers, ['Button']);
+  setEq(map.get('antd/lib/table/interface').specifiers, ['ExpandableConfig']);
+});
+
+check('reconstructs a multi-line import clause', () => {
+  const map = parseAntdImports(`import {\n  Button,\n  Space,\n  Tooltip,\n} from 'antd';\n`);
+  setEq(map.get('antd').specifiers, ['Button', 'Space', 'Tooltip']);
+});
+
+check('returns an empty map when there is no antd import', () => {
+  const map = parseAntdImports(`import { Typography } from '@openmetadata/ui-core-components';\n`);
+  assert.strictEqual(map.size, 0);
+});
+
+// --- end-to-end CLI behaviour, against a throwaway git repo -------------
+
+function makeTmpRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tw-guard-test-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'Test');
+  return { dir, git };
+}
+
+function runGuard(dir, args) {
+  const guardPath = path.join(__dirname, 'tw-deprecation-guard.js');
+  try {
+    const out = execFileSync('node', [guardPath, ...args], { cwd: dir, encoding: 'utf8' });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: (e.stdout || '') + (e.stderr || '') };
+  }
+}
+
+check('PASSES when a diff only removes antd specifiers (no new debt)', () => {
+  const { dir, git } = makeTmpRepo();
+  fs.writeFileSync(
+    path.join(dir, 'Foo.tsx'),
+    `import { Space, Tooltip, Typography } from 'antd';\n`
+  );
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  const baseSha = git('rev-parse', 'HEAD').trim();
+
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `import { Space, Tooltip } from 'antd';\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'remove Typography usage');
+
+  const result = runGuard(dir, [baseSha]);
+  assert.strictEqual(result.code, 0, `expected exit 0, got ${result.code}:\n${result.out}`);
+});
+
+check('FAILS when a diff adds a genuinely new antd specifier to an existing import', () => {
+  const { dir, git } = makeTmpRepo();
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `import { Typography } from 'antd';\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  const baseSha = git('rev-parse', 'HEAD').trim();
+
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `import { Modal, Typography } from 'antd';\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'add Modal');
+
+  const result = runGuard(dir, [baseSha]);
+  assert.strictEqual(result.code, 1, `expected exit 1, got ${result.code}:\n${result.out}`);
+  assert.ok(result.out.includes('Foo.tsx'), `expected the report to name Foo.tsx:\n${result.out}`);
+});
+
+check('FAILS when a diff adds a brand new antd import to a file that had none', () => {
+  const { dir, git } = makeTmpRepo();
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `export const x = 1;\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+  const baseSha = git('rev-parse', 'HEAD').trim();
+
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `import { Modal } from 'antd';\nexport const x = 1;\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'add antd import');
+
+  const result = runGuard(dir, [baseSha]);
+  assert.strictEqual(result.code, 1, `expected exit 1, got ${result.code}:\n${result.out}`);
+});
+
+check('staged mode (--cached) catches new antd debt the same way', () => {
+  const { dir, git } = makeTmpRepo();
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `export const x = 1;\n`);
+  git('add', '-A');
+  git('commit', '-q', '-m', 'base');
+
+  fs.writeFileSync(path.join(dir, 'Foo.tsx'), `import { Modal } from 'antd';\nexport const x = 1;\n`);
+  git('add', '-A');
+
+  const result = runGuard(dir, []);
+  assert.strictEqual(result.code, 1, `expected exit 1, got ${result.code}:\n${result.out}`);
+});
+
+process.stdout.write(`\n${pass} check(s) passed.\n`);


### PR DESCRIPTION
## Problem

The antd deprecation guard flags any **added** diff line matching `import … from 'antd'`. Removing a component from a multi-component import rewrites that line, so the reduction registers as an addition:

```diff
- import { Button, Typography } from 'antd';
+ import { Button } from 'antd';
```

Result: **strictly reducing antd usage fails the "no new antd debt" guard.** It flagged ~20 files on the first migration sweep, every one of them a reduction. Left unfixed this blocks the entire antd → ui-core-components program (epic #30570) — and the eventual feature-branch merge, whose diff is hundreds of such lines.

## Fix

Compare antd **specifier sets** before and after, per file and per module, instead of pattern-matching diff lines. A hit is reported only when the specifier set grows (a genuinely new component) or the file had no antd import for that module at all. Handles named/default/namespace imports, subpath modules (`antd/lib/x`), and multi-line imports (reconstructed from full file content rather than `-U0` hunks). The `.less` check and the CLI contract (staged mode, baseRef mode, output format, exit codes) are unchanged.

## Verification

- Real migration branch (32 files, all reductions): guard **passes**, exit 0 — previously failed.
- Synthetic regression: adding a genuinely new `import { Modal } from 'antd'` to a file with no antd import → guard **fails**, exit 1, file reported.
- New unit tests cover both directions plus subpath/default/namespace/multi-line cases.

Fixes #30774

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces added-line matching with before/after import-specifier comparison.
- Parses named, default, namespace, subpath, and multiline antd imports.
- Reads file contents from the merge base and HEAD in CI mode or HEAD and the index in staged mode.
- Adds focused parser and end-to-end guard tests.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until non-code import text can no longer hide genuinely new antd imports.

The full-file parser treats matching comments and strings as imports, polluting the before-set and allowing newly activated imports to pass; it also compares inline type modifiers as part of the imported name.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.js
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.js | Implements full-file specifier comparison, but lexical parsing can let non-code import text suppress violations and mishandles inline type specifiers. |
| openmetadata-ui/src/main/resources/ui/scripts/tw-deprecation-guard.test.js | Adds focused parser and CLI coverage for reductions, additions, subpaths, multiline imports, and staged mode. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[Changed TS/TSX files] --> B[Read before content]
  D --> A[Read after content]
  B --> PB[Parse antd imports]
  A --> PA[Parse antd imports]
  PB --> C[Compare specifier sets per module]
  PA --> C
  C -->|New specifier| F[Fail guard]
  C -->|No growth| P[Pass guard]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): only flag genuinely new antd im..."](https://github.com/open-metadata/openmetadata/commit/767f7d47ca2536f19d985201b08a40b4474d7a63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49154410)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->