### PR TITLE
fix(ui): restore grid focus after the execCommand copy fallback

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
@@ -135,9 +135,15 @@ function useClipboardHandlers(
         textarea.value = tsv.join('\n');
         document.body.appendChild(textarea);
         textarea.select();
-        const success = document.execCommand('copy');
-        document.body.removeChild(textarea);
-        previouslyFocused?.focus();
+        let success = false;
+        try {
+          success = document.execCommand('copy');
+        } finally {
+          // execCommand can throw in some browsers rather than returning false; clean up and
+          // hand focus back either way, so a failed copy cannot leave the grid unusable.
+          document.body.removeChild(textarea);
+          previouslyFocused?.focus();
+        }
 
         return success;
       }

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
@@ -127,12 +127,17 @@ function useClipboardHandlers(
 
         return undefined;
       } else {
+        // Selecting the textarea moves focus off the grid cell. Restore it afterwards,
+        // otherwise every subsequent key (arrow navigation, Ctrl+V) is delivered to <body>
+        // and the grid stops responding until the user clicks a cell again.
+        const previouslyFocused = document.activeElement as HTMLElement | null;
         const textarea = document.createElement('textarea');
         textarea.value = tsv.join('\n');
         document.body.appendChild(textarea);
         textarea.select();
         const success = document.execCommand('copy');
         document.body.removeChild(textarea);
+        previouslyFocused?.focus();
 
         return success;
       }


### PR DESCRIPTION
## Problem

`useGridEditController`'s `handleCopy` uses the async Clipboard API only when `window.isSecureContext` is true. On a deployment served over plain HTTP that is false and `navigator.clipboard` is `undefined`, so it falls back to the legacy trick: create a `<textarea>`, `select()` it, `document.execCommand('copy')`, remove it.

`select()` moves focus off the grid cell, and the textarea is removed **without restoring focus** — so focus ends up on `<body>`.

From that point every key press after a copy goes to the document instead of the grid:

- arrow navigation no longer moves the cell selection
- `Ctrl+V` never reaches react-data-grid, so `onPaste` (and therefore `handlePaste`) is never invoked

The grid looks frozen until the user clicks a cell again. The copy itself works — I confirmed `execCommand('copy')` does populate the clipboard by reading it back — so the only defect is the lost focus.

## Evidence

Instrumented traces from the bulk-import grid, same build, differing only in origin.

Insecure origin (`http://<host>:3000`, `isSecureContext === false`):

```
keydown C  target=rdg-cell cj343x07-0-0-beta-47 rdg-cell-name
handleCopy -> execCommand branch
keydown V  target=                     <- focus is on <body>
(handlePaste never called)
```

Secure origin (`http://localhost:3000`), for comparison — the Clipboard API branch creates no textarea, so focus is never disturbed:

```
handleCopy -> Clipboard API branch
keydown V  target=rdg-cell cj343x07-0-0-beta-47 rdg-cell-displayName
handlePaste ENTRY -> got "pw-database-schema-…"
```

With this fix applied, the insecure origin produces the same `keydown V target=rdg-cell …` as the secure one and `handlePaste` is invoked.

## Fix

Capture `document.activeElement` before the temporary textarea is inserted and restore it after the textarea is removed.

## Scope / what this does not fix

This restores keyboard interaction with the grid after a copy. It does **not** make paste functional on a plain-HTTP deployment: once `Ctrl+V` reaches the grid, `handlePaste` calls `navigator.clipboard.readText()`, which is `undefined` in an insecure context and throws. Reading the clipboard there is a browser restriction — `navigator.clipboard` is unavailable, `execCommand('paste')` is blocked in page content, and paste events are not delivered to a non-editable grid. Serving the app over HTTPS is the real answer; a follow-up could at least guard that call rather than throwing.

I have deliberately kept this PR to the focus bug, which is self-contained and independently verifiable.

## Testing

Verified manually against a live server on both a secure (`localhost`) and an insecure (LAN IP) origin, using the traces above. No existing test covers the `execCommand` branch, because the Playwright suite runs with clipboard permissions granted where the Clipboard API path is taken instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
