### PR TITLE
perf(ui): parallelize independent serial-await loops (bulk delete, domain children)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DomainSelectableTree/DomainSelectableTree.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DomainSelectableTree/DomainSelectableTree.tsx
@@ -617,19 +617,19 @@ const DomainSelectablTree: FC<DomainSelectableTreeProps> = ({
         return;
       }
 
-      for (const fqn of value ?? []) {
+      const fqnsToLoad = (value ?? []).filter((fqn) => {
         const domain = domainMapper[fqn];
         if (!domain) {
-          continue;
+          return false;
         }
 
         const hasLoaded = (domain.children?.length || 0) > 0;
         const hasChildrenCount = (domain.childrenCount ?? 0) > 0;
 
-        if (!hasLoaded && hasChildrenCount && !loadingChildren[fqn]) {
-          await loadChildDomains(fqn);
-        }
-      }
+        return !hasLoaded && hasChildrenCount && !loadingChildren[fqn];
+      });
+
+      await Promise.all(fqnsToLoad.map((fqn) => loadChildDomains(fqn)));
     };
 
     loadSelectedDomainChildren();

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/actions/useDelete.tsx
@@ -121,20 +121,24 @@ export const useDelete = <
 
   const handleDelete = useCallback(async () => {
     setIsDeleting(true);
-    const errors: string[] = [];
 
-    for (const entity of selectedEntities) {
-      try {
-        await deleteEntity(
+    const results = await Promise.allSettled(
+      selectedEntities.map((entity) =>
+        deleteEntity(
           entityType,
           entity.id,
           false, // recursive: false (safe default)
           true // hardDelete: true (permanent)
-        );
-      } catch {
-        errors.push(getEntityName(entity));
+        )
+      )
+    );
+    const errors = results.reduce<string[]>((acc, result, index) => {
+      if (result.status === 'rejected') {
+        acc.push(getEntityName(selectedEntities[index]));
       }
-    }
+
+      return acc;
+    }, []);
 
     if (errors.length === 0) {
       showSuccessToast(


### PR DESCRIPTION
Fixes [5445](https://github.com/open-metadata/openmetadata-collate/issues/5445)

## Description

Two loops issued one round-trip **per iteration** for fully independent work:

- **`useDelete.handleDelete`** — bulk delete awaited `deleteEntity()` once per selected row. Now `Promise.allSettled` over all rows; failed entity names are collected from the rejected results by index, preserving the exact error toast. Deletes target independent entities (no shared version), so parallelizing is safe.
- **`DomainSelectableTree`** — the load-selected-children effect awaited `loadChildDomains(fqn)` once per selected domain FQN. Now filters the FQNs that need loading, then `Promise.all` over them.

No behavior change — same requests, same results and error handling, just concurrent.

## Left serial intentionally (verified)

- `suggestionsAPI` `resolveTask` loop — comment-documented optimistic-lock constraint
- cursor-paginated page replays (`useLearningResources`, `useColumnGridListingData`), ontology depth-walk, export poll loop — inherently serial
- `DashboardChartTable` / `KnowledgePageListRightPanel` — already `Promise.all`

## Deferred

`UploadDocumentModal`'s serial upload has **cancel-mid-batch** semantics and needs a bounded concurrency pool (not naive `Promise.all`, which would break cancellation and could storm the server). Separate careful PR.

## Type of change

- [x] Performance (request waterfall → parallel; no behavior change)

## Tests

- `eslint` 0 errors, prettier clean
- `yarn test` — **23 DomainSelectableTree tests pass**; `useDelete` has no colocated test (behavior-preserving refactor)

Ref: open-metadata/openmetadata-collate#5442