### PR TITLE
test(e2e): 2.0 glossary skip-list cleanup — drop 4 never-run tests, re-enable 2 that pass

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
@@ -473,8 +473,7 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
     });
 
     // Skip: Requires re-filtering expanded state which isn't fully implemented
-    // eslint-disable-next-line playwright/no-skipped-test -- requires re-filtering expanded state support
-    test.skip('change filter while expanded updates visible root terms', async ({
+    test('change filter while expanded updates visible root terms', async ({
       page,
     }) => {
       // Expand parent first with All filter

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
@@ -338,20 +338,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
       await verifyTermVisible(page, basicChild.data.displayName);
     });
 
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by child status shows child as flat result even if parent does not match', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['Draft']);
-
-      // Parent has Approved status, should NOT be visible
-      await verifyTermNotVisible(page, basicParent.data.displayName);
-
-      // Child is Draft - it should appear as a flat result in the filtered view
-      await verifyTermVisible(page, basicChild.data.displayName);
-    });
-
     test('filter shows parent when status matches and all children on expand', async ({
       page,
     }) => {
@@ -405,40 +391,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
 
       // Parent should be visible even though it's Draft (children loaded without filter)
       await verifyTermVisible(page, multiParent.data.displayName);
-    });
-
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by middle level status shows nested term as flat result', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['Draft']);
-
-      // Parent has Draft status - should appear as flat result
-      await verifyTermVisible(page, multiParent.data.displayName);
-
-      // Grandparent is Approved, should NOT be visible with Draft filter
-      await verifyTermNotVisible(page, multiGrandparent.data.displayName);
-
-      // Child is In Review, should NOT be visible with Draft filter
-      await verifyTermNotVisible(page, multiChild.data.displayName);
-    });
-
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by leaf level status shows nested term as flat result', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['In Review']);
-
-      // Child has In Review status - should appear as flat result
-      await verifyTermVisible(page, multiChild.data.displayName);
-
-      // Grandparent is Approved, should NOT be visible
-      await verifyTermNotVisible(page, multiGrandparent.data.displayName);
-
-      // Parent is Draft, should NOT be visible
-      await verifyTermNotVisible(page, multiParent.data.displayName);
     });
   });
 
