### PR TITLE
fix(test): declare SUCCESSFUL_RUN_STATUS in the 1.13 SearchIndexApplication spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts
@@ -24,6 +24,8 @@ import { settingClick } from '../../utils/sidebar';
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
+const SUCCESSFUL_RUN_STATUS = /success|completed|activeError/i;
+
 /**
  * Installs the Search Indexing Application from the marketplace.
  * Shared by the "Install application" step and the self-healing guard


### PR DESCRIPTION
### Describe your changes:

`SearchIndexApplication.spec.ts` fails deterministically on **both** 1.13 AUT runs (MySQL and PostgreSQL), 3/3 attempts, in ~12s each:

```
ReferenceError: SUCCESSFUL_RUN_STATUS is not defined
  at verifyLastExecutionRun (SearchIndexApplication.spec.ts:158:31)
```

#### Root cause

A cherry-pick landed the *usages* of a constant without its *declaration*.

- `ed5e68c2a5` (#27971, "Make SearchIndexing distributed-only") declares `const SUCCESSFUL_RUN_STATUS = /success|completed|activeError/i;`. `git branch -r --contains ed5e68c2a5` returns **main and 2.0 only — not 1.13**.
- `214e5c572f` is a cherry-pick of #30577 **onto 1.13** which replaced the inline literal `/success|activeError/g` with the identifier `SUCCESSFUL_RUN_STATUS` at two call sites (lines 141 and 160).

The pick applied cleanly because the surrounding context matched, so nothing flagged that its prerequisite was missing — and it introduced a guaranteed `ReferenceError` on a branch where the symbol does not exist.

#### Fix

Declare the constant with the same value it carries on main and 2.0.

I checked for a second instance of the same problem: `SEARCH_INDEX_APP_NAME` is also declared on main and absent from 1.13, but the 1.13 copy never references it, so this is the only missing symbol.

#### Worth noting

This class of failure is invisible to review and to unit CI, and only a nightly catches it. A `tsc --noEmit` / `no-undef` gate on backport PRs to release branches would have caught this one outright.

#
### Type of change:

- [x] Bug fix

#
### Tests:

**Verified with `tsc`, before and after, same config.**

Unmodified `origin/1.13` copy:

```
playwright/e2e/Pages/SearchIndexApplication.spec.ts(139,36): error TS2304: Cannot find name 'SUCCESSFUL_RUN_STATUS'.
playwright/e2e/Pages/SearchIndexApplication.spec.ts(158,31): error TS2304: Cannot find name 'SUCCESSFUL_RUN_STATUS'.
```

This branch: **no TS2304.**

Line 158 is exactly where the AUT `ReferenceError` fires, so the static check reproduces the runtime failure and the fix clears it.

Worth noting for the backport-gating discussion: the project's ESLint config passes this file **both before and after** — `no-undef` is off for TypeScript, as is conventional. Only `tsc` catches it. Any guard against this class of bad cherry-pick has to be a typecheck, not a lint.

No behaviour change — the regex is identical to the one on main and 2.0.

> Note: `Validate PR Metadata` will be red for want of a linked issue. It is not a required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR restores the missing `SUCCESSFUL_RUN_STATUS` declaration used by the Search Index Application Playwright spec.
- Defines the shared successful-run status matcher.
- Prevents the existing status assertions from throwing a `ReferenceError`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge and restores the failing Playwright spec without changing its intended assertion behavior.

The added declaration supplies the previously undefined identifier, and its matcher accepts the known successful terminal statuses while excluding running and failed statuses.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/SearchIndexApplication.spec.ts | Adds the missing regex constant required by two existing application-run status assertions; no issues identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): declare SUCCESSFUL\_RUN\_STATUS..."](https://github.com/open-metadata/openmetadata/commit/2981e70fdda75264b0721f94d97943b6debe9cae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49301402)</sub>

<!-- /greptile_comment -->
