### PR TITLE
perf(ui): fetch database in parallel with permission on DatabaseDetailsPage (W1 template)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
@@ -15,12 +15,23 @@ import { findByTestId, findByText } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
+import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
 import {
   getDatabaseDetailsByFQN,
   patchDatabaseDetails,
 } from '../../rest/databaseAPI';
 import { renderWithQueryClient } from '../../test/unit/test-utils';
 import DatabaseDetailsPage from './DatabaseDetailsPage';
+
+const FULL_PERMISSION = {
+  Create: true,
+  Delete: true,
+  ViewAll: true,
+  EditAll: true,
+  EditDescription: true,
+  EditDisplayName: true,
+  EditCustomFields: true,
+};
 
 const mockDatabase = {
   id: 'b705cc69-55fd-4338-aa45-86f34b655ae6',
@@ -394,5 +405,39 @@ describe('Test DatabaseDetails page', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('Should show the permission placeholder (not the generic error or a forbidden redirect) and still fire the database fetch in parallel when the user lacks view permission', async () => {
+    (usePermissionProvider as jest.Mock).mockReturnValue({
+      getEntityPermissionByFqn: jest.fn().mockReturnValue({
+        ...FULL_PERMISSION,
+        ViewAll: false,
+        ViewBasic: false,
+      }),
+    });
+
+    try {
+      const { container } = renderWithQueryClient(
+        <MemoryRouter>
+          <DatabaseDetailsPage />
+        </MemoryRouter>
+      );
+
+      const permissionPlaceholder = await findByTestId(
+        container,
+        'permission-error-placeholder'
+      );
+
+      expect(permissionPlaceholder).toBeInTheDocument();
+      // The database GET is fired in parallel with the permission fetch — it is
+      // no longer gated on permission, so it runs even for a no-permission user.
+      expect(getDatabaseDetailsByFQN).toHaveBeenCalled();
+    } finally {
+      // Restore the default full-permission mock (clearMocks keeps
+      // implementations, so this override would otherwise leak to later tests).
+      (usePermissionProvider as jest.Mock).mockReturnValue({
+        getEntityPermissionByFqn: jest.fn().mockReturnValue(FULL_PERMISSION),
+      });
+    }
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
@@ -162,9 +162,12 @@ const DatabaseDetails: FunctionComponent = () => {
   } = useQuery({
     queryKey: databaseCacheKey,
     queryFn: databaseQueryFn(decodedDatabaseFQN, DATABASE_DEFAULT_FIELDS),
-    enabled: Boolean(
-      decodedDatabaseFQN && hasViewBasicPermission && !permissionsLoading
-    ),
+    // Fire the database fetch in parallel with the permission fetch rather than
+    // gating it on permission — this removes a serial round-trip on page mount.
+    // A no-permission user's speculative GET 403s and is handled below (the
+    // inline PERMISSION placeholder), so the extra request replaces a
+    // guaranteed extra RTT instead of adding one.
+    enabled: Boolean(decodedDatabaseFQN),
   });
 
   const isError = useMemo(() => Boolean(databaseError), [databaseError]);
@@ -172,7 +175,14 @@ const DatabaseDetails: FunctionComponent = () => {
   useEffect(() => {
     const status = (databaseError as AxiosError | undefined)?.response?.status;
     if (status === ClientErrors.FORBIDDEN) {
-      navigate(ROUTES.FORBIDDEN, { replace: true });
+      // Only redirect on a genuine permission desync — i.e. we believe the user
+      // has view access but the backend still denied the GET. A plain
+      // no-permission user (hasViewBasicPermission false) falls through to the
+      // inline PERMISSION placeholder in render, preserving the prior UX now
+      // that the GET fires speculatively in parallel with the permission fetch.
+      if (hasViewBasicPermission) {
+        navigate(ROUTES.FORBIDDEN, { replace: true });
+      }
     } else if (status && status !== 404) {
       showErrorToast(
         databaseError as AxiosError,
@@ -182,7 +192,7 @@ const DatabaseDetails: FunctionComponent = () => {
         })
       );
     }
-  }, [databaseError, navigate, decodedDatabaseFQN, t]);
+  }, [databaseError, navigate, decodedDatabaseFQN, t, hasViewBasicPermission]);
 
   const setDatabase = useCallback(
     (
@@ -653,14 +663,10 @@ const DatabaseDetails: FunctionComponent = () => {
     return <PageLoader />;
   }
 
-  if (isError) {
-    return (
-      <ErrorPlaceHolder>
-        {getEntityMissingError(EntityType.DATABASE, decodedDatabaseFQN)}
-      </ErrorPlaceHolder>
-    );
-  }
-
+  // Permission is checked before the error state: now that the database GET
+  // fires in parallel with the permission fetch, a no-permission user's GET
+  // 403s and would otherwise fall into the generic error placeholder. Showing
+  // the PERMISSION placeholder first preserves the prior no-permission UX.
   if (!hasViewBasicPermission) {
     return (
       <ErrorPlaceHolder
@@ -670,6 +676,14 @@ const DatabaseDetails: FunctionComponent = () => {
         })}
         type={ERROR_PLACEHOLDER_TYPE.PERMISSION}
       />
+    );
+  }
+
+  if (isError) {
+    return (
+      <ErrorPlaceHolder>
+        {getEntityMissingError(EntityType.DATABASE, decodedDatabaseFQN)}
+      </ErrorPlaceHolder>
     );
   }
 


### PR DESCRIPTION
Fixes [5445](https://github.com/open-metadata/openmetadata-collate/issues/5445)

## Description

The database detail page paid **two serial round-trips** on every mount: a permission fetch, then a database `useQuery` gated on the permission resolving (`enabled: hasViewBasicPermission && !permissionsLoading`). This fires the database GET **in parallel** with the permission fetch instead.

This is the **template** for the W1 request-waterfall fix — the audit lists ~7 primary-render pages (SearchIndexDetailsPage, Database/DatabaseSchema/Version pages, StoredProcedurePage, APICollectionPage) with the identical permission-gates-fetch shape. Reference parallel pattern already in the tree: `PlatformLineage.tsx`.

### Preserving the no-permission UX (the subtle part)

Because the GET now runs speculatively, a no-permission user's GET returns 403. Three coordinated changes keep the prior behaviour exactly:

1. `enabled` is gated only on the FQN → the query fires immediately, in parallel.
2. Render checks `!hasViewBasicPermission` **before** `isError` → a no-permission 403 shows the inline **PERMISSION** placeholder, not the generic error placeholder.
3. The `/forbidden` redirect fires **only on a genuine permission desync** (`hasViewBasicPermission` true but the backend still denied), never for a normal no-permission user.

## Type of change

- [x] Performance (request waterfall → parallel)

## Tests

- **Added a regression unit test**: a no-permission user gets the PERMISSION placeholder (no generic error, no forbidden redirect) **and** the database GET is still fired in parallel.
- All **5** DatabaseDetailsPage unit tests pass; eslint clean.

## Verification note

The 403 / permission UX is guarded by the new unit test, but is best also confirmed in a **running app / Playwright** (Jest mocks permissions and does not exercise the real backend 403 path). Recommend a manual/Playwright pass on: (a) happy path, (b) no-permission user sees the inline placeholder and is **not** redirected to /forbidden.

Ref: open-metadata/openmetadata-collate#5442