### PR TITLE
fix(intake-forms): render all formFields in the 1.13 list page (unblocks 44 AUT cases)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
@@ -43,6 +43,7 @@ import {
   listIntakeForms,
   patchIntakeForm,
 } from '../../rest/intakeFormsAPI';
+import { getIntakeFormFields } from '../../utils/IntakeFormUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import IntakeFormDesignerModal from './IntakeFormDesignerModal';
 
@@ -75,7 +76,7 @@ const IntakeFormsPage = () => {
     setLoading(true);
     try {
       const response = await listIntakeForms({
-        fields: 'owners,requiredFields',
+        fields: 'owners,formFields,requiredFields',
       });
       setForms(response.data ?? []);
     } catch (err) {
@@ -183,7 +184,7 @@ const IntakeFormsPage = () => {
 
   const columns = [
     { id: 'entityType', name: t('label.entity-type') },
-    { id: 'requiredFields', name: t('label.required-fields') },
+    { id: 'formFields', name: t('label.field-plural') },
     { id: 'enabled', name: t('label.enabled') },
     { id: 'actions', name: t('label.action-plural') },
   ];
@@ -271,27 +272,35 @@ const IntakeFormsPage = () => {
               </Table.Cell>
               <Table.Cell>
                 <Box className="tw:gap-1" direction="col">
-                  {(record.requiredFields ?? []).length === 0 ? (
+                  {getIntakeFormFields(record).length === 0 ? (
                     <Typography className="tw:text-tertiary" size="text-sm">
                       {t('label.none')}
                     </Typography>
                   ) : (
-                    (record.requiredFields ?? []).map((rf) => (
+                    getIntakeFormFields(record).map((field) => (
                       <Badge
                         color={
-                          rf.fieldKind === FieldKind.CustomProperty
+                          field.fieldKind === FieldKind.CustomProperty
                             ? 'gray'
                             : 'brand'
                         }
-                        key={rf.fieldPath}
+                        key={field.fieldPath}
                         size="sm"
                         type="pill-color">
-                        {rf.fieldLabel}
+                        {field.fieldLabel}
                         <Typography
                           as="span"
                           className="tw:ml-1 tw:text-tertiary"
                           size="text-xs">
-                          ({rf.fieldPath})
+                          ({field.fieldPath})
+                        </Typography>
+                        <Typography
+                          as="span"
+                          className="tw:ml-1 tw:text-tertiary"
+                          size="text-xs">
+                          {field.required
+                            ? t('label.required')
+                            : t('label.optional')}
                         </Typography>
                       </Badge>
                     ))


### PR DESCRIPTION
### Describe your changes:

`IntakeForm.spec.ts` fails deterministically on **both** 1.13 AUT runs (MySQL and PostgreSQL), 3/3 attempts:

```
expect(locator).toBeVisible() failed
Locator: getByText('extension.pwAudienceString8f4da1c6')
Error: element(s) not found  (15000ms)
  at IntakeForm.spec.ts:389  -- test.step('New row renders in the list')
```

The suite is `describe.serial`, so one assertion takes out the whole file: **1 failed + 21 skipped per database — 44 cases across the two 1.13 runs.** It is the single largest source of non-executed tests in the current AUT reports.

#### Root cause

The 1.13 list page requests only `owners,requiredFields` and iterates `record.requiredFields`, which is the deprecated *required-only* compatibility view. The test creates a form with **three** `formFields` (one required) and asserts all three render as `extension.<propertyName>`. Only the required one is rendered, so the loop fails on the second.

The backend confirms only one field can ever appear there — `IntakeFormUtil.toRequiredFields()`:

```java
return listOrEmpty(formFields).stream()
    .filter(field -> Boolean.TRUE.equals(field.getRequired()))
```

And the test's own preceding assertions — `expect(body.formFields).toHaveLength(3)` and `expect(body.requiredFields).toHaveLength(1)` — **pass**. So the API is correct and the defect is confined to the list page.

#### Why this is missing on 1.13 specifically

The hunk was in the original 1.13 port `b387b7f83b`, was lost when that commit was reverted by `320c061881`, and is absent from **both** follow-ups that re-landed the work — #30724 (backend) and #30726 (UI). It fell through the split.

```
$ git log 320c061881..origin/1.13 -- .../IntakeForms/IntakeFormsPage.tsx
(no output — never restored)
```

It was also written as #30782 and closed unmerged. This is the third attempt; 2.0 and `main` have had the fix since #30614.

#### Fix

- Request `formFields` alongside `requiredFields` so the preferred view is available.
- Render through the existing `getIntakeFormFields(record)` helper, which prefers `formFields` and falls back to the deprecated `requiredFields` — so pre-migration rows still render.
- Rename the column from `label.required-fields` to `label.field-plural`, since all included fields are now shown.

Both prerequisites already exist on 1.13 — `getIntakeFormFields` in `IntakeFormUtils.ts:25` (landed via #30726) and `"field-plural"` in `en-us.json:880` — so this is self-contained.

**The patched file is now byte-identical to `IntakeFormsPage.tsx` on `main`**, so there is no partial-port drift.

#
### Type of change:

- [x] Bug fix

#
### Tests:

**Not executed against a running 1.13 stack** — I don't have one, so this is not empirically demonstrated end to end. Stating that plainly rather than implying otherwise.

What was checked:
- **The patched file is byte-identical to `IntakeFormsPage.tsx` on `main`** (`diff` clean), so there is no partial-port drift.
- Project ESLint: clean.
- `tsc` before/after on the same config: identical error profile, and this version reports *fewer* errors than the baseline. No new error class is introduced.
- Both prerequisites confirmed present on 1.13: `getIntakeFormFields` (`IntakeFormUtils.ts:25`) and `"field-plural"` (`en-us.json:880`).

The decisive check for a reviewer with a 1.13 stack: run `IntakeForm.spec.ts`. The failure is deterministic (3/3 attempts on both databases), so one green run settles it — the list row should render three `extension.<propertyName>` badges instead of one, and the 21 downstream tests in the serial suite should execute instead of being skipped.

Backward compatibility is covered by the helper's fallback — a form with only the legacy `requiredFields` populated still renders, marked required.

> Note: `Validate PR Metadata` will be red for want of a linked issue. It is not a required status check; link one or apply `skip-pr-checks` if you want it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This fix updates the intake-form list to retrieve and render every form field while retaining compatibility with legacy required-only records.
- Requests `formFields` in addition to owners and deprecated `requiredFields`.
- Uses `getIntakeFormFields` to prefer the current representation and fall back to legacy data.
- Renames the column to “Fields” and labels each field as required or optional.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the expanded field rendering aligned with the backend response and compatibility helper contracts.

The list API supports the requested formFields projection, and the selected helper correctly renders current fields while converting legacy requiredFields entries into required form fields.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx | Correctly expands list rendering to all form fields while preserving the legacy requiredFields fallback. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Page[Intake forms list] -->|Request owners, formFields, requiredFields| API[Intake forms API]
  API --> Record[IntakeForm record]
  Record --> Helper[getIntakeFormFields]
  Helper -->|formFields present| Current[Use all current fields]
  Helper -->|legacy requiredFields only| Legacy[Convert entries to required fields]
  Current --> Badges[Render field badges]
  Legacy --> Badges
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(intake-forms): render all formFields..."](https://github.com/open-metadata/openmetadata/commit/42823a0502be24df476fd9490ea19bb3de024aa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49301311)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)

<!-- /greptile_comment -->
