### PR TITLE
fix(e2e): run IntakeFormCustomPropertyFields after chromium to prevent parallel intake-form deletion

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -97,6 +97,10 @@ export default defineConfig({
         '**/SystemCertificationTags.spec.ts',
         '**/SearchRBAC.spec.ts',
         '**/SSOLogin.spec.ts',
+        // Runs in its own post-chromium project to prevent IntakeForm.spec.ts's
+        // per-test beforeEach (which deletes all intake forms) from racing against
+        // the domain intake form this spec creates in beforeAll.
+        '**/IntakeFormCustomPropertyFields.spec.ts',
       ],
     },
     {
@@ -176,6 +180,18 @@ export default defineConfig({
     {
       name: 'SystemCertificationTags',
       testMatch: '**/SystemCertificationTags.spec.ts',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup', 'chromium'],
+      fullyParallel: false,
+    },
+    // IntakeFormCustomPropertyFields creates a domain intake form in beforeAll and
+    // relies on it persisting across two serial tests. IntakeForm.spec.ts (in the
+    // main chromium project) has a beforeEach that deletes ALL intake forms, so the
+    // two specs interfere when run in parallel. Running this file after chromium
+    // completes eliminates the race entirely.
+    {
+      name: 'IntakeFormCustomPropertyFields',
+      testMatch: '**/IntakeFormCustomPropertyFields.spec.ts',
       use: { ...devices['Desktop Chrome'] },
       dependencies: ['setup', 'chromium'],
       fullyParallel: false,


### PR DESCRIPTION
## Root cause

`IntakeForm.spec.ts` has a `beforeEach` that deletes **all** entity-type intake forms before each test (to reset state). `IntakeFormCustomPropertyFields.spec.ts` creates a domain intake form in `beforeAll` and expects it to persist across two serial tests.

With `workers: 3` and `fullyParallel: true` on CI, both specs run in the same `chromium` project on different workers simultaneously. `IntakeForm.spec.ts`'s `beforeEach` races against the second test's 30-second `custom-properties-section` visibility wait — deletes the domain form mid-test — and the wait times out. This is a **hard fail 3/3** every run, not a flake.

The `IntakeForm.spec.ts` flakiness (passes on retry) is the reverse interference: `IntakeFormCustomPropertyFields.spec.ts`'s `beforeAll` creates a domain intake form while `IntakeForm.spec.ts` tests are in-flight.

## Fix

Exclude `IntakeFormCustomPropertyFields.spec.ts` from the `chromium` project and run it in a dedicated post-`chromium` project — the exact same pattern already used for `SystemCertificationTags.spec.ts`.

The `chromium` project (including all `IntakeForm.spec.ts` tests) must fully complete before `IntakeFormCustomPropertyFields` starts, so neither spec's setup/teardown can interfere with the other.

## What changed

- `playwright.config.ts` — added `'**/IntakeFormCustomPropertyFields.spec.ts'` to `chromium.testIgnore`
- `playwright.config.ts` — added `IntakeFormCustomPropertyFields` project that depends on `['setup', 'chromium']` and runs `fullyParallel: false`

No test logic was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)