### PR TITLE
fix(playwright): point Api Service test connection at a raw GitHub fixture URL

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ApiIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ApiIngestionClass.ts
@@ -49,18 +49,19 @@ class ApiIngestionClass extends ServiceBaseClass {
   }
 
   async fillConnectionDetails(page: Page) {
-    // Use the bundled OpenAPI fixture instead of an external URL to keep the test hermetic.
-    const openAPISchemaFilePath =
-      '/home/airflow/ingestion/examples/openapi/sample.json';
+    // Fetch the OpenAPI fixture over HTTP so the test doesn't rely on a file
+    // bundled inside the ingestion image.
+    const openAPISchemaURL =
+      'https://raw.githubusercontent.com/open-metadata/OpenMetadata/main/ingestion/examples/openapi/sample.json';
 
     await page
-      .getByTestId('oneof-option-1')
-      .filter({ hasText: 'Open API Schema File Path' })
+      .getByTestId('oneof-option-0')
+      .filter({ hasText: 'Open API Schema URL' })
       .click();
 
     await page
-      .locator('#root\\/openAPISchemaConnection\\/openAPISchemaFilePath')
-      .fill(openAPISchemaFilePath);
+      .locator('#root\\/openAPISchemaConnection\\/openAPISchemaURL')
+      .fill(openAPISchemaURL);
   }
 
   async deleteService(page: Page): Promise<void> {


### PR DESCRIPTION
### Describe your changes:

Fixes #<issue-number>

I worked on the `Api Service › Create & Ingest Api Service service` Playwright test because its test connection was timing out on Collate.

The test pointed the REST connector at a file baked into the ingestion image (`/home/airflow/ingestion/examples/openapi/sample.json`). That path exists in the OSS Airflow image (`ingestion/Dockerfile.ci` copies the whole ingestion tree) but not in Collate's Argo ingestion image, so the missing file made test connection hang until the 3.5 minute timeout instead of resolving.

This points the test at the same fixture served over raw GitHub, so it is reliable and identical across OpenMetadata (Airflow) and Collate (Argo) with no dependency on the ingestion image contents. It reuses the `raw.githubusercontent.com` pattern already used by `ContextCenter.spec.ts`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Not applicable. Single-file Playwright test-helper change.

#
### Tests:

#### Use cases covered
- Api Service (REST) create and ingest flow: the connection test step resolves the OpenAPI schema over its URL and the test proceeds.

#### Unit tests
Not applicable. No product logic changed; this updates a Playwright test helper.

#### Backend integration tests
Not applicable. No backend API changes.

#### Ingestion integration tests
Not applicable. No ingestion code changes.

#### Playwright (UI) tests
- Updated: `openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/ApiIngestionClass.ts`

#### Manual testing performed
1. Confirmed the fixture URL returns HTTP 200 and valid OpenAPI 3.0.0: `https://raw.githubusercontent.com/open-metadata/OpenMetadata/main/ingestion/examples/openapi/sample.json`
2. Ran Prettier and ESLint on the changed file; both clean.
3. Final end-to-end verification is the Api Service Playwright E2E run going green in CI.

#
### UI screen recording / screenshots:

Not applicable. Test-only change with no user-facing UI change.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: not applicable (test-only, no screen recording needed).
- [x] I have added/updated tests (this updates the Playwright test itself) and listed them above.
