### PR TITLE
test(playwright): remove four latent wait races from the AUT suite

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Pagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Pagination.spec.ts
@@ -45,17 +45,20 @@ test.describe('Pagination Tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     test.beforeAll(async ({ browser }) => {
       const { apiContext, afterAction } = await createNewPage(browser);
 
-      for (let i = 1; i <= 20; i++) {
+      // Created concurrently: 20 sequential round-trips accumulate enough
+      // latency under load to blow the 60s beforeAll budget on their own.
+      const paginationUsers = Array.from({ length: 20 }, () => {
         const uniqueId = uuid();
-        const user = new UserClass({
+
+        return new UserClass({
           firstName: `pw_pagination_User${uniqueId}`,
           lastName: `LastName${uniqueId}`,
           email: `pw_pagination_user${uniqueId}@example.com`,
           password: 'User@OMD123',
         });
+      });
 
-        await user.create(apiContext);
-      }
+      await Promise.all(paginationUsers.map((user) => user.create(apiContext)));
 
       await afterAction();
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -45,10 +45,10 @@ const startAsyncExport = async (page: Page) => {
   return jobId;
 };
 
-const fetchCompletedExportCsv = async (
+const waitForExportJobCompleted = async (
   apiContext: APIRequestContext,
   jobId: string
-): Promise<string> => {
+): Promise<void> => {
   await expect
     .poll(
       async () => {
@@ -63,6 +63,13 @@ const fetchCompletedExportCsv = async (
       { timeout: 90_000 }
     )
     .toBe('COMPLETED');
+};
+
+const fetchCompletedExportCsv = async (
+  apiContext: APIRequestContext,
+  jobId: string
+): Promise<string> => {
+  await waitForExportJobCompleted(apiContext, jobId);
 
   const resultResponse = await apiContext.get(
     `/api/v1/csvAsyncJobs/${jobId}/result`
@@ -440,11 +447,19 @@ test.describe(
       });
 
       await test.step('Download from the tray serves the job result CSV', async () => {
+        // The Download button only renders once the async job finishes, so waiting
+        // blind on it spent up to 90s of the test budget before the download waits
+        // even started -- the remainder then ran out mid-wait and surfaced as
+        // "Target page, context or browser has been closed". Poll the job over the
+        // API first (the same way fetchCompletedExportCsv does), so a stalled job is
+        // named as such and the UI waits that follow are short.
+        await waitForExportJobCompleted(page.request, jobId);
+
         const downloadButton = page
           .getByRole('button', { name: 'Download' })
           .first();
 
-        await expect(downloadButton).toBeVisible({ timeout: 90_000 });
+        await expect(downloadButton).toBeVisible();
 
         const resultResponsePromise = page.waitForResponse(
           (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -58,6 +58,16 @@ const waitForExportJobCompleted = async (
           status: string;
         }>;
 
+        // An unauthenticated or errored call returns an object, not a list, and
+        // `jobs.find` then fails with a TypeError that says nothing about why.
+        if (!Array.isArray(jobs)) {
+          throw new Error(
+            `csvAsyncJobs returned ${response.status()}: ${JSON.stringify(
+              jobs
+            ).slice(0, 200)}`
+          );
+        }
+
         return jobs.find((job) => job.jobId === jobId)?.status;
       },
       { timeout: 90_000 }
@@ -419,6 +429,7 @@ test.describe(
 
     test('Export queues a background job and downloads from the jobs tray', async ({
       page,
+      browser,
     }) => {
       test.slow();
 
@@ -453,7 +464,13 @@ test.describe(
         // "Target page, context or browser has been closed". Poll the job over the
         // API first (the same way fetchCompletedExportCsv does), so a stalled job is
         // named as such and the UI waits that follow are short.
-        await waitForExportJobCompleted(page.request, jobId);
+        //
+        // performAdminLogin, not page.request: the latter carries the page's cookies
+        // but not the bearer token these endpoints need, so it returns an error object
+        // rather than the job array.
+        const { apiContext, afterAction } = await performAdminLogin(browser);
+        await waitForExportJobCompleted(apiContext, jobId);
+        await afterAction();
 
         const downloadButton = page
           .getByRole('button', { name: 'Download' })

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
@@ -43,14 +43,14 @@ const waitForTourBadgeWithRetry = async (
   }
 };
 
-const expectTourBadge = async (page: Page, step: string, timeout = 10000) => {
-  const badge = page.locator('[data-tour-elem="badge"]');
-  await badge.waitFor({ state: 'visible', timeout });
-  await expect
-    .poll(async () => (await badge.textContent())?.trim(), {
-      timeout,
-    })
-    .toBe(step);
+const expectTourBadge = async (page: Page, step: string, timeout = 30000) => {
+  // A single web-first assertion. The badge re-renders on every step transition,
+  // so a separate visibility wait followed by a text poll gave the transition two
+  // independent budgets to lose against; toHaveText auto-waits for the element to
+  // attach *and* carry the expected step, and reports the actual step on failure.
+  await expect(page.locator('[data-tour-elem="badge"]')).toHaveText(step, {
+    timeout,
+  });
 };
 
 const validateTourSteps = async (page: Page) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -336,11 +336,10 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
           const created = await Promise.allSettled(
             newUsers.map((user) => user.create(apiContext))
           );
-          created.forEach((result, index) => {
-            if (result.status === 'fulfilled') {
-              users.push(newUsers[index]);
-            }
-          });
+          // create() persists the user via /users/signup and only then assigns
+          // roles, so a rejection can still leave a real user behind. Register
+          // by "did it get an id", not by "did the promise settle happily".
+          users.push(...newUsers.filter((user) => user.responseData?.id));
           const failed = created.find((result) => result.status === 'rejected');
           if (failed) {
             throw failed.reason;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -327,16 +327,31 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         );
 
         if (key === 'entity_table') {
-          for (let i = 0; i < 5; i++) {
-            const user = new UserClass();
-            await user.create(apiContext);
-            users.push(user);
+          // Created concurrently: sequential round-trips in this hook
+          // accumulate enough latency under load to exhaust its 60s budget.
+          // allSettled rather than all, so a partial failure still registers
+          // whatever was created for teardown before the hook fails — the
+          // rejection is rethrown, never swallowed.
+          const newUsers = Array.from({ length: 5 }, () => new UserClass());
+          const created = await Promise.allSettled(
+            newUsers.map((user) => user.create(apiContext))
+          );
+          created.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+              users.push(newUsers[index]);
+            }
+          });
+          const failed = created.find((result) => result.status === 'rejected');
+          if (failed) {
+            throw failed.reason;
           }
         } else if (key === 'entity_dashboard') {
           dashboardTopic1 = new TopicClass();
           dashboardTopic2 = new TopicClass();
-          await dashboardTopic1.create(apiContext);
-          await dashboardTopic2.create(apiContext);
+          await Promise.all([
+            dashboardTopic1.create(apiContext),
+            dashboardTopic2.create(apiContext),
+          ]);
           await setupCustomPropertyAdvancedSearchTest(
             page,
             cpasTestData,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -868,18 +868,40 @@ export const verifyExportLineagePNG = async (
 
   await expect(page.getByTestId('export-type-select')).toContainText('PNG');
 
-  const [download] = await Promise.all([
-    // Platform lineage renders up to 500 nodes at pixelRatio:3 — give the PNG
-    // render enough headroom before the download event fires.
-    page.waitForEvent('download', { timeout: 120_000 }),
-    page.click(
-      '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
-    ),
-  ]);
+  // If the client-side render throws, no download event ever fires and the wait
+  // below expires with nothing to say. Capture page errors so a silent exception
+  // is reported as the cause instead of an anonymous 120s timeout; a genuinely
+  // slow render still surfaces the original timeout untouched.
+  const pageErrors: string[] = [];
+  const collectPageError = (error: Error) => pageErrors.push(error.message);
+  page.on('pageerror', collectPageError);
 
-  const filePath = await download.path();
+  try {
+    const [download] = await Promise.all([
+      // Platform lineage renders up to 500 nodes at pixelRatio:3 — give the PNG
+      // render enough headroom before the download event fires.
+      page.waitForEvent('download', { timeout: 120_000 }),
+      page.click(
+        '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
+      ),
+    ]);
 
-  expect(filePath).not.toBeNull();
+    const filePath = await download.path();
+
+    expect(filePath).not.toBeNull();
+  } catch (error) {
+    if (pageErrors.length > 0) {
+      throw new Error(
+        `PNG export produced no download because the page threw:\n  ${pageErrors.join(
+          '\n  '
+        )}`
+      );
+    }
+
+    throw error;
+  } finally {
+    page.off('pageerror', collectPageError);
+  }
 };
 
 export const verifyColumnLineageInCSV = async (

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -873,7 +873,8 @@ export const verifyExportLineagePNG = async (
   // is reported as the cause instead of an anonymous 120s timeout; a genuinely
   // slow render still surfaces the original timeout untouched.
   const pageErrors: string[] = [];
-  const collectPageError = (error: Error) => pageErrors.push(error.message);
+  const collectPageError = (error: Error) =>
+    pageErrors.push(error.stack ?? error.message);
   page.on('pageerror', collectPageError);
 
   try {
@@ -890,9 +891,17 @@ export const verifyExportLineagePNG = async (
 
     expect(filePath).not.toBeNull();
   } catch (error) {
-    if (pageErrors.length > 0) {
+    // Only the download wait is ambiguous about its cause. A click or selector
+    // failure already says what went wrong, so a stray page error must never
+    // replace it — and even for a timeout the original message is kept and the
+    // page errors appended, so a slow render still reads as a slow render.
+    const isDownloadTimeout =
+      error instanceof Error &&
+      error.message.includes('waiting for event "download"');
+
+    if (isDownloadTimeout && pageErrors.length > 0) {
       throw new Error(
-        `PNG export produced no download because the page threw:\n  ${pageErrors.join(
+        `${error.message}\n\nThe page also threw during the export, which may be the real cause:\n  ${pageErrors.join(
           '\n  '
         )}`
       );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -901,7 +901,9 @@ export const verifyExportLineagePNG = async (
 
     if (isDownloadTimeout && pageErrors.length > 0) {
       throw new Error(
-        `${error.message}\n\nThe page also threw during the export, which may be the real cause:\n  ${pageErrors.join(
+        `${
+          error.message
+        }\n\nThe page also threw during the export, which may be the real cause:\n  ${pageErrors.join(
           '\n  '
         )}`
       );


### PR DESCRIPTION
### Describe your changes:

Four independent AUT failures, all Playwright-side, all present on `main`. Combined into one PR — same reviewers, same category, one merge-queue pass.

---

#### 1 · SearchExport — job polling instead of a blind UI wait *(1 failure on main, flaky on 2.0)*

```
Test timeout of 180000ms exceeded.
Error: page.waitForResponse: Target page, context or browser has been closed
  at SearchExport.spec.ts:449
```

The reported error is teardown, not the cause. The step waited up to **90s on the Download button** — which only renders once the async CSV job finishes — before the download waits even started; the remainder of the budget then ran out mid-wait.

The test is **already `test.slow()`**, which is why the budget is 180s and not 60s, so raising it again is not the answer. Instead, poll the job over the API first — exactly what `fetchCompletedExportCsv` in the same file already does. `waitForExportJobCompleted` is extracted from that helper and reused, so there's no new polling logic.

A stalled job now fails as a stalled job, and the UI waits that follow are short.

#### 2 · PlatformLineage — say *why* the PNG export produced nothing *(1 failure on main, flaky on 2.0 and 1.13)*

```
TimeoutError: page.waitForEvent: Timeout 120000ms exceeded while waiting for event "download"
```

Two causes are indistinguishable here: the canvas render at pixelRatio 3 × 500 nodes genuinely exceeding two minutes, or the render throwing so no event ever fires. The current failure can't tell you which.

Capture `pageerror` around the wait and report a silent client-side exception as the cause. A genuinely slow render still surfaces the original timeout, untouched. **This is diagnosis, not a workaround** — if it turns out to be an exception, that's a product bug and this is how we'll find out.

#### 3 · Serial fixture creation in 60s `beforeAll` hooks

`Pagination.spec.ts` creates 20 users one at a time; `CustomProperties.spec.ts` creates 5 the same way. Both hooks time out on the 1.13/MySQL AUT run, and **the identical serial code is on `main`** — it simply hasn't lost the race here yet.

Created concurrently instead. `CustomProperties` uses `allSettled` so a partial failure still registers whatever was created for teardown before rethrowing — the hook still fails on a genuine error, nothing is swallowed.

#### 4 · Tour badge — one budget, not two

`expectTourBadge` did a visibility `waitFor` **and** a separate text poll, each capped at 10s, against a badge that re-renders on every step transition. The failing call is mid-tour, after `waitForTourBadgeWithRetry` has already found the badge once. Replaced with a single `toHaveText`, which waits for attachment and the expected step together and names the actual step on failure.

---

### Why 3 and 4 are here as well as on #30787

They're already fixed on 1.13. They belong on `main` too: **release branches are cut from `main`**, so a fix that lands only on 1.13 comes back at the next cut. #30787 does not include the `SUCCESSFUL_RUN_STATUS` fix from that PR — that constant already exists here, and was genuinely 1.13-only.

#
### Type of change:

- [x] Bug fix

#
### Tests:

**Executed against a live `2.0.0-SNAPSHOT` stack** (revision `eedd68bb`), project `Basic`, via `playwright test`:

| Test | Result |
|---|---|
| `Tour should work from help section` — the exact test that fails in the AUT | **passed** (3.2m, re-confirmed at 59.4s after the review fixes) |
| `should test pagination on Users page` — exercises the concurrent 20-user `beforeAll` | **passed** (36.9s) |

Before/after on the fixture change, same command, same stack:

| | Total |
|---|---|
| baseline (serial 20 creates) | **45.7s** |
| this branch (concurrent) | **36.9s** |

~9s on a fast local server, where a round-trip is cheap. The gap widens under AUT load — which is where the 60s hook budget is actually being exceeded.

- **`tsc` clean** on all five changed files.
- **ESLint could not be run here** (flat-config plugin resolution across a linked `node_modules`), so lint is CI's first check — flagging that rather than implying it passed.
- **SearchExport and PlatformLineage were not run** — the first needs `sample_data` present, the second needs a populated platform lineage graph. Those two remain reasoned from the retained traces.

### Follow-up worth its own issue

`Pagination.spec.ts` contains **21 serial fixture loops of this exact shape** (`for (let i = 1; i <= N; i++) { await …create() }`), on all three branches. This PR fixes the one that has actually been failing. The other 20 are the same latent bomb and will surface one at a time on slow nights. Worth a dedicated sweep rather than smuggling a 21-hunk mechanical diff into a bug-fix PR.

> Note: `Validate PR Metadata` will be red for want of a linked issue. It is not a required status check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR makes Playwright AUT tests less susceptible to latent timing races and improves PNG-export failure diagnostics.
- Creates pagination and custom-property fixtures concurrently to reduce setup duration.
- Polls asynchronous CSV export completion before interacting with the jobs tray.
- Replaces separate tour-badge waits with one web-first text assertion.
- Captures page exceptions while waiting for lineage PNG downloads.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Pagination.spec.ts | Replaces serial creation of 20 uniquely named pagination users with concurrent creation. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts | Extracts asynchronous export-job polling and uses it before waiting for the tray download controls. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts | Consolidates badge attachment and text synchronization into a single Playwright assertion. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts | Concurrently creates fixtures while retaining successfully persisted users for teardown after partial failures. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts | Collects client-side page errors during PNG export and appends them to ambiguous download-timeout diagnostics. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(test): poll csvAsyncJobs with an aut..."](https://github.com/open-metadata/openmetadata/commit/4af8a216178ab2e14da6754b7e2d22c4f2a79dce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49304352)</sub>

<!-- /greptile_comment -->