### PR TITLE
test(ui): tolerate dismissed welcome screens

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -128,6 +128,22 @@ export const redirectToExplorePage = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 };
 
+/**
+ * Dismiss the optional welcome screen without waiting for it to appear.
+ *
+ * Storage-state-backed pages may already have dismissed onboarding. Check the button itself (not
+ * the parent screen) so a different first-login variant cannot turn this optional cleanup into a
+ * 30-second click timeout. If the button disappears between the visibility check and the click,
+ * the desired state has already been reached.
+ */
+export const closeWelcomeScreenIfVisible = async (page: Page) => {
+  const closeButton = page.getByTestId('welcome-screen-close-btn');
+
+  if (await closeButton.isVisible()) {
+    await closeButton.click().catch(() => undefined);
+  }
+};
+
 export const removeLandingBanner = async (page: Page) => {
   try {
     const welcomePageCloseButton = page.getByTestId('welcome-screen-close-btn');

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -32,6 +32,7 @@ import { TagClass } from '../support/tag/TagClass';
 import {
   clickOutside,
   closeFirstPopupAlert,
+  closeWelcomeScreenIfVisible,
   descriptionBox,
   getEntityTypeSearchIndexMapping,
   readElementInListWithScroll,
@@ -68,14 +69,7 @@ export const visitEntityPage = async (data: {
 
   await waitForAllLoadersToDisappear(page);
 
-  // Dismiss welcome screen if visible
-  const isWelcomeScreenVisible = await page
-    .getByTestId('welcome-screen')
-    .isVisible();
-
-  if (isWelcomeScreenVisible) {
-    await page.getByTestId('welcome-screen-close-btn').click();
-  }
+  await closeWelcomeScreenIfVisible(page);
 
   const searchResponse = page.waitForResponse(
     (response) =>

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/searchRBAC.ts
@@ -12,19 +12,9 @@
  */
 import { APIRequestContext, expect, Page } from '@playwright/test';
 import { SidebarItem } from '../constant/sidebar';
-import { redirectToHomePage } from './common';
+import { closeWelcomeScreenIfVisible, redirectToHomePage } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
-
-const closeWelcomeScreenIfVisible = async (page: Page) => {
-  const isWelcomeScreenVisible = await page
-    .getByTestId('welcome-screen')
-    .isVisible();
-
-  if (isWelcomeScreenVisible) {
-    await page.getByTestId('welcome-screen-close-btn').click();
-  }
-};
 
 /**
  * Navigate the given (already-logged-in) user to the Explore page, search for an
@@ -172,14 +162,7 @@ export const searchForEntityShouldWork = async (
   page: Page,
   entityName: string
 ) => {
-  // Wait for welcome screen and close it if visible
-  const isWelcomeScreenVisible = await page
-    .getByTestId('welcome-screen')
-    .isVisible();
-
-  if (isWelcomeScreenVisible) {
-    await page.getByTestId('welcome-screen-close-btn').click();
-  }
+  await closeWelcomeScreenIfVisible(page);
 
   await page.getByTestId('searchBox').click();
   await page.getByTestId('searchBox').fill(fqn);
@@ -213,14 +196,7 @@ export const searchForEntityShouldWorkShowNoResult = async (
   displayName: string,
   page: Page
 ) => {
-  // Wait for welcome screen and close it if visible
-  const isWelcomeScreenVisible = await page
-    .getByTestId('welcome-screen')
-    .isVisible();
-
-  if (isWelcomeScreenVisible) {
-    await page.getByTestId('welcome-screen-close-btn').click();
-  }
+  await closeWelcomeScreenIfVisible(page);
 
   await page.getByTestId('searchBox').click();
   await page.getByTestId('searchBox').fill(fqn);


### PR DESCRIPTION
## What changed

Adds a shared helper that closes the welcome screen only when its close button is currently visible, then uses it in the entity and Search RBAC Playwright helpers.

## Root cause

Nightly tests normally log in through the UI, so the onboarding state is predictable. Reusing an authenticated storage state can start on a page where onboarding is already dismissed or differs from the first-login variant. The existing unconditional clicks then wait for a button that will never appear.

## Impact

The existing login path is unchanged. The helpers now tolerate both fresh-login and preseeded-auth UI state, which is required before nightly workflows can safely reuse admin storage state and eliminate roughly 94 cold UI logins.

## Validation

- targeted UI ESLint passed for all three changed files
- targeted Prettier check passed
- `git diff --check` passed
- commit hooks passed

The repository-wide Playwright TypeScript check still reports unrelated existing errors; none are in these files.