### PR TITLE
test(playwright): remove four latent wait races from the AUT suite (#30788) [2.0]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Pagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Pagination.spec.ts
@@ -45,17 +45,20 @@ test.describe('Pagination Tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     test.beforeAll(async ({ browser }) => {
       const { apiContext, afterAction } = await createNewPage(browser);
 
-      for (let i = 1; i <= 20; i++) {
+      // Created concurrently: 20 sequential round-trips accumulate enough
+      // latency under load to blow the 60s beforeAll budget on their own.
+      const paginationUsers = Array.from({ length: 20 }, () => {
         const uniqueId = uuid();
-        const user = new UserClass({
+
+        return new UserClass({
           firstName: `pw_pagination_User${uniqueId}`,
           lastName: `LastName${uniqueId}`,
           email: `pw_pagination_user${uniqueId}@example.com`,
           password: 'User@OMD123',
         });
+      });
 
-        await user.create(apiContext);
-      }
+      await Promise.all(paginationUsers.map((user) => user.create(apiContext)));
 
       await afterAction();
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -45,10 +45,10 @@ const startAsyncExport = async (page: Page) => {
   return jobId;
 };
 
-const fetchCompletedExportCsv = async (
+const waitForExportJobCompleted = async (
   apiContext: APIRequestContext,
   jobId: string
-): Promise<string> => {
+): Promise<void> => {
   await expect
     .poll(
       async () => {
@@ -63,6 +63,13 @@ const fetchCompletedExportCsv = async (
       { timeout: 90_000 }
     )
     .toBe('COMPLETED');
+};
+
+const fetchCompletedExportCsv = async (
+  apiContext: APIRequestContext,
+  jobId: string
+): Promise<string> => {
+  await waitForExportJobCompleted(apiContext, jobId);
 
   const resultResponse = await apiContext.get(
     `/api/v1/csvAsyncJobs/${jobId}/result`
@@ -429,11 +436,19 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
     });
 
     await test.step('Download from the tray serves the job result CSV', async () => {
+      // The Download button only renders once the async job finishes, so waiting
+      // blind on it spent up to 90s of the test budget before the download waits
+      // even started -- the remainder then ran out mid-wait and surfaced as
+      // "Target page, context or browser has been closed". Poll the job over the
+      // API first (the same way fetchCompletedExportCsv does), so a stalled job is
+      // named as such and the UI waits that follow are short.
+      await waitForExportJobCompleted(page.request, jobId);
+
       const downloadButton = page
         .getByRole('button', { name: 'Download' })
         .first();
 
-      await expect(downloadButton).toBeVisible({ timeout: 90_000 });
+      await expect(downloadButton).toBeVisible();
 
       const resultResponsePromise = page.waitForResponse(
         (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/Tour.spec.ts
@@ -43,14 +43,14 @@ const waitForTourBadgeWithRetry = async (
   }
 };
 
-const expectTourBadge = async (page: Page, step: string, timeout = 10000) => {
-  const badge = page.locator('[data-tour-elem="badge"]');
-  await badge.waitFor({ state: 'visible', timeout });
-  await expect
-    .poll(async () => (await badge.textContent())?.trim(), {
-      timeout,
-    })
-    .toBe(step);
+const expectTourBadge = async (page: Page, step: string, timeout = 30000) => {
+  // A single web-first assertion. The badge re-renders on every step transition,
+  // so a separate visibility wait followed by a text poll gave the transition two
+  // independent budgets to lose against; toHaveText auto-waits for the element to
+  // attach *and* carry the expected step, and reports the actual step on failure.
+  await expect(page.locator('[data-tour-elem="badge"]')).toHaveText(step, {
+    timeout,
+  });
 };
 
 const validateTourSteps = async (page: Page) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomProperties.spec.ts
@@ -327,16 +327,30 @@ ALL_ENTITIES.forEach(({ key, makeInstance }) => {
         );
 
         if (key === 'entity_table') {
-          for (let i = 0; i < 5; i++) {
-            const user = new UserClass();
-            await user.create(apiContext);
-            users.push(user);
+          // Created concurrently: sequential round-trips in this hook
+          // accumulate enough latency under load to exhaust its 60s budget.
+          // allSettled rather than all, so a partial failure still registers
+          // whatever was created for teardown before the hook fails — the
+          // rejection is rethrown, never swallowed.
+          const newUsers = Array.from({ length: 5 }, () => new UserClass());
+          const created = await Promise.allSettled(
+            newUsers.map((user) => user.create(apiContext))
+          );
+          // create() persists the user via /users/signup and only then assigns
+          // roles, so a rejection can still leave a real user behind. Register
+          // by "did it get an id", not by "did the promise settle happily".
+          users.push(...newUsers.filter((user) => user.responseData?.id));
+          const failed = created.find((result) => result.status === 'rejected');
+          if (failed) {
+            throw failed.reason;
           }
         } else if (key === 'entity_dashboard') {
           dashboardTopic1 = new TopicClass();
           dashboardTopic2 = new TopicClass();
-          await dashboardTopic1.create(apiContext);
-          await dashboardTopic2.create(apiContext);
+          await Promise.all([
+            dashboardTopic1.create(apiContext),
+            dashboardTopic2.create(apiContext),
+          ]);
           await setupCustomPropertyAdvancedSearchTest(
             page,
             cpasTestData,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -868,18 +868,51 @@ export const verifyExportLineagePNG = async (
 
   await expect(page.getByTestId('export-type-select')).toContainText('PNG');
 
-  const [download] = await Promise.all([
-    // Platform lineage renders up to 500 nodes at pixelRatio:3 — give the PNG
-    // render enough headroom before the download event fires.
-    page.waitForEvent('download', { timeout: 120_000 }),
-    page.click(
-      '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
-    ),
-  ]);
+  // If the client-side render throws, no download event ever fires and the wait
+  // below expires with nothing to say. Capture page errors so a silent exception
+  // is reported as the cause instead of an anonymous 120s timeout; a genuinely
+  // slow render still surfaces the original timeout untouched.
+  const pageErrors: string[] = [];
+  const collectPageError = (error: Error) =>
+    pageErrors.push(error.stack ?? error.message);
+  page.on('pageerror', collectPageError);
 
-  const filePath = await download.path();
+  try {
+    const [download] = await Promise.all([
+      // Platform lineage renders up to 500 nodes at pixelRatio:3 — give the PNG
+      // render enough headroom before the download event fires.
+      page.waitForEvent('download', { timeout: 120_000 }),
+      page.click(
+        '[data-testid="export-entity-modal"] [data-testid="submit-button"]:visible'
+      ),
+    ]);
 
-  expect(filePath).not.toBeNull();
+    const filePath = await download.path();
+
+    expect(filePath).not.toBeNull();
+  } catch (error) {
+    // Only the download wait is ambiguous about its cause. A click or selector
+    // failure already says what went wrong, so a stray page error must never
+    // replace it — and even for a timeout the original message is kept and the
+    // page errors appended, so a slow render still reads as a slow render.
+    const isDownloadTimeout =
+      error instanceof Error &&
+      error.message.includes('waiting for event "download"');
+
+    if (isDownloadTimeout && pageErrors.length > 0) {
+      throw new Error(
+        `${
+          error.message
+        }\n\nThe page also threw during the export, which may be the real cause:\n  ${pageErrors.join(
+          '\n  '
+        )}`
+      );
+    }
+
+    throw error;
+  } finally {
+    page.off('pageerror', collectPageError);
+  }
 };
 
 export const verifyColumnLineageInCSV = async (


### PR DESCRIPTION
### Describe your changes:

Cherry-pick of #30788 (`07e795dabd`) from `main` to `2.0`. **Test files only — no product code, so no customer-facing risk.**

Four independent AUT failures, all Playwright-side, all present on `2.0`:

1. **SearchExport** — the step waited up to 90s on the Download button, which only renders once the async CSV job finishes, before the download waits even started; the remaining test budget then ran out mid-wait and surfaced as `Target page, context or browser has been closed`. The test is already `test.slow()`, so a bigger budget is not the answer. Poll the job over the API first, the way `fetchCompletedExportCsv` in the same file already does.

2. **PlatformLineage** — the PNG export waits 120s for a `download` event. If the client-side render throws, no event fires and the failure says nothing. Capture `pageerror` and report a silent exception as the cause; a genuinely slow render still surfaces the original timeout untouched.

3. **Pagination / CustomProperties** — fixtures created one at a time inside 60s `beforeAll` hooks (20 users and 5 users). Created concurrently instead. `CustomProperties` uses `allSettled` and registers by persisted id, so a partial failure still leaves fixtures reachable for teardown before the hook fails.

4. **Tour** — `expectTourBadge` gave a step transition two independent 10s budgets (a visibility wait, then a text poll) against a badge that re-renders on every step. One `toHaveText` covers attachment and the expected step together.

#### Relevance to 2.0 specifically

`SearchExport` and `PlatformLineage` **flake on 2.0 today**. The `Pagination` / `CustomProperties` / `Tour` changes are prophylactic — the same serial-loop and double-budget code is on 2.0, it just hasn't lost the race there yet.

#### Not a clean pick — one file was hand-adapted

Four of the five files were byte-identical to `main`'s parent and picked cleanly. **`SearchExport.spec.ts` conflicted**: 2.0's copy has diverged in test names and structure. I kept 2.0's version and hand-applied the same change to it — extract `waitForExportJobCompleted` out of the existing `fetchCompletedExportCsv`, then call it in the failing test before asserting on the Download button. No 2.0-specific test content was replaced.

#
### Tests:

- **Prettier**: clean on all five files.
- **`tsc`**: clean on all five files.
- No conflict markers remain (verified across `playwright/`).

> **Verification caveat, stated plainly:** on `main` I ran `Tour` and `Pagination` green against a live stack (with a measured 45.7s → 36.9s improvement on the fixture change). **`SearchExport` and `PlatformLineage` were never executed** — they need `sample_data` and a populated lineage graph respectively. Those two are reasoned from the retained AUT traces, not run. Given `SearchExport.spec.ts` here is additionally a hand-adaptation rather than a clean pick, it deserves a closer look than the rest of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
