### PR TITLE
fix(ui): restore grid focus after execCommand copy, and make the bulk import clipboard mock effective

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -2448,6 +2448,15 @@ export const copyAndGetClipboardText = async (
  */
 export const mockClipboardApi = async (page: Page): Promise<void> => {
   await page.addInitScript(() => {
+    // The grid only calls navigator.clipboard when window.isSecureContext is true. On a
+    // plain-HTTP AUT origin it is false, so the copy half falls through to execCommand and
+    // writes to the real OS clipboard while the paste half reads this mock - the two never
+    // agree and every paste yields an empty cell.
+    Object.defineProperty(window, 'isSecureContext', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
     let clipboardData = '';
     Object.defineProperty(navigator, 'clipboard', {
       value: {
@@ -2460,6 +2469,13 @@ export const mockClipboardApi = async (page: Page): Promise<void> => {
       configurable: true,
     });
   });
+
+  // addInitScript only applies to documents loaded after it is registered. Callers install
+  // this mid-test, by which point the fixture has already navigated, so without a reload the
+  // mock never runs and the grid silently uses the real clipboard.
+  if (!page.url().startsWith('about:')) {
+    await page.reload({ waitUntil: 'domcontentloaded' });
+  }
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
@@ -125,12 +125,23 @@ function useClipboardHandlers(
       if (navigator.clipboard && window.isSecureContext) {
         navigator.clipboard.writeText(tsv.join('\n'));
       } else {
+        // Selecting the textarea moves focus off the grid cell. Restore it afterwards,
+        // otherwise every subsequent key (arrow navigation, Ctrl+V) is delivered to <body>
+        // and the grid stops responding until the user clicks a cell again.
+        const previouslyFocused = document.activeElement as HTMLElement | null;
         const textarea = document.createElement('textarea');
         textarea.value = tsv.join('\n');
         document.body.appendChild(textarea);
         textarea.select();
-        const success = document.execCommand('copy');
-        document.body.removeChild(textarea);
+        let success = false;
+        try {
+          success = document.execCommand('copy');
+        } finally {
+          // execCommand can throw in some browsers rather than returning false; clean up and
+          // hand focus back either way, so a failed copy cannot leave the grid unusable.
+          document.body.removeChild(textarea);
+          previouslyFocused?.focus();
+        }
 
         return success;
       }


### PR DESCRIPTION
Backport of #30823 to `1.13`, **plus** the test-side half that only applies on this branch.

`main` no longer has `mockClipboardApi` and has merged the *Range selection* test into *Keyboard Delete selection*, so #30823 could only carry the product fix. On `1.13` the mock and the test both still exist, so the failure is fully fixable here — and this is the branch the fix was actually validated against.

## Two independent defects

**1. `handleCopy` steals grid focus (product)**

On a plain-HTTP deployment `window.isSecureContext` is false and `navigator.clipboard` is undefined, so `handleCopy` falls back to the textarea + `document.execCommand('copy')` trick. `select()` moves focus off the grid cell and it is never restored, leaving focus on `<body>`.

Every key after a copy then goes to the document rather than the grid: arrow navigation stops moving the selection, and `Ctrl+V` never reaches react-data-grid so `onPaste` is never fired. The grid looks frozen until the user clicks a cell again. The copy itself is fine — `execCommand('copy')` does populate the clipboard, verified by reading it back.

Teardown is in a `finally` because `execCommand` can throw rather than return `false`.

**2. `mockClipboardApi` never ran (test)**

`addInitScript` only applies to documents loaded *after* registration, and the helper is installed once the fixture has already navigated, with no further document load. The init script never executed, so the grid was silently using the real clipboard and the mock protected nothing.

It was also asymmetric: the grid only calls `navigator.clipboard` when `isSecureContext` is true. On the AUT origin it is false, so the copy half fell through to `execCommand` and wrote to the **real OS clipboard** while the paste half read the **mock** — the two never agreed and every paste yielded an empty cell.

Fix: reload after registering the script, and override `isSecureContext` so both halves use the mock.

## Evidence

Instrumented traces from the grid, same build, differing only in origin.

Insecure origin, before:

```
keydown C  target=rdg-cell cj343x07-0-0-beta-47 rdg-cell-name
handleCopy -> execCommand branch
keydown V  target=                     <- focus on <body>
(handlePaste never called)
```

Secure origin, for comparison — the Clipboard API branch creates no textarea, so focus is never disturbed:

```
handleCopy -> Clipboard API branch
keydown V  target=rdg-cell cj343x07-0-0-beta-47 rdg-cell-displayName
handlePaste ENTRY -> got "pw-database-schema-…"
```

Two theories these traces killed, for the record: react-data-grid drives paste from **keydown**, not the `paste` event (no `paste` event fires on either origin), and `execCommand('copy')` is **not** a no-op in headless.

## Testing

Run against a live 1.13 server with the UI served from a dev server, on a genuinely insecure origin (a LAN IP — `localhost` and `127.0.0.1` are treated as secure, so the bug does not reproduce there).

| | Range selection | full `BulkImport.spec.ts` |
|---|---|---|
| insecure origin, before | fails, identical error to nightly | 5 passed / 1 failed |
| insecure origin, after | passes | **6/6** |
| secure origin, after | passes | — |

The nightly failure this addresses:

```
expect(locator).toHaveText(expected) failed
Locator: locator('.rdg-row').first().locator('.rdg-cell').nth(1)
Expected: "pw-database-schema-…"
Received: ""
```

One caveat worth stating: with the test fix in place, copy takes the Clipboard API branch, so the `execCommand` path is **not** exercised by the suite. The focus fix is justified by the traces above rather than by the test going green.

## Not fixed here

Paste still cannot work on a plain-HTTP deployment: once `Ctrl+V` reaches the grid, `handlePaste` calls `navigator.clipboard.readText()`, which is `undefined` in an insecure context and throws. `navigator.clipboard` is unavailable, `execCommand('paste')` is blocked in page content, and paste events are not delivered to a non-editable grid — HTTPS is the real answer. A follow-up should at least guard that call rather than throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