@@ -558,24 +510,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
   // ==================== EDGE CASES ====================
 
   test.describe('Edge Cases', () => {
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('deeply nested term (5 levels) - filter shows matching terms as flat results', async ({
-      page,
-    }) => {
-      // Filter by Draft status
-      await applyStatusFilter(page, ['Draft']);
-
-      // Level 1 (Draft) should appear as flat result regardless of nesting
-      await verifyTermVisible(page, deepTerms[1].data.displayName);
-
-      // Other levels should NOT be visible (different statuses)
-      await verifyTermNotVisible(page, deepTerms[0].data.displayName); // Approved
-      await verifyTermNotVisible(page, deepTerms[2].data.displayName); // In Review
-      await verifyTermNotVisible(page, deepTerms[3].data.displayName); // Rejected
-      await verifyTermNotVisible(page, deepTerms[4].data.displayName); // Deprecated
-    });
-
     test('all children have same status different from parent', async ({
       page,
     }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1969,8 +1969,7 @@ test.describe('Glossary tests', () => {
   });
 
   // Need to fix the workflow from BE end, as it constantly failing in the AUT's
-  // eslint-disable-next-line playwright/no-skipped-test -- skipped: backend workflow issue
-  test.skip('Term should stay approved when changes made by reviewer', async ({
+  test('Term should stay approved when changes made by reviewer', async ({
     browser,
   }) => {
     test.slow(true);


### PR DESCRIPTION
Glossary skip-list cleanup for `2.0`, matching #30843 (main) and #30839 (1.13).

> **Scope note:** this PR originally also cherry-picked #30458 (BulkImport) to 2.0. That has been dropped — it belongs to the team that owns BulkImport, not here. **Consequence: the six `Bulk Import Export` tests remain under `test.describe.fixme` on 2.0**, and 2.0 stays the only branch where they are dark (1.13 and main both run them). That needs a separate owner-driven backport of #30458.

## The rule applied

A test is **deleted** only if it was skipped in the very commit that introduced it — it has never run and never protected anything. Anything that was once green **stays**, even if it is red today, because that redness records a regression rather than a test that never worked.

Every verdict below is a **measurement on a real local stack**, not inspection.

## Removed — 4 tests, skipped at inception, never executed

`GlossaryStatusFilterNestedTerms`: `filter by child status`, `filter by middle level status`, `filter by leaf level status`, `deeply nested term (5 levels)`.

All four arrived skipped in **#25428** (`12d85f310f`, 2026-03-05) — the commit that created the file — each carrying *"Requires backend to return nested terms as flat results when filtered"*. Five months, zero executions. The six later commits to this file never touched the skips.

They cannot pass, by construction. `getFirstLevelGlossaryTermsPaginated` sends the hierarchy and status filters on one request:

```ts
params: { directChildrenOf: parentFQN, entityStatus, ... }
```

and `GlossaryTermResource` ANDs them:

```java
.addQueryParam("directChildrenOf", parentTermFQNParam)
.addQueryParam("entityStatus", entityStatus);
```

`directChildrenOf` means *"first level/immediate children"*, so a nested term is eliminated before its status is considered. Measured: all four fail at ~17.5–17.9s (locator timeout — the term never renders) on both a 1.13 stack and a main stack, while every sibling asserting only root-level terms passes. `glossaryAPI.ts` and `GlossaryTermResource.java` are byte-identical across 1.13, main and 2.0.

## Re-enabled — 2 tests that pass today

| Test | Why it was skipped | Measured |
|---|---|---|
| `Glossary › Term should stay approved when changes made by reviewer` | async approval workflow reverted a PATCHed `entityStatus` | ✅ 3/3 — 1.0m, 58.6s, 58.3s |
| `GlossaryStatusFilter › change filter while expanded updates visible root terms` | born skipped in #25428: *"re-filtering expanded state isn't fully implemented"* | ✅ 2.8s |

**#29931** fixed the approval machinery in July (approve/reject condition scheme, duplicate edges, stuck resolves) — exactly the cause behind the first test. Re-run three times to guard against its known load-dependent race; green every time.

The second was born skipped like the four removed ones, but for a *different* reason, and unlike them it is **green**. It is re-enabled rather than deleted precisely because deleting a passing test loses coverage. It only appeared on the nightly skip list at all because the file is `test.describe.configure({ mode: 'serial' })` — when `filter by child status` fails, Playwright reports every later test in the file as skipped without running it. With those four gone the cascade cannot occur.

## Deliberately left skipped

The five `DataMarketplace` navigation tests. They were born **active and green** in #26255 and ran for ten days before #27377 removed the `/data-marketplace/*` sub-routes and skipped them with *"re-enable when the standalone marketplace shell is reintroduced"*. They fail at 1.0m today on both main and 1.13, but under the rule above they are not deletion candidates — they record a withdrawn capability. The marketplace page itself is alive (11 components on every branch) and 8 sibling tests covering rendering, data-product/domain creation, search empty state and the admin-vs-consumer permission split all still pass, so the spec files stay.

`CustomizeWidgets › KPI Widget` and `ActivityFeed › Mention notification` also pass on main (30.3s / 9.4s) but are out of scope here and remain skipped.

## Verification

- No orphaned fixtures — `basicChild`, `multiChild`, `deepTerms`, `multiChildrenParent` all still used by surviving tests.
- Stale `eslint-disable playwright/no-skipped-test` directives removed with their skips, otherwise they become unused-directive errors.
- `prettier --check` clean; `eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**2.0-specific note on verification:** the measurements above were taken on `1.13` and `main` stacks. All target specs are byte-identical between `main` and `2.0` (`Glossary.spec.ts` differs only at line 535, an unrelated assets empty-state assertion) and #29931 is present on 2.0, so the results carry over. This PR CI run is the confirmation on 2.0 itself.