### PR TITLE
ci(playwright): warn at plan time when a file has no timing history

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 import math
 import re
 import statistics
@@ -333,6 +334,42 @@ def apply_history_weights(
         )
 
 
+# Emit a GitHub Actions ::warning:: for any file where enough tests fall through
+# to FALLBACK_TEST_MS that the plan is at real risk of under-budgeting the shard
+# holding them (see fix #30812 for the failure mode). The gate is intentionally
+# quiet: files with a handful of new tests trip nothing; a re-enabled suite of
+# 10+ tests, or a smaller suite whose fallback allocation crosses one minute,
+# gets an annotation the re-enabling PR author will see on the plan step.
+UNWEIGHTED_WARN_MIN_TESTS = 10
+UNWEIGHTED_WARN_MIN_MS = 60_000
+
+
+def emit_unweighted_warnings(
+    units: list[Unit],
+    test_weights: dict[str, int],
+    identity_weights: dict[tuple[str, str], int],
+) -> None:
+    stats: dict[str, dict[str, int]] = defaultdict(lambda: {"count": 0})
+    for unit in units:
+        for test_id in unit.test_ids:
+            if test_id in test_weights:
+                continue
+            if (unit.file, unit.test_names[test_id]) in identity_weights:
+                continue
+            stats[unit.file]["count"] += 1
+    for file, entry in sorted(stats.items()):
+        reserved_ms = entry["count"] * FALLBACK_TEST_MS
+        if entry["count"] < UNWEIGHTED_WARN_MIN_TESTS and reserved_ms < UNWEIGHTED_WARN_MIN_MS:
+            continue
+        message = (
+            f"{entry['count']} test(s) in {file} have no timing history; "
+            f"planner reserved {reserved_ms / 60_000:.1f} min via FALLBACK_TEST_MS. "
+            "If this suite was recently re-enabled, refresh timing-baseline.json "
+            "with real durations to avoid shard overruns on the first plan."
+        )
+        print(f"::warning file={file}::{message}", file=sys.stderr)
+
+
 def normalize_spec(path: str) -> str:
     prefix = "playwright/e2e/"
     return path.removeprefix(prefix)
@@ -508,6 +545,7 @@ def main() -> None:
         raise SystemExit("Playwright selection produced no runnable test units")
 
     apply_history_weights(units, test_weights, identity_weights)
+    emit_unweighted_warnings(units, test_weights, identity_weights)
 
     oversized_units = [unit for unit in units if unit.weight_ms > TARGET_MS]
     if oversized_units:

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -179,6 +179,95 @@ def test_history_uses_p75_and_leaf_identity_fallback(tmp_path):
     assert identity_weights[("Features/Ingestion.spec.ts", "runs ingestion")] == 250
 
 
+def test_emit_unweighted_warnings_annotates_files_over_threshold(capsys):
+    planner = load_script("build_playwright_shards")
+    # A file with more tests than UNWEIGHTED_WARN_MIN_TESTS should be annotated.
+    file = "Pages/NewSuite.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"missing-{index}"},
+            test_names={f"missing-{index}": f"case {index}"},
+        )
+        for index in range(planner.UNWEIGHTED_WARN_MIN_TESTS)
+    ]
+
+    planner.emit_unweighted_warnings(units, {}, {})
+
+    captured = capsys.readouterr()
+    assert f"::warning file={file}::" in captured.err
+    assert f"{planner.UNWEIGHTED_WARN_MIN_TESTS} test(s) in {file}" in captured.err
+
+
+def test_emit_unweighted_warnings_annotates_when_reserved_minutes_over_threshold(capsys):
+    planner = load_script("build_playwright_shards")
+    # Fewer tests than UNWEIGHTED_WARN_MIN_TESTS but their reserved fallback
+    # time exceeds UNWEIGHTED_WARN_MIN_MS should still annotate.
+    import math
+    trigger_count = max(
+        1,
+        math.ceil(planner.UNWEIGHTED_WARN_MIN_MS / planner.FALLBACK_TEST_MS),
+    )
+    assert trigger_count < planner.UNWEIGHTED_WARN_MIN_TESTS
+    file = "Pages/SmallHeavy.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"missing-{index}"},
+            test_names={f"missing-{index}": f"case {index}"},
+        )
+        for index in range(trigger_count)
+    ]
+
+    planner.emit_unweighted_warnings(units, {}, {})
+
+    assert f"::warning file={file}::" in capsys.readouterr().err
+
+
+def test_emit_unweighted_warnings_stays_quiet_below_threshold(capsys):
+    planner = load_script("build_playwright_shards")
+    # 1 test with fallback = 30_000 ms < UNWEIGHTED_WARN_MIN_MS should not warn.
+    assert planner.FALLBACK_TEST_MS < planner.UNWEIGHTED_WARN_MIN_MS
+    file = "Pages/Trivial.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            "sole-unit",
+            test_ids={"missing"},
+            test_names={"missing": "case"},
+        )
+    ]
+
+    planner.emit_unweighted_warnings(units, {}, {})
+
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_unweighted_warnings_ignores_tests_with_history(capsys):
+    planner = load_script("build_playwright_shards")
+    file = "Pages/Existing.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"present-{index}"},
+            test_names={f"present-{index}": f"case {index}"},
+        )
+        for index in range(planner.UNWEIGHTED_WARN_MIN_TESTS + 5)
+    ]
+    weights = {f"present-{index}": 5_000 for index in range(len(units))}
+
+    planner.emit_unweighted_warnings(units, weights, {})
+
+    assert capsys.readouterr().err == ""
+
+
 def test_history_includes_retry_time_and_skipped_only_ids_fall_to_fallback(tmp_path):
     # Was previously "only_preserves_explicit_skips" — the planner used to pin
     # weight_ms=0 for tests whose only recorded outcome was 'skipped'. That was


### PR DESCRIPTION
## Summary

When a Playwright suite is re-enabled after being skipped at baseline capture, the shard planner falls through to `FALLBACK_TEST_MS` per test. That's safe now (see #30812) but still under-budgets whatever the fallback misses. The first-run gap is invisible today — the plan step logs nothing; the miss surfaces later as a shard timeout.

## Change

`build_playwright_shards.py` now emits a GitHub Actions `::warning file=...::` from the plan step when a file's fallback allocation crosses either threshold:

- **≥ 10 tests** with no timing history, or
- **≥ 1 min** of reserved fallback time on a single file.

The annotation names the file and the reserved minutes, and tells the reader to refresh `timing-baseline.json` if the suite was recently re-enabled.

Non-blocking by design — plan step still succeeds; the re-enabling PR author just sees an annotation. Hard-gate at harness-integrity will follow separately.

## Test plan

- [ ] `python3 -m pytest .github/scripts/tests/test_playwright_ci_planning.py` — 64 passed locally (60 existing + 4 new).
- [ ] Merge-queue plan step will emit no warnings on a normal run (all tests have baseline history).
- [ ] Emits a warning on a synthetic re-enable (verified in unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)