### PR TITLE
Fixes #30860: return metric facts from semantic_search and stop silently dropping filters

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -35,6 +35,9 @@ public class SemanticSearchTool implements McpTool {
   /** Sentinel unit meaning "see customUnitOfMeasurement" rather than a unit in its own right. */
   private static final String UNIT_OF_MEASUREMENT_OTHER = "OTHER";
 
+  /** Read-side ceiling on the metric expression a summary carries. */
+  private static final int MAX_METRIC_CODE_CHARS = 1000;
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
@@ -238,7 +241,7 @@ public class SemanticSearchTool implements McpTool {
     copyIfPresent(hit, cleaned, "certification");
     // Metric facts: a metric summary without its expression, granularity, type and unit cannot be
     // told apart from a similarly named metric, which forced a per-result get_entity_details call.
-    copyIfPresent(hit, cleaned, "metricExpression");
+    copyMetricExpression(hit, cleaned);
     copyIfPresent(hit, cleaned, "metricType");
     copyIfPresent(hit, cleaned, "granularity");
     copyIfPresent(hit, cleaned, "unitOfMeasurement");
@@ -256,6 +259,27 @@ public class SemanticSearchTool implements McpTool {
     }
 
     return cleaned;
+  }
+
+  /**
+   * A metric's expression, capped for the summary.
+   *
+   * <p>The write-side cap in {@code VectorDocBuilder} only covers chunk docs. Entity documents are
+   * members of the same {@code dataAssetEmbeddings} alias and carry the untruncated expression —
+   * and on Elasticsearch, which has no chunk index, every hit is an entity document. A 30 KB SQL
+   * body would then eat most of the response budget and crowd out the other results, so the read
+   * side caps it too, exactly as {@code description} is capped on both sides.
+   */
+  private static void copyMetricExpression(Map<String, Object> hit, Map<String, Object> cleaned) {
+    if (hit.get("metricExpression") instanceof Map<?, ?> expression) {
+      Map<String, Object> summary = new HashMap<>(expression.size());
+      expression.forEach((key, value) -> summary.put(String.valueOf(key), value));
+      Object code = summary.get("code");
+      if (code instanceof String sql) {
+        summary.put("code", McpResponseTrim.truncate(sql, MAX_METRIC_CODE_CHARS));
+      }
+      cleaned.put("metricExpression", summary);
+    }
   }
 
   /**

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -29,8 +29,30 @@ public class SemanticSearchTool implements McpTool {
   private static final int MAX_K = 10_000;
   private static final double DEFAULT_THRESHOLD = 0.0;
 
-  /** Filter fields the tool schema declares under {@code filters}; never valid at the top level. */
-  private static final List<String> FILTER_FIELDS = List.of("entityType", "service", "tags");
+  /**
+   * Every filter key {@code VectorSearchQueryBuilder} understands. A key belongs under
+   * {@code filters} and nowhere else, and a key outside this set would be dropped with nothing but a
+   * debug log — so both mistakes are rejected instead, per {@link #validateParams}. Keep in step
+   * with the switch in {@code VectorSearchQueryBuilder.appendFilterMustClauses}.
+   */
+  private static final List<String> FILTER_FIELDS =
+      List.of(
+          "entityType",
+          "service",
+          "serviceType",
+          "tags",
+          "owners",
+          "domains",
+          "tier",
+          "certification",
+          "database",
+          "databaseSchema",
+          "metricType",
+          "granularity",
+          "unitOfMeasurement");
+
+  /** Filter keys of the form {@code customProperties.<name>}, matched by prefix. */
+  private static final String CUSTOM_PROPERTIES_PREFIX = "customProperties.";
 
   /** Sentinel unit meaning "see customUnitOfMeasurement" rather than a unit in its own right. */
   private static final String UNIT_OF_MEASUREMENT_OTHER = "OTHER";
@@ -86,10 +108,10 @@ public class SemanticSearchTool implements McpTool {
   }
 
   /**
-   * Rejects a filter passed at the top level (e.g. {@code "entityType": "metric"}) instead of under
-   * {@code filters}. Such a parameter used to be dropped by {@link #parseFilters}, so the caller got
-   * an unfiltered search back with no indication their filter had done nothing — a wrong answer that
-   * looks like a right one. Failing loudly with the correct shape is the only honest option.
+   * Rejects the two ways a filter used to be discarded in silence: passed at the top level instead
+   * of under {@code filters}, or named something the query builder does not understand. Either way
+   * the caller got an unfiltered search back with no indication their filter had done nothing — a
+   * wrong answer that looks like a right one.
    *
    * @return the error message, or {@code null} when the parameters are usable
    */
@@ -98,17 +120,40 @@ public class SemanticSearchTool implements McpTool {
     if (query == null || query.isBlank()) {
       error = "'query' parameter is required";
     } else {
-      String misplaced =
-          FILTER_FIELDS.stream().filter(params::containsKey).findFirst().orElse(null);
-      if (misplaced != null) {
-        error =
-            String.format(
-                "'%s' is a filter and must be nested under 'filters' as an array, "
-                    + "for example: {\"query\": \"...\", \"filters\": {\"%s\": [\"value\"]}}",
-                misplaced, misplaced);
+      error = misplacedFilterError(params);
+      if (error == null) {
+        error = unknownFilterError(params);
       }
     }
     return error;
+  }
+
+  private static String misplacedFilterError(Map<String, Object> params) {
+    String misplaced = FILTER_FIELDS.stream().filter(params::containsKey).findFirst().orElse(null);
+    return misplaced == null
+        ? null
+        : String.format(
+            "'%s' is a filter and must be nested under 'filters' as an array, "
+                + "for example: {\"query\": \"...\", \"filters\": {\"%s\": [\"value\"]}}",
+            misplaced, misplaced);
+  }
+
+  private static String unknownFilterError(Map<String, Object> params) {
+    String unknown =
+        parseFilters(params).keySet().stream()
+            .filter(key -> !isSupportedFilter(key))
+            .findFirst()
+            .orElse(null);
+    return unknown == null
+        ? null
+        : String.format(
+            "'%s' is not a supported filter field. Supported fields: %s, "
+                + "or 'customProperties.<name>'.",
+            unknown, String.join(", ", FILTER_FIELDS));
+  }
+
+  private static boolean isSupportedFilter(String key) {
+    return FILTER_FIELDS.contains(key) || key.startsWith(CUSTOM_PROPERTIES_PREFIX);
   }
 
   @Override
@@ -302,7 +347,7 @@ public class SemanticSearchTool implements McpTool {
   }
 
   @SuppressWarnings("unchecked")
-  private Map<String, List<String>> parseFilters(Map<String, Object> params) {
+  private static Map<String, List<String>> parseFilters(Map<String, Object> params) {
     if (!params.containsKey("filters")) {
       return Collections.emptyMap();
     }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -47,6 +47,8 @@ public class SemanticSearchTool implements McpTool {
           "certification",
           "database",
           "databaseSchema",
+          "primaryEntityId",
+          "parentId",
           "metricType",
           "granularity",
           "unitOfMeasurement");

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/SemanticSearchTool.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,12 @@ public class SemanticSearchTool implements McpTool {
   private static final int MAX_K = 10_000;
   private static final double DEFAULT_THRESHOLD = 0.0;
 
+  /** Filter fields the tool schema declares under {@code filters}; never valid at the top level. */
+  private static final List<String> FILTER_FIELDS = List.of("entityType", "service", "tags");
+
+  /** Sentinel unit meaning "see customUnitOfMeasurement" rather than a unit in its own right. */
+  private static final String UNIT_OF_MEASUREMENT_OTHER = "OTHER";
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer, CatalogSecurityContext securityContext, Map<String, Object> params)
@@ -35,8 +42,9 @@ public class SemanticSearchTool implements McpTool {
     LOG.info("Executing semanticSearch with params: {}", params);
 
     String query = (String) params.get("query");
-    if (query == null || query.isBlank()) {
-      return errorResponse("'query' parameter is required");
+    String paramError = validateParams(query, params);
+    if (paramError != null) {
+      return errorResponse(paramError);
     }
 
     if (!Entity.getSearchRepository().isVectorEmbeddingEnabled()) {
@@ -74,6 +82,32 @@ public class SemanticSearchTool implements McpTool {
     }
   }
 
+  /**
+   * Rejects a filter passed at the top level (e.g. {@code "entityType": "metric"}) instead of under
+   * {@code filters}. Such a parameter used to be dropped by {@link #parseFilters}, so the caller got
+   * an unfiltered search back with no indication their filter had done nothing — a wrong answer that
+   * looks like a right one. Failing loudly with the correct shape is the only honest option.
+   *
+   * @return the error message, or {@code null} when the parameters are usable
+   */
+  private static String validateParams(String query, Map<String, Object> params) {
+    String error = null;
+    if (query == null || query.isBlank()) {
+      error = "'query' parameter is required";
+    } else {
+      String misplaced =
+          FILTER_FIELDS.stream().filter(params::containsKey).findFirst().orElse(null);
+      if (misplaced != null) {
+        error =
+            String.format(
+                "'%s' is a filter and must be nested under 'filters' as an array, "
+                    + "for example: {\"query\": \"...\", \"filters\": {\"%s\": [\"value\"]}}",
+                misplaced, misplaced);
+      }
+    }
+    return error;
+  }
+
   @Override
   public Map<String, Object> execute(
       Authorizer authorizer,
@@ -98,10 +132,7 @@ public class SemanticSearchTool implements McpTool {
       return result;
     }
 
-    List<Map<String, Object>> cleanedResults = new ArrayList<>();
-    for (Map<String, Object> hit : response.getHits()) {
-      cleanedResults.add(cleanHit(hit));
-    }
+    List<Map<String, Object>> cleanedResults = collapseByParent(response.getHits());
 
     result.put("results", cleanedResults);
     result.put("returnedCount", cleanedResults.size());
@@ -121,6 +152,40 @@ public class SemanticSearchTool implements McpTool {
         "Showing %d results. Pass 'nextCursor' to fetch the next page, or refine your query. "
             + "Adjust 'threshold' to filter by similarity score.");
     return result;
+  }
+
+  /**
+   * One result per entity, best-scoring chunk first.
+   *
+   * <p>The vector service pages by <em>parent entity</em> but returns every matching chunk of each
+   * parent, ordered best-first. Since {@link #cleanHit} keeps only entity-level fields, the extra
+   * chunks of one entity clean down to near-identical results — duplicate rows that burn response
+   * budget and caller context while adding nothing. Worse, {@code nextCursor} advances by the number
+   * of rows returned (see {@code VectorPagingContract}) while the service's {@code from} skips
+   * parents, so any multi-chunk parent made page two skip entities entirely. Collapsing here makes
+   * the returned count equal the parent count, which is what the cursor arithmetic assumes.
+   */
+  private List<Map<String, Object>> collapseByParent(List<Map<String, Object>> hits) {
+    Map<String, Map<String, Object>> byParent = new LinkedHashMap<>();
+    for (Map<String, Object> hit : hits) {
+      byParent.computeIfAbsent(parentKey(hit), ignored -> cleanHit(hit));
+    }
+    return new ArrayList<>(byParent.values());
+  }
+
+  /**
+   * Identity of the entity a hit belongs to. {@code parentId} is present on chunk docs and on
+   * backfilled entity docs; the FQN and then the hit's own identity hash are fallbacks so a doc
+   * missing both is never silently merged into another entity's result.
+   */
+  private static String parentKey(Map<String, Object> hit) {
+    Object parentId = hit.get("parentId");
+    Object fqn = hit.get("fullyQualifiedName");
+    String key = parentId != null ? parentId.toString() : null;
+    if (key == null) {
+      key = fqn != null ? fqn.toString() : "hit:" + System.identityHashCode(hit);
+    }
+    return key;
   }
 
   /**
@@ -171,6 +236,13 @@ public class SemanticSearchTool implements McpTool {
     copyIfPresent(hit, cleaned, "domains");
     copyIfPresent(hit, cleaned, "columns");
     copyIfPresent(hit, cleaned, "certification");
+    // Metric facts: a metric summary without its expression, granularity, type and unit cannot be
+    // told apart from a similarly named metric, which forced a per-result get_entity_details call.
+    copyIfPresent(hit, cleaned, "metricExpression");
+    copyIfPresent(hit, cleaned, "metricType");
+    copyIfPresent(hit, cleaned, "granularity");
+    copyIfPresent(hit, cleaned, "unitOfMeasurement");
+    resolveCustomUnit(hit, cleaned);
 
     if (hit.containsKey("_score")) {
       cleaned.put("similarityScore", hit.get("_score"));
@@ -184,6 +256,19 @@ public class SemanticSearchTool implements McpTool {
     }
 
     return cleaned;
+  }
+
+  /**
+   * A hit from an entity index carries the raw {@code OTHER} sentinel plus a separate
+   * {@code customUnitOfMeasurement}, while a chunk doc already stores the resolved unit. Resolving
+   * it here keeps the two doc types indistinguishable to the caller — "OTHER" on its own says
+   * nothing about the metric.
+   */
+  private static void resolveCustomUnit(Map<String, Object> hit, Map<String, Object> cleaned) {
+    Object customUnit = hit.get("customUnitOfMeasurement");
+    if (UNIT_OF_MEASUREMENT_OTHER.equals(cleaned.get("unitOfMeasurement")) && customUnit != null) {
+      cleaned.put("unitOfMeasurement", customUnit);
+    }
   }
 
   private void copyIfPresent(Map<String, Object> source, Map<String, Object> target, String key) {

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -208,7 +208,7 @@
           },
           "filters": {
             "type": "object",
-            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard'], also data quality types ['testCase', 'testSuite']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'tags' (e.g., ['PII.Sensitive']). Example: {\"entityType\": [\"table\"], \"service\": [\"BigQuery\"]}. These belong here and nowhere else — passing 'entityType', 'service' or 'tags' at the top level of the call is rejected with an error.",
+            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard'], also data quality types ['testCase', 'testSuite']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'serviceType', 'tags' (e.g., ['PII.Sensitive']), 'owners', 'domains', 'tier', 'certification', 'database', 'databaseSchema', and for metrics 'metricType', 'granularity' (e.g., ['MONTH']) and 'unitOfMeasurement' — the same metric facets returned on every metric result, so you can filter by what you see. Custom properties are filterable as 'customProperties.<name>'. Example: {\"entityType\": [\"metric\"], \"granularity\": [\"MONTH\"]}. These belong here and nowhere else — passing a filter field at the top level of the call, or naming a field that is not in this list, is rejected with an error rather than silently ignored.",
             "additionalProperties": {
               "type": "array",
               "items": {

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -83,7 +83,7 @@
           },
           "queryFilter": {
             "type": "string",
-            "description": "Advanced: Direct OpenSearch JSON query string for precise control. Only use if you can generate valid OpenSearch DSL. When provided, this overrides the 'query' parameter. Must include entityType filter. Example: '{\"bool\": {\"must\": [{\"term\": {\"entityType\": \"table\"}}, {\"nested\": {\"path\": \"owners\", \"query\": {\"term\": {\"owners.name\": \"marketing\"}}}}]}}'. Key rules: Use singular entityType, 'owners.name' (plural), tier format is 'Tier.Tier1', columns are NOT nested, owners IS nested (wrap owners queries in {\"nested\": {\"path\": \"owners\", \"query\": ...}})."
+            "description": "Advanced: Direct OpenSearch JSON query string for precise control. Only use if you can generate valid OpenSearch DSL. When provided, this overrides the 'query' parameter. Must include entityType filter. Example: '{\"bool\": {\"must\": [{\"term\": {\"entityType\": \"table\"}}, {\"nested\": {\"path\": \"owners\", \"query\": {\"term\": {\"owners.name\": \"marketing\"}}}}]}}'. Key rules: Use singular entityType, 'owners.name' (plural), tier format is 'Tier.Tier1', columns are NOT nested, owners IS nested (wrap owners queries in {\"nested\": {\"path\": \"owners\", \"query\": ...}}). 'fullyQualifiedName' is indexed with a lowercase normalizer, so values in 'term'/'terms' clauses must be lowercased — {\"terms\": {\"fullyQualifiedName\": [\"dailyactiveusers\"]}} matches, the original casing silently matches nothing. Combining a 'terms' clause on 'fullyQualifiedName' with 'fields' is the way to hydrate many known entities in one call."
           },
           "from": {
             "type": "integer",
@@ -197,7 +197,7 @@
         "destructiveHint": false,
         "openWorldHint": false
       },
-      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information.",
+      "description": "Meaning-based discovery of data assets using vector embeddings. Best for exploratory or vague queries where you don't know exact names — it finds conceptually related assets even when no keywords match. Use this when the user describes what data they need in plain language (e.g., 'tables about customer spending behavior', 'anything related to revenue forecasting'). Returns entity summaries with name, columns, description, and metadata. Metric results additionally carry 'metricExpression', 'metricType', 'granularity' and 'unitOfMeasurement' — enough to tell similarly named metrics apart (e.g. daily vs monthly active users) and shortlist the right one without fetching each candidate. Choose this over search_metadata when the query is about meaning or concepts rather than specific identifiers or attributes. Results include 'fullyQualifiedName' and 'entityType' — pass these directly to get_entity_details for full entity information, including custom properties ('extension'), which summaries never include. One result is returned per entity: the best-matching passage represents it.",
       "parameters": {
         "description": "Use 'query' to describe what you're looking for in plain language. The system finds conceptually similar assets using vector similarity. Optionally filter by entity type, service, or tags.",
         "type": "object",
@@ -208,7 +208,7 @@
           },
           "filters": {
             "type": "object",
-            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard'], also data quality types ['testCase', 'testSuite']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'tags' (e.g., ['PII.Sensitive']). Example: {\"entityType\": [\"table\"], \"service\": [\"BigQuery\"]}.",
+            "description": "Optional filters to narrow results. Keys are field names and values are arrays of allowed values. Supported filter fields: 'entityType' (e.g., ['table', 'dashboard'], also data quality types ['testCase', 'testSuite']), 'service' (e.g., ['BigQuery', 'Snowflake']), 'tags' (e.g., ['PII.Sensitive']). Example: {\"entityType\": [\"table\"], \"service\": [\"BigQuery\"]}. These belong here and nowhere else — passing 'entityType', 'service' or 'tags' at the top level of the call is rejected with an error.",
             "additionalProperties": {
               "type": "array",
               "items": {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -1,6 +1,7 @@
 package org.openmetadata.mcp.tools;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -330,6 +332,47 @@ class SemanticSearchToolTest {
   }
 
   @Test
+  void testTopLevelFilterIsRejectedInsteadOfIgnored() throws Exception {
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "Active Customers");
+    params.put("entityType", "metric");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    String error = (String) result.get("error");
+    assertNotNull(error);
+    assertTrue(error.contains("entityType"));
+    assertTrue(error.contains("filters"));
+    assertEquals(0, result.get("totalFound"));
+    verify(vectorService, never())
+        .search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble());
+  }
+
+  @Test
+  void testCustomUnitReplacesTheOtherSentinelOnEntityIndexHits() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    // Entity-index hits carry the raw enum plus a separate custom unit; chunk docs carry the
+    // resolved value. Both must look the same to the caller.
+    Map<String, Object> hit = createHit("metric", "SpreadBps", "SpreadBps", 0.9);
+    hit.put("unitOfMeasurement", "OTHER");
+    hit.put("customUnitOfMeasurement", "basis points");
+
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, List.of(hit)));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "spread");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cleaned = (Map<String, Object>) ((List<?>) result.get("results")).get(0);
+    assertEquals("basis points", cleaned.get("unitOfMeasurement"));
+    assertFalse(cleaned.containsKey("customUnitOfMeasurement"));
+  }
+
+  @Test
   void testFiltersPassedAsMap() throws Exception {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
 
@@ -510,6 +553,97 @@ class SemanticSearchToolTest {
     if (returned == 0) {
       assertNull(result.get("nextCursor"), "cursor must not point back to the same page");
     }
+  }
+
+  @Test
+  void testMetricFactsAreReturnedForShortlisting() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    Map<String, Object> hit = createHit("metric", "MonthlyActiveUsers", "MonthlyActiveUsers", 0.9);
+    hit.put("metricExpression", Map.of("language", "SQL", "code", "SELECT COUNT(DISTINCT id)"));
+    hit.put("metricType", "COUNT");
+    hit.put("granularity", "MONTH");
+    hit.put("unitOfMeasurement", "COUNT");
+    hit.put("extension", Map.of("owningTeam", "growth"));
+
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, List.of(hit)));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "active customers");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cleaned = (Map<String, Object>) ((List<?>) result.get("results")).get(0);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> expression = (Map<String, Object>) cleaned.get("metricExpression");
+    assertEquals("SELECT COUNT(DISTINCT id)", expression.get("code"));
+    assertEquals("MONTH", cleaned.get("granularity"));
+    assertEquals("COUNT", cleaned.get("metricType"));
+    assertEquals("COUNT", cleaned.get("unitOfMeasurement"));
+    // Custom properties stay a get_entity_details concern: unbounded user JSON would compete with
+    // results for the response budget.
+    assertFalse(cleaned.containsKey("extension"));
+  }
+
+  @Test
+  void testChunksOfOneEntityCollapseToASingleResult() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    Map<String, Object> best = createHit("page", "kb.long_article", "long_article", 0.91);
+    best.put("parentId", "parent-1");
+    best.put("chunkIndex", 0);
+    Map<String, Object> weaker = createHit("page", "kb.long_article", "long_article", 0.62);
+    weaker.put("parentId", "parent-1");
+    weaker.put("chunkIndex", 3);
+    Map<String, Object> other = createHit("page", "kb.other", "other", 0.55);
+    other.put("parentId", "parent-2");
+
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, List.of(best, weaker, other)));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "anything");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    List<?> results = (List<?>) result.get("results");
+    assertEquals(2, results.size(), "each entity must appear once, not once per matching chunk");
+    assertEquals(2, result.get("returnedCount"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> first = (Map<String, Object>) results.get(0);
+    assertEquals(
+        0.91, first.get("similarityScore"), "the best-scoring chunk must represent the entity");
+  }
+
+  @Test
+  void testCollapsedCountKeepsNextCursorAlignedWithParentPaging() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    // Two entities, three chunk hits: a cursor built from the raw hit count would advance the
+    // vector service's parent-offset by 3 and skip an entity on the next page.
+    Map<String, Object> firstChunk = createHit("page", "kb.a", "a", 0.9);
+    firstChunk.put("parentId", "parent-1");
+    Map<String, Object> secondChunk = createHit("page", "kb.a", "a", 0.8);
+    secondChunk.put("parentId", "parent-1");
+    Map<String, Object> otherEntity = createHit("page", "kb.b", "b", 0.7);
+    otherEntity.put("parentId", "parent-2");
+
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(
+            new VectorSearchResponse(
+                10L, List.of(firstChunk, secondChunk, otherEntity), null, true));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "anything");
+    params.put("size", 2);
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    String cursor = (String) result.get("nextCursor");
+    assertNotNull(cursor, "a full page with more in the index must advertise a cursor");
+    assertEquals(2, PageCursor.decode(cursor).orElseThrow().offset());
   }
 
   private Map<String, Object> createHit(String entityType, String fqn, String name, double score) {

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -588,6 +588,34 @@ class SemanticSearchToolTest {
   }
 
   @Test
+  void testOversizedMetricExpressionIsCappedOnTheReadSide() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+
+    // Entity-index hits never passed through the write-side cap — and on Elasticsearch, which has
+    // no chunk index, every hit is an entity doc. An uncapped 30KB expression would crowd the
+    // other results out of the response budget.
+    Map<String, Object> hit = createHit("metric", "HugeMetric", "HugeMetric", 0.9);
+    hit.put("metricExpression", Map.of("language", "SQL", "code", "x".repeat(30_000)));
+
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, List.of(hit)));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "huge");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cleaned = (Map<String, Object>) ((List<?>) result.get("results")).get(0);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> expression = (Map<String, Object>) cleaned.get("metricExpression");
+    assertTrue(
+        ((String) expression.get("code")).length() < 1100,
+        "the summary must cap a pathological expression");
+    assertEquals("SQL", expression.get("language"), "other expression fields survive the cap");
+  }
+
+  @Test
   void testChunksOfOneEntityCollapseToASingleResult() throws Exception {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -8,8 +8,8 @@ import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.mcp.util.PageCursor;
 import org.openmetadata.service.Entity;
@@ -51,6 +50,7 @@ class SemanticSearchToolTest {
     vectorService = mock(OpenSearchVectorService.class);
 
     Entity.setSearchRepository(searchRepository);
+    lenient().when(searchRepository.getVectorIndexService()).thenReturn(vectorService);
   }
 
   @Test
@@ -95,20 +95,16 @@ class SemanticSearchToolTest {
   @Test
   void testVectorServiceNotInitializedReturnsError() throws Exception {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    when(searchRepository.getVectorIndexService()).thenReturn(null);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(null);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test query");
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test query");
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
-
-      assertNotNull(result);
-      assertEquals(0, result.get("totalFound"));
-      assertTrue(result.get("error").toString().contains("not initialized"));
-    }
+    assertNotNull(result);
+    assertEquals(0, result.get("totalFound"));
+    assertTrue(result.get("error").toString().contains("not initialized"));
   }
 
   @Test
@@ -117,24 +113,20 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(15L, Collections.emptyList());
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test query");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test query");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-      assertEquals("test query", result.get("query"));
-      assertEquals(15L, result.get("tookMillis"));
-      assertEquals(0, result.get("totalFound"));
-      assertEquals(0, result.get("returnedCount"));
-      assertTrue(((List<?>) result.get("results")).isEmpty());
-    }
+    assertNotNull(result);
+    assertEquals("test query", result.get("query"));
+    assertEquals(15L, result.get("tookMillis"));
+    assertEquals(0, result.get("totalFound"));
+    assertEquals(0, result.get("returnedCount"));
+    assertTrue(((List<?>) result.get("results")).isEmpty());
   }
 
   @Test
