### PR TITLE
perf(ui): memoize WebSocketProvider and TourProvider context values

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/context/TourProvider/TourProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/TourProvider/TourProvider.tsx
@@ -113,25 +113,41 @@ const TourProvider: FC<Props> = ({ children }) => {
     []
   );
 
+  const contextValue = useMemo(
+    () => ({
+      isTourOpen,
+      isTourPage,
+      currentTourPage,
+      tourSearchValue: searchValue,
+      activeTabForTourDatasetPage,
+      tourMockSearchResults,
+      tourMockSearchHitCounts,
+      tourMockDatasetData,
+      updateActiveTab: handleActiveTabChange,
+      updateIsTourOpen: handleIsTourOpen,
+      updateTourPage: handleTourPageChange,
+      updateTourSearch: handleUpdateTourSearch,
+      updateTourMockData: handleUpdateTourMockData,
+    }),
+    [
+      isTourOpen,
+      isTourPage,
+      currentTourPage,
+      searchValue,
+      activeTabForTourDatasetPage,
+      tourMockSearchResults,
+      tourMockSearchHitCounts,
+      tourMockDatasetData,
+      handleActiveTabChange,
+      handleIsTourOpen,
+      handleTourPageChange,
+      handleUpdateTourSearch,
+      handleUpdateTourMockData,
+    ]
+  );
+
   return (
-    <TourContext.Provider
-      value={{
-        isTourOpen,
-        isTourPage,
-        currentTourPage,
-        tourSearchValue: searchValue,
-        activeTabForTourDatasetPage,
-        tourMockSearchResults,
-        tourMockSearchHitCounts,
-        tourMockDatasetData,
-        updateActiveTab: handleActiveTabChange,
-        updateIsTourOpen: handleIsTourOpen,
-        updateTourPage: handleTourPageChange,
-        updateTourSearch: handleUpdateTourSearch,
-        updateTourMockData: handleUpdateTourMockData,
-      }}>
-      {children}
-    </TourContext.Provider>
+    <TourContext.Provider value={contextValue}>{children}</TourContext.Provider>
   );
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/context/WebSocketProvider/WebSocketProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/WebSocketProvider/WebSocketProvider.tsx
@@ -18,6 +18,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 import { io, Socket } from 'socket.io-client';
@@ -63,8 +64,10 @@ const WebSocketProvider: FC<Props> = ({ children }: Props) => {
     }
   }, [currentUser]);
 
+  const contextValue = useMemo(() => ({ socket }), [socket]);
+
   return (
-    <WebSocketContext.Provider value={{ socket }}>
+    <WebSocketContext.Provider value={contextValue}>
       {children}
     </WebSocketContext.Provider>
   );


### PR DESCRIPTION
[5445](https://github.com/open-metadata/openmetadata-collate/issues/5445)

## Description

Both providers constructed a fresh object for `Context.Provider value` on every render, so **every consumer re-rendered whenever the provider's parent re-rendered** — even when the context data was unchanged (`react/jsx-no-constructed-context-values`).

- **`WebSocketProvider`** — `value={{ socket }}` → `useMemo(() => ({ socket }), [socket])`.
- **`TourProvider`** — the 13-key value object → `useMemo`. Its 5 handlers are already `useCallback`-stable, so the memo recomputes only when actual tour state changes.

No behavior change — identical value contents, just a stable identity.

## Deferred (not in this PR)

The other two flagged providers — `EntityAttachmentProvider` and `BasicAuthProvider` — have handlers that are **not** `useCallback`-stable (e.g. a large async `handleFileUpload`). Memoizing their `value` alone would be a no-op (an unstable dep defeats the memo). They need handler stabilization first and will follow in a separate, careful PR.

## Type of change

- [x] Performance (re-render reduction; no behavior change)

## Tests

- `eslint` — 0 errors; `jsx-no-constructed-context-values` no longer flagged on either file
- `yarn test` — **17 tests pass** across consumers (NavBar, Suggestions)

Ref: open-metadata/openmetadata-collate#5442