### PR TITLE
Fix filter-condition UI: 'contains' and 'ends with' emit regexes the backend evaluates differently

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
@@ -599,6 +599,8 @@ test.describe('Connection config layout', () => {
     await tableSection
       .getByRole('button', { name: 'Show equivalent regex' })
       .click();
-    await expect(tableSection.getByText('includes += orders')).toBeVisible();
+    await expect(
+      tableSection.getByText('includes += .*orders.*')
+    ).toBeVisible();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/MySqlIngestionClass.ts
@@ -253,7 +253,7 @@ class MysqlIngestionClass extends ServiceBaseClass {
 
     for (const filter of this.tableFilter) {
       await expect(
-        tableIncludes.getByTestId(`include-chip-contains:${filter}`)
+        tableIncludes.getByTestId(`include-chip-contains:.*${filter}.*`)
       ).toBeVisible();
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.test.tsx
@@ -385,7 +385,7 @@ describe('FiltersConfigForm', () => {
         formData: expect.objectContaining({
           tableFilterPattern: {
             excludes: [],
-            includes: ['orders'],
+            includes: ['.*orders.*'],
           },
         }),
       });
@@ -487,7 +487,7 @@ describe('FiltersConfigForm', () => {
       within(tableSection).getAllByText('contains', {
         selector: '.filters-config-form__chip-operator',
       }).length
-    ).toBeGreaterThanOrEqual(2);
+    ).toBeGreaterThanOrEqual(1);
 
     expect(within(tableSection).getAllByText('orders')).toHaveLength(2);
     expect(within(tableSection).getAllByText('finance_')).toHaveLength(2);
@@ -691,7 +691,7 @@ describe('FiltersConfigForm', () => {
       within(tableSection).getByText('includes += ^orders\\.v1$')
     ).toBeInTheDocument();
     expect(
-      within(tableSection).getByText('includes += _fact$')
+      within(tableSection).getByText('includes += .*_fact$')
     ).toBeInTheDocument();
     expect(
       within(tableSection).getByText('excludes += ^tmp_[0-9]+$')
@@ -704,7 +704,7 @@ describe('FiltersConfigForm', () => {
         formData: expect.objectContaining({
           tableFilterPattern: {
             excludes: ['^tmp_[0-9]+$'],
-            includes: ['^orders\\.v1$', '_fact$'],
+            includes: ['^orders\\.v1$', '.*_fact$'],
           },
         }),
       });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.utils.test.ts
@@ -1,0 +1,111 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { FilterCondition } from './FiltersConfigForm.types';
+import { conditionToRegex, parseRegexPattern } from './FiltersConfigForm.utils';
+
+// The ingestion side evaluates these patterns with Python's start-anchored
+// re.match (metadata/utils/filters.py), so every emitted regex must encode its
+// operator explicitly: a bare pattern behaves as startsWith, and `value$`
+// behaves as an exact match, never as endsWith.
+describe('conditionToRegex', () => {
+  const condition = (
+    op: FilterCondition['op'],
+    value: string
+  ): FilterCondition => ({ op, value });
+
+  it('anchors "is" on both ends', () => {
+    expect(conditionToRegex(condition('is', 'Wine'))).toBe('^Wine$');
+  });
+
+  it('anchors "startsWith" at the start', () => {
+    expect(conditionToRegex(condition('startsWith', 'Wine'))).toBe('^Wine');
+  });
+
+  it('wraps "contains" so re.match cannot read it as a prefix', () => {
+    expect(conditionToRegex(condition('contains', 'Wine'))).toBe('.*Wine.*');
+  });
+
+  it('prefixes "endsWith" so re.match cannot read it as an exact match', () => {
+    expect(conditionToRegex(condition('endsWith', 'Wine'))).toBe('.*Wine$');
+  });
+
+  it('escapes regex specials in the value', () => {
+    expect(conditionToRegex(condition('contains', 'my.model'))).toBe(
+      String.raw`.*my\.model.*`
+    );
+  });
+
+  it('passes "regex" values through untouched', () => {
+    expect(conditionToRegex(condition('regex', '.*Wine.*'))).toBe('.*Wine.*');
+  });
+
+  it('re-emits a parsed pattern verbatim via sourceRegex', () => {
+    expect(
+      conditionToRegex({ op: 'contains', sourceRegex: 'Wine', value: 'Wine' })
+    ).toBe('Wine');
+  });
+});
+
+describe('parseRegexPattern', () => {
+  it.each([
+    ['^Wine$', 'is'],
+    ['^Wine', 'startsWith'],
+    ['^Wine.*', 'startsWith'],
+    ['^Wine.*$', 'startsWith'],
+    ['.*Wine.*', 'contains'],
+    ['^.*Wine.*$', 'contains'],
+    ['.*Wine$', 'endsWith'],
+    ['^.*Wine$', 'endsWith'],
+  ])('labels %s as %s', (regex, op) => {
+    expect(parseRegexPattern(regex)).toMatchObject({
+      op,
+      sourceRegex: regex,
+      value: 'Wine',
+    });
+  });
+
+  it('labels a bare pattern as startsWith, matching re.match behavior', () => {
+    expect(parseRegexPattern('Wine')).toMatchObject({
+      op: 'startsWith',
+      value: 'Wine',
+    });
+  });
+
+  it('labels a bare pattern with trailing $ as is, matching re.match behavior', () => {
+    expect(parseRegexPattern('Wine$')).toMatchObject({
+      op: 'is',
+      value: 'Wine',
+    });
+  });
+
+  it('falls back to regex for patterns with unescaped syntax', () => {
+    expect(parseRegexPattern('Wine|Beer')).toMatchObject({ op: 'regex' });
+  });
+
+  it('round-trips every operator through conditionToRegex', () => {
+    const ops: FilterCondition['op'][] = [
+      'is',
+      'startsWith',
+      'endsWith',
+      'contains',
+    ];
+    for (const op of ops) {
+      const emitted = conditionToRegex({ op, value: 'Wine' });
+
+      expect(parseRegexPattern(emitted)).toMatchObject({
+        op,
+        value: 'Wine',
+      });
+    }
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/FiltersConfigForm.utils.ts
@@ -66,6 +66,9 @@ type PatternMatcher = {
   suffix: string;
 };
 
+// Ops are assigned by how Python's start-anchored re.match evaluates the
+// pattern (metadata/utils/filters.py), not by how the regex reads: a bare
+// pattern matches as a prefix and a bare `value$` only matches exactly.
 const PATTERN_MATCHERS: PatternMatcher[] = [
   { op: 'is', prefix: '^', suffix: '$' },
   { op: 'contains', prefix: '^.*', suffix: '.*$' },
@@ -74,9 +77,9 @@ const PATTERN_MATCHERS: PatternMatcher[] = [
   { op: 'startsWith', prefix: '^', suffix: '.*' },
   { op: 'startsWith', prefix: '^', suffix: '' },
   { op: 'endsWith', prefix: '.*', suffix: '$' },
-  { op: 'endsWith', prefix: '', suffix: '$' },
+  { op: 'is', prefix: '', suffix: '$' },
   { op: 'contains', prefix: '.*', suffix: '.*' },
-  { op: 'contains', prefix: '', suffix: '' },
+  { op: 'startsWith', prefix: '', suffix: '' },
 ];
 
 const tryMatchPattern = (
@@ -132,9 +135,9 @@ export const conditionToRegex = (condition: FilterCondition) => {
     case 'startsWith':
       return `^${escapeRegex(condition.value)}`;
     case 'endsWith':
-      return `${escapeRegex(condition.value)}$`;
+      return `.*${escapeRegex(condition.value)}$`;
     case 'contains':
-      return escapeRegex(condition.value);
+      return `.*${escapeRegex(condition.value)}.*`;
     case 'regex':
     default:
       return condition.value;


### PR DESCRIPTION
Cherry-pick of #30707 (`e6dd5c8`) onto `2.0`. Applied cleanly, no conflicts; all five files are byte-identical to `main`.

## Problem

The filter-condition selector (`FiltersConfigForm`) builds regexes assuming **unanchored** matching, but ingestion evaluates filter patterns with Python's start-anchored `re.match(regex, name, re.IGNORECASE)` (`metadata/utils/filters.py`). Two of the four operators are silently wrong:

| UI selector | Emitted | `re.match` behavior |
|---|---|---|
| is | `^value$` | equals — correct |
| starts with | `^value` | prefix — correct |
| **contains** | `value.*` | **behaves as "starts with"** |
| **ends with** | `value$` | **matches nothing unless the value is also a prefix** |

So `contains Wine` fails to match `SecondWineModel`, and `ends with Model` matches nothing.

## Fix

Emit a leading `.*` for both operators, and reorder `PATTERN_MATCHERS` so parsing labels an existing pattern with the operator that actually produced it.

Also updates the two Playwright suites that asserted the old chip text.