### PR TITLE
ci(playwright): list passing tests in the GitHub summary and fix reporter typing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -71,40 +71,48 @@ const combineGrep = (base?: RegExp) => {
     [...new Set(`${base.flags}${shardGrep.flags}`)].join('')
   );
 };
+// Each conditional group is annotated separately: TypeScript does not propagate a
+// contextual type into a spread expression, so inlining these ternaries would widen
+// the tuples to arrays and break assignability to ReporterDescription.
+const htmlReporter: ReporterDescription[] = isPlannedShard
+  ? []
+  : [['html', { outputFolder: './playwright/output/playwright-report' }]];
+
+const blobReporter: ReporterDescription[] = isPlannedShard
+  ? [
+      [
+        'blob',
+        {
+          outputDir: './playwright/output/blob-report',
+          fileName: `report-${process.env.PW_SHARD_ID ?? 'local'}.zip`,
+        },
+      ],
+    ]
+  : [['blob']];
+
+const performanceReporter: ReporterDescription[] = isPlannedShard
+  ? [
+      [
+        './playwright/reporters/PerformanceReporter.ts',
+        { outputFile: './playwright/output/playwright-timings.json' },
+      ],
+    ]
+  : [];
+
 const reporters: ReporterDescription[] = [
   ['list'],
-  ...(!isPlannedShard
-    ? [['html', { outputFolder: './playwright/output/playwright-report' }]]
-    : []),
+  ...htmlReporter,
   [
     '@estruyf/github-actions-reporter',
     {
       useDetails: true,
       showError: true,
-      includeResults: ['skipped', 'fail', 'flaky'],
       showArtifactsLink: true,
     },
   ],
-  ...(isPlannedShard
-    ? [
-        [
-          'blob',
-          {
-            outputDir: './playwright/output/blob-report',
-            fileName: `report-${process.env.PW_SHARD_ID ?? 'local'}.zip`,
-          },
-        ],
-      ]
-    : [['blob']]),
+  ...blobReporter,
   ['json', { outputFile: './playwright/output/results.json' }],
-  ...(isPlannedShard
-    ? [
-        [
-          './playwright/reporters/PerformanceReporter.ts',
-          { outputFile: './playwright/output/playwright-timings.json' },
-        ],
-      ]
-    : []),
+  ...performanceReporter,
 ];
 
 /**


### PR DESCRIPTION
### Describe your changes:

Fixes #30916

Two independent fixes in `openmetadata-ui/src/main/resources/ui/playwright.config.ts`.

**1. The GitHub job summary now lists passing tests.** `includeResults` was pinned to `['skipped', 'fail', 'flaky']`, so the summary table never showed a passing test — leaving no way to tell from the summary whether a spec *ran and passed* on a shard or was simply never collected by it. That distinction is what you need when auditing shard coverage or chasing a lane that quietly stopped picking up a file. Removing the override falls back to the reporter's own default, `["fail", "flaky", "pass", "skipped"]` — see [`dist/index.js`](https://github.com/estruyf/playwright-github-actions-reporter/blob/main/src/index.ts):

```js
if (typeof options.includeResults === "undefined") {
    this.options.includeResults = ["fail", "flaky", "pass", "skipped"];
}
```

Note the guard is `typeof === "undefined"` specifically — an empty array is *not* replaced by the default, so omitting the key is the correct way to get all four levels.

**2. Fixed five pre-existing `TS2322` errors in the `reporters` array.** TypeScript does not propagate a contextual type into a **spread** expression inside an array literal, so the tuples written inside `...(cond ? [[...]] : [])` were inferred in isolation and widened from `['html', {…}]` to `(string | { outputFolder: string })[]`. `ReporterDescription` is a union of tuples, and a plain array "may have fewer" than 2 elements, so assignment failed. Hoisting the three conditional groups into separate `ReporterDescription[]`-annotated consts lets the contextual type reach the literals, so they infer as tuples again — no casts, and the emitted reporter list is byte-for-byte identical in both the default and planned-shard paths.

These went unnoticed because `playwright.config.ts` is in **no** tsconfig — the UI root config is `"include": ["src"]` and `playwright/tsconfig.json` covers only `playwright/**`, so CI's `tsc --noEmit` never type-checked it. Only editors flagged it, through their inferred project.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change, single file.

#
### Tests:

#### Use cases covered
- The Playwright GitHub Actions job summary lists passing tests in addition to skipped/failed/flaky.
- `playwright.config.ts` type-checks cleanly under `--strict`.
- Both reporter code paths still load: default (`html` + plain `blob`) and planned-shard (`blob` with `outputDir`/`fileName` + `PerformanceReporter`).

#### Unit tests
N/A — configuration-only change, no application logic. There is no existing test harness that asserts on `playwright.config.ts`.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — this changes the Playwright *config*, not a spec. No UI behavior is touched.

#### Manual testing performed

1. **Type check — before (on `main`):** five errors.
   ```
   $ ./node_modules/.bin/tsc --noEmit --strict --skipLibCheck --moduleResolution node \
       --module esnext --target es2020 --esModuleInterop --types node playwright.config.ts
   playwright.config.ts(76,3): error TS2322: Type '(string | { outputFolder: string; })[]' is not assignable to type 'ReporterDescription'.
     Type '(string | { outputFolder: string; })[]' is not assignable to type 'readonly [string, any]'.
       Target requires 2 element(s) but source may have fewer.
   playwright.config.ts(80,5): error TS2322: Type 'string | { outputFolder: string; } | { outputDir: string; fileName: string; } | { outputFile: string; }' is not assignable to type 'string'.
   playwright.config.ts(88,3): error TS2322: ... (blob reporter)
   playwright.config.ts(99,4): error TS2322: ...
   playwright.config.ts(100,3): error TS2322: ... (PerformanceReporter)
   ```
   **After:** clean, no output.

2. **Config loads, default path:**
   ```
   $ npx playwright test --list --project=setup
   Using GitHub Actions reporter
   Listing tests:
     [setup] › auth.setup.ts:96:6 › authenticate all users
   Total: 1 test in 1 file
   ```

3. **Config loads, planned-shard path** (exercises the `blob` + `PerformanceReporter` branch):
   ```
   $ PW_SHARD_PLAN=/tmp/plan.json PW_SHARD_ID=test npx playwright test --list --project=setup
   Using GitHub Actions reporter
   Listing tests:
     [setup] › auth.setup.ts:96:6 › authenticate all users
   Total: 1 test in 1 file
   ```

4. **Lint / format:** `npx prettier --check playwright.config.ts` → *All matched files use Prettier code style!*; `npx eslint playwright.config.ts` → clean.

#
### UI screen recording / screenshots:

Not applicable — no UI code is changed. The visible effect is in the GitHub Actions job summary, which will show passing tests on this PR's own Playwright run.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR is linked to a GitHub issue via `Fixes #30916` above.
- [x] I have commented on my code, particularly in hard-to-understand areas — the non-obvious contextual-typing constraint is documented inline above the hoisted consts, so the ternaries don't get re-inlined later.
- [x] For JSON Schema changes: N/A.
- [x] For UI changes: N/A.
- [x] I have added tests: N/A for a config-only change; verification evidence is in "Manual testing performed" above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — N/A. The regression guard here would be putting `playwright.config.ts` under a tsconfig so CI type-checks it; that is a separate change with its own blast radius (it would pull the whole file set of the UI root into a new project) and is tracked in #30916 rather than bundled here.

#
### One caveat worth flagging

GitHub job summaries are capped at **1 MiB**. On a full-suite run with `useDetails: true`, adding every passing test to the table could approach that cap and get the summary truncated — which would hide the failures we actually care about. This PR's own CI run is the check. If it does truncate, the narrow follow-up is to re-add `includeResults` with `'pass'` only on the planned/sharded lanes (where each shard's table is a fraction of the size) rather than globally.