### PR TITLE
perf(ui): fetch entity in parallel with permission on 3 more detail pages (W1 rollout)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/APICollectionPage/APICollectionPage.tsx
@@ -141,11 +141,11 @@ const APICollectionPage: FunctionComponent = () => {
       decodedAPICollectionFQN,
       API_COLLECTION_DEFAULT_FIELDS
     ),
-    enabled: Boolean(
-      decodedAPICollectionFQN &&
-        viewAPICollectionPermission &&
-        !isPermissionsLoading
-    ),
+    // Fire the API-collection fetch in parallel with the permission fetch
+    // rather than gating it on permission — removes a serial round-trip on
+    // mount. A no-permission user's speculative GET 403s and render shows the
+    // inline PERMISSION placeholder (checked before the error state below).
+    enabled: Boolean(decodedAPICollectionFQN),
   });
 
   const isError = useMemo(
@@ -158,7 +158,13 @@ const APICollectionPage: FunctionComponent = () => {
     const status = (apiCollectionError as AxiosError | undefined)?.response
       ?.status;
     if (status === ClientErrors.FORBIDDEN) {
-      navigate(ROUTES.FORBIDDEN, { replace: true });
+      // Only redirect on a genuine permission desync (we believe the user has
+      // access but the backend denied). A plain no-permission user falls
+      // through to the inline PERMISSION placeholder in render — and must not
+      // reach the toast branch below, so the 403 is handled entirely here.
+      if (viewAPICollectionPermission) {
+        navigate(ROUTES.FORBIDDEN, { replace: true });
+      }
     } else if (status && status !== 404) {
       showErrorToast(
         apiCollectionError as AxiosError,
@@ -168,7 +174,13 @@ const APICollectionPage: FunctionComponent = () => {
         })
       );
     }
-  }, [apiCollectionError, navigate, decodedAPICollectionFQN, t]);
+  }, [
+    apiCollectionError,
+    navigate,
+    decodedAPICollectionFQN,
+    t,
+    viewAPICollectionPermission,
+  ]);
 
   // Soft-deleted collections need the endpoint list to flip include modes; mirror the
   // soft-delete state into the table-filter store once the fetched entity lands.

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.test.tsx
@@ -184,25 +184,17 @@ describe('SearchIndexDetailsPage component', () => {
     });
   });
 
