### PR TITLE
ci(playwright): guard against lane-tag drops at PR time + better oversized-unit error

### DIFF
--- a/.github/scripts/build_playwright_shards.py
+++ b/.github/scripts/build_playwright_shards.py
@@ -102,6 +102,26 @@ ATOMIC_PARALLEL_SCOPES = {
     ): 120_000,
 }
 
+# Filename convention → the tag-routed project each file MUST land on. When a
+# planned unit's file matches a hint pattern but its project doesn't match the
+# expected one, the plan step hard-fails with a clear message. This catches
+# the tag-drop failure mode from PR #30834 (a re-enable rewrote
+# `test.describe.fixme('...', { tag: '@import-export' }, ...)` as
+# `test.describe('...', ...)`, silently dropping the tag → suite landed on
+# chromium instead of the dedicated import-export lane).
+#
+# Today `BulkImport*.spec.ts` and `*ImportExport*.spec.ts` uniformly carry
+# `@import-export` (12 of 13 matching files as of writing; the 13th is the
+# bug this guard catches). Add other conventions as they emerge — the entry
+# shape is (filename regex, expected project name, expected tag literal).
+FILE_LANE_HINTS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"(?:^|/)(?:BulkImport|[^/]*ImportExport)[^/]*\.spec\.ts$"),
+        "ImportExport",
+        "@import-export",
+    ),
+]
+
 
 @dataclass
 class Unit:
@@ -420,6 +440,31 @@ def stale_baseline_files_in_plan(
     )
 
 
+def misrouted_lane_hint_violations(
+    units: list[Unit],
+) -> list[tuple[str, str, str, str]]:
+    """Return (file, actual_project, expected_project, expected_tag) tuples
+    for every planned unit whose file matches a FILE_LANE_HINTS pattern but
+    whose project doesn't match the expected one. That's the tag-drop
+    signature from PR #30834 — a describe was rewritten (`.fixme` removed,
+    tag option accidentally dropped along with it) and the suite silently
+    routed to the wrong lane.
+    """
+    violations: list[tuple[str, str, str, str]] = []
+    for unit in units:
+        for pattern, expected_project, expected_tag in FILE_LANE_HINTS:
+            if not pattern.search(unit.file):
+                continue
+            if unit.project == expected_project:
+                continue
+            violations.append(
+                (unit.file, unit.project, expected_project, expected_tag)
+            )
+            break  # one hint per file — first-match wins
+    # Sort + dedupe: multiple units per file (audit-split) collapse to one line.
+    return sorted(set(violations))
+
+
 def normalize_spec(path: str) -> str:
     prefix = "playwright/e2e/"
     return path.removeprefix(prefix)
@@ -647,6 +692,36 @@ def main() -> None:
             "shard and blocks every downstream PR."
         )
 
+    # (B) Check filename → expected-lane routing BEFORE the oversized-unit
+    # gate below. This catches the tag-drop failure mode directly with an
+    # actionable message; without it, the developer sees the generic
+    # oversized-unit error (see A below) and has to guess whether they
+    # need to split a suite or restore a tag.
+    lane_violations = misrouted_lane_hint_violations(units)
+    if lane_violations:
+        for file, actual, expected, tag in lane_violations:
+            print(
+                f"::error file={file}::planned under `{actual}` project but its "
+                f"filename convention expects `{expected}` (via `{tag}` tag). "
+                "The describe likely lost its tag option — see PR #30834.",
+                file=sys.stderr,
+            )
+        details = "\n".join(
+            f"  {file}: on `{actual}` project, expected `{expected}` "
+            f"(add `{{ tag: '{tag}' }}` to the top-level describe)"
+            for file, actual, expected, tag in lane_violations
+        )
+        raise SystemExit(
+            "Playwright spec files are routed to the wrong project. "
+            "Each file below matches a FILE_LANE_HINTS pattern that expects a "
+            "specific tag on its top-level describe, but the tag is missing "
+            "so the suite falls through to another project.\n\n"
+            f"{details}\n\n"
+            "To fix, restore the expected `{ tag: '...' }` option on the "
+            "describe. If this file was intentionally moved off its dedicated "
+            "lane, update FILE_LANE_HINTS in .github/scripts/build_playwright_shards.py."
+        )
+
     oversized_units = [unit for unit in units if unit.weight_ms > TARGET_MS]
     if oversized_units:
         details = ", ".join(
@@ -655,9 +730,24 @@ def main() -> None:
                 oversized_units, key=lambda item: item.weight_ms, reverse=True
             )
         )
