### PR TITLE
fix(e2e): enable KPI widget test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -333,7 +333,7 @@ test('My Data Widget', async ({ page }) => {
   });
 });
 
-test.fixme('KPI Widget', async ({ page }) => {
+test('KPI Widget', async ({ page }) => {
   test.slow(true);
 
   await test.step('Add KPI', async () => {
@@ -371,8 +371,6 @@ test.fixme('KPI Widget', async ({ page }) => {
       widgetKey,
       link: 'data-insights/kpi',
     });
-
-    await redirectToHomePage(page);
   });
 
   await test.step('Test widget loads KPI data correctly', async () => {
@@ -390,6 +388,7 @@ test.fixme('KPI Widget', async ({ page }) => {
         response.url().includes('/kpiResult')
     );
 
+    await redirectToHomePage(page);
     await waitForAllLoadersToDisappear(page);
 
     const widget = await waitForLandingPageWidget(page, widgetKey);


### PR DESCRIPTION
### Describe your changes:

Issue: N/A — trivial test-only change.

Re-enable the KPI widget Playwright test by removing `test.fixme`. Move the home navigation after the KPI response listeners are registered so fast list and result responses cannot be missed.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small test-only change.

#
### Tests:

#### Use cases covered
- KPI widget creates a KPI and verifies header and footer navigation.
- KPI widget verifies rendered KPI data and customization behavior.

#### Unit tests
- [x] Not applicable; no production logic changed.

#### Backend integration tests
- [x] Not applicable; no backend API changes.

#### Ingestion integration tests
- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests
- [x] Re-enabled `KPI Widget` in `CustomizeWidgets.spec.ts`.
- Focused Chromium run repeated twice: 5/5 tests passed, including setup and teardown.

#### Manual testing performed
- Ran the focused KPI widget Playwright scenario locally against the development stack.
- Ran Playwright ESLint, organize-imports, Prettier, and `git diff --check`.

#
### UI screen recording / screenshots:

Not applicable; no UI behavior changed.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] I have added Playwright coverage for the changed scenario.
- [x] I have run the relevant local checks.