@@ -143,21 +135,17 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(5L, null);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test query");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test query");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-      assertEquals(0, result.get("totalFound"));
-      assertEquals(0, result.get("returnedCount"));
-    }
+    assertNotNull(result);
+    assertEquals(0, result.get("totalFound"));
+    assertEquals(0, result.get("returnedCount"));
   }
 
   @Test
@@ -170,27 +158,23 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(25L, hits);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "user data");
-      params.put("size", 10);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "user data");
+    params.put("size", 10);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-      assertEquals("user data", result.get("query"));
-      assertEquals(25L, result.get("tookMillis"));
-      assertEquals(2, result.get("totalFound"));
-      assertEquals(2, result.get("returnedCount"));
+    assertNotNull(result);
+    assertEquals("user data", result.get("query"));
+    assertEquals(25L, result.get("tookMillis"));
+    assertEquals(2, result.get("totalFound"));
+    assertEquals(2, result.get("returnedCount"));
 
-      List<?> results = (List<?>) result.get("results");
-      assertEquals(2, results.size());
-    }
+    List<?> results = (List<?>) result.get("results");
+    assertEquals(2, results.size());
   }
 
   @Test
@@ -213,34 +197,30 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, List.of(hit));
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "users");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "users");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      List<?> results = (List<?>) result.get("results");
-      @SuppressWarnings("unchecked")
-      Map<String, Object> cleaned = (Map<String, Object>) results.get(0);
+    List<?> results = (List<?>) result.get("results");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cleaned = (Map<String, Object>) results.get(0);
 
