### PR TITLE
Fix table and entity reference value updation issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeFormCustomPropertyFields.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeFormCustomPropertyFields.spec.ts
@@ -1,0 +1,328 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { APIRequestContext, expect, Page } from '@playwright/test';
+import { SidebarItem } from '../../constant/sidebar';
+import { Glossary } from '../../support/glossary/Glossary';
+import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
+import { performAdminLogin } from '../../utils/admin';
+import { descriptionBox, redirectToHomePage, uuid } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { sidebarClick } from '../../utils/sidebar';
+import { test } from '../fixtures/pages';
+
+const DOMAIN_ENTITY_TYPE = 'domain';
+const ID = uuid();
+
+const CP = {
+  str: `pwCpString${ID}`,
+  table: `pwCpTable${ID}`,
+  link: `pwCpLink${ID}`,
+  interval: `pwCpInterval${ID}`,
+  ref: `pwCpRef${ID}`,
+};
+
+const ensureNoIntakeForm = async (
+  api: APIRequestContext,
+  entityType: string
+) => {
+  const listRes = await api.get(
+    '/api/v1/governance/intakeForms?limit=100&include=all'
+  );
+  if (listRes.status() !== 200) {
+    return;
+  }
+  const list = await listRes.json();
+  const forms = (list.data ?? []) as Array<{ id: string; entityType: string }>;
+  for (const form of forms) {
+    if (form.entityType === entityType) {
+      await api.delete(
+        `/api/v1/governance/intakeForms/${form.id}?hardDelete=true`
+      );
+    }
+  }
+};
+
+const ensureCustomProperty = async (
+  api: APIRequestContext,
+  entityType: string,
+  propertyName: string,
+  propertyTypeName: string,
+  config?: unknown
+) => {
+  const typeRes = await api.get(
+    `/api/v1/metadata/types/name/${entityType}?fields=customProperties`
+  );
+  expect(typeRes.status()).toBe(200);
+  const type = await typeRes.json();
+  const exists = (type.customProperties ?? []).some(
+    (cp: { name: string }) => cp.name === propertyName
+  );
+  if (exists) {
+    return;
+  }
+  const propertyTypeRes = await api.get(
+    `/api/v1/metadata/types/name/${propertyTypeName}`
+  );
+  expect(propertyTypeRes.status()).toBe(200);
+  const propertyType = await propertyTypeRes.json();
+  const put = await api.put(`/api/v1/metadata/types/${type.id}`, {
+    data: {
+      name: propertyName,
+      description: 'Custom property for intake-form field playwright test',
+      propertyType: { id: propertyType.id, type: 'type' },
+      ...(config === undefined ? {} : { customPropertyConfig: { config } }),
+    },
+  });
+  expect(put.status()).toBe(200);
+};
+
+const createIntakeForm = async (
+  api: APIRequestContext,
+  entityType: string,
+  requiredPropertyNames: string[]
+) => {
+  const response = await api.post('/api/v1/governance/intakeForms', {
+    data: {
+      name: entityType,
+      entityType,
+      enabled: true,
+      formFields: requiredPropertyNames.map((name) => ({
+        fieldPath: `extension.${name}`,
+        fieldLabel: name,
+        fieldKind: 'customProperty',
+        required: true,
+      })),
+    },
+  });
+  expect(response.status()).toBe(201);
+};
+
+const extensionInput = (page: Page, testId: string) =>
+  page
+    .locator(
+      `[data-testid="${testId}"] input, input[data-testid="${testId}"], textarea[data-testid="${testId}"]`
+    )
+    .first();
+
+const openCreateDomainForm = async (page: Page) => {
+  await redirectToHomePage(page);
+  await sidebarClick(page, SidebarItem.DOMAIN);
+  await waitForAllLoadersToDisappear(page);
+  await page.getByTestId('add-domain').click();
+  await page.getByTestId('form-heading').waitFor({ timeout: 10000 });
+};
+
+const glossary = new Glossary();
+const glossaryTerm = new GlossaryTerm(glossary);
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe(
+  'IntakeForm custom-property fields render and serialize correctly on the create form',
+  { tag: ['@Governance'] },
+  () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeAll('Set up custom properties + intake form', async ({
+      browser,
+    }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+
+      await glossary.create(apiContext);
+      await glossaryTerm.create(apiContext);
+
+      await ensureNoIntakeForm(apiContext, DOMAIN_ENTITY_TYPE);
+      await ensureCustomProperty(apiContext, DOMAIN_ENTITY_TYPE, CP.str, 'string');
+      await ensureCustomProperty(apiContext, DOMAIN_ENTITY_TYPE, CP.table, 'table-cp', {
+        columns: ['id', 'value'],
+      });
+      await ensureCustomProperty(apiContext, DOMAIN_ENTITY_TYPE, CP.link, 'hyperlink-cp');
+      await ensureCustomProperty(
+        apiContext,
+        DOMAIN_ENTITY_TYPE,
+        CP.interval,
+        'timeInterval'
+      );
+      await ensureCustomProperty(apiContext, DOMAIN_ENTITY_TYPE, CP.ref, 'entityReference', [
+        'glossaryTerm',
+      ]);
+
+      await createIntakeForm(apiContext, DOMAIN_ENTITY_TYPE, [
+        CP.str,
+        CP.table,
+        CP.link,
+        CP.interval,
+        CP.ref,
+      ]);
+
+      await afterAction();
+    });
+
+    test.afterAll('Tear down', async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await ensureNoIntakeForm(apiContext, DOMAIN_ENTITY_TYPE);
+      await glossaryTerm.delete(apiContext);
+      await glossary.delete(apiContext);
+      await afterAction();
+    });
+
+    test('required custom properties show the asterisk and block an empty submit', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await openCreateDomainForm(page);
+
+      // Required marker is on the labelled Form.Item for every required field,
+      // including the split-layout hyperlink and timeInterval fields.
+      await expect(
+        page.locator('.ant-form-item-required', { hasText: CP.link })
+      ).toBeVisible();
+      await expect(
+        page.locator('.ant-form-item-required', { hasText: CP.interval })
+      ).toBeVisible();
+
+      // A submit with required custom properties empty must NOT reach the API.
+      let postFired = false;
+      const listener = (r: import('@playwright/test').Response) => {
+        if (
+          r.url().endsWith('/api/v1/domains') &&
+          r.request().method() === 'POST'
+        ) {
+          postFired = true;
+        }
+      };
+      page.on('response', listener);
+
+      await extensionInput(page, `extension-${CP.str}`).fill(`d ${ID}`);
+      await page.locator('#root\\/name').fill(`pwDomainNeg${ID}`);
+      await page.getByRole('button', { name: 'Save' }).click();
+
+      await expect(async () => {
+        expect(postFired).toBe(false);
+      }).toPass({ intervals: [300], timeout: 4000 });
+      page.off('response', listener);
+    });
+
+    test('all custom-property widgets fill and the submit payload preserves every value', async ({
+      page,
+    }) => {
+      test.slow();
+
+      const name = `pwDomainPos${ID}`;
+      const tableId = '42';
+      const tableValue = 'answer';
+      const linkUrl = 'https://collate.io';
+      const startVal = '10';
+      const endVal = '20';
+      const strVal = `hello ${ID}`;
+
+      await openCreateDomainForm(page);
+
+      await page.locator('#root\\/name').fill(name);
+      await page.locator('#root\\/displayName').fill(name);
+      await page.locator(descriptionBox).fill('intake field test');
+
+      await page.getByRole('combobox', { name: 'Domain Type' }).click();
+      await page.getByRole('option', { name: 'Aggregate' }).click();
+
+      // string
+      await extensionInput(page, `extension-${CP.str}`).fill(strVal);
+
+      // hyperlink (url + display text)
+      await extensionInput(page, `extension-${CP.link}-url`).fill(linkUrl);
+      await extensionInput(page, `extension-${CP.link}-displayText`).fill(
+        'Collate'
+      );
+
+      // time interval (start + end)
+      await extensionInput(page, `extension-${CP.interval}-start`).fill(startVal);
+      await extensionInput(page, `extension-${CP.interval}-end`).fill(endVal);
+
+      // entity reference (glossaryTerm -> async search picker)
+      const refPicker = page
+        .locator(`[data-testid="extension-${CP.ref}"] input`)
+        .first();
+      await refPicker.click();
+      await refPicker.fill(glossaryTerm.data.name);
+      await page
+        .getByRole('option')
+        .filter({ hasText: glossaryTerm.data.displayName })
+        .first()
+        .click();
+
+      const table = page.getByTestId(`extension-${CP.table}`);
+      await table.getByRole('button', { name: /add\s*row/i }).click();
+
+      const idCell = table.locator('.rdg-cell-id').first();
+      await idCell.dblclick();
+      await page.keyboard.type(tableId);
+      await page.keyboard.press('Enter');
+
+      const valueCell = table.locator('.rdg-cell-value').first();
+      await valueCell.dblclick();
+      await page.keyboard.type(tableValue);
+      await page.keyboard.press('Enter');
+
+      await expect(idCell).toContainText(tableId);
+      await expect(valueCell).toContainText(tableValue);
+
+      // Capture the create request and its response together.
+      const [request, response] = await Promise.all([
+        page.waitForRequest(
+          (r) => r.url().endsWith('/api/v1/domains') && r.method() === 'POST'
+        ),
+        page.waitForResponse(
+          (r) =>
+            r.url().endsWith('/api/v1/domains') &&
+            r.request().method() === 'POST'
+        ),
+        page.getByRole('button', { name: 'Save' }).click(),
+      ]);
+
+      // Server accepted it (required validation satisfied, no dropped values).
+      expect(response.status()).toBe(201);
+
+      const ext = request.postDataJSON().extension;
+
+      expect(ext[CP.str]).toBe(strVal);
+
+      // table: id column preserved, and NO stray keys beyond the config columns
+      expect(ext[CP.table].rows).toHaveLength(1);
+      expect(ext[CP.table].rows[0]).toEqual({ id: tableId, value: tableValue });
+      expect(Object.keys(ext[CP.table].rows[0]).sort()).toEqual(['id', 'value']);
+
+      // hyperlink object
+      expect(ext[CP.link].url).toBe(linkUrl);
+
+      // time interval serialized to numbers
+      expect(ext[CP.interval]).toEqual({
+        start: Number(startVal),
+        end: Number(endVal),
+      });
+
+      // single entity reference present (not dropped)
+      expect(ext[CP.ref]).toMatchObject({ type: 'glossaryTerm' });
+      expect(ext[CP.ref].id).toBeTruthy();
+
+      // Clean up the created domain.
+      const { apiContext, afterAction } = await performAdminLogin(
+        page.context().browser()!
+      );
+      await apiContext.delete(
+        `/api/v1/domains/name/${name}?recursive=true&hardDelete=true`
+      );
+      await afterAction();
+    });
+  }
+);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
@@ -18,7 +18,6 @@ import {
   type SelectItemType,
 } from '@openmetadata/ui-core-components';
 import { Button, Form } from 'antd';
