### PR TITLE
test(glossary): drop four status-filter tests that were never implemented (2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryStatusFilterNestedTerms.spec.ts
@@ -338,20 +338,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
       await verifyTermVisible(page, basicChild.data.displayName);
     });
 
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by child status shows child as flat result even if parent does not match', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['Draft']);
-
-      // Parent has Approved status, should NOT be visible
-      await verifyTermNotVisible(page, basicParent.data.displayName);
-
-      // Child is Draft - it should appear as a flat result in the filtered view
-      await verifyTermVisible(page, basicChild.data.displayName);
-    });
-
     test('filter shows parent when status matches and all children on expand', async ({
       page,
     }) => {
@@ -405,40 +391,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
 
       // Parent should be visible even though it's Draft (children loaded without filter)
       await verifyTermVisible(page, multiParent.data.displayName);
-    });
-
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by middle level status shows nested term as flat result', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['Draft']);
-
-      // Parent has Draft status - should appear as flat result
-      await verifyTermVisible(page, multiParent.data.displayName);
-
-      // Grandparent is Approved, should NOT be visible with Draft filter
-      await verifyTermNotVisible(page, multiGrandparent.data.displayName);
-
-      // Child is In Review, should NOT be visible with Draft filter
-      await verifyTermNotVisible(page, multiChild.data.displayName);
-    });
-
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('filter by leaf level status shows nested term as flat result', async ({
-      page,
-    }) => {
-      await applyStatusFilter(page, ['In Review']);
-
-      // Child has In Review status - should appear as flat result
-      await verifyTermVisible(page, multiChild.data.displayName);
-
-      // Grandparent is Approved, should NOT be visible
-      await verifyTermNotVisible(page, multiGrandparent.data.displayName);
-
-      // Parent is Draft, should NOT be visible
-      await verifyTermNotVisible(page, multiParent.data.displayName);
     });
   });
 
@@ -558,24 +510,6 @@ test.describe('Glossary Status Filter - Nested Terms', () => {
   // ==================== EDGE CASES ====================
 
   test.describe('Edge Cases', () => {
-    // Skip: Requires backend to return nested terms as flat results when filtered
-    // eslint-disable-next-line playwright/no-skipped-test -- requires backend flat result support
-    test.skip('deeply nested term (5 levels) - filter shows matching terms as flat results', async ({
-      page,
-    }) => {
-      // Filter by Draft status
-      await applyStatusFilter(page, ['Draft']);
-
-      // Level 1 (Draft) should appear as flat result regardless of nesting
-      await verifyTermVisible(page, deepTerms[1].data.displayName);
-
-      // Other levels should NOT be visible (different statuses)
-      await verifyTermNotVisible(page, deepTerms[0].data.displayName); // Approved
-      await verifyTermNotVisible(page, deepTerms[2].data.displayName); // In Review
-      await verifyTermNotVisible(page, deepTerms[3].data.displayName); // Rejected
-      await verifyTermNotVisible(page, deepTerms[4].data.displayName); // Deprecated
-    });
-
     test('all children have same status different from parent', async ({
       page,
     }) => {


### PR DESCRIPTION
Cherry-pick of the `main` change (#30843) onto `2.0`. Applied cleanly, no conflicts — the spec, `glossaryAPI.ts` and `GlossaryTermResource.java` are byte-identical on this branch.

---

Removes four Playwright tests that have **never executed since the day they were written**.

### Archaeology

All four arrived skipped in **#25428** (`12d85f310f`, 2026-03-05) — *"fix glossary status frontend filtering logic to move to backend"* — the same commit that created the file. They have been skipped for five months and have never run once. The six subsequent commits to this file are all incidental (Prettier #26358, eslint-plugin-playwright #26494, checkstyle #26445, TableV2 #29728, ETag stripping #30371, shard runtime #30310) and never touched the skips.

They are not regressions and not flakes. They are a **specification for behaviour the product does not have**, written ahead of an implementation that never landed.

### Why they cannot pass

Each carried its reason inline from birth: *"Requires backend to return nested terms as flat results when filtered"*. That is exactly right.

`getFirstLevelGlossaryTermsPaginated` (`src/rest/glossaryAPI.ts`) sends the hierarchy filter and the status filter on the **same request**:

```ts
params: {
  directChildrenOf: parentFQN,   // "first level/immediate children" per GlossaryTermResource
  entityStatus,
  ...
}
```

and the backend ANDs them (`GlossaryTermResource`):

```java
.addQueryParam("directChildrenOf", parentTermFQNParam)
.addQueryParam("entityStatus", entityStatus);
```

A nested term is eliminated by `directChildrenOf` **before** `entityStatus` is evaluated, so no status value can ever surface a grandchild as a flat result.

### Measured, not assumed

Ran them un-skipped against real local stacks. The pass/fail split matches the mechanism exactly — every test asserting a **non-root** term fails; every sibling asserting **only root** terms passes:

| Test | Asserts | 1.13 | main |
|---|---|---|---|
| `filter by parent status … allows expansion` (kept) | root term | ✅ | ✅ |
| `filter by child status shows child as flat result` | depth-2 | ✘ 17.3s | ✘ 17.8s |
| `filter by middle level status` | depth-2 | ✘ 17.6s | — |
| `filter by leaf level status` | depth-3 | ✘ 17.5s | — |
| `deeply nested term (5 levels)` | depth-5 | ✘ 17.6s | — |

The uniform ~17.5s is the `verifyTermVisible` locator timeout expiring — the term genuinely never renders. `glossaryAPI.ts` and `GlossaryTermResource.java` are **byte-identical across 1.13, main and 2.0**, so the outcome is identical on every branch.

### Why remove rather than leave skipped

Five bare `test.skip`s show up on every nightly triage list looking like failures, and cost review attention each time someone asks why the glossary suite is red — which is how this investigation started. If flat subtree filtering is ever built, these are better rewritten against the real API than resurrected from a five-month-old skip.

### Deliberately kept

`change filter while expanded updates visible root terms` stays. It was also born skipped, but for a **different** reason (*"Requires re-filtering expanded state which isn't fully implemented"*) and unlike these four it **passes today** (2.8s on 1.13). Whatever was missing in March shipped since and nobody revisited the marker. Re-enabling it is a separate change so this PR stays a pure deletion.

### Verification

- 66 deletions, 0 insertions; no behavioural change to any surviving test.
- No orphaned fixtures — `basicChild`, `multiChild`, `deepTerms` and `multiChildrenParent` are all still used by remaining tests (`multiChildrenParent` still parents `multiChildren`).
- 15 tests remain in the file.
- `prettier --check` clean, `eslint` 0 problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)