### PR TITLE
fix(dar): format Data Access Request expiry as a date in the task tab

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/Task/TaskTab/TaskTabNew.component.tsx
@@ -99,7 +99,10 @@ import {
   TaskPayload,
   TaskResolutionType,
 } from '../../../../rest/tasksAPI';
-import { formatIsoDuration } from '../../../../utils/date-time/DateTimeUtils';
+import {
+  formatDate,
+  formatIsoDuration,
+} from '../../../../utils/date-time/DateTimeUtils';
 import EntityLink from '../../../../utils/EntityLink';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { getNameFromFQN } from '../../../../utils/FqnUtils';
@@ -231,6 +234,10 @@ const DAR_FIELD_ICONS: Record<string, string> = {
 
 const DAR_FIELD_FORMATTERS: Record<string, (value: unknown) => string> = {
   duration: (value) => formatIsoDuration(String(value ?? '')),
+  // Show the expiry as a human date (matching the DAR detail drawer) instead of
+  // the raw epoch number the schema field would otherwise render.
+  expirationDate: (value) =>
+    value == null || value === '' ? '--' : formatDate(Number(value)) || '--',
 };
 
 const ASSIGNEES_COLLAPSED_COUNT = 5;


### PR DESCRIPTION
## What & why
On the entity **Activity Feed & Tasks** tab, a Data Access Request's **Expiration Date** was shown as a raw epoch number (e.g. `1786699421850`), while the DAR detail drawer showed the same value as a friendly date. The task tab renders the DAR payload generically via `TaskPayloadSchemaFields`, applying per-field `DAR_FIELD_FORMATTERS` — that map formatted `duration` but had no entry for `expirationDate`, so the number fell through unformatted.

## How
Add an `expirationDate` entry to `DAR_FIELD_FORMATTERS` that reuses the existing shared `formatDate` util (the same one the DAR detail drawer uses), so both surfaces render the expiry consistently.

Issue -
<img width="1028" height="427" alt="Screenshot 2026-08-03 at 8 01 04 PM" src="https://github.com/user-attachments/assets/383f09ab-436e-4f5e-a5c5-ffdd56b157c8" />



## Testing
- Open a table → Activity Feed & Tasks → a Data Access Request task: the Expiration Date now renders as a date, matching the DAR detail drawer.
- Prettier/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)