### PR TITLE
Cherry-pick #30451 to 2.0: re-enable Domains, Data Product & domain-rename E2E suites

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts
@@ -643,8 +643,7 @@ test.describe(
     // DOMAIN TESTS
     // ===================================================================
 
-    // eslint-disable-next-line playwright/no-skipped-test -- domain rename consolidation not yet stable
-    test.skip('Domain - rename then update description should work', async ({
+    test('Domain - rename then update description should work', async ({
       page,
       browser,
     }) => {
@@ -699,8 +698,7 @@ test.describe(
       }
     });
 
-    // eslint-disable-next-line playwright/no-skipped-test -- domain rename consolidation not yet stable
-    test.skip('Domain - multiple rename + update cycles should work', async ({
+    test('Domain - multiple rename + update cycles should work', async ({
       page,
       browser,
     }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryNavigation.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryNavigation.spec.ts
@@ -228,9 +228,7 @@ test.describe('Glossary Navigation', () => {
   });
 
   // UI-01: Empty glossary state (no terms)
-  // Skip: Test isolation issue - selectActiveGlossary not selecting the correct glossary
-  // eslint-disable-next-line playwright/no-skipped-test -- test isolation issue with selectActiveGlossary
-  test.skip('should show empty state when glossary has no terms', async ({
+  test('should show empty state when glossary has no terms', async ({
     page,
   }) => {
     const { apiContext, afterAction } = await getApiContext(page);
@@ -243,8 +241,11 @@ test.describe('Glossary Navigation', () => {
       await sidebarClick(page, SidebarItem.GLOSSARY);
       await selectActiveGlossary(page, emptyGlossary.data.displayName);
 
-      // Verify empty state is shown (with default status filter active)
-      await expect(page.getByText('No Glossary Term found')).toBeVisible();
+      // A glossary with zero terms renders the empty-glossary placeholder, not
+      // the "No Glossary Term found" row that a non-matching status filter shows.
+      await expect(
+        page.getByTestId('create-error-placeholder-Glossary Term')
+      ).toBeVisible();
 
       // Verify add term button is available
       await expect(page.getByTestId('add-new-tag-button-header')).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Page, test as base } from '@playwright/test';
+import { Page, test as base } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { DataProduct } from '../../../support/domain/DataProduct';
 import { Domain } from '../../../support/domain/Domain';
@@ -91,7 +91,7 @@ base.afterAll('Cleanup', async ({ browser }) => {
   await afterAction();
 });
 
-test.describe.fixme('Domain and Data Product Asset Counts', () => {
+test.describe.serial('Domain and Data Product Asset Counts', () => {
   test.slow(); // Slow Test
   test.beforeEach(async ({ page }, testInfo) => {
     await redirectToHomePage(page, false);
@@ -265,46 +265,25 @@ test.describe.fixme('Domain and Data Product Asset Counts', () => {
     await page.getByTestId('assets').click();
     await dataProductAssetsResponse;
 
-    let hasAssets = true;
-    while (hasAssets) {
-      const checkboxes = page.locator(
-        '[data-testid^="table-data-card_"] input[type="checkbox"]'
-      );
-      const count = await checkboxes.count();
+    // Remove every asset currently attached to the data product. The card
+    // list paints asynchronously after the assets response resolves, and
+    // count() does not auto-wait — so wait for the first card to render
+    // before counting, otherwise the loop reads 0 and removes nothing.
+    await waitForAllLoadersToDisappear(page);
+    const assetCard = page.locator('[data-testid^="table-data-card_"]');
+    await assetCard.first().waitFor({ state: 'visible' });
 
-      if (count === 0) {
-        hasAssets = false;
-        break;
-      }
-
-      const selectAll = page.getByRole('checkbox', { name: 'Select All' });
-      if (await selectAll.isVisible()) {
-        await selectAll.check();
-      } else {
-        for (let i = 0; i < count; i++) {
-          await checkboxes.nth(i).check();
-        }
-      }
-
-      const previousCount = count;
-      const removeRes = page.waitForResponse('**/assets/remove');
-      await page.getByTestId('delete-all-button').click();
-      await removeRes;
-
-      await expect
-        .poll(
-          async () =>
-            page
-              .locator(
-                '[data-testid^="table-data-card_"] input[type="checkbox"]'
-              )
-              .count(),
-          { timeout: 10_000 }
-        )
-        .toBeLessThan(previousCount);
+    const attachedCount = await assetCard.count();
+    for (let i = 0; i < attachedCount; i++) {
+      await assetCard.nth(i).locator('input[type="checkbox"]').check();
     }
 
+    const removeRes = page.waitForResponse('**/assets/remove');
+    await page.getByTestId('delete-all-button').click();
+    await removeRes;
+
     await page.reload();
+    await waitForAllLoadersToDisappear(page);
     await checkAssetsCount(page, 0);
 
     await redirectToHomePage(page);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
@@ -117,7 +117,7 @@ const test = base.extend<{
   },
 });
 
-test.describe.fixme('Domains', () => {
+test.describe('Domains', () => {
   test.slow(true);
 
   test.beforeAll('Setup pre-requests', async ({ browser }) => {
@@ -384,16 +384,17 @@ test.describe.fixme('Domains', () => {
       // Verify empty state message
       await expect(page.getByText('No assets linked yet')).toBeVisible();
 
-      const addButton = page.getByTestId('data-assets-add-button');
+      // `CreatePlaceholder` applies the action's `data-assets-add-button` as the
+      // button's DOM id, so this CTA has no testid to select it by.
+      const addButton = page.locator('#data-assets-add-button');
       await expect(addButton).toBeVisible();
       await addButton.click();
 
       await waitForAllLoadersToDisappear(page);
 
-      // Verify Add Assets form is displayed
-      await expect(page.getByTestId('form-heading')).toContainText(
-        'Add Assets'
-      );
+      // Verify Add Assets modal is displayed (migrated to the core-ui Dialog
+      // `asset-selection-modal`; the old `form-heading` testid no longer applies)
+      await expect(page.getByTestId('asset-selection-modal')).toBeVisible();
 
       await expect(page.getByTestId('cancel-btn')).toBeVisible();
       await expect(page.getByTestId('save-btn')).toBeDisabled();
@@ -1698,7 +1699,7 @@ test.describe.fixme('Domains', () => {
   });
 });
 
-test.describe.fixme('Domain Rename Comprehensive Tests', () => {
+test.describe('Domain Rename Comprehensive Tests', () => {
   test.slow(true);
 
   test.beforeEach('Visit home page', async ({ page }) => {
@@ -2721,7 +2722,7 @@ test.describe.fixme('Domain Rename Comprehensive Tests', () => {
   });
 });
 
-test.describe.fixme('Domains Rbac', () => {
+test.describe('Domains Rbac', () => {
   test.slow(true);
 
   let domain1: Domain;
@@ -2877,7 +2878,7 @@ test.describe.fixme('Domains Rbac', () => {
   });
 });
 
-test.describe.fixme('Data Consumer Domain Ownership', () => {
+test.describe('Data Consumer Domain Ownership', () => {
   test.slow(true);
 
   let classification: ClassificationClass;
@@ -2976,7 +2977,7 @@ test.describe.fixme('Data Consumer Domain Ownership', () => {
   });
 });
 
-test.describe.fixme('Domain Access with hasDomain() Rule', () => {
+test.describe('Domain Access with hasDomain() Rule', () => {
   test.slow(true);
 
   let testResources: {
@@ -3045,7 +3046,7 @@ test.describe.fixme('Domain Access with hasDomain() Rule', () => {
   });
 });
 
-test.describe.fixme('Domain Access with noDomain() Rule', () => {
+test.describe('Domain Access with noDomain() Rule', () => {
   test.slow(true);
 
   let testResources: {
@@ -3119,7 +3120,7 @@ test.describe.fixme('Domain Access with noDomain() Rule', () => {
   });
 });
 
-test.describe.fixme('Domain Tree View Functionality', () => {
+test.describe('Domain Tree View Functionality', () => {
   let subDomain: SubDomain;
   const domain = EntityDataClass.domain1;
   const domainDisplayName = domain.responseData.displayName;
@@ -3149,7 +3150,7 @@ test.describe.fixme('Domain Tree View Functionality', () => {
     await sidebarClick(page, SidebarItem.DOMAIN);
     await waitForAllLoadersToDisappear(page);
 
-    const treeViewButton = page.getByRole('button', { name: 'tree' });
+    const treeViewButton = page.getByRole('radio', { name: 'tree' });
     await expect(treeViewButton).toBeVisible();
     await treeViewButton.click();
 
@@ -3392,7 +3393,7 @@ test.describe.fixme('Domain Tree View Functionality', () => {
   });
 });
 
-test.describe.fixme('Domain asset dryRun — add confirmation', () => {
+test.describe('Domain asset dryRun — add confirmation', () => {
   test.slow(true);
 
   const openDomainAssetsAddModal = async (page: Page, domain: Domain) => {
@@ -3653,78 +3654,75 @@ test.describe.fixme('Domain asset dryRun — add confirmation', () => {
   });
 });
 
-test.describe.fixme(
-  'Domain assets — glossary and inherited glossary term',
-  () => {
-    test.slow(true);
+test.describe('Domain assets — glossary and inherited glossary term', () => {
+  test.slow(true);
 
-    let assetDomain: Domain;
-    let assetGlossary: Glossary;
-    let inheritedTerm: GlossaryTerm;
+  let assetDomain: Domain;
+  let assetGlossary: Glossary;
+  let inheritedTerm: GlossaryTerm;
 
-    test.beforeAll(
-      'Setup domain with glossary and inherited term',
-      async ({ browser }) => {
-        const { apiContext, afterAction } = await performAdminLogin(browser);
+  test.beforeAll(
+    'Setup domain with glossary and inherited term',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
 
-        assetDomain = new Domain();
-        assetGlossary = new Glossary();
+      assetDomain = new Domain();
+      assetGlossary = new Glossary();
 
-        await assetDomain.create(apiContext);
-        await assetGlossary.create(apiContext);
+      await assetDomain.create(apiContext);
+      await assetGlossary.create(apiContext);
 
-        await assetGlossary.patch(apiContext, [
-          {
-            op: 'add',
-            path: '/domains/0',
-            value: {
-              id: assetDomain.responseData.id,
-              type: 'domain',
-              name: assetDomain.responseData.name,
-              displayName: assetDomain.responseData.displayName,
-            },
+      await assetGlossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/domains/0',
+          value: {
+            id: assetDomain.responseData.id,
+            type: 'domain',
+            name: assetDomain.responseData.name,
+            displayName: assetDomain.responseData.displayName,
           },
-        ]);
+        },
+      ]);
 
-        inheritedTerm = new GlossaryTerm(assetGlossary);
-        await inheritedTerm.create(apiContext);
+      inheritedTerm = new GlossaryTerm(assetGlossary);
+      await inheritedTerm.create(apiContext);
 
-        await afterAction();
-      }
+      await afterAction();
+    }
+  );
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await inheritedTerm.delete(apiContext);
+    await assetGlossary.delete(apiContext);
+    await assetDomain.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach('Visit home page', async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('Assets tab lists the assigned glossary and its inherited term', async ({
+    page,
+  }) => {
+    await sidebarClick(page, SidebarItem.DOMAIN);
+    await waitForAllLoadersToDisappear(page);
+
+    await goToAssetsTab(page, assetDomain.data);
+
+    const glossaryCard = page.getByTestId(
+      `table-data-card_${assetGlossary.responseData.fullyQualifiedName}`
+    );
+    const inheritedTermCard = page.getByTestId(
+      `table-data-card_${inheritedTerm.responseData.fullyQualifiedName}`
     );
 
-    test.afterAll('Cleanup', async ({ browser }) => {
-      const { apiContext, afterAction } = await performAdminLogin(browser);
-      await inheritedTerm.delete(apiContext);
-      await assetGlossary.delete(apiContext);
-      await assetDomain.delete(apiContext);
-      await afterAction();
-    });
-
-    test.beforeEach('Visit home page', async ({ page }) => {
-      await redirectToHomePage(page);
-    });
-
-    test('Assets tab lists the assigned glossary and its inherited term', async ({
-      page,
-    }) => {
-      await sidebarClick(page, SidebarItem.DOMAIN);
-      await waitForAllLoadersToDisappear(page);
-
-      await goToAssetsTab(page, assetDomain.data);
-
-      const glossaryCard = page.getByTestId(
-        `table-data-card_${assetGlossary.responseData.fullyQualifiedName}`
-      );
-      const inheritedTermCard = page.getByTestId(
-        `table-data-card_${inheritedTerm.responseData.fullyQualifiedName}`
-      );
-
-      await expect(glossaryCard).toBeVisible({ timeout: 30_000 });
-      await expect(inheritedTermCard).toBeVisible({ timeout: 30_000 });
-    });
-  }
-);
+    await expect(glossaryCard).toBeVisible({ timeout: 30_000 });
+    await expect(inheritedTermCard).toBeVisible({ timeout: 30_000 });
+  });
+});
 
 test.describe('Domain description editor popups', () => {
   const table = new TableClass();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1248,61 +1248,52 @@ test.describe('Glossary tests', () => {
     }
   });
 
-  test.fixme(
-    'Request description task for Glossary Term',
-    async ({ browser }) => {
-      const { page, afterAction, apiContext } = await performAdminLogin(
-        browser,
-        { navigate: true }
-      );
-      const glossary1 = new Glossary();
-      const user1 = new UserClass();
-      const glossaryTerm1 = new GlossaryTerm(glossary1);
-      glossary1.data.terms = [glossaryTerm1];
+  test('Request description task for Glossary Term', async ({ browser }) => {
+    const { page, afterAction, apiContext } = await performAdminLogin(browser, {
+      navigate: true,
+    });
+    const glossary1 = new Glossary();
+    const user1 = new UserClass();
+    const glossaryTerm1 = new GlossaryTerm(glossary1);
+    glossary1.data.terms = [glossaryTerm1];
 
-      try {
-        await user1.create(apiContext);
-        await glossary1.create(apiContext);
-        await glossaryTerm1.create(apiContext);
-        await sidebarClick(page, SidebarItem.GLOSSARY);
-        await selectActiveGlossary(page, glossary1.data.displayName);
-        await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
+    try {
+      await user1.create(apiContext);
+      await glossary1.create(apiContext);
+      await glossaryTerm1.create(apiContext);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary1.data.displayName);
+      await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
 
-        const value: TaskDetails = {
-          term: glossaryTerm1.data.name,
-          assignee: user1.responseData.name,
-        };
+      const value: TaskDetails = {
+        term: glossaryTerm1.data.name,
+        assignee: user1.responseData.name,
+      };
 
-        await page.getByTestId('request-description').click();
+      await page.getByTestId('request-description').click();
 
-        await createDescriptionTaskForGlossary(
-          page,
-          value,
-          glossaryTerm1,
-          false
-        );
+      await createDescriptionTaskForGlossary(page, value, glossaryTerm1, false);
 
-        const taskResolve = waitForTaskResolveResponse(page);
-        await page.getByTestId('approve-button').first().click();
-        await taskResolve;
+      const taskResolve = waitForTaskResolveResponse(page);
+      await page.getByTestId('approve-button').first().click();
+      await taskResolve;
 
-        await redirectToHomePage(page);
-        await sidebarClick(page, SidebarItem.GLOSSARY);
-        await selectActiveGlossary(page, glossary1.data.displayName);
-        await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
+      await redirectToHomePage(page);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary1.data.displayName);
+      await selectActiveGlossaryTerm(page, glossaryTerm1.data.displayName);
 
-        const viewerContainerText = await page.textContent(
-          '[data-testid="viewer-container"]'
-        );
-
-        expect(viewerContainerText).toContain('Updated description');
-      } finally {
-        await glossaryTerm1.delete(apiContext);
-        await glossary1.delete(apiContext);
-        await afterAction();
-      }
+      // The description renders after the term page finishes loading, so assert
+      // on the locator rather than reading textContent once.
+      await expect(
+        page.locator('[data-testid="viewer-container"]')
+      ).toContainText('Updated description');
+    } finally {
+      await glossaryTerm1.delete(apiContext);
+      await glossary1.delete(apiContext);
+      await afterAction();
     }
-  );
+  });
 
   test('Request tags for Glossary', async ({ browser }) => {
     test.slow(true);


### PR DESCRIPTION
Cherry-pick of #30451 onto `2.0`.

Applied cleanly with no conflicts. See #30451 for the full write-up.

## What it carries

Re-enables E2E coverage that was disabled on this branch — **10 `test.describe.fixme` suites** turned back on and **3 `test.skip`s** removed across 5 spec files (+133/−166):

| Spec | Change |
|---|---|
| `Pages/Domains.spec.ts` | Un-`fixme`s Domains, Domain Rename Comprehensive, Domains Rbac, Data Consumer Domain Ownership, hasDomain()/noDomain() Rule, Domain Tree View, asset dryRun |
| `Pages/Glossary.spec.ts` | Un-skips the empty-state term case; selector hardening |
| `Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts` | Un-`fixme`s Domain and Data Product Asset Counts |
| `Features/EntityRenameConsolidation.spec.ts` | Un-skips the two domain rename + description cycles |
| `Features/Glossary/GlossaryNavigation.spec.ts` | Selector hardening |

The substantive selector fix it carries: `CreatePlaceholder` applies its action's `data-assets-add-button` as the button's **DOM id**, not a testid, so the CTA is selected with `page.locator('#data-assets-add-button')` instead of `getByTestId(...)`.

## Backport notes

The applied diff is byte-identical to `main`'s except for **one context line** — `Domains.spec.ts` asserts the assets empty state differently on each branch:

- `main`: `page.getByTestId('empty-placeholder')`
- `2.0`: `page.getByText('No assets linked yet')`

That divergence is pre-existing (`main` changed it in a later, unrelated commit) and untouched here. Verified valid on `2.0`: the string resolves to `no-assets-linked-yet` in this branch's `en-us.json`.

## Verification

- Cherry-pick applied with **no conflicts**; `-`/`+` lines identical to the original commit.
- `CreatePlaceholder.tsx` and `EmptyPlaceholder.utils.ts` are **identical** between `2.0` and `main`, so the DOM-id selector change is valid here — `resolveSingleAction`'s contract ("`id`, when provided, is applied to the generated button as its DOM id") holds on this branch.
- Every selector the patch introduces resolves in `2.0` source: `approve-button`, `asset-selection-modal`, `delete-all-button`, `request-description`, `viewer-container`, `table-data-card_`, `data-assets-add-button`.
- Prettier clean on all 5 files.

Runtime behaviour of the re-enabled suites on `2.0` is **not** verified locally — that is what this PR's Playwright run is for.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Re-enables domain, data-product, glossary, and rename Playwright coverage while updating selectors and stabilizing asynchronous asset-removal assertions.
- Activates previously skipped domain and glossary suites.
- Runs the landing-page widget tests serially and waits for asset cards before bulk removal.
- Updates empty-state, dialog, tree-view, and description selectors for the current UI.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The shared-fixture lifecycle in the re-enabled Domains suite should be fixed before merging because parallel tests can lose their domain or user while still running.

Activating the Domains describe block exposes an individual test that deletes resources owned by the suite-level setup, allowing fully parallel tests to observe missing shared state.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Domains.spec.ts | Re-enables several domain suites and updates selectors, but exposes unsafe deletion of fixtures shared by the fully parallel Domains suite. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts | Re-enables widget count coverage serially and makes the two-asset bulk-removal flow wait for rendered cards. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/EntityRenameConsolidation.spec.ts | Re-enables two independently provisioned domain rename and description-update tests. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryNavigation.spec.ts | Re-enables the empty-glossary case and targets the placeholder representing the actual zero-term state. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts | Re-enables glossary-term description task coverage and replaces a one-shot text read with a web-first assertion. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): re-enable Domains, Data Produc..."](https://github.com/open-metadata/openmetadata/commit/a81acc7ef503609204a857e692c6225294d03a57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49169985)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->