### PR TITLE
ci(playwright): retry docker pulls when starting the fast environment

### DIFF
--- a/.github/scripts/start_playwright_fast_environment.sh
+++ b/.github/scripts/start_playwright_fast_environment.sh
@@ -178,6 +178,37 @@ if [[ -n "$ingestion_image_path" ]]; then
   fi
 fi
 
+# Pre-pull the compose images with retries so a transient Docker Hub blip does
+# not fail the shard on the very first step. Docker Hub's auth endpoint is
+# unreliable enough that a single request per image regularly times out (see
+# run 30730142750 where chromium-14/19/20 all failed on
+# `Get "https://auth.docker.io/token?..."` with no test having run). Separating
+# the pull from `docker compose up` also gives a clearer error when pulls
+# actually fail — no orphan containers, exit before the health-wait loop.
+pull_image_with_retry() {
+  local image=$1
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    return 0  # already cached from a previous invocation on the same runner
+  fi
+  local delay=10
+  local attempt
+  for attempt in 1 2 3; do
+    if docker pull --quiet "$image"; then
+      return 0
+    fi
+    if [[ $attempt -eq 3 ]]; then
+      echo "docker pull failed for $image after 3 attempts" >&2
+      return 1
+    fi
+    echo "docker pull $image failed on attempt $attempt; retrying in ${delay}s" >&2
+    sleep "$delay"
+    delay=$(( delay * 2 ))
+  done
+}
+
+pull_image_with_retry "$PW_POSTGRES_IMAGE"
+pull_image_with_retry "$PW_OPENSEARCH_IMAGE"
+
 docker compose -f "$compose_file" -f "$fast_compose_file" up -d --no-build postgresql opensearch
 
 for service in postgresql opensearch; do


### PR DESCRIPTION
## Summary

Three chromium shards (14, 19, 20) on [merge-queue run 30730142750](https://github.com/open-metadata/OpenMetadata/actions/runs/30730142750/job/91451373058) all died at the *very first* playwright step (`Restore fast Playwright environment`) with the same error, seconds apart:

```
Get "https://auth.docker.io/token?account=githubactions&..."
net/http: request canceled while waiting for connection
(Client.Timeout exceeded while awaiting headers)
```

Docker Hub's auth endpoint had a blip. The single-shot `docker compose up` in `start_playwright_fast_environment.sh:181` gave the shard no way to recover — no tests ran, the merge queue had to be manually retried.

## Change

Small `pull_image_with_retry` helper in the same script, called for both `PW_POSTGRES_IMAGE` and `PW_OPENSEARCH_IMAGE` before the compose `up`:

- **Skip the pull if the image is already cached** on the runner (`docker image inspect` first) — repeat invocations on the same runner stay zero-cost.
- **3 attempts with 10s / 20s / 40s backoff.** Worst case adds ~70 s of sleep inside the existing 5-minute wrapper.
- **Fail with a clear message** rather than orphaning the compose stack — separating the network step from the container start also gives a cleaner failure surface.

Compose `up` itself is unchanged. Nothing else in the script moves.

## Test plan

- [x] `bash -n` syntax check clean.
- [x] `shellcheck` clean.
- [ ] Merge-queue runs where Docker Hub is healthy: no behavior change (images are pre-pulled, compose up finds them locally).
- [ ] Merge-queue runs where Docker Hub hiccups on one attempt: the shard sleeps 10 s and retries, succeeds, continues to tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)