### PR TITLE
ci(playwright): fail the plan step at PR time when a spec's baseline is stale

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -588,16 +588,30 @@ def main() -> None:
     apply_history_weights(units, test_weights, identity_weights)
     emit_unweighted_warnings(units, test_weights, identity_weights)
 
-    stale_files = stale_baseline_files_in_plan(
-        units, test_weights, identity_weights
+    # Only enforce the stale-baseline gate for targeted (PR-time) planning.
+    # A full-mode run is what generates the new timing-history artifact in
+    # the first place — the "wait for a nightly full-mode run" remediation
+    # below requires that full-mode planning stay unblocked even when a
+    # newly re-enabled suite has no baseline. In full mode, the softer
+    # emit_unweighted_warnings above still surfaces the issue as a warning.
+    stale_files = (
+        stale_baseline_files_in_plan(units, test_weights, identity_weights)
+        if selection["mode"] != "full"
+        else []
     )
     if stale_files:
+        # `::error file=...::` annotations resolve against the repo root, so
+        # prefix the discovery-report file path (relative to `playwright/e2e/`)
+        # with the full spec directory so the annotation attaches to the file
+        # in the PR checks UI.
+        spec_root = "openmetadata-ui/src/main/resources/ui/playwright/e2e"
         for file, count in stale_files:
             print(
-                f"::error file={file}::All {count} planned test(s) in {file} "
-                "have no timing history in timing-baseline.json. This is the "
-                "stale-baseline pattern that caused the chromium-12 SIGTERM "
-                "in run 30716060441 (see PR #30812).",
+                f"::error file={spec_root}/{file}::All {count} planned "
+                f"test(s) in {file} have no timing history in "
+                "timing-baseline.json. This is the stale-baseline pattern "
+                "that caused the chromium-12 SIGTERM in run 30716060441 "
+                "(see PR #30812).",
                 file=sys.stderr,
             )
         details = "\n".join(

--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -342,6 +342,17 @@ def apply_history_weights(
 # gets an annotation the re-enabling PR author will see on the plan step.
 UNWEIGHTED_WARN_MIN_TESTS = 10
 UNWEIGHTED_WARN_MIN_MS = 60_000
+# Hard-fail threshold: a file whose every planned test falls through to
+# FALLBACK_TEST_MS AND has at least this many tests is the exact pattern that
+# killed chromium-12 in #30812 — a suite that was `test.skip`'d at baseline
+# capture, re-enabled without a baseline refresh, then packed at zero apparent
+# cost by LPT. Any real re-enable of an existing suite will trip this (Domains
+# was 47 tests, DomainDataProductsWidgets was 6); a single new test being
+# added to a well-covered file will not (the file's other tests carry
+# history). Kept intentionally low so a new spec-file addition also fails
+# fast — a wholly-new file's author has just written the tests and knows the
+# durations.
+STALE_BASELINE_MIN_TESTS = 5
 
 
 def emit_unweighted_warnings(
@@ -368,6 +379,36 @@ def emit_unweighted_warnings(
             "with real durations to avoid shard overruns on the first plan."
         )
         print(f"::warning file={file}::{message}", file=sys.stderr)
+
+
+def stale_baseline_files_in_plan(
+    units: list[Unit],
+    test_weights: dict[str, int],
+    identity_weights: dict[tuple[str, str], int],
+) -> list[tuple[str, int]]:
+    """Return (file, planned_test_count) for each spec file where every test
+    in the plan falls through to FALLBACK_TEST_MS — no test_weights hit and
+    no identity_weights hit, for any test in the file's units. This is the
+    stale-baseline signature that caused the chromium-12 SIGTERM (#30812)
+    and shows up as a hard-fail here rather than the softer per-count
+    warning above.
+    """
+    by_file_planned: dict[str, int] = defaultdict(int)
+    by_file_unweighted: dict[str, int] = defaultdict(int)
+    for unit in units:
+        for test_id in unit.test_ids:
+            by_file_planned[unit.file] += 1
+            if test_id in test_weights:
+                continue
+            if (unit.file, unit.test_names[test_id]) in identity_weights:
+                continue
+            by_file_unweighted[unit.file] += 1
+    return sorted(
+        (file, by_file_planned[file])
+        for file, planned in by_file_planned.items()
+        if planned >= STALE_BASELINE_MIN_TESTS
+        and by_file_unweighted[file] == planned
+    )
 
 
 def normalize_spec(path: str) -> str:
@@ -546,6 +587,42 @@ def main() -> None:
 
     apply_history_weights(units, test_weights, identity_weights)
     emit_unweighted_warnings(units, test_weights, identity_weights)
+
+    stale_files = stale_baseline_files_in_plan(
+        units, test_weights, identity_weights
+    )
+    if stale_files:
+        for file, count in stale_files:
+            print(
+                f"::error file={file}::All {count} planned test(s) in {file} "
+                "have no timing history in timing-baseline.json. This is the "
+                "stale-baseline pattern that caused the chromium-12 SIGTERM "
+                "in run 30716060441 (see PR #30812).",
+                file=sys.stderr,
+            )
+        details = "\n".join(
+            f"  {file}: {count} planned test(s), 0 with baseline history"
+            for file, count in stale_files
+        )
+        raise SystemExit(
+            "Stale timing-baseline.json entries detected for spec file(s) in "
+            "this plan. Every planned test in each file below falls through "
+            "to FALLBACK_TEST_MS, so the planner will under-budget the shard "
+            "containing them and the merge-queue wrapper will time out.\n\n"
+            f"{details}\n\n"
+            "To fix, either:\n"
+            "  * Seed the observed durations for these files into "
+            ".github/playwright/timing-baseline.json (see PR #30812 for the "
+            "pattern — parse a passing job's log and write real durationMs "
+            "with outcome: expected).\n"
+            "  * Wait for a nightly full-mode run to organically refresh the "
+            "baseline, then rebase.\n"
+            "  * If this is a wholly-new spec file, run it locally and copy "
+            "its durations into the baseline before merging.\n\n"
+            "This gate catches the failure at PR time rather than on the "
+            "merge queue — a wrapper timeout in the queue costs ~25 min per "
+            "shard and blocks every downstream PR."
+        )
 
     oversized_units = [unit for unit in units if unit.weight_ms > TARGET_MS]
     if oversized_units:

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -268,6 +268,158 @@ def test_emit_unweighted_warnings_ignores_tests_with_history(capsys):
     assert capsys.readouterr().err == ""
 
 
+def test_stale_baseline_files_flag_all_fallback_files_over_threshold():
+    # The exact chromium-12 pattern (#30812): every planned test in a file
+    # has no timing evidence (test_weights miss + identity_weights miss)
+    # AND the file has >= STALE_BASELINE_MIN_TESTS planned tests.
+    planner = load_script("build_playwright_shards")
+    stale_file = "Pages/Reactivated.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            stale_file,
+            f"unit-{index}",
+            test_ids={f"reactivated-{index}"},
+            test_names={f"reactivated-{index}": f"case {index}"},
+        )
+        for index in range(planner.STALE_BASELINE_MIN_TESTS)
+    ]
+
+    result = planner.stale_baseline_files_in_plan(units, {}, {})
+
+    assert result == [(stale_file, planner.STALE_BASELINE_MIN_TESTS)]
+
+
+def test_stale_baseline_files_ignore_files_below_threshold():
+    # A file with fewer than STALE_BASELINE_MIN_TESTS on the fallback path
+    # is a legitimate "wrote a couple of tests" case, not a re-enable.
+    planner = load_script("build_playwright_shards")
+    file = "Pages/JustTwoNewTests.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"new-{index}"},
+            test_names={f"new-{index}": f"case {index}"},
+        )
+        for index in range(planner.STALE_BASELINE_MIN_TESTS - 1)
+    ]
+
+    assert planner.stale_baseline_files_in_plan(units, {}, {}) == []
+
+
+def test_stale_baseline_files_ignore_files_with_any_history():
+    # If even one test in the file has real history, it's not the stale
+    # pattern — it's just "someone added some new tests to a covered file",
+    # which the softer emit_unweighted_warnings covers.
+    planner = load_script("build_playwright_shards")
+    file = "Pages/Existing.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"test-{index}"},
+            test_names={f"test-{index}": f"case {index}"},
+        )
+        for index in range(planner.STALE_BASELINE_MIN_TESTS + 3)
+    ]
+    weights = {"test-0": 5_000}  # a single existing test carries the file
+
+    assert planner.stale_baseline_files_in_plan(units, weights, {}) == []
+
+
+def test_stale_baseline_files_ignore_files_covered_by_identity_match():
+    # Identity fallback (file + leaf title) is treated as real history —
+    # the planner uses those weights, so the file is not "stale".
+    planner = load_script("build_playwright_shards")
+    file = "Pages/RenamedIds.spec.ts"
+    units = [
+        planner.Unit(
+            "chromium",
+            file,
+            f"unit-{index}",
+            test_ids={f"drifted-id-{index}"},
+            test_names={f"drifted-id-{index}": f"case {index}"},
+        )
+        for index in range(planner.STALE_BASELINE_MIN_TESTS + 2)
+    ]
+    identity_weights = {
+        (file, f"case {index}"): 4_000
+        for index in range(len(units))
+    }
+
+    assert planner.stale_baseline_files_in_plan(units, {}, identity_weights) == []
+
+
+def test_main_fails_when_a_planned_file_has_stale_baseline(tmp_path):
+    # End-to-end: the planner exits non-zero at plan time when a file's
+    # every planned test is on the fallback path. This is the gate that
+    # catches the pattern on PRs instead of on the merge queue (#30812
+    # trigger scenario).
+    import subprocess
+    planner_path = SCRIPTS / "build_playwright_shards.py"
+    test_list = tmp_path / "test-list.json"
+    selection = tmp_path / "selection.json"
+    history = tmp_path / "history.json"
+    output_dir = tmp_path / "plans"
+
+    # A spec file with 5 tests (== STALE_BASELINE_MIN_TESTS default), all
+    # newly discovered — no baseline entries.
+    file = "Pages/Reactivated.spec.ts"
+    test_list.write_text(
+        json.dumps(
+            {
+                "suites": [
+                    {
+                        "file": file,
+                        "suites": [
+                            {
+                                "title": "Reactivated tests",
+                                "specs": [
+                                    {
+                                        "id": f"synthetic-{index}",
+                                        "title": f"case {index}",
+                                        "tests": [{"projectName": "chromium"}],
+                                    }
+                                    for index in range(5)
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    selection.write_text(json.dumps({"mode": "full"}))
+    # History file exists but does not cover any of the discovered specs —
+    # every test in the file falls through to FALLBACK_TEST_MS.
+    history.write_text(json.dumps({"mode": "full", "tests": []}))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(planner_path),
+            "--test-list", str(test_list),
+            "--selection", str(selection),
+            "--history", str(history),
+            "--output-dir", str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "Stale timing-baseline.json entries detected" in combined
+    assert file in combined
+    assert "5 planned test(s)" in combined
+    # The gate must fire BEFORE the plan is written — matrix.json must not
+    # exist, so a downstream `jq` step will visibly fail on the plan step.
+    assert not (output_dir / "matrix.json").exists()
+
+
 def test_history_includes_retry_time_and_skipped_only_ids_fall_to_fallback(tmp_path):
     # Was previously "only_preserves_explicit_skips" — the planner used to pin
     # weight_ms=0 for tests whose only recorded outcome was 'skipped'. That was

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -353,11 +353,13 @@ def test_stale_baseline_files_ignore_files_covered_by_identity_match():
     assert planner.stale_baseline_files_in_plan(units, {}, identity_weights) == []
 
 
-def test_main_fails_when_a_planned_file_has_stale_baseline(tmp_path):
-    # End-to-end: the planner exits non-zero at plan time when a file's
-    # every planned test is on the fallback path. This is the gate that
-    # catches the pattern on PRs instead of on the merge queue (#30812
-    # trigger scenario).
+def test_main_fails_when_a_targeted_plan_has_a_stale_baseline_file(tmp_path):
+    # End-to-end: the planner exits non-zero at PR (targeted) plan time
+    # when a file's every planned test is on the fallback path. This is
+    # the gate that catches the pattern on PRs instead of on the merge
+    # queue (#30812 trigger scenario). Full-mode planning is exempt so
+    # nightly/merge_group runs can still generate the timing-history
+    # artifact that unblocks the "wait for the next full run" fix.
     import subprocess
     planner_path = SCRIPTS / "build_playwright_shards.py"
     test_list = tmp_path / "test-list.json"
@@ -392,7 +394,18 @@ def test_main_fails_when_a_planned_file_has_stale_baseline(tmp_path):
             }
         )
     )
-    selection.write_text(json.dumps({"mode": "full"}))
+    # Targeted selection matching the stale file — mirrors what the PR
+    # selection artifact carries when the PR touches this spec.
+    selection.write_text(
+        json.dumps(
+            {
+                "mode": "targeted",
+                "selectors": [
+                    {"spec": f"playwright/e2e/{file}", "projects": ["auto"]}
+                ],
+            }
+        )
+    )
     # History file exists but does not cover any of the discovered specs —
     # every test in the file falls through to FALLBACK_TEST_MS.
     history.write_text(json.dumps({"mode": "full", "tests": []}))
@@ -415,9 +428,74 @@ def test_main_fails_when_a_planned_file_has_stale_baseline(tmp_path):
     assert "Stale timing-baseline.json entries detected" in combined
     assert file in combined
     assert "5 planned test(s)" in combined
+    # The `::error file=...::` annotation must carry the full repo-relative
+    # spec path so GitHub Actions attaches it inline in the PR checks UI.
+    assert (
+        f"::error file=openmetadata-ui/src/main/resources/ui/playwright/e2e/{file}::"
+        in combined
+    )
     # The gate must fire BEFORE the plan is written — matrix.json must not
     # exist, so a downstream `jq` step will visibly fail on the plan step.
     assert not (output_dir / "matrix.json").exists()
+
+
+def test_main_skips_stale_baseline_gate_in_full_mode(tmp_path):
+    # Full-mode (nightly / merge_group) planning must not trip the
+    # stale-baseline gate — otherwise the very run that captures the
+    # missing timing evidence would fail before it could execute.
+    import subprocess
+    planner_path = SCRIPTS / "build_playwright_shards.py"
+    test_list = tmp_path / "test-list.json"
+    selection = tmp_path / "selection.json"
+    history = tmp_path / "history.json"
+    output_dir = tmp_path / "plans"
+
+    file = "Pages/Reactivated.spec.ts"
+    test_list.write_text(
+        json.dumps(
+            {
+                "suites": [
+                    {
+                        "file": file,
+                        "suites": [
+                            {
+                                "title": "Reactivated tests",
+                                "specs": [
+                                    {
+                                        "id": f"synthetic-{index}",
+                                        "title": f"case {index}",
+                                        "tests": [{"projectName": "chromium"}],
+                                    }
+                                    for index in range(5)
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    selection.write_text(json.dumps({"mode": "full"}))
+    history.write_text(json.dumps({"mode": "full", "tests": []}))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(planner_path),
+            "--test-list", str(test_list),
+            "--selection", str(selection),
+            "--history", str(history),
+            "--output-dir", str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    combined = result.stdout + result.stderr
+    # The stale-baseline gate must NOT fire in full mode — a plan should
+    # still be written so the run can execute and refresh the baseline.
+    assert "Stale timing-baseline.json entries detected" not in combined
+    assert (output_dir / "matrix.json").exists()
 
 
 def test_history_includes_retry_time_and_skipped_only_ids_fall_to_fallback(tmp_path):


### PR DESCRIPTION
## Summary

Turn the soft plan-time warning from #30813 into a hard **PR-time gate** for the exact pattern that caused the chromium-12 SIGTERM ([#30812](https://github.com/open-metadata/OpenMetadata/pull/30812)): a spec file where every planned test falls through to `FALLBACK_TEST_MS` because the baseline is stale.

The idea: **align planner + implementation at PR time**, so a stale baseline can't reach the merge queue. A wrapper timeout there costs ~25 min per shard and blocks every downstream PR; catching it at the plan step is ~1 s.

## What trips the gate

`stale_baseline_files_in_plan` returns files where:
- ≥ `STALE_BASELINE_MIN_TESTS` (default 5) tests are in the plan for that file.
- Every one of those tests is on the fallback path — no `test_weights` hit, no `identity_weights` hit.

That combination is the "re-enabled suite" or "wholly-new spec" signature — it doesn't match a normal PR that adds a couple of tests to a well-covered file.

## What does NOT trip it

Kept as warnings via `emit_unweighted_warnings` (PR #30813):
- Files with fewer than 5 fallback tests — "wrote a couple of new tests" case.
- Files where any test carries real history — mixed coverage is not a re-enable.
- Files whose fallback tests match the baseline via **identity** (file + leaf title) — `@tag` drift, renamed IDs, etc. still resolve.

## The error message

If the gate fires, the plan step exits non-zero after writing:

```
::error file=Pages/Reactivated.spec.ts::All 6 planned test(s) in Pages/Reactivated.spec.ts
have no timing history in timing-baseline.json. This is the stale-baseline pattern that
caused the chromium-12 SIGTERM in run 30716060441 (see PR #30812).

Stale timing-baseline.json entries detected for spec file(s) in this plan. Every planned
test in each file below falls through to FALLBACK_TEST_MS, so the planner will
under-budget the shard containing them and the merge-queue wrapper will time out.

  Pages/Reactivated.spec.ts: 6 planned test(s), 0 with baseline history

To fix, either:
  * Seed the observed durations for these files into .github/playwright/timing-baseline.json
    (see PR #30812 for the pattern — parse a passing job's log and write real durationMs
    with outcome: expected).
  * Wait for a nightly full-mode run to organically refresh the baseline, then rebase.
  * If this is a wholly-new spec file, run it locally and copy its durations into the
    baseline before merging.

This gate catches the failure at PR time rather than on the merge queue — a wrapper timeout
in the queue costs ~25 min per shard and blocks every downstream PR.
```

The `::error file=...::` annotation surfaces on the PR checks page next to the file, so reviewers see it inline.

## Test plan

- [x] 6 new pytest cases (`test_stale_baseline_*`) covering the threshold, the three ignore paths (below threshold, mixed history, identity match), and the end-to-end `main()` SystemExit.
- [x] Manually reproduced the pre-#30812 pattern with a synthetic test-list + all-skipped baseline — gate exits 1 with the expected message.
- [x] All 69 planning tests pass locally.

Related: #30812 (planner all-zero-history fix), #30813 (soft warning), #30814 (harness baseline-freshness warning), #30822 (glossary hang fix), #30824 (perf gate alignment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)