### PR TITLE
Fixes #30819: Count non-ASCII sub-tokens to match om_ngram token_chars

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchUtils.java
@@ -788,12 +788,15 @@ public final class SearchUtils {
    * input on non-alphanumeric characters ({@code token_chars: [letter, digit]}), so it reflects
    * the actual number of terms the ngram path will process for a fuzzy multi_match — which is
    * the driver of clause count, not whitespace word count.
+   *
+   * <p>The split uses {@code \p{L}\p{Nd}} rather than POSIX {@code \p{Alnum}} because
+   * {@code token_chars} is Unicode-aware, while POSIX character classes match US-ASCII only.
    */
   private static int analyzedSubTokenCount(String query) {
     if (query == null || query.isBlank()) {
       return 0;
     }
-    String[] parts = query.trim().split("[^\\p{Alnum}]+");
+    String[] parts = query.trim().split("[^\\p{L}\\p{Nd}]+");
     int count = 0;
     for (String p : parts) {
       if (!p.isEmpty()) count++;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchUtilsTest.java
@@ -447,6 +447,15 @@ class SearchUtilsTest {
         "kochi__expected_vessels__portcall_v1 | 0", // 5 sub-tokens
         "scraped/kochi/expected_vessels/parsed/portcall/v1 | 0",
         "foo-bar.baz_qux | 0", // 4 sub-tokens via mixed separators
+        // non-ASCII scripts count as sub-tokens, matching om_ngram's Unicode token_chars
+        "顧客 注文 履歴 | 0", // Japanese, 3 sub-tokens
+        "客户订单 明细 记录 | 0", // Chinese, 3 sub-tokens
+        "клиент заказ история | 0", // Russian, 3 sub-tokens
+        // accented Latin is no longer split on its accents, so these count as 2, not 3/4
+        "café münchen | 1",
+        "größe prüfung | 1",
+        // an unsegmented script still yields a single sub-token, so the guard stays off
+        "顧客注文履歴 | 1",
       })
   void getFuzzinessReturnsExpected(String query, String expected) {
     assertEquals(expected, SearchUtils.getFuzziness(query));
@@ -487,6 +496,10 @@ class SearchUtilsTest {
         "lhr__incoming_flights | 1",
         "kochi__expected_vessels__portcall_v1 | 1",
         "scraped/kochi/expected_vessels/parsed/portcall/v1 | 1",
+        // non-ASCII scripts count as sub-tokens here too
+        "顧客 注文 履歴 | 1",
+        "клиент заказ история | 1",
+        "顧客注文履歴 | 10", // unsegmented, single sub-token
       })
   void getMaxExpansionsReturnsExpected(String query, int expected) {
     assertEquals(expected, SearchUtils.getMaxExpansions(query));


### PR DESCRIPTION
### Describe your changes:

Fixes #30819

`analyzedSubTokenCount` says in its own javadoc that it mirrors how the `om_ngram` analyzer splits input on `token_chars: [letter, digit]`. It did not: the split used POSIX `\p{Alnum}`, which matches US-ASCII only unless `UNICODE_CHARACTER_CLASS` is set, while `token_chars` is Unicode-aware.

The consequence was that every non-ASCII character counted as a separator. A query written entirely in a non-Latin script split into nothing but empty strings and returned 0 sub-tokens, so the `> 2` clause-count guard in `getFuzziness` and `getMaxExpansions` never engaged for `JP`, `ZH` or `RU` queries — they always took the `fuzziness=1` / `max_expansions=10` path regardless of length.

This switches the split to `\p{L}\p{Nd}`, which follows the same Unicode semantics as `token_chars`. I used the explicit classes rather than the `(?U)` inline flag so the intent is visible at the call site and `UNICODE_CASE` isn't enabled as a side effect.

#### Behaviour change worth calling out

This is not a pure no-op. Accented-Latin queries are no longer split on their accents, so `café münchen` counts as 2 sub-tokens instead of 3 — which *relaxes* the guard for those queries (fuzziness `0` → `1`, max_expansions `1` → `10`). That is the same treatment their ASCII equivalents already get, since `cafe munchen` counts as 2 today, but it does affect relevance and may deserve a release note. Both cases are pinned by new test cases.

#### Scope

This does not fully solve clause explosion for CJK. A query with no whitespace such as `顧客注文履歴` still counts as a single sub-token, so the guard still does not engage — that is pinned by a test case too, to document the limit rather than hide it. Making the guard robust for unsegmented scripts likely needs a different metric (alphanumeric character length rather than sub-token count), which seems better as a separate change.

#### Testing

`SearchUtilsTest` gains 9 cases across the two `@CsvSource` blocks, in three groups:

- **Bug reproduction** — `顧客 注文 履歴`, `客户订单 明细 记录`, `клиент заказ история` return `"1"` before the fix and `"0"` after.
- **Behaviour change** — `café münchen`, `größe prüfung` flip the other way, `"0"` to `"1"`.
- **Unchanged control** — `顧客注文履歴` stays `"1"` either way, showing where the guard still does not reach.

Before the fix: `Tests run: 154, Failures: 7`. After: `Tests run: 154, Failures: 0`.

No regressions in the neighbouring suites — `FuzzySearchClauseTest` (3) and `SearchSourceBuilderFactoryTest` (17) both pass.

The only callers of these two methods are `ElasticSearchSourceBuilderFactory` (lines 668, 875, 876, 931) and `OpenSearchSourceBuilderFactory` (lines 1107, 1315, 1316, 1371), so the blast radius is limited to the fuzzy multi_match paths.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. — *no schema changes in this PR.*