-      assertEquals("table", cleaned.get("entityType"));
-      assertEquals("db.schema.users", cleaned.get("fullyQualifiedName"));
-      assertEquals("users", cleaned.get("name"));
-      assertEquals("Users", cleaned.get("displayName"));
-      assertEquals("BigQuery", cleaned.get("serviceType"));
-      assertEquals("A short description", cleaned.get("description"));
-      assertNotNull(cleaned.get("columns"));
-      assertEquals(0.95, cleaned.get("similarityScore"));
-      assertTrue(!cleaned.containsKey("_score"));
-      assertTrue(!cleaned.containsKey("embedding"));
-      assertTrue(!cleaned.containsKey("fingerprint"));
-      assertTrue(!cleaned.containsKey("textToLLMContext"));
-    }
+    assertEquals("table", cleaned.get("entityType"));
+    assertEquals("db.schema.users", cleaned.get("fullyQualifiedName"));
+    assertEquals("users", cleaned.get("name"));
+    assertEquals("Users", cleaned.get("displayName"));
+    assertEquals("BigQuery", cleaned.get("serviceType"));
+    assertEquals("A short description", cleaned.get("description"));
+    assertNotNull(cleaned.get("columns"));
+    assertEquals(0.95, cleaned.get("similarityScore"));
+    assertTrue(!cleaned.containsKey("_score"));
+    assertTrue(!cleaned.containsKey("embedding"));
+    assertTrue(!cleaned.containsKey("fingerprint"));
+    assertTrue(!cleaned.containsKey("textToLLMContext"));
   }
 
   @Test
