### PR TITLE
fix(ui-core): stop Typography ellipsis tooltip from swallowing ancestor clicks

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx
@@ -11,8 +11,9 @@
  *  limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 import { Typography } from './typography';
 
 describe('Typography', () => {
@@ -74,5 +75,94 @@ describe('Typography', () => {
 
     expect(el).toHaveClass('tw:text-tertiary');
     expect(el.className).not.toMatch(/tw:text-error-primary/);
+  });
+});
+
+describe('Typography ellipsis tooltip', () => {
+  it('propagates a click through to an ancestor onClick handler', () => {
+    const handleAncestorClick = vi.fn();
+
+    render(
+      <div onClick={handleAncestorClick}>
+        <Typography ellipsis={{ tooltip: true }}>
+          A very long piece of text that gets truncated with an ellipsis
+        </Typography>
+      </div>
+    );
+
+    fireEvent.click(
+      screen.getByText(
+        'A very long piece of text that gets truncated with an ellipsis'
+      )
+    );
+
+    // Regression guard: react-aria's `usePress` stops a completed press from
+    // propagating to ancestor DOM listeners by default. Typography's
+    // ellipsis-tooltip wrapper must opt back into propagation so a click on
+    // truncated text still reaches whatever ancestor `onClick` the consumer
+    // attached (e.g. a selectable card or a persona-switcher row).
+    expect(handleAncestorClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('still shows the tooltip on hover', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Typography ellipsis={{ tooltip: 'Full text' }}>
+        Truncated text
+      </Typography>
+    );
+
+    expect(screen.queryByText('Full text')).not.toBeInTheDocument();
+
+    // react-aria only treats hover as a tooltip-showing interaction when the
+    // current "interaction modality" is pointer (see
+    // @react-aria/interactions/useFocusVisible, which falls back to
+    // mousemove/mousedown/mouseup listeners in test environments since jsdom
+    // has no PointerEvent). A bare hover with no prior mouse movement leaves
+    // the modality at its initial `null`, so establish it first.
+    fireEvent.mouseMove(document);
+
+    await user.hover(screen.getByText('Truncated text'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Full text')).toBeInTheDocument();
+    });
+  });
+
+  it('still shows the tooltip on keyboard focus', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Typography ellipsis={{ tooltip: 'Full text' }}>
+        Truncated text
+      </Typography>
+    );
+
+    expect(screen.queryByText('Full text')).not.toBeInTheDocument();
+
+    await user.tab();
+
+    await waitFor(() => {
+      expect(screen.getByText('Full text')).toBeInTheDocument();
+    });
+  });
+
+  it('does not wrap non-ellipsis Typography in a tooltip trigger', () => {
+    const handleAncestorClick = vi.fn();
+
+    render(
+      <div onClick={handleAncestorClick}>
+        <Typography>Plain text</Typography>
+      </div>
+    );
+
+    const el = screen.getByText('Plain text');
+
+    expect(el.closest('button')).toBeNull();
+
+    fireEvent.click(el);
+
+    expect(handleAncestorClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx
@@ -14,6 +14,26 @@
 import { Tooltip, TooltipTrigger } from '@/components/base/tooltip/tooltip';
 import { cx } from '@/utils/cx';
 import type { ElementType, HTMLAttributes, ReactNode, Ref } from 'react';
+import type { PressEvent } from 'react-aria-components';
+
+// `TooltipTrigger` renders a react-aria `Button`, whose `usePress` hook stops
+// a completed press from propagating to ancestor DOM listeners by default
+// (react-aria's documented behavior: "the default for React Spectrum
+// components is not to propagate. This can be overridden by calling
+// continuePropagation() on the event" - see
+// node_modules/@react-types/shared/src/events.d.ts). For most `TooltipTrigger`
+// call sites that is desirable (e.g. a help-icon tooltip nested inside a
+// sortable table header should not also trigger the header's sort-on-click).
+// But Typography's ellipsis tooltip wraps *arbitrary, non-interactive* text
+// content: the wrapper is only there to host the hover/focus tooltip, so a
+// click on the truncated text should reach whatever ancestor `onClick` the
+// consumer attached (e.g. a selectable card, a persona-switcher row). Calling
+// `continuePropagation()` here restores that click, scoped to this call site
+// only - it does not change `TooltipTrigger`'s default for its other
+// consumers (form-item-label, input, table column header, avatar add button).
+const allowEllipsisTooltipPressToPropagate = (e: PressEvent) => {
+  e.continuePropagation();
+};
 
 const lineClampClasses: Record<number, string> = {
   1: 'tw:line-clamp-1',
@@ -160,7 +180,9 @@ export const Typography = (props: TypographyProps) => {
   if (ellipsisTooltip) {
     return (
       <Tooltip title={ellipsisTooltip}>
-        <TooltipTrigger className="tw:block tw:w-full tw:min-w-0">
+        <TooltipTrigger
+          className="tw:block tw:w-full tw:min-w-0"
+          onPress={allowEllipsisTooltipPressToPropagate}>
           <div
             className={cx(
               'prose',


### PR DESCRIPTION
## The bug

`Typography` with `ellipsis={{ tooltip: … }}` wraps its content in `TooltipTrigger`, which renders a react-aria `Button`. react-aria's `usePress` defaults `shouldStopPropagation` to `true`, so **a click on truncated text never reaches an ancestor's `onClick`**.

That wrapper exists purely to host a hover/focus tooltip over non-interactive text. Swallowing clicks is not intended behavior there.

## Real breakage this caused

Surfaced during the antd → ui-core-components Typography migration (#30780):

- **Persona switcher** — clicking a persona in the profile dropdown did nothing; the handler is on an ancestor row, so persona/navigation settings silently never applied.
- **Test-case selection cards** (`AddTestCaseList`) — cards couldn't be selected at all; three Playwright specs hung waiting on API calls that never fired.

There are **~57** `ellipsis={{ tooltip: true }}` call sites in `openmetadata-ui`. Only a few sit on e2e-covered paths, so an unknown number of click targets are broken today with nothing watching — which is why this is fixed in core rather than at call sites.

## The fix

Pass `onPress={(e) => e.continuePropagation()}` to the single `TooltipTrigger` inside Typography's ellipsis branch. This is react-aria's own documented escape hatch (`@react-types/shared`: *"the default … is not to propagate. This can be overridden by calling continuePropagation()"*), verified against the installed `@react-aria/interactions` source rather than docs alone.

**Deliberately scoped to Typography, not the shared `TooltipTrigger`.** Auditing consumers (`form-item-label`, `input/label`, `input`, `table`, `avatar-add-button`) found that `table.tsx`'s sortable-column help icon *relies* on the swallowing default — clicking it must not also trigger column sort. A global default change would have regressed that.

No visual or className changes; truncation, line-clamp, width behavior and tooltip appearance are untouched.

## Tests

4 new cases in `typography.test.tsx`: click propagates to an ancestor handler (the regression guard), tooltip still opens on hover, tooltip still opens on **keyboard focus** (a11y guard), and non-ellipsis Typography unaffected. Verified failing-before by stashing only the `typography.tsx` change. After: **11/11** in typography, **15/15** package-wide. Lint, prettier, `tsc --noEmit` clean.

## For reviewers

Any call site that accidentally relied on the old swallow as a click guard will now see its ancestor `onClick` fire. I audited the core package; a sweep of `openmetadata-ui` call sites is worth a look during review.

Fixes #30803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores ancestor click propagation specifically for Typography’s ellipsis tooltip wrapper while preserving the shared TooltipTrigger’s default behavior.
- Adds a scoped `onPress` handler that calls `continuePropagation()`.
- Adds regression coverage for ancestor clicks, hover and keyboard tooltip activation, and unaffected non-ellipsis Typography.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the propagation change narrowly scoped and covered by behavior-focused tests.

The implementation restores the intended ancestor click behavior only for ellipsis-wrapped Typography while leaving other TooltipTrigger consumers unchanged, and no concrete regression remains established.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.tsx | Correctly scopes press propagation to the non-interactive ellipsis tooltip wrapper without changing shared TooltipTrigger behavior. |
| openmetadata-ui-core-components/src/main/resources/ui/src/components/foundations/typography.test.tsx | Adds focused regression and accessibility coverage for click propagation and tooltip activation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui-core): stop Typography ellipsis t..."](https://github.com/open-metadata/openmetadata/commit/c84f23053041f72752ad37073767581efc76806a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49335564)</sub>

<!-- /greptile_comment -->