### PR TITLE
chore(ui): correct eslint backlog counts from a full-repo run

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -334,9 +334,12 @@ export default [
 
       // React correctness and re-render cost — the enforceable slice of
       // frontend-performance.md.
-      'react/no-array-index-key': 'warn', // 23
-      'react/jsx-no-constructed-context-values': 'warn', // 1
-      'react/no-unstable-nested-components': 'warn', // 1
+      // Backlog counts below are full-repo, not sampled. Re-measure with:
+      //   eslint 'src/**/*.{ts,tsx}' --format json \
+      //     | jq '[.[].messages[]|select(.ruleId=="<rule>")]|length'
+      'react/no-array-index-key': 'warn', // 93
+      'react/jsx-no-constructed-context-values': 'warn', // 8
+      'react/no-unstable-nested-components': 'warn', // 25
       'react/no-danger': 'warn', // 0 in sample
       '@typescript-eslint/no-non-null-assertion': 'warn',
 


### PR DESCRIPTION
## Description

The backlog comments on three react rules in `eslint.config.mjs` were **sampled, not full-repo**, and understated the real counts. A full run:

```bash
eslint 'src/**/*.{ts,tsx}' --format json \
  | jq '[.[].messages[]|select(.ruleId=="<rule>")]|length'
```

gives:

| Rule | Comment said | Actual |
|---|---|---|
| `react/no-array-index-key` | 23 | **93** |
| `react/jsx-no-constructed-context-values` | 1 | **8** |
| `react/no-unstable-nested-components` | 1 | **25** |

The stated promotion path for these rules is "clear the backlog, re-measure, promote to `error`" — so wrong baselines drive that decision on bad data. This corrects the three comments and records the re-measure command inline so the next check is reproducible.

Comment-only change; no rule severity changed, no code touched.

## Type of change

- [x] Chore (accuracy of gate metadata)

## Tests

- eslint config still loads/parses (verified by running eslint on a file)
- prettier clean

Ref: open-metadata/openmetadata-collate#5442