### PR TITLE
fix(playwright): route BulkImport back to import-export lane and audit-split the atomic describe

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -78,6 +78,15 @@ COMMON_MAX_SHARDS = 24
 FALLBACK_TEST_MS = 30_000
 AUDITED_PARALLEL_SUITES = {
     ("Features/AdvancedSearch.spec.ts", "Advanced Search"),
+    # Six long-running tests (each 5-10 min per test.setTimeout) inside one
+    # top-level describe. Left as a single atomic unit, its total weight
+    # exceeds the 20-minute per-unit ceiling — merge-queue plan step for
+    # PR #30697 failed with "chromium|Features/BulkImport.spec.ts|Bulk Import
+    # Export (25.8m)" once the suite was re-enabled by #30458. Split it into
+    # per-spec parallel units. beforeAll setup is per-test-instance
+    # (module-scoped entity constructors generate unique names), so each
+    # parallel unit brings its own state without cross-worker collision.
+    ("Features/BulkImport.spec.ts", "Bulk Import Export"),
     ("Pages/DataContracts.spec.ts", "Data Contracts"),
     ("Pages/ExplorePageRightPanel.spec.ts", "Right Panel Test Suite"),
     ("Pages/Glossary.spec.ts", "Glossary tests"),

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkImport.spec.ts
@@ -147,7 +147,7 @@ const storedProcedureDetails = {
   glossary: glossaryDetails,
 };
 
-test.describe('Bulk Import Export', () => {
+test.describe('Bulk Import Export', { tag: '@import-export' }, () => {
   test.beforeAll('setup pre-test', async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
 


### PR DESCRIPTION
## Summary

The [merge-queue plan step for PR #30697](https://github.com/open-metadata/OpenMetadata/actions/runs/30758459100/job/91525522370) failed with:

```
Atomic Playwright units exceed the 20-minute execution budget; refactor or explicitly
audit them for parallel splitting: chromium|Features/BulkImport.spec.ts|Bulk Import Export (25.8m)
```

Two orthogonal issues from #30458's re-enable of the suite, both fixed here.

## Issue 1 — the `@import-export` tag was dropped along with `.fixme`

Before #30458:

```ts
test.describe.fixme('Bulk Import Export', { tag: '@import-export' }, () => { … })
```

After #30458 (current `origin/main`):

```ts
test.describe('Bulk Import Export', () => { … })
```

`.fixme` was removed correctly, but the `{ tag: '@import-export' }` option went with it. Without the tag:

- `ImportExport` project's `grep: combineGrep(/@import-export/)` doesn't match → tests are **excluded** from the dedicated project.
- `chromium` project's `grepInvert: [.., /@import-export/, ..]` (active with `PW_DEDICATED_IMPORT_EXPORT=true`) doesn't exclude them → they land on the chromium lane.

**Fix**: restore the tag on the describe. The whole suite routes back to the dedicated `ImportExport` project → `import-export` lane.

## Issue 2 — the atomic-unit ceiling still trips even in the import-export lane

The `Bulk Import Export` describe wraps six tests, each declaring `test.setTimeout(300_000-600_000)` (5-10 min per test). The planner's `oversized_units` check compares each unit's `weight_ms` against `TARGET_MS = 20 * 60 * 1000` regardless of destination lane — so a >20-min aggregate breaks the plan step wherever it lands.

**Fix**: add `("Features/BulkImport.spec.ts", "Bulk Import Export")` to `AUDITED_PARALLEL_SUITES`. `discover_units` then splits the describe into six per-spec parallel units. Module-scoped entity constructors (`new UserClass()`, `new GlossaryClass()` etc.) generate unique names per test instance, so each parallel unit brings its own `beforeAll` state without cross-worker collision.

## Verification

- 64 planning tests pass locally.
- Reproduced the split against a synthetic test-list mirroring the CI shape — one atomic unit becomes six per-spec units (each carrying one test id).
- Prettier + ESLint clean on the modified spec.

## Test plan

- [ ] Next merge-queue run: plan step succeeds, matrix includes an `import-export` shard with BulkImport specs.
- [ ] BulkImport tests execute on the import-export lane (visible in the shard-job name), not chromium.
- [ ] Chromium lane content drops by the BulkImport aggregate — small headroom win.

Related: #30812 (planner all-zero-history fix), #30822 (glossary hang fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)