### PR TITLE
Chore(UI): Fix the ExploreTree spec failure

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomPropertiesApiContract.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/CustomPropertiesApiContract.spec.ts
@@ -112,7 +112,9 @@ const ENTITY_CONTRACTS: EntityContract[] = [
   {
     apiPath: 'dashboards',
     createInstance: (namespace) =>
-      new DashboardClass(namespace.name('dashboard-service')),
+      new DashboardClass(undefined, undefined, {
+        name: namespace.name('dashboard-service'),
+      }),
     typeName: 'dashboard',
   },
   {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/ExploreTree.spec.ts
@@ -14,8 +14,10 @@ import test, { expect } from '@playwright/test';
 import { get } from 'lodash';
 import { PLAYWRIGHT_BASIC_TEST_TAG_OBJ } from '../../constant/config';
 import { SidebarItem } from '../../constant/sidebar';
+import { ApiEndpointClass } from '../../support/entity/ApiEndpointClass';
+import { DashboardClass } from '../../support/entity/DashboardClass';
 import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
-import { EntityDataClass } from '../../support/entity/EntityDataClass';
+import { SearchIndexClass } from '../../support/entity/SearchIndexClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
 import {
@@ -68,6 +70,15 @@ test.describe('Explore Tree scenarios', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 
     await table1.create(apiContext);
     await table2.create(apiContext);
+
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+
+    await table1.delete(apiContext);
+    await table2.delete(apiContext);
 
     await afterAction();
   });
@@ -355,10 +366,44 @@ test.describe('Explore Tree scenarios', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
 });
 
 test.describe('Explore page', () => {
-  const table = EntityDataClass.table1;
-  const dashboard = EntityDataClass.dashboard1;
-  const apiEndpoint = EntityDataClass.apiEndpoint1;
-  const searchIndex = EntityDataClass.searchIndex1;
+  let table: TableClass;
+  let dashboard: DashboardClass;
+  let apiEndpoint: ApiEndpointClass;
+  let searchIndex: SearchIndexClass;
+
+  test.beforeAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+
+    // Explore tree's service bucket is capped and sorted alphabetically
+    // (ElasticSearchAggregationManager orders by _key ASC), so a name starting
+    // with a digit guarantees these services land within that bucket
+    // regardless of how many other `pw-*` services have accumulated.
+    table = new TableClass(undefined, undefined, {
+      name: `0-pw-database-service-${uuid()}`,
+    });
+    dashboard = new DashboardClass(undefined, undefined, {
+      name: `0-pw-dashboard-service-${uuid()}`,
+    });
+    apiEndpoint = new ApiEndpointClass(`0-pw-api-endpoint-service-${uuid()}`);
+    searchIndex = new SearchIndexClass(`0-pw-search-index-service-${uuid()}`);
+
+    await table.create(apiContext);
+    await dashboard.create(apiContext);
+    await apiEndpoint.create(apiContext);
+    await searchIndex.create(apiContext);
+
+    await afterAction();
+  });
+
+  test.afterAll(async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await table.delete(apiContext);
+    await dashboard.delete(apiContext);
+    await apiEndpoint.delete(apiContext);
+    await searchIndex.delete(apiContext);
+
+    await afterAction();
+  });
 
   test('Check the listing of tags', async ({ page }) => {
     await page

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DashboardClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/DashboardClass.ts
@@ -27,27 +27,19 @@ export interface DataModelType extends ResponseDataWithServiceType {
   columns?: unknown[];
   dataModelType?: string;
 }
+export interface DashboardServiceConfig {
+  name: string;
+  serviceType: string;
+  connection: {
+    config: Record<string, unknown>;
+  };
+}
 
 export class DashboardClass extends EntityClass {
   private dashboardName: string;
   private dashboardDataModelName: string;
   private projectName: string;
-  service: {
-    name: string;
-    serviceType: string;
-    connection: {
-      config: {
-        type: string;
-        hostPort: string;
-        connection: {
-          provider: string;
-          username: string;
-          password: string;
-        };
-        supportsMetadataExtraction: boolean;
-      };
-    };
-  };
+  service: DashboardServiceConfig;
   charts: { name: string; displayName: string; service: string };
   entity: {
     name: string;
@@ -71,13 +63,17 @@ export class DashboardClass extends EntityClass {
   dataModelResponseData: DataModelType = {} as DataModelType;
   chartsResponseData: ResponseDataType = {} as ResponseDataType;
 
-  constructor(name?: string, dataModelType = 'SupersetDataModel') {
+  constructor(
+    name?: string,
+    dataModelType = 'SupersetDataModel',
+    service?: Partial<DashboardServiceConfig>
+  ) {
     super(EntityTypeEndpoint.Dashboard);
     this.type = 'Dashboard';
     this.serviceCategory = SERVICE_TYPE.Dashboard;
     this.serviceType = ServiceTypes.DASHBOARD_SERVICES;
 
-    const serviceName = name ?? `pw-dashboard-service-${uuid()}`;
+    const serviceName = service?.name ?? `pw-dashboard-service-${uuid()}`;
     this.dashboardName = `pw-dashboard-${uuid()}`;
     this.dashboardDataModelName = `pw-dashboard-data-model-${uuid()}`;
     this.projectName = `pw-project-${uuid()}`;
@@ -106,7 +102,7 @@ export class DashboardClass extends EntityClass {
     };
 
     this.entity = {
-      name: this.dashboardName,
+      name: name ?? this.dashboardName,
       displayName: this.dashboardName,
       service: this.service.name,
       project: this.projectName,


### PR DESCRIPTION
This pull request refactors and improves the way test data is created and managed for Playwright E2E tests, particularly for dashboard entities and related services. The changes make entity creation more flexible, ensure proper cleanup after tests, and improve test isolation and reliability.

### Test Data Creation and Cleanup Improvements

* Refactored the `DashboardClass` constructor to accept a partial `DashboardServiceConfig`, allowing more flexible and explicit service configuration for test dashboards. [[1]](diffhunk://#diff-07e5e48677d531c65cd097e8ee43fe994458197942dfca4c9dc80ccf5d9474ceR30-R42) [[2]](diffhunk://#diff-07e5e48677d531c65cd097e8ee43fe994458197942dfca4c9dc80ccf5d9474ceL74-R76)
* Updated entity instantiation in `ExploreTree.spec.ts` and related tests to use the new `DashboardClass` constructor signature, passing service configuration as an object instead of just a name. [[1]](diffhunk://#diff-17376eb02ae918f719d0f780ac875076b1040bc25f514cf8bba7cf29dd3c336cL115-R117) [[2]](diffhunk://#diff-371cd5a28d8a9da7a0c245a7094db0c33a43745a3fa2bfd0fe7df280db2532d2L358-R406)
* Added `beforeAll` and `afterAll` hooks in `ExploreTree.spec.ts` to programmatically create and delete test entities (`TableClass`, `DashboardClass`, `ApiEndpointClass`, `SearchIndexClass`), ensuring tests have isolated and unique data and that resources are cleaned up after test execution. [[1]](diffhunk://#diff-371cd5a28d8a9da7a0c245a7094db0c33a43745a3fa2bfd0fe7df280db2532d2R77-R85) [[2]](diffhunk://#diff-371cd5a28d8a9da7a0c245a7094db0c33a43745a3fa2bfd0fe7df280db2532d2L358-R406)

### Codebase Consistency and Minor Improvements

* Updated imports in `ExploreTree.spec.ts` to use the new entity class structure, ensuring consistency and clarity in test setup.
* Fixed entity name assignment in `DashboardClass` to correctly use the provided name or fallback to a generated one.