### PR TITLE
fix(ui): show all form fields (not just required) in intake forms list

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
@@ -43,6 +43,7 @@ import {
   listIntakeForms,
   patchIntakeForm,
 } from '../../rest/intakeFormsAPI';
+import { getIntakeFormFields } from '../../utils/IntakeFormUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import IntakeFormDesignerModal from './IntakeFormDesignerModal';
 
@@ -75,7 +76,7 @@ const IntakeFormsPage = () => {
     setLoading(true);
     try {
       const response = await listIntakeForms({
-        fields: 'owners,requiredFields',
+        fields: 'owners,formFields,requiredFields',
       });
       setForms(response.data ?? []);
     } catch (err) {
@@ -183,7 +184,7 @@ const IntakeFormsPage = () => {
 
   const columns = [
     { id: 'entityType', name: t('label.entity-type') },
-    { id: 'requiredFields', name: t('label.required-fields') },
+    { id: 'formFields', name: t('label.field-plural') },
     { id: 'enabled', name: t('label.enabled') },
     { id: 'actions', name: t('label.action-plural') },
   ];
@@ -271,27 +272,35 @@ const IntakeFormsPage = () => {
               </Table.Cell>
               <Table.Cell>
                 <Box className="tw:gap-1" direction="col">
-                  {(record.requiredFields ?? []).length === 0 ? (
+                  {getIntakeFormFields(record).length === 0 ? (
                     <Typography className="tw:text-tertiary" size="text-sm">
                       {t('label.none')}
                     </Typography>
                   ) : (
-                    (record.requiredFields ?? []).map((rf) => (
+                    getIntakeFormFields(record).map((field) => (
                       <Badge
                         color={
-                          rf.fieldKind === FieldKind.CustomProperty
+                          field.fieldKind === FieldKind.CustomProperty
                             ? 'gray'
                             : 'brand'
                         }
-                        key={rf.fieldPath}
+                        key={field.fieldPath}
                         size="sm"
                         type="pill-color">
-                        {rf.fieldLabel}
+                        {field.fieldLabel}
                         <Typography
                           as="span"
                           className="tw:ml-1 tw:text-tertiary"
                           size="text-xs">
-                          ({rf.fieldPath})
+                          ({field.fieldPath})
+                        </Typography>
+                        <Typography
+                          as="span"
+                          className="tw:ml-1 tw:text-tertiary"
+                          size="text-xs">
+                          {field.required
+                            ? t('label.required')
+                            : t('label.optional')}
                         </Typography>
                       </Badge>
                     ))


### PR DESCRIPTION
## Summary

- `fetchForms` was requesting `fields=owners,requiredFields` — `formFields` was missing
- `getIntakeFormFields` therefore fell back to the legacy path and returned only the single required field
- The table column was labelled "Required Fields" and rendered `record.requiredFields` directly, so optional fields were never shown
- The E2E test (`IntakeForm.spec.ts`) checks that **all** included fields are visible after saving — causing a timeout on the audience and source fields

## Changes

- Add `formFields` to the `listIntakeForms` fields param: `owners,formFields,requiredFields`
- Rename column from **Required Fields** → **Fields** (`label.field-plural`)
- Replace direct `record.requiredFields` render with `getIntakeFormFields(record)`, which handles both the new `formFields` contract and legacy `requiredFields` fallback
- Each badge now also shows **required / optional** status to match the main-branch UI

## Test plan

- [ ] Run `IntakeForm.spec.ts` on 1.13 — the "New row renders in the list" step should pass for all three custom properties
- [ ] Verify the table shows all included fields (required + optional) after creating an intake form
- [ ] Verify existing forms with only `requiredFields` (legacy) still render correctly via the `getIntakeFormFields` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)