### PR TITLE
fix(databricks): dedupe pipeline runs by start_time to prevent bulk status 500 (#30471) [1.13.3]

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/databrickspipeline/metadata.py
@@ -262,11 +262,20 @@ class DatabrickspipelineSource(PipelineServiceSource):
                 * 1000
             )
             statuses: List[PipelineStatus] = []
+            seen_start_times = set()
 
             for run in self.client.get_job_runs(job_id=pipeline_details.job_id) or []:
                 run = DBRun(**run)
                 if run.start_time and run.start_time < cutoff_ts:
                     break
+                # OpenMetadata keys a pipeline status by its timestamp, so it can
+                # store only one status per start_time. Databricks' inclusive
+                # `start_time_to` pagination returns boundary runs more than once;
+                # skip already-seen start_times so the bulk upsert does not receive
+                # duplicate-timestamp rows (which the Postgres ON CONFLICT rejects).
+                if run.start_time in seen_start_times:
+                    continue
+                seen_start_times.add(run.start_time)
                 task_status = [
                     TaskStatus(
                         name=str(task.name),

--- a/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
+++ b/ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py
@@ -300,6 +300,31 @@ class DatabricksPipelineTests(TestCase):
         ]
         self.assertEqual(pipeline_status, EXPECTED_PIPELINE_STATUS)
 
+    @patch(
+        "metadata.ingestion.source.database.databricks.client.DatabricksClient.get_job_runs"
+    )
+    def test_yield_pipeline_status_deduplicates_run_timestamps(self, get_job_runs):
+        # Databricks' inclusive `start_time_to` pagination returns boundary runs
+        # more than once. OpenMetadata stores a single status per timestamp
+        # (entityFQNHash, extension, timestamp), so runs sharing a start_time must
+        # collapse to one status or the Postgres bulk upsert fails with
+        # "ON CONFLICT DO UPDATE command cannot affect row a second time".
+        duplicate_run = dict(mock_run_data[0])
+        older_run = dict(mock_run_data[0])
+        older_run["start_time"] = mock_run_data[0]["start_time"] - 900000
+        get_job_runs.return_value = [mock_run_data[0], duplicate_run, older_run]
+
+        result = list(
+            self.databricks.yield_pipeline_status(
+                DataBrickPipelineDetails(**mock_data[0])
+            )
+        )
+        statuses = result[0].right.pipeline_statuses
+        timestamps = [status.timestamp.root for status in statuses]
+
+        self.assertEqual(len(statuses), 2)
+        self.assertEqual(len(timestamps), len(set(timestamps)))
+
     def test_databricks_pipeline_lineage(self):
         self.databricks.context.get().__dict__["pipeline"] = "11223344"
         self.databricks.context.get().__dict__[


### PR DESCRIPTION
### Describe your changes:

Cherry-pick of #30471 onto `1.13.3` (fixes #30459).

Databricks' paginated run list returns boundary runs more than once (inclusive `start_time_to`), producing duplicate-timestamp PipelineStatus rows. OpenMetadata stores one status per timestamp, so the PostgreSQL bulk status upsert failed with `ON CONFLICT DO UPDATE command cannot affect row a second time` (HTTP 500), dropping run history for the affected pipelines. This skips already-seen `start_time`s in `yield_pipeline_status` before yielding.

Conflict resolution: trivial — `main` had been reformatted (ruff long-line style) around the `cutoff_ts` block; kept the branch's black formatting and ran `black` on the touched files.

#
### Type of change:
- [x] Bug fix

#
### Tests:
- `ingestion/tests/unit/topology/pipeline/test_databricks_pipeline.py` — all 6 tests pass locally on this branch, including the new `test_yield_pipeline_status_deduplicates_run_timestamps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)