+        # (A) Common fixes list — the generic "refactor or audit" message
+        # left developers guessing whether to split a suite or restore a
+        # dropped lane tag. Point at both fixes concretely.
         raise SystemExit(
-            "Atomic Playwright units exceed the 20-minute execution budget; "
-            f"refactor or explicitly audit them for parallel splitting: {details}"
+            "Atomic Playwright units exceed the 20-minute execution budget: "
+            f"{details}\n\n"
+            "Common fixes:\n"
+            "  * If this suite belongs on a dedicated lane (import-export, "
+            "domain-isolation, ingestion, reindex), verify the top-level "
+            "describe still carries the correct `{ tag: '...' }` option — a "
+            "recent edit (e.g. removing `.fixme` or `.skip`) may have dropped "
+            "it, landing the suite on the wrong project. See FILE_LANE_HINTS "
+            "and PR #30834 for the pattern.\n"
+            "  * Otherwise add `(file, describe_title)` to "
+            "AUDITED_PARALLEL_SUITES in "
+            ".github/scripts/build_playwright_shards.py — the planner will "
+            "then split the describe into per-spec parallel units so no "
+            "single unit exceeds the ceiling."
         )
 
     lanes: dict[str, list[Unit]] = defaultdict(list)

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -353,6 +353,93 @@ def test_stale_baseline_files_ignore_files_covered_by_identity_match():
     assert planner.stale_baseline_files_in_plan(units, {}, identity_weights) == []
 
 
+def test_misrouted_lane_hint_violations_flags_bulk_import_on_chromium():
+    # Reproduces PR #30834's bug — BulkImport.spec.ts landed on chromium
+    # because the `@import-export` tag was dropped when un-`fixme`ing the
+    # describe. The hint check names the file and the expected tag.
+    planner = load_script("build_playwright_shards")
+    unit = planner.Unit(
+        "chromium",  # actual project — wrong
+        "Features/BulkImport.spec.ts",
+        "Bulk Import Export",
+    )
+
+    violations = planner.misrouted_lane_hint_violations([unit])
+
+    assert violations == [
+        (
+            "Features/BulkImport.spec.ts",
+            "chromium",
+            "ImportExport",
+            "@import-export",
+        )
+    ]
+
+
+def test_misrouted_lane_hint_violations_stays_quiet_when_route_matches():
+    planner = load_script("build_playwright_shards")
+    unit = planner.Unit(
+        "ImportExport",
+        "Features/BulkImport.spec.ts",
+        "Bulk Import Export",
+    )
+
+    assert planner.misrouted_lane_hint_violations([unit]) == []
+
+
+def test_misrouted_lane_hint_violations_matches_import_export_filename_family():
+    planner = load_script("build_playwright_shards")
+    matching_files = [
+        "Features/BulkImport.spec.ts",
+        "Features/BulkImportWithDotInName.spec.ts",
+        "Features/MetricBulkImportExportEdit.spec.ts",
+        "Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts",
+        "Pages/GlossaryImportExport.spec.ts",
+    ]
+    units = [
+        planner.Unit("chromium", file, "describe title")
+        for file in matching_files
+    ]
+
+    violations = planner.misrouted_lane_hint_violations(units)
+
+    assert {v[0] for v in violations} == set(matching_files)
+
+
+def test_misrouted_lane_hint_violations_ignores_unmatched_filenames():
+    # Files without Import/Export or matching patterns must not trip the
+    # hint even when they land on chromium — chromium is the correct
+    # destination for the vast majority of specs.
+    planner = load_script("build_playwright_shards")
+    units = [
+        planner.Unit("chromium", "Pages/Users.spec.ts", "user tests"),
+        planner.Unit("chromium", "Features/AdvancedSearch.spec.ts", "Advanced Search"),
+        planner.Unit("chromium", "Pages/Entity.spec.ts", "entity tests"),
+    ]
+
+    assert planner.misrouted_lane_hint_violations(units) == []
+
+
+def test_misrouted_lane_hint_violations_dedupes_across_units():
+    # After AUDITED_PARALLEL_SUITES splits a file into per-spec units,
+    # each unit shares the same file — the violation should collapse to
+    # a single entry, not fire once per test.
+    planner = load_script("build_playwright_shards")
+    units = [
+        planner.Unit(
+            "chromium",
+            "Features/BulkImport.spec.ts",
+            f"Bulk Import Export › case {index}",
+        )
+        for index in range(4)
+    ]
+
+    violations = planner.misrouted_lane_hint_violations(units)
+
+    assert len(violations) == 1
+    assert violations[0][0] == "Features/BulkImport.spec.ts"
+
+
 def test_main_fails_when_a_targeted_plan_has_a_stale_baseline_file(tmp_path):
     # End-to-end: the planner exits non-zero at PR (targeted) plan time
     # when a file's every planned test is on the fallback path. This is