-import { isEmpty, omit } from 'lodash';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Column, textEditor } from 'react-data-grid';
 import { useTranslation } from 'react-i18next';
@@ -416,7 +415,7 @@ const CoreTableEditor: React.FC<CoreTableEditorProps> = ({
         ? value.rows
         : [];
 
-    return rawRows.map((row, i) => ({ ...row, id: String(i) }));
+    return rawRows.map((row) => ({ ...row }));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // initialize once from initial value
 
@@ -435,6 +434,9 @@ const CoreTableEditor: React.FC<CoreTableEditorProps> = ({
     dataSource,
     setDataSource,
     columns: gridColumns,
+    // No injected row-id key: the grid keys rows by array index, and injecting
+    // an `id` field would clobber a user-defined column literally named "id".
+    rowIdKey: null,
   });
 
   // Keep a stable ref to onChange so the effect below never re-fires solely
@@ -443,9 +445,9 @@ const CoreTableEditor: React.FC<CoreTableEditorProps> = ({
   onChangeRef.current = onChange;
 
   useEffect(() => {
-    const rows = dataSource
-      .map((row) => omit(row, 'id'))
-      .filter((row) => !isEmpty(row) && Object.values(row).some(Boolean));
+    const rows = dataSource.filter((row) =>
+      Object.values(row).some(Boolean)
+    );
     onChangeRef.current?.({ rows, columns });
   }, [dataSource, columns]);
 
@@ -640,7 +642,8 @@ const AddDomainFormExtensionFields = ({
           return (
             <Form.Item
               key={formField.fieldPath}
-              label={labelWithBadge}>
+              label={labelWithBadge}
+              required={isRequired}>
               <Form.Item
                 name={[...namePath, 'url']}
                 noStyle
@@ -702,7 +705,8 @@ const AddDomainFormExtensionFields = ({
           return (
             <Form.Item
               key={formField.fieldPath}
-              label={labelWithBadge}>
+              label={labelWithBadge}
+              required={isRequired}>
               <Form.Item
                 name={[...namePath, 'start']}
                 noStyle
@@ -718,14 +722,7 @@ const AddDomainFormExtensionFields = ({
                 />
               </Form.Item>
               <div style={{ marginTop: 8 }}>
-                <Form.Item
-                  name={[...namePath, 'end']}
-                  noStyle
-                  rules={
-                    isRequired
-                      ? [{ required: true, message: requiredMessage }]
-                      : []
-                  }>
+                <Form.Item noStyle name={[...namePath, 'end']}>
                   <CoreTextInput
                     data-testid={`${dataTestId}-end`}
                     placeholder={t('label.end')}
@@ -743,11 +740,11 @@ const AddDomainFormExtensionFields = ({
             ? (config as string[])
             : typeof config === 'string'
             ? [config]
-            : ['glossaryTerm'];
+            : [];
 
-          const isUserOrTeam = allowedTypes.every(
-            (t) => t === 'user' || t === 'team'
-          );
+          const isUserOrTeam =
+            allowedTypes.length > 0 &&
+            allowedTypes.every((t) => t === 'user' || t === 'team');
 
           if (isUserOrTeam) {
             const fieldProp: FieldProp = {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
@@ -190,10 +190,12 @@ export function useGridEditController({
   dataSource,
   setDataSource,
   columns,
+  rowIdKey = 'id',
 }: {
   dataSource: Record<string, string>[];
   setDataSource: React.Dispatch<React.SetStateAction<Record<string, string>[]>>;
   columns: Column<Record<string, string>[]>[];
+  rowIdKey?: string | null;
 }) {
   const [gridContainer, setGridContainer] = useState<HTMLElement | null>(null);
   const [isSelecting, setIsSelecting] = useState(false);
@@ -813,10 +815,13 @@ export function useGridEditController({
           }
         }, 1);
 
-        return [...data, { id: data.length + '' }];
+        return [
+          ...data,
+          rowIdKey === null ? {} : { [rowIdKey]: data.length + '' },
+        ];
       }
     );
-  }, [gridContainer, setDataSource]);
+  }, [gridContainer, rowIdKey, setDataSource]);
 
   const focusFirstCell = useCallback(() => {
     const firstCell = gridContainer?.querySelector(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormDesignerModal.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormDesignerModal.tsx
@@ -383,109 +383,125 @@ const IntakeFormDesignerModal = ({
   return (
     <SlideoutMenu
       isDismissable
+      dialogClassName="tw:overflow-hidden!"
       isOpen={open}
-      width="75%"
+      width={900}
       onOpenChange={(isOpenState) => {
         if (!isOpenState) {
           onCancel();
         }
       }}>
-      <SlideoutMenu.Header onClose={onCancel}>
-        <Typography size="text-lg" weight="semibold">
-          {title}
-        </Typography>
-      </SlideoutMenu.Header>
-
-      <SlideoutMenu.Content data-testid="intake-form-designer-modal">
-        <Alert
-          title={t('message.intake-form-one-per-type-help', {
-            entityType: t(ENTITY_TYPE_LABEL_KEYS[entityType]),
-          })}
-          variant="brand"
-        />
-
-        <Box className="tw:gap-1.5" direction="col">
-          <Typography size="text-sm" weight="semibold">
-            {t('label.description')}
-          </Typography>
-          <TextArea
-            aria-label={t('label.description')}
-            data-testid="intake-form-description"
-            placeholder={t('message.intake-form-description-placeholder')}
-            value={description}
-            onChange={setDescription}
-          />
-        </Box>
-
-        <Box align="center" className="tw:gap-3">
-          <Typography size="text-sm" weight="semibold">
-            {t('label.enabled')}
-          </Typography>
-          <Toggle
-            aria-label={t('label.enabled')}
-            data-testid="intake-form-enabled"
-            isSelected={enabled}
-            onChange={setEnabled}
-          />
-          <Typography className="tw:text-tertiary" size="text-sm">
-            {t('message.intake-form-enabled-help')}
-          </Typography>
-        </Box>
-
-        <Divider />
-
-        <Box className="tw:gap-3" direction="col">
-          <Box className="tw:gap-1" direction="col">
-            <Typography size="text-md" weight="semibold">
-              {t('label.native-field-plural')}
+      {() => (
+        <>
+          <SlideoutMenu.Header onClose={onCancel}>
+            <Typography size="text-lg" weight="semibold">
+              {title}
             </Typography>
-            <Typography className="tw:text-tertiary" size="text-sm">
-              {t('message.intake-form-native-fields-help')}
-            </Typography>
-          </Box>
-          {renderFieldTable(nativeRows, t('message.no-native-fields'), false)}
-        </Box>
+          </SlideoutMenu.Header>
 
-        <Divider />
+          <SlideoutMenu.Content
+            className="tw:relative tw:min-h-0 tw:flex-1 tw:overflow-hidden! tw:p-0!"
+            data-testid="intake-form-designer-modal">
+            {/* Content is absolutely positioned so it stays out of flow: its
+                intrinsic height can't feed back into the flex-sized panel, so a
+                row re-render (toggling a checkbox) can never move the footer. */}
+            <div className="tw:absolute tw:inset-0 tw:flex tw:flex-col tw:gap-6 tw:overflow-y-auto tw:px-4 tw:py-6 tw:md:px-6">
+              <Alert
+                title={t('message.intake-form-one-per-type-help', {
+                  entityType: t(ENTITY_TYPE_LABEL_KEYS[entityType]),
+                })}
+                variant="brand"
+              />
 
-        <Box className="tw:gap-3" direction="col">
-          <Box align="center" className="tw:gap-2">
-            <Typography size="text-md" weight="semibold">
-              {t('label.custom-property-plural')}
-            </Typography>
-            <Badge color="gray" size="sm" type="pill-color">
-              {customRows.length}
-            </Badge>
-          </Box>
-          <Typography className="tw:text-tertiary" size="text-sm">
-            {t('message.intake-form-custom-properties-help')}
-          </Typography>
-          {renderFieldTable(
-            customRows,
-            t('message.no-custom-properties-defined'),
-            loadingProps
-          )}
-        </Box>
-      </SlideoutMenu.Content>
+              <Box className="tw:gap-1.5" direction="col">
+                <Typography size="text-sm" weight="semibold">
+                  {t('label.description')}
+                </Typography>
+                <TextArea
+                  aria-label={t('label.description')}
+                  data-testid="intake-form-description"
+                  placeholder={t('message.intake-form-description-placeholder')}
+                  value={description}
+                  onChange={setDescription}
+                />
+              </Box>
 
-      <SlideoutMenu.Footer>
-        <Box className="tw:justify-end tw:gap-3">
-          <Button
-            color="tertiary"
-            data-testid="intake-form-cancel"
-            size="sm"
-            onClick={onCancel}>
-            {t('label.cancel')}
-          </Button>
-          <Button
-            color="primary"
-            data-testid="intake-form-submit"
-            size="sm"
-            onClick={handleOk}>
-            {initialValue ? t('label.save') : t('label.create')}
-          </Button>
-        </Box>
-      </SlideoutMenu.Footer>
+              <Box align="center" className="tw:gap-3">
+                <Typography size="text-sm" weight="semibold">
+                  {t('label.enabled')}
+                </Typography>
+                <Toggle
+                  aria-label={t('label.enabled')}
+                  data-testid="intake-form-enabled"
+                  isSelected={enabled}
+                  onChange={setEnabled}
+                />
+                <Typography className="tw:text-tertiary" size="text-sm">
+                  {t('message.intake-form-enabled-help')}
+                </Typography>
+              </Box>
+
+              <Divider />
+
+              <Box className="tw:gap-3" direction="col">
+                <Box className="tw:gap-1" direction="col">
+                  <Typography size="text-md" weight="semibold">
+                    {t('label.native-field-plural')}
+                  </Typography>
+                  <Typography className="tw:text-tertiary" size="text-sm">
+                    {t('message.intake-form-native-fields-help')}
+                  </Typography>
+                </Box>
+                {renderFieldTable(
+                  nativeRows,
+                  t('message.no-native-fields'),
+                  false
+                )}
+              </Box>
+
+              <Divider />
+
+              <Box className="tw:gap-3" direction="col">
+                <Box align="center" className="tw:gap-2">
+                  <Typography size="text-md" weight="semibold">
+                    {t('label.custom-property-plural')}
+                  </Typography>
+                  <Badge color="gray" size="sm" type="pill-color">
+                    {customRows.length}
+                  </Badge>
+                </Box>
+                <Typography className="tw:text-tertiary" size="text-sm">
+                  {t('message.intake-form-custom-properties-help')}
+                </Typography>
+                {renderFieldTable(
+                  customRows,
+                  t('message.no-custom-properties-defined'),
+                  loadingProps
+                )}
+              </Box>
+            </div>
+          </SlideoutMenu.Content>
+
+          <SlideoutMenu.Footer>
+            <Box className="tw:justify-end tw:gap-3">
+              <Button
+                color="tertiary"
+                data-testid="intake-form-cancel"
+                size="sm"
+                onClick={onCancel}>
+                {t('label.cancel')}
+              </Button>
+              <Button
+                color="primary"
+                data-testid="intake-form-submit"
+                size="sm"
+                onClick={handleOk}>
+                {initialValue ? t('label.save') : t('label.create')}
+              </Button>
+            </Box>
+          </SlideoutMenu.Footer>
+        </>
+      )}
     </SlideoutMenu>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.test.ts
@@ -17,12 +17,26 @@ import {
   ENTITY_REFERENCE_OPTIONS,
   SUPPORTED_DATE_TIME_FORMATS_ANTD_FORMAT_MAPPING,
 } from '../constants/CustomProperty.constants';
+import { CustomProperty } from '../generated/entity/type';
 import {
   formatTableCellValue,
   getCustomPropertyDateTimeDefaultFormat,
   getCustomPropertyEntityPathname,
   getCustomPropertyMomentFormat,
+  hasPopulatedTableRows,
+  serializeExtensionValue,
 } from './CustomProperty.utils';
+
+const makeDefinition = (
+  typeName: string,
+  config?: unknown
+): CustomProperty =>
+  ({
+    name: 'cp',
+    description: 'cp',
+    propertyType: { id: 'type-id', type: 'type', name: typeName },
+    ...(config === undefined ? {} : { customPropertyConfig: { config } }),
+  } as unknown as CustomProperty);
 
 describe('CustomProperty.utils', () => {
   it('getCustomPropertyEntityPathname should return entityPath[0] if entityPath is found', () => {
@@ -340,6 +354,149 @@ describe('CustomProperty.utils', () => {
       const result = formatTableCellValue({ value: undefined });
 
       expect(result).toBe('{}');
+    });
+  });
+
+  describe('hasPopulatedTableRows', () => {
+    it('returns true for an object whose rows array has data', () => {
+      expect(
+        hasPopulatedTableRows({
+          columns: ['id', 'value'],
+          rows: [{ id: '1', value: 'a' }],
+        })
+      ).toBe(true);
+    });
+
+    it('returns false when the rows array is empty', () => {
+      expect(
+        hasPopulatedTableRows({ columns: ['id', 'value'], rows: [] })
+      ).toBe(false);
+    });
+
+    it('returns false when every row is blank', () => {
+      expect(
+        hasPopulatedTableRows({ columns: ['id'], rows: [{ id: '' }] })
+      ).toBe(false);
+    });
+
+    it('returns false for a bare array (the incorrect shape that dropped tables)', () => {
+      expect(hasPopulatedTableRows([{ id: '1', value: 'a' }])).toBe(false);
+    });
+
+    it('returns false for null, undefined, or an object without rows', () => {
+      expect(hasPopulatedTableRows(null)).toBe(false);
+      expect(hasPopulatedTableRows(undefined)).toBe(false);
+      expect(hasPopulatedTableRows({ columns: ['id'] })).toBe(false);
+    });
+  });
+
+  describe('serializeExtensionValue - table', () => {
+    const tableDefinition = makeDefinition('table-cp', {
+      columns: ['id', 'value'],
+    });
+
+    it('keeps a populated table value in the {columns, rows} shape', () => {
+      const value = {
+        columns: ['id', 'value'],
+        rows: [{ id: '1', value: 'a' }],
+      };
+
+      expect(serializeExtensionValue(tableDefinition, value)).toEqual(value);
+    });
+
+    it('drops a table value that has no populated rows', () => {
+      expect(
+        serializeExtensionValue(tableDefinition, {
+          columns: ['id', 'value'],
+          rows: [],
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  describe('serializeExtensionValue - entity reference', () => {
+    const reference = {
+      id: 'u1',
+      type: 'user',
+      name: 'alec',
+      displayName: 'Alec Kane',
+    };
+
+    it('unwraps a single reference wrapped in an array (user/team picker shape)', () => {
+      expect(
+        serializeExtensionValue(makeDefinition('entityReference'), [reference])
+      ).toEqual(reference);
+    });
+
+    it('keeps a single reference passed as a plain object', () => {
+      expect(
+        serializeExtensionValue(makeDefinition('entityReference'), reference)
+      ).toEqual(reference);
+    });
+
+    it('serializes a list of references to an array', () => {
+      const references = [reference, { id: 'u2', type: 'user' }];
+
+      expect(
+        serializeExtensionValue(
+          makeDefinition('entityReferenceList'),
+          references
+        )
+      ).toEqual(references);
+    });
+  });
+
+  describe('serializeExtensionValue - scalar and structured types', () => {
+    it('coerces numeric strings to numbers', () => {
+      expect(serializeExtensionValue(makeDefinition('integer'), '5')).toBe(5);
+      expect(serializeExtensionValue(makeDefinition('number'), '6.5')).toBe(6.5);
+      expect(serializeExtensionValue(makeDefinition('timestamp'), '100')).toBe(
+        100
+      );
+    });
+
+    it('wraps a single enum value in an array and keeps multi values', () => {
+      expect(serializeExtensionValue(makeDefinition('enum'), 'High')).toEqual([
+        'High',
+      ]);
+      expect(
+        serializeExtensionValue(makeDefinition('enum'), ['A', 'B'])
+      ).toEqual(['A', 'B']);
+    });
+
+    it('serializes a hyperlink object', () => {
+      const hyperlink = { url: 'https://collate.io', displayText: 'Collate' };
+
+      expect(
+        serializeExtensionValue(makeDefinition('hyperlink-cp'), hyperlink)
+      ).toEqual(hyperlink);
+    });
+
+    it('serializes a time interval to numbers', () => {
+      expect(
+        serializeExtensionValue(makeDefinition('timeInterval'), {
+          start: '1',
+          end: '2',
+        })
+      ).toEqual({ start: 1, end: 2 });
+    });
+
+    it('passes date and string values through unchanged', () => {
+      expect(
+        serializeExtensionValue(makeDefinition('date-cp'), '2026-08-01')
+      ).toBe('2026-08-01');
+      expect(serializeExtensionValue(makeDefinition('string'), 'abc')).toBe(
+        'abc'
+      );
+    });
+
+    it('returns undefined for empty raw values', () => {
+      expect(
+        serializeExtensionValue(makeDefinition('string'), '')
+      ).toBeUndefined();
+      expect(
+        serializeExtensionValue(makeDefinition('string'), undefined)
+      ).toBeUndefined();
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts
@@ -258,11 +258,11 @@ export const getCustomPropertyPageHeaderFromEntity = (
 };
 
 export const hasPopulatedTableRows = (value: unknown): boolean => {
-  if (!Array.isArray(value)) {
+  if (!isRecord(value) || !Array.isArray(value.rows)) {
     return false;
   }
 
-  return value.some(
+  return value.rows.some(
     (row) =>
       isRecord(row) && Object.values(row).some((v) => !isEmptyExtensionValue(v))
   );
@@ -302,10 +302,14 @@ export const serializeExtensionValue = (
 
       break;
     }
-    case 'entityReference':
-      serializedValue = unwrapEntityReference(raw);
+    case 'entityReference': {
+      // The user/team picker (MUIUserTeamSelect) always emits an array, even
+      // for a single reference, so unwrap the first element before serializing.
+      const singleRef = Array.isArray(raw) ? raw[0] : raw;
+      serializedValue = unwrapEntityReference(singleRef);
 
       break;
+    }
     case 'entityReferenceList': {
       const references = (Array.isArray(raw) ? raw : [raw])
         .map(unwrapEntityReference)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

The issue was introduced because of an incorrect cherry-pick during merge conflict resolution.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Bug Fixes:**
    - Fixed table and entity reference extension property value updates by properly unwrapping array-wrapped entity references and validating table row shapes in `CustomProperty.utils.ts`.
    - Removed injected `id` key from table editor and updated row filtering logic to prevent clobbering user-defined columns.
    - Updated `IntakeFormDesignerModal` layout structure and styling for improved stability.
- **Tests:**
    - Added comprehensive unit tests in `CustomProperty.utils.test.ts` covering table and entity reference serialization as well as row validation logic.
    - Added playwright end-to-end tests for intake form custom property fields in `IntakeFormCustomPropertyFields.spec.ts`.

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes serialization of table and single entity-reference custom properties in domain intake forms while preserving user-defined `id` columns.
- Adds an optional grid row-ID key and disables synthetic IDs for the domain custom-property table editor.
- Corrects populated-table detection and unwraps array-shaped single entity references.
- Improves required-field presentation, intake-form modal layout, and end-to-end/unit coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported synthetic row-ID leak is fixed on the affected domain intake-form path.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx | Removes synthetic table row IDs, preserves configured `id` values, filters blank rows during form serialization, and improves required-field rendering. |
| openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts | Adds configurable row-ID generation while retaining the existing default for other grid consumers. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.ts | Corrects table-shape validation and single entity-reference serialization. |
| openmetadata-ui/src/main/resources/ui/src/utils/CustomProperty.utils.test.ts | Adds focused coverage for table, entity-reference, scalar, and structured custom-property serialization. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/IntakeFormCustomPropertyFields.spec.ts | Adds end-to-end coverage for required custom properties and their submitted extension payload. |
| openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormDesignerModal.tsx | Constricts the slideout layout and makes its content independently scrollable without introducing a blocking failure. |

</details>

<sub>Reviews (2): Last reviewed commit: ["nit"](https://github.com/open-metadata/openmetadata/commit/89dbacebbdaaf4bfd2dda153f246e61dd85b07d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49284266)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
- Knowledge Base — [IntakeForm: Configurable Required Fields for Governance Entities](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/intake-form-governance.md)

<!-- /greptile_comment -->