### PR TITLE
test(playwright): scope the SearchRBAC no-result assertion to its entity category

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts
@@ -134,7 +134,8 @@ for (const entity of searchRBACEntities) {
       await searchForEntityShouldWorkShowNoResult(
         entityObj.entityResponseData?.fullyQualifiedName ?? '',
         entityObj.entityResponseData?.displayName ?? '',
-        userWithoutPermissionPage
+        userWithoutPermissionPage,
+        entity.name
       );
     });
   });
@@ -258,7 +259,8 @@ test.describe(`Table Column`, () => {
     await searchForEntityShouldWorkShowNoResult(
       column.fullyQualifiedName ?? '',
       column.displayName ?? column.name ?? '',
-      userWithoutPermissionPage
+      userWithoutPermissionPage,
+      'Columns'
     );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
@@ -78,7 +78,8 @@ export const searchForEntityShouldWork = async (
 export const searchForEntityShouldWorkShowNoResult = async (
   fqn: string,
   displayName: string,
-  page: Page
+  page: Page,
+  entityName: string
 ) => {
   // Wait for welcome screen and close it if visible
   const isWelcomeScreenVisible = await page
@@ -95,6 +96,13 @@ export const searchForEntityShouldWorkShowNoResult = async (
 
   await page.waitForResponse(`api/v1/search/query?**`);
 
+  await waitForAllLoadersToDisappear(page);
+  // Scope to the entity category before asserting absence, the same way
+  // searchForEntityShouldWork does. Unscoped, the assertion is made against
+  // whatever category Explore happens to be showing, so a match from an
+  // unrelated category leaves the result attached and the "no results"
+  // placeholder unrendered — which is exactly how this fails on 1.13.
+  await page.getByRole('menuitem').filter({ hasText: entityName }).click();
   await waitForAllLoadersToDisappear(page);
 
   await expect(


### PR DESCRIPTION
### Describe your changes:

`Table Column > User without permission` fails **deterministically on both 1.13 AUT runs**, in two different ways that share one cause:

```
MySQL       expect(locator).not.toBeAttached() failed
            locator('[data-testid="entity-header-display-name"]')
              .filter({ hasText: 'user_ida06c5f92' })   — was attached

PostgreSQL  expect(locator).toBeVisible() failed
            getByTestId('no-search-results').getByText('No result found.')
```

#### Root cause

`searchForEntityShouldWorkShowNoResult` searches globally, then asserts absence against **whatever entity category Explore happens to be showing**. A match from an unrelated category leaves a result attached *and* keeps the "no results" placeholder from rendering — so the two failures above are the same defect observed from either side.

Its sibling `searchForEntityShouldWork` already selects the category before asserting presence:

```ts
await page.getByRole('menuitem').filter({ hasText: entityName }).click();
```

The negative-case helper never got the same treatment.

#### Fix

Apply the same scoping to `searchForEntityShouldWorkShowNoResult` and pass the category from both call sites (`entity.name` and `'Columns'`, matching what the positive helper is already given). The absence assertion is then made against the category under test rather than the whole index.

#### This is *not* a port of #30768

Worth stating plainly, since that was the obvious assumption: **#30768's change is already on 1.13.** `searchForEntityShouldWork` here already takes `entityName` and clicks the category, and both call sites already pass it. #30768 only touched the positive-case helper; the negative one was missed on every branch. So there is nothing to backport — this is the missing half.

#
### Type of change:

- [x] Bug fix

#
### Tests:

- **`tsc` clean** — which also confirms both call sites were updated, since the new parameter is required.
- **Prettier clean.**
- **Not run against a live stack.** SearchRBAC needs the two permission-scoped users and RBAC search settings, which I don't have an environment for. This is reasoned from the two failure signatures plus the existing positive-case helper it mirrors.

One thing a reviewer with an environment should sanity-check: that the entity-category menu item renders even when the scoped category has **zero** results for this user. The positive helper only ever clicks it when results exist. If Explore hides empty categories, this needs the click guarded instead — I'd rather that be verified than assumed.

#### Also on this branch

The same unscoped-search shape exists on `main` and `2.0`, where `Table Column > User with permission` flakes. Worth the same fix there once this is confirmed.

> Note: `ui-checkstyle` and `Validate PR Metadata` will be red. `ui-checkstyle` fails for **every** UI PR on 1.13 (see #30781 and #30726, both merged through it) — it is not caused by this change, and neither check is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the negative SearchRBAC helper to select the requested entity category before checking that a permission-restricted entity and the category’s results are absent.

- Adds a required entity-category argument to `searchForEntityShouldWorkShowNoResult`.
- Updates the general entity and table-column test cases to pass their expected categories.
- Mirrors the category-selection behavior already used by the positive-search helper.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the accepted review findings, with no unacknowledged actionable defect remaining.

The helper signature and both repository call sites are consistent, and the only concrete failure mechanism identified is already expressly documented by the author as requiring environment validation.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts | Adds category selection to the negative-search helper; the known empty-category rendering concern is already explicitly called out in the PR description. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/SearchRBAC.spec.ts | Updates both helper call sites with the appropriate entity-category labels. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(playwright): scope the SearchRBAC n..."](https://github.com/open-metadata/openmetadata/commit/f9a5a6e32ba044035bd7a35e30200c649ec913cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49319686)</sub>

<!-- /greptile_comment -->