@@ -254,25 +234,21 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, List.of(hit));
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      List<?> results = (List<?>) result.get("results");
-      @SuppressWarnings("unchecked")
-      Map<String, Object> cleaned = (Map<String, Object>) results.get(0);
-      String truncated = (String) cleaned.get("description");
+    List<?> results = (List<?>) result.get("results");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cleaned = (Map<String, Object>) results.get(0);
+    String truncated = (String) cleaned.get("description");
 
-      assertEquals(453, truncated.length());
-      assertTrue(truncated.endsWith("..."));
-    }
+    assertEquals(453, truncated.length());
+    assertTrue(truncated.endsWith("..."));
   }
 
   @Test
@@ -281,18 +257,14 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, Collections.emptyList());
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 100);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 100);
 
-      semanticSearchTool.execute(authorizer, securityContext, params);
-    }
+    semanticSearchTool.execute(authorizer, securityContext, params);
   }
 
   @Test
@@ -306,21 +278,17 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 3);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 3);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result.get("message"));
-      assertTrue(result.get("message").toString().contains("Showing 3 results"));
-    }
+    assertNotNull(result.get("message"));
+    assertTrue(result.get("message").toString().contains("Showing 3 results"));
   }
 
   @Test
@@ -332,41 +300,33 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, hits);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 10);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 10);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertTrue(!result.containsKey("message"));
-    }
+    assertTrue(!result.containsKey("message"));
   }
 
   @Test
   void testSearchExceptionReturnsError() throws Exception {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenThrow(new RuntimeException("Connection refused"));
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenThrow(new RuntimeException("Connection refused"));
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-      assertEquals(0, result.get("totalFound"));
-      assertTrue(result.get("error").toString().contains("Connection refused"));
-    }
+    assertNotNull(result);
+    assertEquals(0, result.get("totalFound"));
+    assertTrue(result.get("error").toString().contains("Connection refused"));
   }
 
   @Test
@@ -375,25 +335,21 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, Collections.emptyList());
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> filters = new HashMap<>();
-      filters.put("entityType", List.of("table", "topic"));
-      filters.put("service", "my_db");
+    Map<String, Object> filters = new HashMap<>();
+    filters.put("entityType", List.of("table", "topic"));
+    filters.put("service", "my_db");
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("filters", filters);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("filters", filters);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-      assertEquals(0, result.get("totalFound"));
-    }
+    assertNotNull(result);
+    assertEquals(0, result.get("totalFound"));
   }
 
   @Test
@@ -402,22 +358,18 @@ class SemanticSearchToolTest {
 
     VectorSearchResponse response = new VectorSearchResponse(10L, Collections.emptyList());
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", "5");
-      params.put("k", "500");
-      params.put("threshold", "0.5");
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", "5");
+    params.put("k", "500");
+    params.put("threshold", "0.5");
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNotNull(result);
-    }
+    assertNotNull(result);
   }
 
   @Test
