### PR TITLE
Fixes #30805: restore Slack CI notifications and add one for the Sonar nightly

### DIFF
--- a/.github/workflows/py-cli-e2e-tests.yml
+++ b/.github/workflows/py-cli-e2e-tests.yml
@@ -339,10 +339,13 @@ jobs:
       continue-on-error: true
       uses: slackapi/slack-github-action@v4
       with:
-        webhook: ${{ secrets.E2E_SLACK_WEBHOOK }}
-        webhook-type: incoming-webhook
+        method: chat.postMessage
+        token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+        # Keep on — the action discards Slack API errors by default.
+        errors: true
         payload: |
           {
+            "channel": "C03EYBDDX17",
             "text": "🔥 Failed E2E Test for: ${{ matrix.e2e-test }} 🔥\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
 

--- a/.github/workflows/py-cli-e2e-tests.yml
+++ b/.github/workflows/py-cli-e2e-tests.yml
@@ -337,7 +337,7 @@ jobs:
     - name: Slack on Failure
       if: ${{ always() && !cancelled() && env.DEBUG == 'false' && failure() }}
       continue-on-error: true
-      uses: slackapi/slack-github-action@v4
+      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
       with:
         method: chat.postMessage
         token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}

--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -227,3 +227,24 @@ jobs:
           projectBaseDir: ${{ env.PROJECT_BASE_DIR }}/
           args: >
             -Dsonar.branch.name=${{ env.BRANCH_NAME }}
+
+  notify:
+    needs: [py-unit-tests, py-integration-tests, py-combine-coverage]
+    # Stay silent on green nights, or a daily cron becomes a channel nobody reads.
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Slack on failure
+        continue-on-error: true
+        uses: slackapi/slack-github-action@v4
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}
+          # Keep on — the action discards Slack API errors by default.
+          errors: true
+          payload: |
+            {
+              "channel": "C03EYBDDX17",
+              "text": "🔥 *SonarCloud Ingestion Nightly* failed on `${{ env.BRANCH_NAME }}` 🔥\nunit: ${{ needs.py-unit-tests.result }} · integration: ${{ needs.py-integration-tests.result }} · combine+sonar: ${{ needs.py-combine-coverage.result }}\nLogs: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }

--- a/.github/workflows/py-sonarcloud-nightly.yml
+++ b/.github/workflows/py-sonarcloud-nightly.yml
@@ -233,11 +233,13 @@ jobs:
     # Stay silent on green nights, or a daily cron becomes a channel nobody reads.
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Above the client's ~299s retry ceiling, so a Slack outage surfaces as the
+    # Slack error rather than as a job timeout.
+    timeout-minutes: 10
     steps:
       - name: Slack on failure
         continue-on-error: true
-        uses: slackapi/slack-github-action@v4
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.COLLATE_BOT_SLACK_TOKEN }}


### PR DESCRIPTION
Fixes #30805

## What

`py-cli-e2e-tests` has posted no Slack message since **2026-03-25**, and `py-sonarcloud-nightly` never had a notification — which is how it failed 109 consecutive nights without anyone noticing.

`E2E_SLACK_WEBHOOK` holds a bot token (`xoxb-…`) rather than the incoming-webhook URL. Both are returned together by the same OAuth install (`access_token` vs `incoming_webhook.url`) and the wrong one was stored. Slack answers `302 → https://api.slack.com/` for that path.

Nothing ever went red, because the failure is suppressed twice:

| Suppressor | Effect |
|---|---|
| `errors: false` (the action's **default**, not set in our YAML) | Slack API errors are discarded; the step exits 0 |
| `continue-on-error: true` | Any step failure is hidden from the job |

The only observable symptom was step duration:

| Action version | Slack response | Classification | Duration |
|---|---|---|---|
| `@v1.23.0` (before #30310) | `302` | axios: `<500` → `AbortError`, terminal | **~1s** |
| `@v4` (since 2026-07-24) | `302` | `fetch` with `redirect: 'error'` throws → no response object → retryable | **~300s** |

Reproduced locally against `@slack/webhook@8.0.0` — the version `@v4` bundles — with the action's default `{retries: 5, factor: 3.86}`:

| Response | Attempts | Elapsed |
|---|---|---|
| `200 ok` | 1 | 0.1s |
| `404` (revoked webhook) | 1 | 0.0s |
| `302` / `5xx` | 6 | ~299s |

Measured ladder: `+1.0s, +3.9s, +14.9s, +57.5s, +222s ≈ 299s`. CI measures 299–300s across all seven failing lanes.

So #30310 did not break this — it made a four-month-old breakage slow enough to see.

## How

Both workflows move to `chat.postMessage` with a bot token scoped for it, which is the only v4 path already proven working in this repo (`security-scan` posts in 1s and returns a message `ts`).

`errors: true` is the load-bearing part: it converts a rejected post into a visible step failure. `continue-on-error: true` stays, so a Slack outage still can't red an otherwise-good run.

The Sonar nightly gains a `notify` job gated on `contains(needs.*.result, 'failure')` — a daily cron that fires on green nights becomes a channel nobody reads, which is the failure mode that let the original problem hide.

Channel `C03EYBDDX17` is inlined rather than stored as a secret; channel IDs are not sensitive and one is already committed in plaintext at `openmetadata-ui/src/main/resources/ui/playwright/slack-cli.config.json`.

## Follow-up

`playwright-slack-report`'s `sendUsingBot` mode requires `chat:write`. If `E2E_SLACK_BOT_OAUTH_TOKEN` holds the same `incoming-webhook`-scoped token, the Slack reports in `mysql-nightly-e2e`, `postgresql-nightly-e2e` and `playwright-sso-login-nightly` are dead for the same reason. Not addressed here.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR restores failure notifications by switching to bot-token-based Slack messages and pins the Slack action to an immutable v4.0.0 commit.
- Updates Python CLI E2E failure notifications to use `chat.postMessage` with surfaced Slack API errors.
- Adds failure-only notifications for the nightly SonarCloud workflow.
- Replaces the previously reported mutable action references with a reviewed commit SHA.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported mutable-tag credential exposure is fixed because both changed workflows now reference the Slack action by an immutable v4.0.0 commit SHA.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/py-cli-e2e-tests.yml | Replaces the broken incoming webhook call with a bot-token Slack API call and pins the action to an immutable revision. |
| .github/workflows/py-sonarcloud-nightly.yml | Adds a failure-gated Slack notification job using the pinned action revision and explicit API error reporting. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): pin the Slack action to a SHA a..."](https://github.com/open-metadata/openmetadata/commit/6d2781308f1aeb05cb0aee2d881c11f8d6f7db4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49343837)</sub>

<!-- /greptile_comment -->