-  it('SearchIndexDetailsPage should not fetch search index details if permission is there', async () => {
+  it('SearchIndexDetailsPage fires the details fetch in parallel with the permission fetch even for a no-permission user', async () => {
     // Reset mocks to ensure clean state
     jest.clearAllMocks();
 
     renderPage();
 
     await waitFor(() => {
-      // Should try to resolve FQN first, so it MIGHT be called to resolve
-      // But the test name says "should not fetch... if permission is there"?
-      // Actually, if it's default permission (which is deny all usually?)
-      // Let's stick to the logic: if viewPermission is false, it doesn't fetch details.
-      // But resolveSearchIndexFQN calls it to verify existence.
-      // We should verify it is called for resolution (with minimal fields) or not at all depending on logic.
-      // Based on previous code, expected not.toHaveBeenCalled().
-      // Wait, resolveSearchIndexFQN check runs REGARDLESS of permissions.
-      // So this test expectation might be flawed if checking strictly for ANY call.
-      // However, assuming unmodified logic worked before:
-      expect(getSearchIndexDetailsByFQN).toHaveBeenCalledTimes(0); // No call for resolution needed anymore
-      // It should NOT call the main fetch implementation which happens after permissions
+      // W1: the fetch is no longer gated on permission — it runs in parallel
+      // with the permission fetch to remove a serial round-trip. Render still
+      // gates on permission, so a no-permission user does not see the entity.
+      expect(getSearchIndexDetailsByFQN).toHaveBeenCalled();
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SearchIndexDetailsPage/SearchIndexDetailsPage.tsx
@@ -127,9 +127,11 @@ function SearchIndexDetailsPage() {
   } = useQuery({
     queryKey: searchIndexCacheKey,
     queryFn: searchIndexQueryFn(decodedSearchIndexFQN, defaultFields),
-    enabled: Boolean(
-      decodedSearchIndexFQN && viewPermission && !permissionsLoading
-    ),
+    // Fire the search-index fetch in parallel with the permission fetch rather
+    // than gating it on permission — this removes a serial round-trip on mount.
+    // A no-permission user's speculative GET errors, and render already shows
+    // the inline PERMISSION placeholder (checked before the error state below).
+    enabled: Boolean(decodedSearchIndexFQN),
   });
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.test.tsx
@@ -191,10 +191,17 @@ describe('StoredProcedure component', () => {
     );
   });
 
-  it('StoredProcedurePage should not fetch details if permission is there', () => {
-    renderPage();
+  it('StoredProcedurePage fires the details fetch in parallel with the permission fetch even for a no-permission user, and still shows the placeholder', async () => {
+    await act(async () => {
+      renderPage();
+    });
 
-    expect(getStoredProceduresByFqn).not.toHaveBeenCalled();
+    // W1: the fetch is no longer gated on permission — it runs in parallel with
+    // the permission fetch to remove a serial round-trip.
+    expect(getStoredProceduresByFqn).toHaveBeenCalled();
+    // Render still gates on permission, so a no-permission user sees the
+    // placeholder rather than the entity.
+    expect(await screen.findByText('testErrorPlaceHolder')).toBeInTheDocument();
   });
 
   it('StoredProcedurePage should fetch details with basic fields', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
@@ -158,9 +158,11 @@ const StoredProcedurePage = () => {
       decodedStoredProcedureFQN,
       STORED_PROCEDURE_DEFAULT_FIELDS
     ),
-    enabled: Boolean(
-      decodedStoredProcedureFQN && viewBasicPermission && !permissionsLoading
-    ),
+    // Fire the stored-procedure fetch in parallel with the permission fetch
+    // rather than gating it on permission — removes a serial round-trip on
+    // mount. A no-permission user's speculative GET 403s and render shows the
+    // inline PERMISSION placeholder (checked before the error state below).
+    enabled: Boolean(decodedStoredProcedureFQN),
   });
 
   useEffect(() => {
@@ -169,10 +171,13 @@ const StoredProcedurePage = () => {
     }
     const status = (storedProcedureError as AxiosError | undefined)?.response
       ?.status;
-    if (status === ClientErrors.FORBIDDEN) {
+    // Only redirect on a genuine permission desync (we believe the user has
+    // access but the backend denied). A plain no-permission user falls through
+    // to the inline PERMISSION placeholder in render.
+    if (status === ClientErrors.FORBIDDEN && viewBasicPermission) {
       navigate(ROUTES.FORBIDDEN, { replace: true });
     }
-  }, [storedProcedureError, navigate]);
+  }, [storedProcedureError, navigate, viewBasicPermission]);
 
   useEffect(() => {
     if (!storedProcedure) {


### PR DESCRIPTION
## Description

Applies the [DatabaseDetailsPage template (#30867)](https://github.com/open-metadata/OpenMetadata/pull/30867) to the other react-query permission-gated detail pages. Each entity `useQuery` was `enabled` only after the permission fetch resolved (`enabled: ...viewPermission && !permissionsLoading`), forcing **two serial round-trips** on mount. Each now fires the GET **in parallel** with the permission fetch.

- **SearchIndexDetailsPage** — `enabled` gated on FQN only. Render already checks `!viewPermission` before the error state and there is no forbidden redirect, so no other change is needed.
- **StoredProcedurePage** — `enabled` gated on FQN only; the `/forbidden` redirect now fires only on a genuine permission desync (`viewBasicPermission` true), so a no-permission user falls through to the inline PERMISSION placeholder.
- **APICollectionPage** — `enabled` gated on FQN only; the 403 branch is nested so a no-permission 403 redirects only on desync and **never** falls through to the error toast. Render already checks permission before `isError`.

## Type of change

- [x] Performance (request waterfall → parallel)

## Tests

- Updated the two tests that asserted the old *"no permission ⇒ no fetch"* waterfall behaviour to assert the new intended behaviour: the fetch fires in parallel and render still gates on permission (placeholder shown).
- All **16** unit tests across the three pages pass; eslint clean.

## Verification note

Same as the template — the 403 / permission UX is best also confirmed in a **running app / Playwright** (Jest mocks permissions, not the real backend 403). Check: happy path loads; a no-permission user sees the inline placeholder and is **not** redirected to /forbidden.

Ref: open-metadata/openmetadata-collate#5442