### PR TITLE
perf(ui): drop dayjs and date-fns, use luxon (repo standard)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.tsx
@@ -11,8 +11,8 @@
  *  limitations under the License.
  */
 import { Select, Skeleton, Table } from '@openmetadata/ui-core-components';
-import { format } from 'date-fns';
 import { isEmpty, split, toLower } from 'lodash';
+import { DateTime } from 'luxon';
 import { DateRangeObject } from 'Models';
 import type { ComponentType, ReactElement } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -142,13 +142,17 @@ const DimensionalityTab = () => {
         return;
       }
 
-      const resultDate = format(new Date(result.timestamp), 'yyyy-MM-dd');
+      const resultDate = DateTime.fromJSDate(
+        new Date(result.timestamp)
+      ).toFormat('yyyy-MM-dd');
       const existing = dimensionMap.get(dimensionValue);
 
       if (!existing || !existing.timestamp) {
         dimensionMap.set(dimensionValue, result);
       } else {
-        const existingDate = format(new Date(existing.timestamp), 'yyyy-MM-dd');
+        const existingDate = DateTime.fromJSDate(
+          new Date(existing.timestamp)
+        ).toFormat('yyyy-MM-dd');
         const existingTime = existing.timestamp;
         const currentTime = result.timestamp;
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.tsx
@@ -22,7 +22,6 @@ import {
 import { SearchLg, XClose } from '@untitledui/icons';
 import { Modal, Progress } from 'antd';
 import { AxiosError } from 'axios';
-import dayjs from 'dayjs';
 import { debounce } from 'lodash';
 import { DateTime } from 'luxon';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -218,8 +217,8 @@ const AuditLogsPage = () => {
     const element = document.createElement('a');
     const file = new Blob([data], { type: 'application/json' });
 
-    const now = dayjs();
-    const fileName = `audit_logs_${now.format('YYYYMMDD_HHmmss')}.json`;
+    const now = DateTime.now();
+    const fileName = `audit_logs_${now.toFormat('yyyyMMdd_HHmmss')}.json`;
 
     element.href = URL.createObjectURL(file);
     element.download = fileName;


### PR DESCRIPTION
Fixes [5443](https://github.com/open-metadata/openmetadata-collate/issues/5443)
## Description

`dayjs` and `date-fns` each had **exactly one importer** and were fully removable in favour of **luxon**, which is the de-facto date standard in this codebase (the core `utils/date-time/DateTimeUtils.ts` is luxon-based).

- **`AuditLogsPage`** — `dayjs().format('YYYYMMDD_HHmmss')` → `DateTime.now().toFormat('yyyyMMdd_HHmmss')`. The file already imported luxon. Removes **dayjs** from the build entirely.
- **`DimensionalityTab`** — `format(new Date(ts), 'yyyy-MM-dd')` → `DateTime.fromJSDate(new Date(ts)).toFormat('yyyy-MM-dd')` (preserves the exact `Date` construction and local timezone). This one `format` call pulled **313 date-fns modules**; removes **date-fns** from the build entirely.

No behavior change — same rendered strings, same local timezone.

### Not touched: `moment`

The 4 `moment` importers are left as-is. `moment` is anchored in the bundle by **antd v4's `rc-picker` DatePicker adapter** and by `@react-awesome-query-builder/core`, so migrating our own files would not remove it — that's an antd v5 migration, out of scope.

## Type of change

- [x] Performance / bundle (no behavior change)

## Tests

- `eslint` — 0 errors
- `yarn test` — **34 tests pass** (AuditLogsPage + DimensionalityTab)
- `vite build --mode analyze` — **green**; `vendor-dayjs` and `vendor-date-fns` **no longer emitted**
- No test changes needed — no test referenced `dayjs`/`date-fns` or asserted on the migrated output.

Ref: open-metadata/openmetadata-collate#5442