### PR TITLE
test(playwright): seed IncidentManager pagination incidents instead of running a pipeline

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -168,6 +168,7 @@
       "specs": [
         "playwright/e2e/Features/DataQuality/**/*.spec.ts",
         "playwright/e2e/Features/IncidentManager.spec.ts",
+        "playwright/e2e/Features/IncidentManagerPagination.spec.ts",
         "playwright/e2e/Flow/ObservabilityAlerts.spec.ts",
         "playwright/e2e/Flow/NotificationAlerts.spec.ts",
         "playwright/e2e/Pages/TestSuite*.spec.ts"

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -779,9 +779,11 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
    * to re-evaluate incident state.
    */
   test('Resolving incident & re-run pipeline', async ({ page }) => {
-    // Re-run waits on a pipeline; the default 60s test timeout is below its
-    // poll, so bump to test.slow() (180s) and cap the poll under that.
-    test.slow();
+    // This test does UI steps and then waits on a pipeline re-run. The wait can
+    // consume the helper's appearance window (up to 60s) plus the success poll
+    // (successTimeout below), so the budget must exceed those combined plus the
+    // UI steps — test.slow() (180s) is not enough.
+    test.setTimeout(5 * 60 * 1000);
     const testCase = table1.testCasesResponseData[1];
     const testCaseName = testCase?.['name'];
     const pipeline = table1.testSuitePipelineResponseData[0];
@@ -903,9 +905,11 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
    * @description Acknowledges and assigns an open incident, reruns pipeline, and validates status reflects Assigned.
    */
   test('Rerunning pipeline for an open incident', async ({ page }) => {
-    // Re-run waits on a pipeline; the default 60s test timeout is below its
-    // poll, so bump to test.slow() (180s) and cap the poll under that.
-    test.slow();
+    // This test does UI steps and then waits on a pipeline re-run. The wait can
+    // consume the helper's appearance window (up to 60s) plus the success poll
+    // (successTimeout below), so the budget must exceed those combined plus the
+    // UI steps — test.slow() (180s) is not enough.
+    test.setTimeout(5 * 60 * 1000);
     const testCase = table1.testCasesResponseData[2];
     const testCaseName = testCase?.['name'];
     const pipeline = table1.testSuitePipelineResponseData[0];

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -42,8 +42,6 @@ let user2: UserClass;
 let user3: UserClass;
 let users: UserClass[] = [];
 let table1: TableClass;
-let tablePagination: TableClass;
-const PAGINATION_INCIDENT_COUNT = 22;
 
 const performIncidentAdminLogin = async (browser: Browser) => {
   try {
@@ -452,7 +450,6 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     user3 = new UserClass();
     users = [user1, user2, user3];
     table1 = new TableClass();
-    tablePagination = new TableClass();
 
     if (!process.env.PLAYWRIGHT_IS_OSS) {
       // Todo: Remove this patch once the issue is fixed #19140
@@ -782,6 +779,9 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
    * to re-evaluate incident state.
    */
   test('Resolving incident & re-run pipeline', async ({ page }) => {
+    // Re-run waits on a pipeline; the default 60s test timeout is below its
+    // poll, so bump to test.slow() (180s) and cap the poll under that.
+    test.slow();
     const testCase = table1.testCasesResponseData[1];
     const testCaseName = testCase?.['name'];
     const pipeline = table1.testSuitePipelineResponseData[0];
@@ -870,6 +870,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
         page,
         pipeline,
         apiContext,
+        // Warm re-run completes fast; keep the poll under the 180s test budget.
+        successTimeout: 150_000,
       });
     });
 
@@ -901,6 +903,9 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
    * @description Acknowledges and assigns an open incident, reruns pipeline, and validates status reflects Assigned.
    */
   test('Rerunning pipeline for an open incident', async ({ page }) => {
+    // Re-run waits on a pipeline; the default 60s test timeout is below its
+    // poll, so bump to test.slow() (180s) and cap the poll under that.
+    test.slow();
     const testCase = table1.testCasesResponseData[2];
     const testCaseName = testCase?.['name'];
     const pipeline = table1.testSuitePipelineResponseData[0];
@@ -951,6 +956,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
         page,
         pipeline,
         apiContext,
+        // Warm re-run completes fast; keep the poll under the 180s test budget.
+        successTimeout: 150_000,
       });
     });
 
@@ -1134,119 +1141,5 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
         page.locator(`[data-testid="test-case-${testCase?.['name']}"]`)
       ).toBeVisible();
     }
-  });
-
-  /**
-   * Incident Manager pagination
-   * @description Uses a dedicated table with 20+ test cases to ensure multiple pages of incidents.
-   * Verifies Next/Previous and page indicator when pagination is shown.
-   */
-  test.describe('Incident Manager pagination', () => {
-    test.beforeAll(async ({ browser }) => {
-      test.slow();
-      const { afterAction, apiContext, page } = await performAdminLogin(
-        browser,
-        { navigate: true }
-      );
-
-      if (!process.env.PLAYWRIGHT_IS_OSS) {
-        await resetTokenFromBotPage(page, 'testsuite-bot');
-      }
-
-      for (let i = 0; i < PAGINATION_INCIDENT_COUNT; i++) {
-        await tablePagination.createTestCase(apiContext, {
-          parameterValues: [
-            { name: 'minColValue', value: 12 },
-            { name: 'maxColValue', value: 24 },
-          ],
-          testDefinition: 'tableColumnCountToBeBetween',
-        });
-      }
-
-      const pipeline = await tablePagination.createTestSuitePipeline(
-        apiContext
-      );
-
-      await makeRetryRequest({
-        page,
-        fn: () =>
-          apiContext.post(
-            `/api/v1/services/ingestionPipelines/deploy/${pipeline.id}`
-          ),
-      });
-
-      await triggerTestSuitePipelineAndWaitForSuccess({
-        page,
-        pipeline,
-        apiContext,
-      });
-
-      await afterAction();
-    });
-
-    test('Next, Previous and page indicator', async ({ page }) => {
-      test.slow();
-      const listUrl =
-        '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
-
-      const initialListRes = page.waitForResponse((res) =>
-        res.url().includes(listUrl)
-      );
-      await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
-      await initialListRes;
-
-      await expect(
-        page.getByTestId('test-case-incident-manager-table')
-      ).toBeVisible();
-      await expect(page.getByTestId('pagination')).toBeVisible();
-      await expect(page.getByTestId('page-indicator')).toContainText('1');
-
-      const nextListRes = page.waitForResponse(
-        (res) => res.url().includes(listUrl) && res.url().includes('offset=15')
-      );
-      await page.getByTestId('next').click();
-      await nextListRes;
-
-      await expect(page.getByTestId('page-indicator')).toContainText('2');
-
-      const prevListRes = page.waitForResponse(
-        (res) => res.url().includes(listUrl) && res.url().includes('offset=0')
-      );
-      await page.getByTestId('previous').click();
-      await prevListRes;
-
-      await expect(page.getByTestId('page-indicator')).toContainText('1');
-    });
-
-    test('Page size dropdown updates list limit and resets to page 1', async ({
-      page,
-    }) => {
-      test.slow();
-      const listUrl =
-        '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
-
-      const initialListRes = page.waitForResponse((res) =>
-        res.url().includes(listUrl)
-      );
-      await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
-      await initialListRes;
-
-      await expect(page.getByTestId('pagination')).toBeVisible();
-      await expect(
-        page.getByTestId('page-size-selection-dropdown')
-      ).toBeVisible();
-
-      await page.getByTestId('page-size-selection-dropdown').click();
-      const listWithLimit50 = page.waitForResponse(
-        (res) => res.url().includes(listUrl) && res.url().includes('limit=50')
-      );
-      await page.getByRole('menuitem', { name: /50.*page/i }).click();
-      await listWithLimit50;
-
-      await expect(page.getByTestId('page-indicator')).toContainText('1');
-      await expect(
-        page.getByTestId('page-size-selection-dropdown')
-      ).toContainText('50');
-    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManagerPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManagerPagination.spec.ts
@@ -34,8 +34,10 @@ test.describe('Incident Manager pagination', () => {
   test.beforeAll(async ({ browser }) => {
     // Seed incidents directly via the API — these tests only need many incidents
     // to exist, not a real ingestion pipeline run. This keeps setup fast and
-    // deterministic and off the Airflow-dependent path.
-    test.slow();
+    // deterministic and off the Airflow-dependent path. `test.slow()` does not
+    // extend a hook's timeout, so set an explicit budget for creating 22 test
+    // cases + results and waiting for them to be indexed.
+    test.setTimeout(3 * 60 * 1000);
     const { apiContext, afterAction } = await performAdminLogin(browser);
     await seedFailedIncidents({
       apiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManagerPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManagerPagination.spec.ts
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect } from '@playwright/test';
+import { SidebarItem } from '../../constant/sidebar';
+import { TableClass } from '../../support/entity/TableClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
+import { seedFailedIncidents } from '../../utils/incidentManager';
+import { sidebarClick } from '../../utils/sidebar';
+import { test } from '../fixtures/pages';
+
+// 22 incidents guarantees more than one page at the default page size of 15 —
+// the minimum needed to exercise Next/Previous and the page indicator.
+const PAGINATION_INCIDENT_COUNT = 22;
+
+const table = new TableClass();
+
+const listUrl =
+  '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list';
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Incident Manager pagination', () => {
+  test.beforeAll(async ({ browser }) => {
+    // Seed incidents directly via the API — these tests only need many incidents
+    // to exist, not a real ingestion pipeline run. This keeps setup fast and
+    // deterministic and off the Airflow-dependent path.
+    test.slow();
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await seedFailedIncidents({
+      apiContext,
+      table,
+      count: PAGINATION_INCIDENT_COUNT,
+    });
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    await table.delete(apiContext);
+    await afterAction();
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await redirectToHomePage(page);
+  });
+
+  test('Next, Previous and page indicator', async ({ page }) => {
+    const initialListRes = page.waitForResponse((res) =>
+      res.url().includes(listUrl)
+    );
+    await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+    await initialListRes;
+
+    await expect(
+      page.getByTestId('test-case-incident-manager-table')
+    ).toBeVisible();
+    await expect(page.getByTestId('pagination')).toBeVisible();
+    await expect(page.getByTestId('page-indicator')).toContainText('1');
+
+    const nextListRes = page.waitForResponse(
+      (res) => res.url().includes(listUrl) && res.url().includes('offset=15')
+    );
+    await page.getByTestId('next').click();
+    await nextListRes;
+
+    await expect(page.getByTestId('page-indicator')).toContainText('2');
+
+    const prevListRes = page.waitForResponse(
+      (res) => res.url().includes(listUrl) && res.url().includes('offset=0')
+    );
+    await page.getByTestId('previous').click();
+    await prevListRes;
+
+    await expect(page.getByTestId('page-indicator')).toContainText('1');
+  });
+
+  test('Page size dropdown updates list limit and resets to page 1', async ({
+    page,
+  }) => {
+    const initialListRes = page.waitForResponse((res) =>
+      res.url().includes(listUrl)
+    );
+    await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
+    await initialListRes;
+
+    await expect(page.getByTestId('pagination')).toBeVisible();
+    await expect(
+      page.getByTestId('page-size-selection-dropdown')
+    ).toBeVisible();
+
+    await page.getByTestId('page-size-selection-dropdown').click();
+    const listWithLimit50 = page.waitForResponse(
+      (res) => res.url().includes(listUrl) && res.url().includes('limit=50')
+    );
+    await page.getByRole('menuitem', { name: /50.*page/i }).click();
+    await listWithLimit50;
+
+    await expect(page.getByTestId('page-indicator')).toContainText('1');
+    await expect(
+      page.getByTestId('page-size-selection-dropdown')
+    ).toContainText('50');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -19,7 +19,6 @@ import { getEncodedFqn } from '../../src/utils/StringUtils';
 import { SidebarItem } from '../constant/sidebar';
 import { ResponseDataType } from '../support/entity/Entity.interface';
 import { TableClass } from '../support/entity/TableClass';
-import { waitForIncidentToBeIndexed } from './dataQuality';
 import { getCurrentMillis } from './dateTime';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
@@ -59,14 +58,40 @@ export const seedFailedIncidents = async (data: {
     testCases.push(testCase);
   }
 
-  // Confirm the last incident is indexed so UI assertions don't race the write.
-  if (testCases.length > 0) {
-    await waitForIncidentToBeIndexed(
-      apiContext,
-      testCases[testCases.length - 1]['fullyQualifiedName'],
-      failTimestamp
-    );
-  }
+  // Wait until ALL seeded incidents are indexed, not just the last — Elasticsearch
+  // indexing is not ordered, so an earlier incident can still be missing when the
+  // last one is searchable, which would under-fill the list and defeat the point.
+  const seededFqns = new Set(
+    testCases.map((testCase) => testCase['fullyQualifiedName'])
+  );
+  await expect
+    .poll(
+      async () => {
+        const response = await apiContext.get(
+          `/api/v1/dataQuality/testCases/testCaseIncidentStatus?latest=true` +
+            `&startTs=${failTimestamp - 60_000}` +
+            `&endTs=${failTimestamp + 120_000}` +
+            `&limit=${count + 50}`
+        );
+
+        if (!response.ok()) {
+          return 0;
+        }
+
+        const body = await response.json();
+        const indexedFqns = new Set(
+          (body.data ?? []).map(
+            (incident: {
+              testCaseReference?: { fullyQualifiedName?: string };
+            }) => incident.testCaseReference?.fullyQualifiedName
+          )
+        );
+
+        return [...seededFqns].filter((fqn) => indexedFqns.has(fqn)).length;
+      },
+      { timeout: 90_000, intervals: [2_000, 3_000, 5_000] }
+    )
+    .toBeGreaterThanOrEqual(count);
 
   return testCases;
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -19,9 +19,57 @@ import { getEncodedFqn } from '../../src/utils/StringUtils';
 import { SidebarItem } from '../constant/sidebar';
 import { ResponseDataType } from '../support/entity/Entity.interface';
 import { TableClass } from '../support/entity/TableClass';
+import { waitForIncidentToBeIndexed } from './dataQuality';
+import { getCurrentMillis } from './dateTime';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 import { waitForTaskResolveResponse } from './task';
+
+/**
+ * Seeds `count` failing test cases on `table`, each of which produces an
+ * incident, WITHOUT deploying or running an ingestion pipeline. A failed test
+ * case result is posted directly via the API, which is what actually creates an
+ * incident — the pipeline is only one way to produce that result.
+ *
+ * Use this for tests that just need incidents to exist (UI, pagination,
+ * filters). It is deterministic and takes seconds, so those tests no longer
+ * depend on Airflow or queue behaviour. Tests that verify pipeline behaviour
+ * (e.g. re-running a pipeline resolves an incident) must still use a real
+ * pipeline via triggerTestSuitePipelineAndWaitForSuccess.
+ *
+ * Returns the created test cases (in creation order).
+ */
+export const seedFailedIncidents = async (data: {
+  apiContext: APIRequestContext;
+  table: TableClass;
+  count: number;
+}): Promise<ResponseDataType[]> => {
+  const { apiContext, table, count } = data;
+  const failTimestamp = getCurrentMillis();
+  const testCases: ResponseDataType[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const testCase = await table.createTestCase(apiContext);
+    await table.addTestCaseResult(apiContext, testCase['fullyQualifiedName'], {
+      result: 'Seeded failing result to create an incident.',
+      testResultValue: [{ name: 'seeded', value: '0' }],
+      testCaseStatus: 'Failed',
+      timestamp: failTimestamp,
+    });
+    testCases.push(testCase);
+  }
+
+  // Confirm the last incident is indexed so UI assertions don't race the write.
+  if (testCases.length > 0) {
+    await waitForIncidentToBeIndexed(
+      apiContext,
+      testCases[testCases.length - 1]['fullyQualifiedName'],
+      failTimestamp
+    );
+  }
+
+  return testCases;
+};
 
 export const visitProfilerTab = async (page: Page, table: TableClass) => {
   await page.goto(
@@ -254,12 +302,24 @@ const NEW_RUN_APPEARANCE_TIMEOUT = 60_000;
 const NEW_RUN_POLL_INTERVAL = 2_000;
 const TRIGGER_ATTEMPTS = 3;
 
+// Default budget the poll waits for a triggered run to reach `success`. Heavier
+// suites (many test cases) validate for longer and queue behind other pipelines
+// under load, so callers can raise it. The calling test's own timeout must
+// exceed whatever is used here, or the test dies before the poll can finish.
+const DEFAULT_PIPELINE_SUCCESS_TIMEOUT = 300_000;
+
 export const triggerTestSuitePipelineAndWaitForSuccess = async (data: {
   page: Page;
   apiContext: APIRequestContext;
   pipeline: ResponseDataType;
+  successTimeout?: number;
 }) => {
-  const { page, apiContext, pipeline } = data;
+  const {
+    page,
+    apiContext,
+    pipeline,
+    successTimeout = DEFAULT_PIPELINE_SUCCESS_TIMEOUT,
+  } = data;
   const encodedPipelineFqn = encodeURIComponent(
     pipeline?.['fullyQualifiedName']
   );
@@ -443,7 +503,7 @@ export const triggerTestSuitePipelineAndWaitForSuccess = async (data: {
         } to be successful (run recorded before trigger: ${
           previousRun?.runId ?? 'none'
         })`,
-        timeout: 300_000,
+        timeout: successTimeout,
         intervals: [2_000, 5_000, 10_000],
       }
     )


### PR DESCRIPTION
## Problem
The **Incident Manager pagination** tests (`Next/Previous/page indicator`, `Page size dropdown`) only need many incidents to exist so the list spans multiple pages — they verify paging UI, nothing about ingestion. But their setup deployed and ran a **real 22-test-case ingestion pipeline through Airflow** just to manufacture those incidents.

Under full-suite load that pipeline queues behind other ingestion pipelines and the wait times out — a recurring flaky failure (`Received: "queued"` at the 300s poll). The heavy 22-case run also made this the slowest block in the suite.

## Fix — create incidents directly, no pipeline
- **`seedFailedIncidents(table, count)`** — posts a failed test-case result per test case (which is what actually creates an incident) and waits for it to be indexed. No deploy, no trigger, no Airflow: deterministic and seconds-fast. This is the same `addTestCaseResult(Failed)` pattern ~10 DataQuality specs already use.
- **`IncidentManagerPagination.spec.ts`** (new) — the pagination tests, seeded via the helper, **without `@ingestion`** so they run in the regular chromium lane instead of the Airflow-dependent Ingestion lane.
- **`IncidentManager.spec.ts`** — removed the pagination block and its dead `tablePagination` setup.
- **Re-run tests kept on a real pipeline** (they verify pipeline behaviour) with `test.slow()` and the success poll capped under that budget — the default 60s test timeout was below the 300s poll, itself a latent timeout trap.
- **`impact-map.json`** — routes the new spec.

## Validation
On a live stack the seeded pagination spec passes in **~3s** (was a multi-minute, flaky pipeline):

```
✓ Next, Previous and page indicator                              2.6s
✓ Page size dropdown updates list limit and resets to page 1     3.3s
expected 2, unexpected 0, flaky 0
```

## Scope / follow-up
This is the first slice of splitting IncidentManager by concern. The lifecycle/tab/filters tests can likewise seed incidents and drop `@ingestion` (leaving only the re-run tests on a real pipeline) — a follow-up PR, validated against a real Airflow run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the pagination tests’ Airflow pipeline setup with direct failed-result seeding and moves those tests into a dedicated regular-lane specification.
- Adds a helper that creates failed test-case results and waits for all resulting incidents to be indexed.
- Moves pagination coverage into a dedicated serial Playwright specification and updates impact routing.
- Makes the pipeline success timeout configurable and raises the two rerun tests’ overall timeout.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because valid reruns can still be terminated by the test timeout before the helper exhausts its permitted waits.

Each changed rerun test allows 300 seconds, while the helper can spend up to 180 seconds across three run-appearance attempts and then another 150 seconds polling for success, excluding preceding UI work and request retries.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts; openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts | Removes pagination coverage and raises rerun-test budgets, although the previously reported timeout overflow remains possible. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManagerPagination.spec.ts | Adds dedicated pagination tests backed by directly seeded incidents and explicit setup cleanup. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts | Adds deterministic incident seeding and configurable pipeline-success polling; repeated appearance waits can still outlast the callers’ total timeout. |
| .github/playwright/impact-map.json | Routes relevant data-quality changes to the new pagination specification. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(playwright): address review feedbac..."](https://github.com/open-metadata/openmetadata/commit/ef6db1519f57efa1f91081df9516e29702462e6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49305142)</sub>

<!-- /greptile_comment -->