### PR TITLE
perf(ui): parallelize independent fetches in two DQ pie-chart widgets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataAssetsCoveragePieChartWidget/DataAssetsCoveragePieChartWidget.component.tsx
@@ -90,11 +90,10 @@ const DataAssetsCoveragePieChartWidget = ({
   const fetchDataAssetsCoverage = async () => {
     setIsLoading(true);
     try {
-      const { data: coverageData } = await fetchEntityCoveredWithDQ(
-        chartFilter,
-        false
-      );
-      const { data: totalData } = await fetchTotalEntityCount(chartFilter);
+      const [{ data: coverageData }, { data: totalData }] = await Promise.all([
+        fetchEntityCoveredWithDQ(chartFilter, false),
+        fetchTotalEntityCount(chartFilter),
+      ]);
       if (coverageData.length === 0 || totalData.length === 0) {
         setDataAssetsCoverageStates(INITIAL_DATA_ASSETS_COVERAGE_STATES);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.component.tsx
@@ -84,14 +84,10 @@ const EntityHealthStatusPieChartWidget = ({
   const fetchEntityHealthSummary = async () => {
     setIsLoading(true);
     try {
-      const { data: unhealthyData } = await fetchEntityCoveredWithDQ(
-        chartFilter,
-        true
-      );
-      const { data: totalData } = await fetchEntityCoveredWithDQ(
-        chartFilter,
-        false
-      );
+      const [{ data: unhealthyData }, { data: totalData }] = await Promise.all([
+        fetchEntityCoveredWithDQ(chartFilter, true),
+        fetchEntityCoveredWithDQ(chartFilter, false),
+      ]);
       if (unhealthyData.length === 0 || totalData.length === 0) {
         setEntityHealthStates(INITIAL_ENTITY_HEALTH_MATRIX);
 


### PR DESCRIPTION
Fixes [5445](https://github.com/open-metadata/openmetadata-collate/issues/5445)

## Description

Two Data Quality dashboard widgets each awaited two **independent** requests sequentially, costing an extra serial round-trip on every dashboard mount. Both collapse to a single `Promise.all`:

- **`EntityHealthStatusPieChartWidget`** — `fetchEntityCoveredWithDQ(filter, true)` and `fetchEntityCoveredWithDQ(filter, false)` now run in parallel.
- **`DataAssetsCoveragePieChartWidget`** — `fetchEntityCoveredWithDQ(filter, false)` and `fetchTotalEntityCount(filter)` now run in parallel.

No behavior change — same two results consumed, same empty-check and parse logic.

## Type of change

- [x] Performance (request waterfall → parallel; no behavior change)

## Tests

- `eslint` 0 errors, prettier clean
- `yarn test` — **11 tests pass** across both widgets

## Follow-up (not in this PR)

Both widgets independently call `fetchEntityCoveredWithDQ(filter, false)`, so the same GET is fetched twice per dashboard. Hoisting that fetch to the dashboard owner (or a shared query) would dedupe it — a larger change than this one-file-each parallelization.

Ref: open-metadata/openmetadata-collate#5442