### PR TITLE
fix(playwright): re-trigger when a test-suite pipeline run never leaves the queue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -455,16 +455,28 @@ export const triggerTestSuitePipelineAndWaitForSuccess = async (data: {
     latestRun.runId !== previousRun?.runId ||
     (latestRun.timestamp ?? 0) > (previousRun?.timestamp ?? 0);
 
-  // Wait for a genuinely new run to surface after a trigger. Returns false if
-  // none appears within the window, which means the trigger raced an
-  // unserialized DAG and produced an empty run that wrote no status.
+  // Wait for a genuinely new run to actually START after a trigger. Returns
+  // false if none does within the window, which means the trigger raced an
+  // unserialized DAG.
+  //
+  // The race has two shapes: the trigger produces no status at all, OR it
+  // produces a transient `queued` run that then vanishes because the empty DAG
+  // finished instantly and wrote nothing. A plain "a run exists" check is
+  // fooled by that transient `queued` and skips the re-trigger, so require the
+  // run to have LEFT the queue (running/success/…) — a real run does so within
+  // seconds, the empty-DAG run never does.
   const waitForNewRunToAppear = async () => {
     const startedAt = Date.now();
 
     while (Date.now() - startedAt < NEW_RUN_APPEARANCE_TIMEOUT) {
       const { run } = await fetchLatestPipelineStatus();
 
-      if (run && isNewRun(run)) {
+      if (
+        run &&
+        isNewRun(run) &&
+        run.pipelineState !== undefined &&
+        run.pipelineState !== PipelineState.Queued
+      ) {
         return true;
       }
 


### PR DESCRIPTION
Follow-up to #30789 (already merged).

## Problem
IncidentManager tests that keep a real pipeline (the main `beforeAll` and the re-run tests) intermittently fail in CI with `Received: "queued"` → 300s timeout. Confirmed from a merge-queue run's Airflow diagnostics: the freshly-deployed DAG isn't serialized when OM triggers it (`AirflowRESTClient: 404 "DAG … not found"`), so the DagRun executes **empty** (`run_duration=0.026s`, no task) and writes no status. In the trace this shows as a brief **`queued`** status followed by an **empty** `pipelineStatus`.

## Why the existing recovery missed it
`waitForNewRunToAppear` re-triggers only when *no* run appears — but the empty-DAG race produces a transient **`queued`** run, and the check counted any run as "materialized", so it skipped the re-trigger. The run then vanished and the success poll waited out the full timeout.

## Fix
Require the run to have actually **left the queue** before counting it:

```ts
if (
  run &&
  isNewRun(run) &&
  run.pipelineState !== undefined &&
  run.pipelineState !== PipelineState.Queued
) {
  return true;
}
```

A real run leaves `queued` within seconds; the empty-DAG run never does. So the transient `queued` no longer short-circuits the existing re-trigger loop, which fires and triggers again against the now-serialized DAG. If even that fails 3× (pathological saturation) it throws a clear error instead of the silent 300s hang.

## Scope / validation
- One-line-ish change to the shared helper; ESLint/Prettier/tsc clean.
- Behavioral validation is via CI under load — the race is an Airflow-3.x, load-dependent timing bug and can't be reproduced on a non-Airflow local stack. The change only makes the appearance check stricter and reuses the already-shipped re-trigger path, so it's low-risk.
- Note: the durable fix for the UI tests is seeding incidents (landed for pagination in #30789; lifecycle/tab/filters is a further follow-up). This patch hardens the tests that genuinely keep a pipeline. The underlying product race (deploy returns before the DAG is serialized) is a separate backend concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)