### PR TITLE
fix(export): correlate CSV export websocket results by jobId on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -61,6 +61,12 @@ export const EntityExportModalProvider = ({
   const [downloading, setDownloading] = useState<boolean>(false);
 
   const csvExportJobRef = useRef<Partial<CSVExportJob>>();
+  // Websocket export results are broadcast to every connection belonging to the
+  // user, so a response can arrive before this tab knows its own jobId. Hold
+  // those by jobId until the id is known rather than applying them blind.
+  const pendingCSVExportResponsesRef = useRef<
+    Map<string, Partial<CSVExportWebsocketResponse>>
+  >(new Map());
 
   const [csvExportJob, setCSVExportJob] = useState<Partial<CSVExportJob>>();
 
@@ -91,6 +97,50 @@ export const EntityExportModalProvider = ({
   const showModal = (data: ExportData) => {
     setExportData(data);
   };
+
+  const handleCSVExportSuccess = useCallback(
+    (data: string, fileName?: string) => {
+      if (isBulkEdit) {
+        setCSVExportData(data);
+      } else {
+        const csvFileName =
+          fileName ?? `${exportData?.name}_${getCurrentISODate()}`;
+        downloadFile(data, `${csvFileName}.csv`);
+      }
+      setDownloading(false);
+      handleCancel();
+      setCSVExportJob(undefined);
+      csvExportJobRef.current = undefined;
+      pendingCSVExportResponsesRef.current.clear();
+    },
+    [isBulkEdit]
+  );
+
+  const applyCSVExportJobUpdate = useCallback(
+    (response: Partial<CSVExportWebsocketResponse>) => {
+      const updatedCSVExportJob: Partial<CSVExportJob> = {
+        ...response,
+        ...csvExportJobRef.current,
+      };
+
+      setCSVExportJob(updatedCSVExportJob);
+
+      csvExportJobRef.current = updatedCSVExportJob;
+
+      if (response.status === 'COMPLETED' && response.data) {
+        handleCSVExportSuccess(
+          response.data ?? '',
+          csvExportJobRef.current?.fileName
+        );
+      } else if (response.status === 'IN_PROGRESS') {
+        // Keep downloading state true during progress
+        setDownloading(true);
+      } else {
+        setDownloading(false);
+      }
+    },
+    [isBulkEdit, handleCSVExportSuccess]
+  );
 
   const handleExport = async ({
     fileName,
@@ -148,9 +198,19 @@ export const EntityExportModalProvider = ({
           fileName: fileName,
           message: data.message,
         };
+        // A result for this job may have arrived while we were still waiting
+        // for the jobId; replay it now that we can attribute it.
+        const pendingResponse = pendingCSVExportResponsesRef.current.get(
+          data.jobId
+        );
 
         setCSVExportJob(jobData);
         csvExportJobRef.current = jobData;
+        pendingCSVExportResponsesRef.current.clear();
+
+        if (pendingResponse) {
+          applyCSVExportJobUpdate(pendingResponse);
+        }
       }
     } catch (error) {
       showErrorToast(error as AxiosError);
@@ -158,58 +218,45 @@ export const EntityExportModalProvider = ({
     }
   };
 
-  const handleCSVExportSuccess = useCallback(
-    (data: string, fileName?: string) => {
-      if (isBulkEdit) {
-        setCSVExportData(data);
-      } else {
-        const csvFileName =
-          fileName ?? `${exportData?.name}_${getCurrentISODate()}`;
-        downloadFile(data, `${csvFileName}.csv`);
-      }
-      setDownloading(false);
-      handleCancel();
-      setCSVExportJob(undefined);
-      csvExportJobRef.current = undefined;
-    },
-    [isBulkEdit]
-  );
-
   const handleClearCSVExportData = useCallback(() => {
     setCSVExportData(undefined);
     setCSVExportJob(undefined);
     setExportData(null);
     csvExportJobRef.current = undefined;
+    pendingCSVExportResponsesRef.current.clear();
   }, []);
 
   const handleCSVExportJobUpdate = useCallback(
     (response: Partial<CSVExportWebsocketResponse>) => {
-      // If multiple tab is open, then we need to check if the tab has active job or not before initiating the download
-      if (!csvExportJobRef.current) {
+      const activeJob = csvExportJobRef.current;
+      const responseJobId = response.jobId;
+
+      // No export in flight in this tab, or a payload we cannot attribute.
+      if (!activeJob || !responseJobId) {
         return;
       }
-      const updatedCSVExportJob: Partial<CSVExportJob> = {
-        ...response,
-        ...csvExportJobRef.current,
-      };
 
-      setCSVExportJob(updatedCSVExportJob);
+      // The export request has not returned its jobId yet. Park the response
+      // instead of assuming it belongs to us — the backend fans results out to
+      // every socket this user has open, so it may well be another tab's.
+      if (!activeJob.jobId) {
+        const pendingResponse =
+          pendingCSVExportResponsesRef.current.get(responseJobId);
+        pendingCSVExportResponsesRef.current.set(responseJobId, {
+          ...pendingResponse,
+          ...response,
+        });
 
-      csvExportJobRef.current = updatedCSVExportJob;
-
-      if (response.status === 'COMPLETED' && response.data) {
-        handleCSVExportSuccess(
-          response.data ?? '',
-          csvExportJobRef.current?.fileName
-        );
-      } else if (response.status === 'IN_PROGRESS') {
-        // Keep downloading state true during progress
-        setDownloading(true);
-      } else {
-        setDownloading(false);
+        return;
       }
+
+      if (responseJobId !== activeJob.jobId) {
+        return;
+      }
+
+      applyCSVExportJobUpdate(response);
     },
-    [isBulkEdit, handleCSVExportSuccess]
+    [applyCSVExportJobUpdate]
   );
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -242,10 +242,16 @@ export const EntityExportModalProvider = ({
       if (!activeJob.jobId) {
         const pendingResponse =
           pendingCSVExportResponsesRef.current.get(responseJobId);
-        pendingCSVExportResponsesRef.current.set(responseJobId, {
-          ...pendingResponse,
-          ...response,
-        });
+        // Frames can arrive out of order. A COMPLETED result carries the data
+        // we ultimately need, so never let a later IN_PROGRESS overwrite it —
+        // replaying that would take the "still downloading" branch and hang.
+        const merged =
+          pendingResponse?.status === 'COMPLETED' &&
+          response.status !== 'COMPLETED'
+            ? { ...response, ...pendingResponse }
+            : { ...pendingResponse, ...response };
+
+        pendingCSVExportResponsesRef.current.set(responseJobId, merged);
 
         return;
       }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.test.tsx
@@ -96,7 +96,8 @@ describe('EntityExportModalProvider CSV export job correlation', () => {
 
     fireEvent.click(await screen.findByText('Manage'));
     await act(async () => {
-      fireEvent.click(await screen.findByText('label.export'));
+      // by role, not text: the modal title also renders 'label.export'
+      fireEvent.click(screen.getByRole('button', { name: 'label.export' }));
     });
 
     // This job id is not ours; the payload must be discarded rather than
@@ -108,6 +109,74 @@ describe('EntityExportModalProvider CSV export job correlation', () => {
     expect(mockDownloadFile).not.toHaveBeenCalled();
   });
 
+  it('parks a result that arrives before the jobId, then replays it', async () => {
+    // The window this covers is the reason the pending buffer exists:
+    // handleExport seeds the ref with only a fileName before awaiting
+    // onExport, so a websocket result can land while there is still no jobId
+    // to compare against. It must be held and replayed, not discarded.
+    let resolveExport: (value: typeof mockExportJob) => void = () => undefined;
+    const deferredShowModal: ExportData = {
+      ...mockShowModal,
+      onExport: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveExport = resolve;
+          })
+      ),
+    };
+
+    const DeferredComponent = () => {
+      const { showModal, onUpdateCSVExportJob } = useEntityExportModalProvider();
+
+      return (
+        <>
+          <button onClick={() => showModal(deferredShowModal)}>Manage</button>
+          <button
+            onClick={() =>
+              onUpdateCSVExportJob({
+                jobId: mockExportJob.jobId,
+                status: 'COMPLETED',
+                data: 'EARLY,CSV',
+              })
+            }>
+            emit-early
+          </button>
+        </>
+      );
+    };
+
+    render(
+      <EntityExportModalProvider>
+        <DeferredComponent />
+      </EntityExportModalProvider>
+    );
+
+    fireEvent.click(await screen.findByText('Manage'));
+    // Let the submit run as far as its await on onExport: by then the provider
+    // has seeded the ref with a fileName but has no jobId. onExport is
+    // deferred, so it stays suspended there.
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'label.export' }));
+    });
+
+    // onExport has not resolved, so the provider has no jobId yet.
+    await act(async () => {
+      fireEvent.click(screen.getByText('emit-early'));
+    });
+
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+
+    // The jobId now arrives; the parked result must be replayed.
+    await act(async () => {
+      resolveExport(mockExportJob);
+    });
+
+    expect(mockDownloadFile).toHaveBeenCalledWith(
+      'EARLY,CSV',
+      expect.stringContaining('.csv')
+    );
+  });
+
   it('downloads the export matching its own job id', async () => {
     render(
       <EntityExportModalProvider>
@@ -117,7 +186,8 @@ describe('EntityExportModalProvider CSV export job correlation', () => {
 
     fireEvent.click(await screen.findByText('Manage'));
     await act(async () => {
-      fireEvent.click(await screen.findByText('label.export'));
+      // by role, not text: the modal title also renders 'label.export'
+      fireEvent.click(screen.getByRole('button', { name: 'label.export' }));
     });
 
     await act(async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.test.tsx
@@ -36,11 +36,100 @@ jest.mock('react-router-dom', () => ({
   })),
 }));
 
+const mockDownloadFile = jest.fn();
+jest.mock('../../../utils/Export/ExportUtils', () => ({
+  downloadFile: (...args: unknown[]) => mockDownloadFile(...args),
+}));
+
 const ConsumerComponent = () => {
   const { showModal } = useEntityExportModalProvider();
 
   return <button onClick={() => showModal(mockShowModal)}>Manage</button>;
 };
+
+/**
+ * Drives the websocket callback directly, the way the socket listener does.
+ * The backend broadcasts export results to every connection belonging to the
+ * user, so this provider receives other tabs' jobs too.
+ */
+const CorrelationComponent = () => {
+  const { showModal, onUpdateCSVExportJob } = useEntityExportModalProvider();
+
+  return (
+    <>
+      <button onClick={() => showModal(mockShowModal)}>Manage</button>
+      <button
+        onClick={() =>
+          onUpdateCSVExportJob({
+            jobId: 'another-tabs-job',
+            status: 'COMPLETED',
+            data: 'WRONG,CSV',
+          })
+        }>
+        emit-foreign
+      </button>
+      <button
+        onClick={() =>
+          onUpdateCSVExportJob({
+            jobId: mockExportJob.jobId,
+            status: 'COMPLETED',
+            data: 'OURS,CSV',
+          })
+        }>
+        emit-ours
+      </button>
+    </>
+  );
+};
+
+describe('EntityExportModalProvider CSV export job correlation', () => {
+  beforeEach(() => {
+    mockDownloadFile.mockClear();
+  });
+
+  it('ignores a completed export belonging to a different job', async () => {
+    render(
+      <EntityExportModalProvider>
+        <CorrelationComponent />
+      </EntityExportModalProvider>
+    );
+
+    fireEvent.click(await screen.findByText('Manage'));
+    await act(async () => {
+      fireEvent.click(await screen.findByText('label.export'));
+    });
+
+    // This job id is not ours; the payload must be discarded rather than
+    // downloaded under our own file name.
+    await act(async () => {
+      fireEvent.click(screen.getByText('emit-foreign'));
+    });
+
+    expect(mockDownloadFile).not.toHaveBeenCalled();
+  });
+
+  it('downloads the export matching its own job id', async () => {
+    render(
+      <EntityExportModalProvider>
+        <CorrelationComponent />
+      </EntityExportModalProvider>
+    );
+
+    fireEvent.click(await screen.findByText('Manage'));
+    await act(async () => {
+      fireEvent.click(await screen.findByText('label.export'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('emit-ours'));
+    });
+
+    expect(mockDownloadFile).toHaveBeenCalledWith(
+      'OURS,CSV',
+      expect.stringContaining('.csv')
+    );
+  });
+});
 
 describe('EntityExportModalProvider component', () => {
   it('Component should render', async () => {


### PR DESCRIPTION
### Describe your changes:

Backport of the CSV export job-correlation logic from `e9318cf6f8` (#30310), which is on `main` and `2.0` but **not** `1.13`.

**This is a user-facing 1.13 bug, independent of any test.** Open OpenMetadata in two tabs, start an export in each, and one tab downloads the other's CSV.

#### Cause

`WebSocketManager.sendToOne` fans a completed export out to **every connection belonging to the user**:

```java
activityFeedEndpoints.get(receiver).forEach((key, value) -> value.send(event, message));
```

`EntityExportModalProvider` on 1.13 accepts the first `COMPLETED` it sees:

```ts
// If multiple tab is open, then we need to check if the tab has active job or not
if (!csvExportJobRef.current) {
  return;
}
```

The comment describes a check the code never performs — it never compares **which** job. So any tab with an export in flight downloads whichever export completed first, under its own file name.

#### Fix

Compare the response `jobId` against the active job before applying it.

**The pending buffer is load-bearing, not incidental.** `handleExport` deliberately seeds the ref with only a `fileName` before awaiting `onExport`, with a comment noting the websocket may answer first. In that window there is no `jobId` to compare, so a strict equality check *alone* would discard our own result and hang the export — worse than today's behaviour. Responses arriving then are parked by `jobId` and replayed once the id is known, mirroring `main`.

Frames can also arrive out of order, so a `COMPLETED` status is kept sticky — a later `IN_PROGRESS` must not overwrite it, or the replay takes the still-downloading branch and hangs the modal.

I deliberately did **not** port main's wider polling rework (`startCSVExportPolling`, abort controllers, `exportOnErrorRef`). Not needed for correlation, and far more surface on a release branch.

`handleCSVExportSuccess` and `applyCSVExportJobUpdate` move above `handleExport` so the new call site doesn't reference them before definition. Pure move.

#### Regression risk — checked, not assumed

The way this change could hurt a customer is if a websocket message ever lacked a `jobId`: the strict comparison would drop it and hang the export forever. Every `CSVExportMessage` constructed on 1.13 takes `jobId` as its first argument, and these are the only three senders on `CSV_EXPORT_CHANNEL`:

```java
new CSVExportMessage(jobId, "COMPLETED", csvData, null)
new CSVExportMessage(jobId, "FAILED", null, errorMessage)
new CSVExportMessage(jobId, "IN_PROGRESS", null, null, progress, total, message)
```

There is no path that emits one without an id, and the pending buffer covers the only window where *our* side lacks one.

#
### Type of change:

- [x] Bug fix

#
### Tests:

`EntityExportModalProvider.test.tsx` — **all 9 in the suite pass**, run locally against a real 1.13 build:

- a `COMPLETED` for a different `jobId` must not download
- a `COMPLETED` for its own `jobId` must download
- a result arriving **before** the `jobId` is known must be parked and replayed

The third is mutation-verified: removing the replay call makes it fail, restoring it makes it pass. It covers the buffer, which is the part most likely to regress.

#### Scope note

An earlier revision of this PR also carried a `useGridEditController` clipboard change, presented as fixing `BulkImport › Range selection`. **That commit has been removed.** The hypothesis behind it (insecure-context clipboard access) was disproven on a live stack: the test fails intermittently on every origin, including `localhost`, with or without that change. `Range selection` remains unexplained and is not addressed here.

> `ui-checkstyle` will be red — it fails for every UI PR on 1.13 (see #30781, #30726, both merged through it). Not caused by this change, not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR correlates CSV-export websocket updates with each tab's active job and buffers updates that arrive before the REST response supplies its job ID.
- Ignores websocket updates belonging to another export job.
- Replays matching early responses once the active job ID becomes available.
- Preserves a buffered completion when progress frames arrive out of order.
- Adds regression coverage for foreign, matching, and early completion responses.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported early-response test gap is fixed, while the remaining provisional-state cleanup issue is non-blocking.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx | Adds job-ID filtering, early-response buffering and replay, and sticky completion handling to the CSV export websocket flow. |
| openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.test.tsx | Adds focused tests proving foreign-job rejection, matching-job download, and deferred early-response replay. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Tab as Export tab
  participant API as Export API
  participant WS as Websocket
  Tab->>API: Start CSV export
  Note over Tab: Store provisional fileName
  WS-->>Tab: Update(jobId)
  alt Active jobId is not known
    Tab->>Tab: Buffer update by jobId
  end
  API-->>Tab: Export job(jobId)
  Tab->>Tab: Set active jobId
  alt Buffered update matches jobId
    Tab->>Tab: Replay buffered update
  end
  WS-->>Tab: Later update(jobId)
  alt jobId matches active export
    Tab->>Tab: Apply status or download CSV
  else Different jobId
    Tab->>Tab: Ignore update
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(export): cover the parking/replay w..."](https://github.com/open-metadata/openmetadata/commit/c70587d8197c30b0a5e985ca36093d9e23df21f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49322017)</sub>

<!-- /greptile_comment -->