### PR TITLE
feat(ui): validate confidence and sample-count in Auto Classification agent form

### DIFF
--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/databaseServiceAutoClassificationPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/databaseServiceAutoClassificationPipeline.json
@@ -66,12 +66,15 @@
       "description": "Set the Confidence value for which you want the column to be tagged as PII. Confidence value ranges from 0 to 100. A higher number will yield less false positives but more false negatives. A lower number will yield more false positives but less false negatives.",
       "type": "number",
       "default": 80,
+      "minimum": 0,
+      "maximum": 100,
       "title": "Auto Classification Inference Confidence Level"
     },
     "sampleDataCount": {
       "description": "Number of sample rows to ingest when 'Generate Sample Data' is enabled",
       "type": "integer",
       "default": 50,
+      "minimum": 1,
       "title": "Sample Data Rows Count"
     },
     "classificationLanguage": {

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/messagingServiceAutoClassificationPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/messagingServiceAutoClassificationPipeline.json
@@ -47,12 +47,15 @@
     "confidence": {
       "description": "Set the Confidence value for which you want the column to be tagged as PII. Confidence value ranges from 0 to 100. A higher number will tag less columns as PII, whereas a lower number will tag more columns as PII.",
       "type": "number",
-      "default": 80
+      "default": 80,
+      "minimum": 0,
+      "maximum": 100
     },
     "sampleDataCount": {
       "description": "No. of messages to fetch during sample data ingestion.",
       "type": "integer",
       "default": 50,
+      "minimum": 1,
       "title": "Sample Data Count"
     },
     "classificationLanguage": {

--- a/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/storageServiceAutoClassificationPipeline.json
+++ b/openmetadata-spec/src/main/resources/json/schema/metadataIngestion/storageServiceAutoClassificationPipeline.json
@@ -55,12 +55,15 @@
       "description": "Set the Confidence value for which you want the column to be tagged as PII. Confidence value ranges from 0 to 100. A higher number will yield less false positives but more false negatives. A lower number will yield more false positives but less false negatives.",
       "type": "number",
       "default": 80,
+      "minimum": 0,
+      "maximum": 100,
       "title": "Auto Classification Inference Confidence Level"
     },
     "sampleDataCount": {
       "description": "Number of sample rows to ingest when 'Generate Sample Data' is enabled",
       "type": "integer",
       "default": 50,
+      "minimum": 1,
       "title": "Sample Data Rows Count"
     },
     "classificationLanguage": {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -285,9 +285,7 @@ test.describe(
       page,
     }) => {
       await openAutoClassificationAgentForm(page, acService);
-      await page
-        .getByTestId('ingestion-section-advanced-toggle')
-        .click();
+      await page.getByTestId('ingestion-section-advanced-toggle').click();
       const confidenceField = page.locator('#root\\/confidence');
       await confidenceField.clear();
       await confidenceField.fill('1000');
@@ -321,9 +319,7 @@ test.describe(
       page,
     }) => {
       await openAutoClassificationAgentForm(page, acService);
-      await page
-        .getByTestId('ingestion-section-advanced-toggle')
-        .click();
+      await page.getByTestId('ingestion-section-advanced-toggle').click();
 
       const sampleCountField = page.locator('#root\\/sampleDataCount');
       await sampleCountField.clear();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -238,7 +238,10 @@ test.describe(
   }
 );
 
-const openAutoClassificationAgentForm = async (page: Page, svc: StorageServiceClass) => {
+const openAutoClassificationAgentForm = async (
+  page: Page,
+  svc: StorageServiceClass
+) => {
   await redirectToHomePage(page);
   await svc.visitEntityPage(page);
   await page.getByTestId('data-assets-header').waitFor();
@@ -281,9 +284,10 @@ test.describe(
     test('confidence field rejects values outside 0-100 and blocks next step', async ({
       page,
     }) => {
-
       await openAutoClassificationAgentForm(page, acService);
-      await page.getByRole('button', { name: 'Advanced Config Driver-level' }).click();
+      await page
+        .getByRole('button', { name: 'Advanced Config Driver-level' })
+        .click();
       const confidenceField = page.locator('#root\\/confidence');
       await confidenceField.clear();
       await confidenceField.fill('1000');
@@ -297,9 +301,7 @@ test.describe(
       });
 
       await test.step('Wizard stays on the configuration step', async () => {
-        await expect(
-          page.getByTestId('add-ingestion-container')
-        ).toBeVisible();
+        await expect(page.getByTestId('add-ingestion-container')).toBeVisible();
         await expect(
           page.locator('[data-testid="schedular-schedule"]')
         ).not.toBeVisible();
@@ -318,9 +320,10 @@ test.describe(
     test('sampleDataCount rejects non-positive values and blocks next step', async ({
       page,
     }) => {
-
       await openAutoClassificationAgentForm(page, acService);
-      await page.getByRole('button', { name: 'Advanced Config Driver-level' }).click();
+      await page
+        .getByRole('button', { name: 'Advanced Config Driver-level' })
+        .click();
 
       const sampleCountField = page.locator('#root\\/sampleDataCount');
       await sampleCountField.clear();
@@ -330,14 +333,15 @@ test.describe(
 
       await test.step('Error message is shown for negative sample count', async () => {
         await expect(
-          page.locator('[id="root/sampleDataCount"]').locator('..').locator('..')
+          page
+            .locator('[id="root/sampleDataCount"]')
+            .locator('..')
+            .locator('..')
         ).toContainText('1');
       });
 
       await test.step('Wizard stays on the configuration step', async () => {
-        await expect(
-          page.getByTestId('add-ingestion-container')
-        ).toBeVisible();
+        await expect(page.getByTestId('add-ingestion-container')).toBeVisible();
         await expect(
           page.locator('[data-testid="schedular-schedule"]')
         ).not.toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -286,7 +286,7 @@ test.describe(
     }) => {
       await openAutoClassificationAgentForm(page, acService);
       await page
-        .getByRole('button', { name: 'Advanced Config Driver-level' })
+        .getByTestId('ingestion-section-advanced-toggle')
         .click();
       const confidenceField = page.locator('#root\\/confidence');
       await confidenceField.clear();
@@ -322,7 +322,7 @@ test.describe(
     }) => {
       await openAutoClassificationAgentForm(page, acService);
       await page
-        .getByRole('button', { name: 'Advanced Config Driver-level' })
+        .getByTestId('ingestion-section-advanced-toggle')
         .click();
 
       const sampleCountField = page.locator('#root\\/sampleDataCount');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -281,10 +281,9 @@ test.describe(
     test('confidence field rejects values outside 0-100 and blocks next step', async ({
       page,
     }) => {
-      test.slow();
 
       await openAutoClassificationAgentForm(page, acService);
-
+      await page.getByRole('button', { name: 'Advanced Config Driver-level' }).click();
       const confidenceField = page.locator('#root\\/confidence');
       await confidenceField.clear();
       await confidenceField.fill('1000');
@@ -319,9 +318,9 @@ test.describe(
     test('sampleDataCount rejects non-positive values and blocks next step', async ({
       page,
     }) => {
-      test.slow();
 
       await openAutoClassificationAgentForm(page, acService);
+      await page.getByRole('button', { name: 'Advanced Config Driver-level' }).click();
 
       const sampleCountField = page.locator('#root\\/sampleDataCount');
       await sampleCountField.clear();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts
@@ -14,6 +14,7 @@ import { expect, Page, test } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { StorageServiceClass } from '../../support/entity/service/StorageServiceClass';
 import { createNewPage, redirectToHomePage, uuid } from '../../utils/common';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
 
 // use the admin user to login
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -233,6 +234,124 @@ test.describe(
         ).CodeMirror.getValue()
       );
       expect(value).toBe('{x}');
+    });
+  }
+);
+
+const openAutoClassificationAgentForm = async (page: Page, svc: StorageServiceClass) => {
+  await redirectToHomePage(page);
+  await svc.visitEntityPage(page);
+  await page.getByTestId('data-assets-header').waitFor();
+  await page.getByTestId('agents').click();
+
+  const metadataSubTab = page.getByTestId('metadata-sub-tab');
+  if (await metadataSubTab.isVisible()) {
+    await metadataSubTab.click();
+  }
+
+  await page.getByTestId('add-new-ingestion-button').click();
+  await page.locator('[data-menu-id*="autoClassification"]').waitFor();
+  await page.locator('[data-menu-id*="autoClassification"]').click();
+  await waitForAllLoadersToDisappear(page);
+  await page.getByTestId('add-ingestion-container').waitFor();
+};
+
+test.describe(
+  'Auto Classification agent form field validation',
+  PLAYWRIGHT_INGESTION_TAG_OBJ,
+  () => {
+    const acService = new StorageServiceClass();
+
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      await acService.create(apiContext);
+
+      await afterAction();
+    });
+
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+
+      await acService.delete(apiContext);
+
+      await afterAction();
+    });
+
+    test('confidence field rejects values outside 0-100 and blocks next step', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await openAutoClassificationAgentForm(page, acService);
+
+      const confidenceField = page.locator('#root\\/confidence');
+      await confidenceField.clear();
+      await confidenceField.fill('1000');
+
+      await page.getByTestId('next-button').click();
+
+      await test.step('Error message is shown for out-of-range confidence', async () => {
+        await expect(
+          page.locator('[id="root/confidence"]').locator('..').locator('..')
+        ).toContainText('100');
+      });
+
+      await test.step('Wizard stays on the configuration step', async () => {
+        await expect(
+          page.getByTestId('add-ingestion-container')
+        ).toBeVisible();
+        await expect(
+          page.locator('[data-testid="schedular-schedule"]')
+        ).not.toBeVisible();
+      });
+
+      await test.step('Wizard advances after correcting the value', async () => {
+        await confidenceField.clear();
+        await confidenceField.fill('80');
+        await page.getByTestId('next-button').click();
+        await expect(
+          page.locator('[data-testid="schedular-schedule"]')
+        ).toBeVisible();
+      });
+    });
+
+    test('sampleDataCount rejects non-positive values and blocks next step', async ({
+      page,
+    }) => {
+      test.slow();
+
+      await openAutoClassificationAgentForm(page, acService);
+
+      const sampleCountField = page.locator('#root\\/sampleDataCount');
+      await sampleCountField.clear();
+      await sampleCountField.fill('-1');
+
+      await page.getByTestId('next-button').click();
+
+      await test.step('Error message is shown for negative sample count', async () => {
+        await expect(
+          page.locator('[id="root/sampleDataCount"]').locator('..').locator('..')
+        ).toContainText('1');
+      });
+
+      await test.step('Wizard stays on the configuration step', async () => {
+        await expect(
+          page.getByTestId('add-ingestion-container')
+        ).toBeVisible();
+        await expect(
+          page.locator('[data-testid="schedular-schedule"]')
+        ).not.toBeVisible();
+      });
+
+      await test.step('Wizard advances after correcting the value', async () => {
+        await sampleCountField.clear();
+        await sampleCountField.fill('50');
+        await page.getByTestId('next-button').click();
+        await expect(
+          page.locator('[data-testid="schedular-schedule"]')
+        ).toBeVisible();
+      });
     });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/IngestionObjectFieldTemplate/IngestionObjectFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/IngestionObjectFieldTemplate/IngestionObjectFieldTemplate.tsx
@@ -151,6 +151,7 @@ const SectionHeader = ({
   description,
   index,
   open,
+  sectionKey,
   title,
   onToggle,
 }: {
@@ -158,11 +159,13 @@ const SectionHeader = ({
   description: string;
   index?: number;
   open: boolean;
+  sectionKey: string;
   title: string;
   onToggle: () => void;
 }) => (
   <button
     className="tw:flex tw:w-full tw:items-center tw:gap-2.5 tw:border-0 tw:bg-transparent tw:p-0 tw:text-left"
+    data-testid={`ingestion-section-${sectionKey}-toggle`}
     type="button"
     onClick={() => {
       if (collapsible) {
@@ -308,6 +311,7 @@ const SectionCard = ({ section }: { section: IngestionSectionConfig }) => {
         description={section.description}
         index={section.index}
         open={showBody}
+        sectionKey={section.key}
         title={section.title}
         onToggle={() => setOpen((prev) => !prev)}
       />

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "الرجاء فحص جميع الأصول التي تتم إضافتها",
     "value-count-profile-metric-description": "العدد الإجمالي للقيم في العمود",
     "value-must-be-greater-than": "يجب أن تكون قيمة {{field}} أكبر من {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} يجب أن يكون أقل من أو يساوي {{maximum}}",
     "value-should-equal-to-value": "يجب أن تكون القيمة مساوية لـ {{value}}.",
     "value-should-not-equal-to-value": "يجب أن لا تكون القيمة مساوية لـ {{value}}.",
     "version-released-try-now": "تم إصدار {{version}} <0>شاهد ما الجديد!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Bitte überprüfen Sie alle Assets, die hinzugefügt werden.",
     "value-count-profile-metric-description": "Gesamtzahl der Werte in der Spalte",
     "value-must-be-greater-than": "{{field}} muss größer als {{minimum}} sein",
+    "value-must-be-less-than-or-equal": "{{field}} muss kleiner oder gleich {{maximum}} sein",
     "value-should-equal-to-value": "Der Wert sollte gleich {{value}} sein.",
     "value-should-not-equal-to-value": "Der Wert sollte nicht gleich {{value}} sein.",
     "version-released-try-now": "{{version}} Veröffentlicht <0>Sehen Sie, was es Neues gibt!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Please examine all your assets that are being added",
     "value-count-profile-metric-description": "Total number of values in the column",
     "value-must-be-greater-than": "{{field}} must be greater than {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} must be less than or equal to {{maximum}}",
     "value-should-equal-to-value": "The value should be equal to {{value}}.",
     "value-should-not-equal-to-value": "The value should not be equal to {{value}}.",
     "version-released-try-now": "{{version}} Released <0>See What's New!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Por favor, examine todos sus activos que se están agregando",
     "value-count-profile-metric-description": "Número total de valores en la columna",
     "value-must-be-greater-than": "{{field}} debe ser mayor que {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} debe ser menor o igual que {{maximum}}",
     "value-should-equal-to-value": "El valor debería de ser equivalente a {{value}}.",
     "value-should-not-equal-to-value": "El valor no debería de ser equivalente a {{value}}.",
     "version-released-try-now": "{{version}} Lanzado <0>¡Mira qué hay de nuevo!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Veuillez exmanier tous les actifs qui sont ajoutés",
     "value-count-profile-metric-description": "Nombre total de valeurs dans la colonne",
     "value-must-be-greater-than": "{{field}} doit être supérieur à {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} doit être inférieur ou égal à {{maximum}}",
     "value-should-equal-to-value": "La valeur devrait être égale à {{value}}.",
     "value-should-not-equal-to-value": "La valeur ne devrait pas être égale à {{value}}.",
     "version-released-try-now": "{{version}} publié essayez maintenant !",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Examina todos os teus activos que están sendo engadidos",
     "value-count-profile-metric-description": "Número total de valores na columna",
     "value-must-be-greater-than": "{{field}} debe ser maior que {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} debe ser menor ou igual a {{maximum}}",
     "value-should-equal-to-value": "O valor debe ser igual a {{value}}.",
     "value-should-not-equal-to-value": "O valor non debe ser igual a {{value}}.",
     "version-released-try-now": "{{version}} Lançada <0>Vexa as Novidades!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "אנא בדוק את כל הנכסים שלך שמתווספים",
     "value-count-profile-metric-description": "מספר סך הערכים בעמודה",
     "value-must-be-greater-than": "{{field}} חייב להיות גדול מ-{{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} חייב להיות קטן מ- או שווה ל-{{maximum}}",
     "value-should-equal-to-value": "הערך צריך להיות שווה ל-{{value}}.",
     "value-should-not-equal-to-value": "הערך לא צריך להיות שווה ל-{{value}}.",
     "version-released-try-now": "{{version}} שוחרר <0>ראה מה חדש!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "追加されるすべてのアセットを確認してください",
     "value-count-profile-metric-description": "列内の値の合計数",
     "value-must-be-greater-than": "{{field}} は {{minimum}} より大きくなければなりません",
+    "value-must-be-less-than-or-equal": "{{field}} は {{maximum}} 以下である必要があります",
     "value-should-equal-to-value": "値は{{value}}と等しくなければなりません。",
     "value-should-not-equal-to-value": "値は{{value}}と等しくあってはいけません。",
     "version-released-try-now": "{{version}} がリリースされました <0>新機能を見る</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "추가 중인 모든 자산을 검토하세요",
     "value-count-profile-metric-description": "컬럼의 전체 값 수",
     "value-must-be-greater-than": "{{field}}는 {{minimum}}보다 커야 합니다",
+    "value-must-be-less-than-or-equal": "{{field}} 은(는) {{maximum}} 이하여야 합니다",
     "value-should-equal-to-value": "값은 {{value}}와(과) 같아야 합니다.",
     "value-should-not-equal-to-value": "값은 {{value}}와(과) 같지 않아야 합니다.",
     "version-released-try-now": "{{version}} 출시됨 <0>새로운 기능 확인하기!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "कृपया तुम्ही जोडत असलेल्या सर्व ॲसेट्सची तपासणी करा",
     "value-count-profile-metric-description": "स्तंभातील मूल्यांची एकूण संख्या",
     "value-must-be-greater-than": "{{field}} {{minimum}} पेक्षा मोठा असावा",
+    "value-must-be-less-than-or-equal": "{{field}} हे {{maximum}} पेक्षा कमी किंवा समान असणे आवश्यक आहे",
     "value-should-equal-to-value": "मूल्य {{value}} च्या बरोबरीचे असावे.",
     "value-should-not-equal-to-value": "मूल्य {{value}} च्या बरोबरीचे नसावे.",
     "version-released-try-now": "{{version}} रिलीझ झाले <0>नवीन काय आहे ते पहा!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Onderzoek al je assets die worden toegevoegd",
     "value-count-profile-metric-description": "Totaal aantal waarden in de kolom",
     "value-must-be-greater-than": "{{field}} moet groter zijn dan {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} moet kleiner dan of gelijk zijn aan {{maximum}}",
     "value-should-equal-to-value": "De waarde moet gelijk zijn aan {{value}}.",
     "value-should-not-equal-to-value": "De waarde mag niet gelijk zijn aan {{value}}.",
     "version-released-try-now": "{{version}} vrijgegeven <0>Zie wat er veranderd is!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "لطفاً تمام دارایی‌هایی که در حال اضافه کردن آن‌ها هستید را بررسی کنید.",
     "value-count-profile-metric-description": "تعداد کل مقادیر در ستون",
     "value-must-be-greater-than": "{{field}} {{minimum}} से अधिक होना चाहिए",
+    "value-must-be-less-than-or-equal": "{{field}} باید کمتر یا برابر {{maximum}} باشد",
     "value-should-equal-to-value": "مقدار باید برابر با {{value}} باشد.",
     "value-should-not-equal-to-value": "مقدار نباید برابر با {{value}} باشد.",
     "version-released-try-now": "{{version}} منتشر شد <0>مشاهده کنید چه خبر است!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Por favor, verifique todos os seus ativos que estão sendo adicionados",
     "value-count-profile-metric-description": "Número total de valores na coluna",
     "value-must-be-greater-than": "{{field}} deve ser maior que {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} deve ser menor ou igual a {{maximum}}",
     "value-should-equal-to-value": "O valor deve ser igual a {{value}}.",
     "value-should-not-equal-to-value": "O valor não deve ser igual a {{value}}.",
     "version-released-try-now": "{{version}} Lançada <0>Veja o que há de novo!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Por favor, verifique todos os seus ativos que estão sendo adicionados",
     "value-count-profile-metric-description": "Número total de valores na coluna",
     "value-must-be-greater-than": "{{field}} deve ser superior a {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} deve ser inferior ou igual a {{maximum}}",
     "value-should-equal-to-value": "O valor deve ser igual a {{value}}.",
     "value-should-not-equal-to-value": "O valor não deve ser igual a {{value}}.",
     "version-released-try-now": "{{version}} Lançada <0>Veja o que há de novo!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Пожалуйста, проверьте добавляемые объекты",
     "value-count-profile-metric-description": "Общее количество значений в столбце",
     "value-must-be-greater-than": "Значение «{{field}}» должно быть больше чем {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} должно быть меньше или равно {{maximum}}",
     "value-should-equal-to-value": "Значение должно быть равно {{value}}.",
     "value-should-not-equal-to-value": "Значение не должно быть равно {{value}}.",
     "version-released-try-now": "Выпущена версия {{version}} <0>Посмотрите, что нового!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Granska alla dina tillgångar som läggs till",
     "value-count-profile-metric-description": "Totalt antal värden i kolumnen",
     "value-must-be-greater-than": "{{field}} måste vara större än {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} måste vara mindre än eller lika med {{maximum}}",
     "value-should-equal-to-value": "Värdet ska vara lika med {{value}}.",
     "value-should-not-equal-to-value": "Värdet ska inte vara lika med {{value}}.",
     "version-released-try-now": "{{version}} släppt <0>Se vad som är nytt!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "โปรดตรวจสอบสินทรัพย์ทั้งหมดที่กำลังถูกเพิ่ม",
     "value-count-profile-metric-description": "จำนวนค่าทั้งหมดในคอลัมน์",
     "value-must-be-greater-than": "{{field}} ต้องมากกว่า {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} ต้องน้อยกว่าหรือเท่ากับ {{maximum}}",
     "value-should-equal-to-value": "ค่าต้องเท่ากับ {{value}}",
     "value-should-not-equal-to-value": "ค่าต้องไม่เท่ากับ {{value}}",
     "version-released-try-now": "{{version}} ได้ออกแล้ว <0>ดูสิ่งใหม่!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "Lütfen eklenen tüm varlıklarınızı inceleyin",
     "value-count-profile-metric-description": "Sütundaki toplam değer sayısı",
     "value-must-be-greater-than": "{{field}} değeri {{minimum}} dan büyük olmalıdır.",
+    "value-must-be-less-than-or-equal": "{{field}} değeri {{maximum}} ile eşit veya daha küçük olmalıdır",
     "value-should-equal-to-value": "Değer {{value}} değerine eşit olmalıdır.",
     "value-should-not-equal-to-value": "Değer {{value}} değerine eşit olmamalıdır.",
     "version-released-try-now": "{{version}} Yayınlandı <0>Yeniliklere Göz Atın!</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "请检查您正在添加的全部资产",
     "value-count-profile-metric-description": "列中值的总数",
     "value-must-be-greater-than": "{{field}} 必须大于 {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} 必须小于或等于 {{maximum}}",
     "value-should-equal-to-value": "该值应等于{{value}}.",
     "value-should-not-equal-to-value": "该值不应等于{{value}}.",
     "version-released-try-now": "查看新版本 {{version}} 的新特性！",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -4315,6 +4315,7 @@
     "validation-error-assets": "請檢查您正在新增的所有資產",
     "value-count-profile-metric-description": "欄位中值的總數",
     "value-must-be-greater-than": "{{field}} 必須大於 {{minimum}}",
+    "value-must-be-less-than-or-equal": "{{field}} 必須小於或等於 {{maximum}}",
     "value-should-equal-to-value": "該值應等於 {{value}}。",
     "value-should-not-equal-to-value": "該值不應等於 {{value}}。",
     "version-released-try-now": "{{version}} 已發布 <0>看看有什麼新功能！</0>",

--- a/openmetadata-ui/src/main/resources/ui/src/utils/formPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/formPureUtils.ts
@@ -42,6 +42,12 @@ export const transformErrors: ErrorTransformer = (errors) => {
             minimum: params?.limit,
           }),
         }),
+        maximum: () => ({
+          message: t('message.value-must-be-less-than-or-equal', {
+            field: fieldName,
+            maximum: params?.limit,
+          }),
+        }),
       };
 
       const errorHandler = errorMessages[name as keyof typeof errorMessages];


### PR DESCRIPTION
### Describe your changes:

Fixes [30931](https://github.com/open-metadata/OpenMetadata/issues/30931)

I added form-level validation to the Auto Classification agent configuration wizard because users could previously enter values like 1000 for the confidence field (0–100 range) or negative numbers for sample row count (must be ≥ 1), and the wizard would silently proceed.

The fix is schema-first: `minimum`/`maximum` constraints are added to the three auto-classification JSON schemas (database, messaging, storage), which RJSF+AJV8 enforces automatically — invalid values now block the "Next" button and show an inline error message. A `maximum` error handler was added to `transformErrors` with a new i18n key (`value-must-be-less-than-or-equal`) translated into all 19 non-English locales.

#
### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Confidence value > 100 (e.g. 1000) shows an inline error and blocks advancing to the schedule step
- Confidence value < 0 shows an inline error and blocks advancing
- Sample data rows count ≤ 0 (e.g. -1) shows an inline error and blocks advancing
- Correcting the values allows the wizard to proceed normally

#### Unit tests
- N/A — validation is driven by JSON Schema constraints enforced by AJV8; no isolated unit logic was added.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/StorageMetadataAgentForm.spec.ts`

#### Manual testing performed
1. Opened Add Auto Classification Agent on a database service
2. Entered `1000` in the Confidence field and clicked Next — inline error appeared, wizard stayed on config step
3. Entered `-1` in Sample Data Rows Count and clicked Next — inline error appeared, wizard stayed on config step
4. Corrected both fields to valid values — wizard advanced normally

#
### UI screen recording / screenshots:

<img width="838" height="313" alt="Screenshot 2026-08-03 at 11 50 58 PM" src="https://github.com/user-attachments/assets/d6f36b6d-eabf-4864-80ac-3d48302477e3" />


Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.