@@ -496,6 +583,80 @@ def test_main_skips_stale_baseline_gate_in_full_mode(tmp_path):
     # still be written so the run can execute and refresh the baseline.
     assert "Stale timing-baseline.json entries detected" not in combined
     assert (output_dir / "matrix.json").exists()
+
+
+def test_main_fails_on_misrouted_lane_hint(tmp_path):
+    # End-to-end: the planner exits non-zero at plan time when a hint-file
+    # is on the wrong project. This is the guardrail that would have caught
+    # PR #30834 at PR review instead of on the merge queue.
+    import subprocess
+    planner_path = SCRIPTS / "build_playwright_shards.py"
+    test_list = tmp_path / "test-list.json"
+    selection = tmp_path / "selection.json"
+    history = tmp_path / "history.json"
+    output_dir = tmp_path / "plans"
+
+    test_list.write_text(
+        json.dumps(
+            {
+                "suites": [
+                    {
+                        "file": "Features/BulkImport.spec.ts",
+                        "suites": [
+                            {
+                                "title": "Bulk Import Export",
+                                "specs": [
+                                    {
+                                        "id": f"bulk-{index}",
+                                        "title": f"case {index}",
+                                        "tests": [{"projectName": "chromium"}],
+                                    }
+                                    for index in range(3)
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+    )
+    selection.write_text(json.dumps({"mode": "full"}))
+    history.write_text(json.dumps({"mode": "full", "tests": []}))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(planner_path),
+            "--test-list", str(test_list),
+            "--selection", str(selection),
+            "--history", str(history),
+            "--output-dir", str(output_dir),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0, result.stdout + result.stderr
+    combined = result.stdout + result.stderr
+    assert "routed to the wrong project" in combined
+    assert "Features/BulkImport.spec.ts" in combined
+    assert "@import-export" in combined
+    assert not (output_dir / "matrix.json").exists()
+
+
+def test_oversized_units_error_names_both_common_fixes():
+    # The improved error message must point the reader at BOTH the tag
+    # option and the AUDITED_PARALLEL_SUITES escape hatch — the old
+    # message just said "refactor or audit" and left developers guessing.
+    planner = load_script("build_playwright_shards")
+    src = (SCRIPTS / "build_playwright_shards.py").read_text()
+
+    assert "FILE_LANE_HINTS" in src
+    # The oversized branch mentions both remediation paths:
+    oversized_index = src.index("Atomic Playwright units exceed")
+    following = src[oversized_index:oversized_index + 2000]
+    assert "tag:" in following or "tag option" in following.lower() or "'{ tag:" in following
+    assert "AUDITED_PARALLEL_SUITES" in following
 
 
 def test_history_includes_retry_time_and_skipped_only_ids_fall_to_fallback(tmp_path):


### PR DESCRIPTION
## Summary

Two changes so the tag-drop failure mode from #30834 (a re-enable dropped `{ tag: '@import-export' }` along with `.fixme`, silently routing the whole suite to chromium) fails at PR time with an actionable error instead of a merge-queue plan failure.

## A — improved `oversized_units` error message

The existing gate at `build_playwright_shards.py:oversized_units` correctly fires when any unit exceeds `TARGET_MS`, but the message ("refactor or explicitly audit them for parallel splitting") left developers guessing between two very different fixes. Rewrite it to spell out both remediation paths:

- **Restore a `{ tag: '...' }` option** that a recent edit dropped (points at `FILE_LANE_HINTS` and #30834 for the pattern).
- **Add `(file, describe_title)` to `AUDITED_PARALLEL_SUITES`** to split the describe into per-spec parallel units.

## B — `FILE_LANE_HINTS` filename → expected-project check

Small mapping from filename regex → expected project + expected tag. For every planned unit whose file matches a hint but whose project doesn't match, hard-fail with:

```
::error file=Features/BulkImport.spec.ts::planned under `chromium` project but its
filename convention expects `ImportExport` (via `@import-export` tag). The describe
likely lost its tag option — see PR #30834.

Playwright spec files are routed to the wrong project. Each file below matches a
FILE_LANE_HINTS pattern that expects a specific tag on its top-level describe, but
the tag is missing so the suite falls through to another project.

  Features/BulkImport.spec.ts: on `chromium` project, expected `ImportExport`
  (add `{ tag: '@import-export' }` to the top-level describe)

To fix, restore the expected `{ tag: '...' }` option on the describe. If this file
was intentionally moved off its dedicated lane, update FILE_LANE_HINTS in
.github/scripts/build_playwright_shards.py.
```

Runs before the oversized-unit check so the developer gets the specific error, not the generic one.

## The initial hint

Seeded with one entry today:

```python
(re.compile(r"(?:^|/)(?:BulkImport|[^/]*ImportExport)[^/]*\.spec\.ts$"),
 "ImportExport", "@import-export"),
```

That matches 12 of 13 files with those names currently in the tree — every one carries `@import-export` today except `Features/BulkImport.spec.ts`, which is the bug this guard would have caught. Adding other conventions (domain-isolation, reindex, etc.) is a one-line edit each.

## Verified

- 7 new pytest cases (`test_misrouted_lane_hint_violations_*`, `test_main_fails_on_misrouted_lane_hint`, `test_oversized_units_error_names_both_common_fixes`).
- 71 total planner tests pass locally.
- Reproduced the actual PR #30834 scenario against the updated planner — exits 1 with the actionable error, no `matrix.json` written.

## Test plan

- [ ] Merge-queue plan step on a PR that reintroduces the tag-drop (or the initial BulkImport regression) fails with the specific FILE_LANE_HINTS error.
- [ ] Merge-queue plan step on healthy PRs succeeds unchanged — the hint check is a no-op when routing matches.
- [ ] Merge-queue plan step on a PR whose spec exceeds `TARGET_MS` for a different reason (not a tag drop) gets the improved "Common fixes" message with both remediation paths.

Related: #30812 (planner all-zero-history fix), #30813 (plan-time warning), #30827 (stale-baseline gate), #30834 (the bug this guards against).

🤖 Generated with [Claude Code](https://claude.com/claude-code)