@@ -430,24 +382,20 @@ class SemanticSearchToolTest {
     }
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 3);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 3);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertEquals(Boolean.TRUE, result.get("hasMore"));
-      Optional<PageCursor.Cursor> decoded = PageCursor.decode((String) result.get("nextCursor"));
-      assertTrue(decoded.isPresent());
-      assertTrue(decoded.get().isOffset());
-      assertEquals(3, decoded.get().offset());
-    }
+    assertEquals(Boolean.TRUE, result.get("hasMore"));
+    Optional<PageCursor.Cursor> decoded = PageCursor.decode((String) result.get("nextCursor"));
+    assertTrue(decoded.isPresent());
+    assertTrue(decoded.get().isOffset());
+    assertEquals(3, decoded.get().offset());
   }
 
   @Test
@@ -455,23 +403,19 @@ class SemanticSearchToolTest {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
     VectorSearchResponse response = new VectorSearchResponse(5L, Collections.emptyList());
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      ArgumentCaptor<Integer> fromCaptor = ArgumentCaptor.forClass(Integer.class);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    ArgumentCaptor<Integer> fromCaptor = ArgumentCaptor.forClass(Integer.class);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("cursor", PageCursor.encodeOffset(30));
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("cursor", PageCursor.encodeOffset(30));
 
-      semanticSearchTool.execute(authorizer, securityContext, params);
+    semanticSearchTool.execute(authorizer, securityContext, params);
 
-      verify(vectorService)
-          .search(anyString(), anyMap(), anyInt(), fromCaptor.capture(), anyInt(), anyDouble());
-      assertEquals(30, fromCaptor.getValue());
-    }
+    verify(vectorService)
+        .search(anyString(), anyMap(), anyInt(), fromCaptor.capture(), anyInt(), anyDouble());
+    assertEquals(30, fromCaptor.getValue());
   }
 
   @Test
@@ -484,21 +428,17 @@ class SemanticSearchToolTest {
     }
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, 3L, false);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 3);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 3);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNull(result.get("hasMore"));
-      assertNull(result.get("nextCursor"));
-    }
+    assertNull(result.get("hasMore"));
+    assertNull(result.get("nextCursor"));
   }
 
   @Test
@@ -511,21 +451,17 @@ class SemanticSearchToolTest {
     }
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, false);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 3);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 3);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNull(result.get("hasMore"));
-      assertNull(result.get("nextCursor"));
-    }
+    assertNull(result.get("hasMore"));
+    assertNull(result.get("nextCursor"));
   }
 
   @Test
@@ -538,21 +474,17 @@ class SemanticSearchToolTest {
     }
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, null);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 3);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 3);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      assertNull(result.get("hasMore"));
-      assertNull(result.get("nextCursor"));
-    }
+    assertNull(result.get("hasMore"));
+    assertNull(result.get("nextCursor"));
   }
 
   @Test
@@ -565,22 +497,18 @@ class SemanticSearchToolTest {
     hits.add(huge);
     VectorSearchResponse response = new VectorSearchResponse(10L, hits, null, true);
 
-    try (MockedStatic<OpenSearchVectorService> vectorMock =
-        mockStatic(OpenSearchVectorService.class)) {
-      vectorMock.when(OpenSearchVectorService::getInstance).thenReturn(vectorService);
-      when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
-          .thenReturn(response);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(response);
 
-      Map<String, Object> params = new HashMap<>();
-      params.put("query", "test");
-      params.put("size", 1);
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "test");
+    params.put("size", 1);
 
-      Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
 
-      int returned = result.get("returnedCount") instanceof Number n ? n.intValue() : -1;
-      if (returned == 0) {
-        assertNull(result.get("nextCursor"), "cursor must not point back to the same page");
-      }
+    int returned = result.get("returnedCount") instanceof Number n ? n.intValue() : -1;
+    if (returned == 0) {
+      assertNull(result.get("nextCursor"), "cursor must not point back to the same page");
     }
   }
 

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -620,6 +620,23 @@ class SemanticSearchToolTest {
   }
 
   @Test
