### PR TITLE
test(playwright): filter the glossary tree before expanding on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -2051,17 +2051,24 @@ export const expandToGlossaryTermChildren = async (
     timeout: 10000,
   });
 
+  // Always narrow the tree to the glossary first. It is virtualized, so on an instance with
+  // enough glossaries a freshly created one is simply not among the rendered rows and the
+  // lookup below fails with "element(s) not found" - which is exactly what happens on a loaded
+  // AUT where parallel specs have created many glossaries.
+  //
+  // Only search at the top level: searching re-queries the API and returns matched terms one
+  // level deep, so a nested term found that way looks like a leaf and its expand chevron never
+  // becomes interactive. The parent term is resolved from the glossary's already-loaded subtree.
+  const searchResponse = page.waitForResponse(
+    /\/api\/v1\/search\/query\?q=.*index=glossaryTerm.*/
+  );
+  await glossaryField.fill(glossaryDisplayName);
+  await searchResponse;
+  await waitForAllLoadersToDisappear(page);
+  await expandTreeNodeByName(page, glossaryDisplayName);
+
   if (parentTermDisplayName) {
-    await expandTreeNodeByName(page, glossaryDisplayName);
     await expandTreeNodeByName(page, parentTermDisplayName);
-  } else {
-    const searchResponse = page.waitForResponse(
-      /\/api\/v1\/search\/query\?q=.*index=glossaryTerm.*/
-    );
-    await glossaryField.fill(glossaryDisplayName);
-    await searchResponse;
-    await waitForAllLoadersToDisappear(page);
-    await expandTreeNodeByName(page, glossaryDisplayName);
   }
 };
 


### PR DESCRIPTION
Backport of behaviour `main` already has, shaped for 1.13.

## Problem

`expandToGlossaryTermChildren` only narrowed the tree in one of its two branches:

```ts
if (parentTermDisplayName) {
  await expandTreeNodeByName(page, glossaryDisplayName);   // expects it in the default listing
  await expandTreeNodeByName(page, parentTermDisplayName);
} else {
  await glossaryField.fill(glossaryDisplayName);           // filters, awaits the search
  await searchResponse;
  await expandTreeNodeByName(page, glossaryDisplayName);
}
```

When a parent term is passed it opens the dropdown and expects a freshly created glossary to already be among the rendered rows. The tree is **virtualized**, so on an instance with enough glossaries that node is not in the DOM at all and the lookup fails:

```
expect(locator).toBeVisible() failed
Locator: getByRole('tooltip').getByText('PW % c06f3259 Brave81108377', { exact: true })
Expected: visible
Error: element(s) not found
```

Note the text is the **glossary** display name, not the term. `scrollIntoViewIfNeeded()` cannot help because it runs after the visibility assertion.

This is why it presents as flaky and lands on a different test each run — it depends on how many glossaries parallel specs happen to have created. In two nightly runs it hit `MUI-ME-R01`, `S01` and `S03` in one and `R02` in the other.

## Fix

Always search for the glossary first, then expand.

Only at the top level: searching re-queries the API and returns matched terms one level deep, so a nested term found that way looks like a leaf and its expand chevron never becomes interactive. The parent term is resolved from the glossary's already-loaded subtree.

`main` already does exactly this, via the `search` option introduced when the tree was refactored to a `role="row"` grid with a `glossary-terms-popover` testid. That refactor does not exist on 1.13, which still renders `MuiTreeItem`, so `main`'s version cannot be cherry-picked verbatim — this is the same intent expressed against the 1.13 tree.

## Testing

Reproduced against a live 1.13 server. Locally the suite passes regardless, because a handful of glossaries all fit in the virtualized window — so I seeded 60 glossaries whose names sort ahead of the `PW %` fixtures, pushing them out of it. That reproduces the nightly error exactly, on the glossary name, on 6 of the 7 tests.

| | result |
|---|---|
| loaded tree, before | **6 of 7 failed** |
| loaded tree, after | **7 of 7 passed** |

`expandToGlossaryTermChildren` has no callers outside `MUIGlossaryMutualExclusivity.spec.ts`, so the behaviour change is contained to that spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