+  void testEveryFilterKeyTheQueryBuilderHandlesIsAccepted() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, Collections.emptyList()));
+
+    // Validation must not reject a filter the engine understands. These two are not in the tool
+    // schema but VectorSearchQueryBuilder has switch arms for them.
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "anything");
+    params.put("filters", Map.of("parentId", List.of("abc"), "primaryEntityId", List.of("def")));
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    assertNull(result.get("error"));
+  }
+
+  @Test
   void testTopLevelMetricFacetIsRejectedToo() throws Exception {
     Map<String, Object> params = new HashMap<>();
     params.put("query", "active users");

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/SemanticSearchToolTest.java
@@ -588,6 +588,50 @@ class SemanticSearchToolTest {
   }
 
   @Test
+  void testUnknownFilterKeyIsRejectedInsteadOfIgnored() throws Exception {
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "active users");
+    params.put("filters", Map.of("granularityy", List.of("MONTH")));
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    String error = (String) result.get("error");
+    assertNotNull(error);
+    assertTrue(error.contains("granularityy"));
+    assertTrue(error.contains("granularity"), "the error lists the supported fields");
+    verify(vectorService, never())
+        .search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble());
+  }
+
+  @Test
+  void testSupportedMetricFacetFilterIsAccepted() throws Exception {
+    when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
+    when(vectorService.search(anyString(), anyMap(), anyInt(), anyInt(), anyInt(), anyDouble()))
+        .thenReturn(new VectorSearchResponse(10L, Collections.emptyList()));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "active users");
+    params.put("filters", Map.of("granularity", List.of("MONTH"), "metricType", List.of("COUNT")));
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    assertNull(result.get("error"));
+    assertEquals(0, result.get("totalFound"));
+  }
+
+  @Test
+  void testTopLevelMetricFacetIsRejectedToo() throws Exception {
+    Map<String, Object> params = new HashMap<>();
+    params.put("query", "active users");
+    params.put("granularity", "MONTH");
+
+    Map<String, Object> result = semanticSearchTool.execute(authorizer, securityContext, params);
+
+    assertTrue(result.get("error").toString().contains("granularity"));
+    assertTrue(result.get("error").toString().contains("filters"));
+  }
+
+  @Test
   void testOversizedMetricExpressionIsCappedOnTheReadSide() throws Exception {
     when(searchRepository.isVectorEmbeddingEnabled()).thenReturn(true);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -867,9 +867,9 @@ public class AIContextBuilder {
    */
   private static GenericAssetContext buildMetricContext(Metric metric) {
     MetricExpression expression = metric.getMetricExpression();
-    GenericAssetContext context = new GenericAssetContext();
+    GenericAssetContext context = null;
     if (expression != null && !nullOrEmpty(expression.getCode())) {
-      context.withDefinition(expression.getCode());
+      context = new GenericAssetContext().withDefinition(expression.getCode());
     }
     return context;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextBuilder.java
@@ -63,6 +63,7 @@ import org.openmetadata.schema.type.aicontext.ColumnProfileSummary;
 import org.openmetadata.schema.type.aicontext.DataQuality;
 import org.openmetadata.schema.type.aicontext.FieldContext;
 import org.openmetadata.schema.type.aicontext.ForeignKey;
+import org.openmetadata.schema.type.aicontext.GenericAssetContext;
 import org.openmetadata.schema.type.aicontext.JoinHint;
 import org.openmetadata.schema.type.aicontext.KnowledgeItem;
 import org.openmetadata.schema.type.aicontext.LineageEdgeContext;
@@ -852,6 +853,23 @@ public class AIContextBuilder {
     AssetContext context = new AssetContext();
     if (entity instanceof Table table) {
       context.withTable(buildTableContext(table));
+    }
+    if (entity instanceof Metric metric) {
+      context.withGeneric(buildMetricContext(metric));
+    }
+    return context;
+  }
+
+  /**
+   * A metric's structural context is its expression — the query that defines it. Without this, asking
+   * get_asset_context about a metric returned only its description, while the same expression was
+   * already reachable through get_knowledge_content and as attached knowledge of a table.
+   */
+  private static GenericAssetContext buildMetricContext(Metric metric) {
+    MetricExpression expression = metric.getMetricExpression();
+    GenericAssetContext context = new GenericAssetContext();
+    if (expression != null && !nullOrEmpty(expression.getCode())) {
+      context.withDefinition(expression.getCode());
     }
     return context;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/AIContextMarkdown.java
@@ -28,6 +28,7 @@ import org.openmetadata.schema.type.aicontext.ColumnProfileSummary;
 import org.openmetadata.schema.type.aicontext.DataQuality;
 import org.openmetadata.schema.type.aicontext.FieldContext;
 import org.openmetadata.schema.type.aicontext.ForeignKey;
+import org.openmetadata.schema.type.aicontext.GenericAssetContext;
 import org.openmetadata.schema.type.aicontext.JoinHint;
 import org.openmetadata.schema.type.aicontext.KnowledgeItem;
 import org.openmetadata.schema.type.aicontext.LineageEdgeContext;
@@ -311,6 +312,32 @@ public final class AIContextMarkdown {
       String headingPrefix) {
     if (assetContext != null && assetContext.getTable() != null) {
       appendTableContext(markdown, assetContext.getTable(), sections, headingPrefix);
+    }
+    if (assetContext != null && assetContext.getGeneric() != null) {
+      appendGenericContext(markdown, assetContext.getGeneric(), sections, headingPrefix);
+    }
+  }
+
+  /**
+   * The fallback sub-context: an asset's fields plus the definition backing it (a metric's
+   * expression, a stored procedure's code, a query). Gated on SCHEMA like the table equivalent.
+   */
+  private static void appendGenericContext(
+      StringBuilder markdown,
+      GenericAssetContext generic,
+      Set<ContextSection> sections,
+      String headingPrefix) {
+    if (sections.contains(ContextSection.SCHEMA)) {
+      appendSchemaTable(markdown, generic.getFields(), headingPrefix);
+      appendDefinition(markdown, generic.getDefinition(), headingPrefix);
+    }
+  }
+
+  private static void appendDefinition(
+      StringBuilder markdown, String definition, String headingPrefix) {
+    if (!nullOrEmpty(definition)) {
+      appendHeading(markdown, headingPrefix, "Definition");
+      appendSqlBlock(markdown, definition);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -893,7 +893,8 @@ public class OpenSearchVectorService implements VectorIndexService {
             "serviceType",
             "metricType",
             "granularity",
-            "unitOfMeasurement")) {
+            "unitOfMeasurement",
+            "customUnitOfMeasurement")) {
       properties.set(keyword, MAPPER.createObjectNode().put("type", "keyword"));
     }
     // name/displayName keep a keyword root but gain a `.keyword` subfield so the shard-fair exact
@@ -1399,6 +1400,9 @@ public class OpenSearchVectorService implements VectorIndexService {
       hitMap.put("_score", score);
 
       String parentId = (String) hitMap.getOrDefault("parentId", hit.path("_id").asText());
+      // Persist the fallback into the result map so consumers (e.g. SemanticSearchTool collapsing
+      // chunks by entity) see the same parentId this grouping used, matching the ES service.
+      hitMap.put("parentId", parentId);
       List<Map<String, Object>> group =
           byParent.computeIfAbsent(parentId, ignored -> new ArrayList<>());
       // During chunk-index migration the same chunk can surface twice — once from the legacy

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -882,8 +882,18 @@ public class OpenSearchVectorService implements VectorIndexService {
             .set("method", method);
     var properties = MAPPER.createObjectNode();
     properties.set("embedding", embedding);
+    // The three metric enums are mapped as real keywords, not source-only: they are cheap to index
+    // and are the natural facets to filter a metric search on (granularity DAY vs MONTH).
     for (String keyword :
-        List.of("parentId", "fingerprint", "entityType", "fullyQualifiedName", "serviceType")) {
+        List.of(
+            "parentId",
+            "fingerprint",
+            "entityType",
+            "fullyQualifiedName",
+            "serviceType",
+            "metricType",
+            "granularity",
+            "unitOfMeasurement")) {
       properties.set(keyword, MAPPER.createObjectNode().put("type", "keyword"));
     }
     // name/displayName keep a keyword root but gain a `.keyword` subfield so the shard-fair exact
@@ -917,6 +927,11 @@ public class OpenSearchVectorService implements VectorIndexService {
     properties.set("columns", columnsMapping());
     properties.set(
         "relatedTerms", MAPPER.createObjectNode().put("type", "object").put("enabled", false));
+    // Display-only: semantic_search returns a metric's expression, nothing filters or scores on it,
+    // and the code is already searchable through textToEmbed. `enabled: false` keeps it in _source
+    // without paying to index it on a dynamic:false index.
+    properties.set(
+        "metricExpression", MAPPER.createObjectNode().put("type", "object").put("enabled", false));
     return properties;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -1,5 +1,7 @@
 package org.openmetadata.service.search.vector;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +51,7 @@ public class VectorDocBuilder {
    * embedding-reuse backfill on the next Search Reindex — without forcing a re-embed (the
    * fingerprint is deliberately left untouched, see {@link #computeFingerprintForEntity}).
    */
-  public static final int CHUNK_DOC_VERSION = 1;
+  public static final int CHUNK_DOC_VERSION = 2;
 
   /**
    * Upper bound on the denormalized {@code description} copied onto each chunk doc. The full body
@@ -58,6 +60,17 @@ public class VectorDocBuilder {
    * chunk docs, so a hard cap keeps chunk {@code _source} growth bounded on pathological bodies.
    */
   static final int MAX_CHUNK_DESCRIPTION_CHARS = 5000;
+
+  /**
+   * Upper bound on the metric expression code copied onto a metric's chunk docs. A metric summary
+   * without its definition tells a caller almost nothing, so semantic_search returns the expression
+   * directly rather than forcing a per-result detail fetch; the cap keeps a pathological query body
+   * from crowding results out of the response budget.
+   */
+  static final int MAX_CHUNK_METRIC_CODE_CHARS = 1000;
+
+  /** Sentinel unit meaning "see customUnitOfMeasurement" rather than a unit in its own right. */
+  private static final String UNIT_OF_MEASUREMENT_OTHER = "OTHER";
 
   /**
    * Source of the per-chunk embedding vector. The normal write path calls the embedding client;
@@ -296,6 +309,10 @@ public class VectorDocBuilder {
    *   <li>Filter parity: {@code owners}, {@code serviceType}, {@code service}/{@code database}/
    *       {@code databaseSchema} and {@code certification} so NLQ filters on those facets no longer
    *       exclude every chunk doc.
+   *   <li>Display parity for metrics: {@code metricExpression} (capped), {@code metricType},
+   *       {@code granularity} and {@code unitOfMeasurement}, the fields that tell two similarly
+   *       named metrics apart. All four already feed {@code textToEmbed}, so they were searchable
+   *       but invisible in results until a caller made a second per-result detail fetch.
    * </ul>
    *
    * <p>Every field here is already covered by the fingerprint (via {@code metaLight}/{@code body}),
@@ -357,7 +374,52 @@ public class VectorDocBuilder {
         fields.put("columns", columns);
       }
     }
+    if (entity instanceof Metric metric) {
+      addMetricFields(fields, metric);
+    }
     return fields;
+  }
+
+  /**
+   * The metric facts a caller needs to tell "Daily Active Users" from "Monthly Active Users"
+   * without fetching either in full: the expression, and the three enums that qualify it.
+   */
+  private static void addMetricFields(Map<String, Object> fields, Metric metric) {
+    Map<String, Object> expression = metricExpressionObject(metric.getMetricExpression());
+    if (!expression.isEmpty()) {
+      fields.put("metricExpression", expression);
+    }
+    putIfPresent(fields, "metricType", enumValue(metric.getMetricType()));
+    putIfPresent(fields, "granularity", enumValue(metric.getGranularity()));
+    putIfPresent(fields, "unitOfMeasurement", unitOfMeasurement(metric));
+  }
+
+  /**
+   * The metric's expression as a {@code {language, code}} object, mirroring the shape the metric
+   * entity index stores so a chunk hit and an entity-doc hit look the same to the read side.
+   */
+  private static Map<String, Object> metricExpressionObject(MetricExpression expression) {
+    Map<String, Object> fields = new HashMap<>();
+    if (expression != null && !nullOrEmpty(expression.getCode())) {
+      fields.put("code", capText(expression.getCode(), MAX_CHUNK_METRIC_CODE_CHARS));
+      putIfPresent(fields, "language", enumValue(expression.getLanguage()));
+    }
+    return fields;
+  }
+
+  /**
+   * {@code OTHER} means the real unit lives in {@code customUnitOfMeasurement}; surfacing the
+   * literal "OTHER" would tell a caller nothing.
+   */
+  private static String unitOfMeasurement(Metric metric) {
+    String unit = enumValue(metric.getUnitOfMeasurement());
+    return UNIT_OF_MEASUREMENT_OTHER.equals(unit) && metric.getCustomUnitOfMeasurement() != null
+        ? metric.getCustomUnitOfMeasurement()
+        : unit;
+  }
+
+  private static String enumValue(Object value) {
+    return value == null ? null : value.toString();
   }
 
   private static String capText(String text, int maxChars) {
@@ -588,12 +650,7 @@ public class VectorDocBuilder {
         parts.add("metricType: " + metric.getMetricType().value());
       }
       if (metric.getUnitOfMeasurement() != null) {
-        String unit = metric.getUnitOfMeasurement().value();
-        if ("OTHER".equals(unit) && metric.getCustomUnitOfMeasurement() != null) {
-          parts.add("unitOfMeasurement: " + metric.getCustomUnitOfMeasurement());
-        } else {
-          parts.add("unitOfMeasurement: " + unit);
-        }
+        parts.add("unitOfMeasurement: " + unitOfMeasurement(metric));
       }
       if (metric.getGranularity() != null) {
         parts.add("granularity: " + metric.getGranularity().toString());
@@ -751,12 +808,7 @@ public class VectorDocBuilder {
       parts.add(metric.getMetricType().value() + " metric");
     }
     if (metric.getUnitOfMeasurement() != null) {
-      String unit = metric.getUnitOfMeasurement().value();
-      String value =
-          "OTHER".equals(unit) && metric.getCustomUnitOfMeasurement() != null
-              ? metric.getCustomUnitOfMeasurement()
-              : unit;
-      parts.add("measured in " + value);
+      parts.add("measured in " + unitOfMeasurement(metric));
     }
     if (metric.getGranularity() != null) {
       parts.add("granularity " + metric.getGranularity());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorDocBuilder.java
@@ -391,7 +391,12 @@ public class VectorDocBuilder {
     }
     putIfPresent(fields, "metricType", enumValue(metric.getMetricType()));
     putIfPresent(fields, "granularity", enumValue(metric.getGranularity()));
-    putIfPresent(fields, "unitOfMeasurement", unitOfMeasurement(metric));
+    // Store the raw enum, not the resolved custom text: this field is a filterable keyword and the
+    // entity indices (also members of the dataAssetEmbeddings alias) hold the enum under the same
+    // name. Diverging would make a facet filter match one index and silently miss the other. The
+    // read side resolves OTHER -> customUnitOfMeasurement for display.
+    putIfPresent(fields, "unitOfMeasurement", enumValue(metric.getUnitOfMeasurement()));
+    putIfPresent(fields, "customUnitOfMeasurement", metric.getCustomUnitOfMeasurement());
   }
 
   /**
@@ -408,8 +413,10 @@ public class VectorDocBuilder {
   }
 
   /**
-   * {@code OTHER} means the real unit lives in {@code customUnitOfMeasurement}; surfacing the
-   * literal "OTHER" would tell a caller nothing.
+   * The unit as it should read in the embedded text: {@code OTHER} means the real unit lives in
+   * {@code customUnitOfMeasurement}, and embedding the literal "OTHER" would teach the model
+   * nothing. The denormalized keyword field keeps the raw enum instead — see
+   * {@link #addMetricFields}.
    */
   private static String unitOfMeasurement(Metric metric) {
     String unit = enumValue(metric.getUnitOfMeasurement());

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
@@ -174,6 +174,20 @@ public class VectorSearchQueryBuilder {
             sb.append(',');
             appendFlat(sb, "parentId", values);
           }
+            // Metric facets: semantic_search returns these on every metric result, so a caller
+            // that sees "granularity": "MONTH" will reasonably filter by it.
+          case "metricType" -> {
+            sb.append(',');
+            appendFlat(sb, "metricType", values);
+          }
+          case "granularity" -> {
+            sb.append(',');
+            appendFlat(sb, "granularity", values);
+          }
+          case "unitOfMeasurement" -> {
+            sb.append(',');
+            appendFlat(sb, "unitOfMeasurement", values);
+          }
           default -> LOG.debug("Ignoring unrecognized filter key: {}", field);
         }
       }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilder.java
@@ -184,9 +184,12 @@ public class VectorSearchQueryBuilder {
             sb.append(',');
             appendFlat(sb, "granularity", values);
           }
+            // Matches the raw enum or the custom text, because a metric whose unit is OTHER
+            // displays its customUnitOfMeasurement ("basis points") and a caller will filter by
+            // what they saw. Accepting only the stored enum would match nothing, silently.
           case "unitOfMeasurement" -> {
             sb.append(',');
-            appendFlat(sb, "unitOfMeasurement", values);
+            appendFlatOr(sb, "unitOfMeasurement", "customUnitOfMeasurement", values);
           }
           default -> LOG.debug("Ignoring unrecognized filter key: {}", field);
         }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/AIContextMarkdownTest.java
@@ -28,6 +28,7 @@ import org.openmetadata.schema.type.aicontext.ColumnProfileSummary;
 import org.openmetadata.schema.type.aicontext.DataQuality;
 import org.openmetadata.schema.type.aicontext.FieldContext;
 import org.openmetadata.schema.type.aicontext.ForeignKey;
+import org.openmetadata.schema.type.aicontext.GenericAssetContext;
 import org.openmetadata.schema.type.aicontext.JoinHint;
 import org.openmetadata.schema.type.aicontext.KnowledgeItem;
 import org.openmetadata.schema.type.aicontext.LineageEdgeContext;
@@ -497,6 +498,26 @@ class AIContextMarkdownTest {
     assertTrue(markdown.toString().contains("### Schema"));
     assertTrue(markdown.toString().contains("Orders placed by customers."));
     assertFalse(markdown.toString().contains("Foreign Keys"));
+  }
+
+  @Test
+  void render_emitsMetricDefinitionFromGenericAssetContext() {
+    AIContext context =
+        new AIContext()
+            .withEntityType("metric")
+            .withFullyQualifiedName("MonthlyActiveUsers")
+            .withAssetContext(
+                new AssetContext()
+                    .withGeneric(
+                        new GenericAssetContext()
+                            .withDefinition("SELECT COUNT(DISTINCT user_id) FROM events")));
+
+    String markdown = AIContextMarkdown.render(context);
+
+    assertTrue(markdown.contains("# Definition"), "missing Definition heading");
+    assertTrue(
+        markdown.contains("```sql\nSELECT COUNT(DISTINCT user_id) FROM events\n```"),
+        "missing metric expression block");
   }
 
   private String render() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
@@ -23,10 +23,16 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.data.MetricExpression;
+import org.openmetadata.schema.entity.data.Metric;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.MetricExpressionLanguage;
+import org.openmetadata.schema.type.MetricGranularity;
+import org.openmetadata.schema.type.MetricType;
+import org.openmetadata.schema.type.MetricUnitOfMeasurement;
 import org.openmetadata.service.search.vector.client.EmbeddingClient;
 
 /**
@@ -169,6 +175,77 @@ class VectorDocBuilderChunkTest {
     List<Map<String, Object>> docs = VectorDocBuilder.fromEntity(table, new MockEmbeddingClient());
     String description = (String) docs.get(0).get("description");
     assertEquals(VectorDocBuilder.MAX_CHUNK_DESCRIPTION_CHARS, description.length());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fromEntity_denormalizesTheMetricFactsThatTellSimilarMetricsApart() {
+    Metric metric =
+        new Metric()
+            .withId(UUID.randomUUID())
+            .withName("MonthlyActiveUsers")
+            .withDescription("Distinct users in a month")
+            .withMetricType(MetricType.COUNT)
+            .withGranularity(MetricGranularity.MONTH)
+            .withUnitOfMeasurement(MetricUnitOfMeasurement.COUNT)
+            .withMetricExpression(
+                new MetricExpression()
+                    .withLanguage(MetricExpressionLanguage.SQL)
+                    .withCode("SELECT COUNT(DISTINCT user_id) FROM events"));
+
+    Map<String, Object> doc = VectorDocBuilder.fromEntity(metric, new MockEmbeddingClient()).get(0);
+
+    Map<String, Object> expression = (Map<String, Object>) doc.get("metricExpression");
+    assertEquals("SELECT COUNT(DISTINCT user_id) FROM events", expression.get("code"));
+    assertEquals("SQL", expression.get("language"));
+    assertEquals("COUNT", doc.get("metricType"));
+    assertEquals("MONTH", doc.get("granularity"));
+    assertEquals("COUNT", doc.get("unitOfMeasurement"));
+  }
+
+  @Test
+  void fromEntity_prefersTheCustomUnitOverTheOtherSentinel() {
+    Metric metric =
+        new Metric()
+            .withId(UUID.randomUUID())
+            .withName("m")
+            .withUnitOfMeasurement(MetricUnitOfMeasurement.OTHER)
+            .withCustomUnitOfMeasurement("basis points");
+
+    Map<String, Object> doc = VectorDocBuilder.fromEntity(metric, new MockEmbeddingClient()).get(0);
+
+    assertEquals("basis points", doc.get("unitOfMeasurement"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fromEntity_capsDenormalizedMetricCode() {
+    Metric metric =
+        new Metric()
+            .withId(UUID.randomUUID())
+            .withName("m")
+            .withMetricExpression(
+                new MetricExpression()
+                    .withCode("x".repeat(VectorDocBuilder.MAX_CHUNK_METRIC_CODE_CHARS + 500)));
+
+    Map<String, Object> doc = VectorDocBuilder.fromEntity(metric, new MockEmbeddingClient()).get(0);
+
+    Map<String, Object> expression = (Map<String, Object>) doc.get("metricExpression");
+    assertEquals(
+        VectorDocBuilder.MAX_CHUNK_METRIC_CODE_CHARS, ((String) expression.get("code")).length());
+  }
+
+  @Test
+  void fromEntity_omitsMetricFieldsWhenTheMetricHasNone() {
+    Metric metric =
+        new Metric().withId(UUID.randomUUID()).withName("m").withDescription("no expression here");
+
+    Map<String, Object> doc = VectorDocBuilder.fromEntity(metric, new MockEmbeddingClient()).get(0);
+
+    assertFalse(doc.containsKey("metricExpression"));
+    assertFalse(doc.containsKey("metricType"));
+    assertFalse(doc.containsKey("granularity"));
+    assertFalse(doc.containsKey("unitOfMeasurement"));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorDocBuilderChunkTest.java
@@ -204,7 +204,7 @@ class VectorDocBuilderChunkTest {
   }
 
   @Test
-  void fromEntity_prefersTheCustomUnitOverTheOtherSentinel() {
+  void fromEntity_keepsTheRawUnitEnumSoFacetFiltersMatchBothIndexes() {
     Metric metric =
         new Metric()
             .withId(UUID.randomUUID())
@@ -214,7 +214,10 @@ class VectorDocBuilderChunkTest {
 
     Map<String, Object> doc = VectorDocBuilder.fromEntity(metric, new MockEmbeddingClient()).get(0);
 
-    assertEquals("basis points", doc.get("unitOfMeasurement"));
+    // The entity indices store the raw enum under this name and share the dataAssetEmbeddings
+    // alias; resolving it here would make a facet filter match one index and miss the other.
+    assertEquals("OTHER", doc.get("unitOfMeasurement"));
+    assertEquals("basis points", doc.get("customUnitOfMeasurement"));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilderTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/VectorSearchQueryBuilderTest.java
@@ -397,6 +397,55 @@ class VectorSearchQueryBuilderTest {
   }
 
   @Test
+  void testBuildsQueryWithMetricFacetFilters() throws Exception {
+    float[] vector = {0.1f};
+    Map<String, List<String>> filters =
+        Map.of("granularity", List.of("MONTH"), "metricType", List.of("COUNT"));
+
+    String query = VectorSearchQueryBuilder.build(vector, 10, 0, 100, filters, 0.0);
+
+    JsonNode mustFilters =
+        MAPPER
+            .readTree(query)
+            .get("query")
+            .get("knn")
+            .get("embedding")
+            .get("filter")
+            .get("bool")
+            .get("must");
+
+    String filtersJson = mustFilters.toString();
+    assertTrue(filtersJson.contains("granularity"));
+    assertTrue(filtersJson.contains("MONTH"));
+    assertTrue(filtersJson.contains("metricType"));
+    assertTrue(filtersJson.contains("COUNT"));
+  }
+
+  @Test
+  void testUnitOfMeasurementFilterAlsoMatchesTheCustomUnit() throws Exception {
+    float[] vector = {0.1f};
+    // A metric whose unit is OTHER displays its customUnitOfMeasurement, so filtering by the
+    // displayed value must match; otherwise the filter silently returns nothing.
+    Map<String, List<String>> filters = Map.of("unitOfMeasurement", List.of("basis points"));
+
+    String query = VectorSearchQueryBuilder.build(vector, 10, 0, 100, filters, 0.0);
+
+    String filtersJson =
+        MAPPER
+            .readTree(query)
+            .get("query")
+            .get("knn")
+            .get("embedding")
+            .get("filter")
+            .get("bool")
+            .get("must")
+            .toString();
+    assertTrue(filtersJson.contains("unitOfMeasurement"));
+    assertTrue(filtersJson.contains("customUnitOfMeasurement"));
+    assertTrue(filtersJson.contains("basis points"));
+  }
+
+  @Test
   void testIgnoresEmptyFilterValues() throws Exception {
     float[] vector = {0.1f};
     int size = 10;

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/metric_index_mapping.json
@@ -302,6 +302,9 @@
       "unitOfMeasurement": {
         "type": "keyword"
       },
+      "customUnitOfMeasurement": {
+        "type": "keyword"
+      },
       "granularity": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/metric_index_mapping.json
@@ -306,6 +306,9 @@
       "unitOfMeasurement": {
         "type": "keyword"
       },
+      "customUnitOfMeasurement": {
+        "type": "keyword"
+      },
       "granularity": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/metric_index_mapping.json
@@ -273,6 +273,9 @@
       "unitOfMeasurement": {
         "type": "keyword"
       },
+      "customUnitOfMeasurement": {
+        "type": "keyword"
+      },
       "granularity": {
         "type": "keyword"
       },

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/metric_index_mapping.json
@@ -303,6 +303,9 @@
       "unitOfMeasurement": {
         "type": "keyword"
       },
+      "customUnitOfMeasurement": {
+        "type": "keyword"
+      },
       "granularity": {
         "type": "keyword"
       },


### PR DESCRIPTION
### Describe your changes:

Fixes #30860

A customer reported that `semantic_search` returns the right metric but not its Expression or Custom Properties. What this PR changes:

- **Metric results now include `metricExpression`, `metricType`, `granularity` and `unitOfMeasurement`.** Previously a metric summary had no way to tell "Daily Active Users" from "Monthly Active Users", so an agent had to call `get_entity_details` once per candidate just to shortlist.
- **A filter passed at the top level is now an error instead of being ignored.** `{"query": ..., "entityType": "metric"}` used to run an *unfiltered* search and return e.g. a `database` in a metric-only search, with no warning.
- **An unrecognised filter key is now an error too**, rather than being dropped with a debug log.
- **The metric facets are filterable and documented**, and filtering by `unitOfMeasurement` matches the value shown in results, including custom units.
- **One result per entity instead of one per matching chunk** — duplicates were wasting response budget.
- **`nextCursor` no longer skips entities.** The cursor advanced by rows returned while the service pages by entity, so multi-chunk entities made page two jump over results.
- **`get_asset_context` on a metric now returns its definition**, matching what `get_knowledge_content` already returned for the same entity.
- `extension` (custom properties) stays a `get_entity_details` call — it is unbounded user JSON and would push real results out of the response budget.

The four metric fields are denormalized onto chunk documents with `CHUNK_DOC_VERSION` bumped 1 → 2, so the existing additive mapping upgrade and backfill pick them up on the next Search Reindex with no re-embedding cost.