### PR TITLE
Cherry-pick #30594 to 2.0: move auto-assigned incidents to the Assigned stage

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AutoAssignIncidentIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AutoAssignIncidentIT.java
@@ -1,0 +1,274 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.it.tests;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
+import org.openmetadata.it.factories.TableTestFactory;
+import org.openmetadata.it.factories.UserTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.tests.CreateTestCaseResult;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.services.DatabaseService;
+import org.openmetadata.schema.entity.tasks.Task;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.type.Assigned;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatus;
+import org.openmetadata.schema.tests.type.TestCaseResolutionStatusTypes;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
+import org.openmetadata.schema.type.TaskEntityStatus;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.fluent.builders.TestCaseBuilder;
+import org.openmetadata.sdk.models.ListParams;
+import org.openmetadata.sdk.models.ListResponse;
+import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
+
+/**
+ * E2E tests for automatic incident assignment (issue #22967).
+ *
+ * <p>When a test case fails and the incident inherits assignees from the target entity's owners,
+ * the incident must land on the workflow's {@code assigned} stage rather than sitting in {@code
+ * new} with an assignee no consumer of the TCRS time series can see.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+@ExtendWith(TestNamespaceExtension.class)
+public class AutoAssignIncidentIT {
+
+  private static final String WORKFLOW_NAME = "TestCaseResolutionTaskWorkflow";
+  private static final String NEW_STAGE_ID = "new";
+  private static final String ASSIGNED_STAGE_ID = "assigned";
+  private static final Duration PIPELINE_TIMEOUT = Duration.ofSeconds(120);
+
+  @Test
+  void ownedTestCase_failedResult_incidentAutoAssigned(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String id = ns.shortPrefix();
+
+    User owner = UserTestFactory.createUser(ns, "own" + id);
+    TestCase testCase = createFailingTestCaseOwnedBy(client, ns, id, owner);
+
+    Task task = awaitIncidentTask(client, testCase);
+    assertEquals(
+        ASSIGNED_STAGE_ID,
+        task.getWorkflowStageId(),
+        "Incident with inherited owners should advance past the New stage");
+    assertEquals(TaskEntityStatus.InProgress, task.getStatus());
+    assertTrue(
+        task.getAssignees().stream().anyMatch(a -> owner.getId().equals(a.getId())),
+        "Owner should be an assignee of the incident task");
+
+    TestCase failedTc =
+        client.testCases().getByName(testCase.getFullyQualifiedName(), "incidentId");
+    UUID stateId = failedTc.getIncidentId();
+    assertNotNull(stateId);
+
+    await()
+        .atMost(PIPELINE_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(2))
+        .until(
+            () -> findTcrsOfType(client, stateId, TestCaseResolutionStatusTypes.Assigned) != null);
+
+    TestCaseResolutionStatus assigned =
+        findTcrsOfType(client, stateId, TestCaseResolutionStatusTypes.Assigned);
+    Assigned details =
+        JsonUtils.convertValue(assigned.getTestCaseResolutionStatusDetails(), Assigned.class);
+    assertNotNull(details.getAssignee(), "Assigned TCRS record must carry an assignee");
+    assertEquals(
+        owner.getId(),
+        details.getAssignee().getId(),
+        "Assigned TCRS record should name the owner as assignee");
+  }
+
+  @Test
+  void unownedTestCase_failedResult_incidentStaysNew(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String id = ns.shortPrefix();
+
+    TestCase testCase = createFailingTestCaseOwnedBy(client, ns, id, null);
+
+    Task task = awaitIncidentTask(client, testCase);
+    assertEquals(
+        NEW_STAGE_ID,
+        task.getWorkflowStageId(),
+        "Incident without owners has nobody to assign to and must stay New");
+    assertEquals(TaskEntityStatus.Open, task.getStatus());
+
+    TestCase failedTc =
+        client.testCases().getByName(testCase.getFullyQualifiedName(), "incidentId");
+    UUID stateId = failedTc.getIncidentId();
+    assertNotNull(stateId);
+
+    await()
+        .atMost(PIPELINE_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(2))
+        .until(() -> findTcrsOfType(client, stateId, TestCaseResolutionStatusTypes.New) != null);
+    assertNull(
+        findTcrsOfType(client, stateId, TestCaseResolutionStatusTypes.Assigned),
+        "An unowned incident must not produce an Assigned record");
+  }
+
+  private TestCase createFailingTestCaseOwnedBy(
+      OpenMetadataClient client, TestNamespace ns, String id, User owner) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgresWithName("sv" + id, ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimpleWithName("sc" + id, ns, service);
+    Table table =
+        TableTestFactory.createSimpleWithName("tbl" + id, ns, schema.getFullyQualifiedName());
+
+    if (owner != null) {
+      setTableOwner(client, table, owner);
+    }
+
+    TestCase testCase =
+        TestCaseBuilder.create(client)
+            .name("tc" + id)
+            .forTable(table)
+            .testDefinition("tableRowCountToEqual")
+            .parameter("value", "100")
+            .create();
+
+    awaitWorkflowDeployed(client);
+    createFailedTestResult(client, testCase);
+    return testCase;
+  }
+
+  private void setTableOwner(OpenMetadataClient client, Table table, User owner) {
+    String patchJson =
+        String.format(
+            "[{\"op\": \"add\", \"path\": \"/owners\", \"value\": "
+                + "[{\"id\": \"%s\", \"type\": \"user\"}]}]",
+            owner.getId());
+    client
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/tables/" + table.getId(),
+            patchJson,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+  }
+
+  private void awaitWorkflowDeployed(OpenMetadataClient client) {
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(2))
+        .until(
+            () -> {
+              try {
+                var wd = client.workflowDefinitions().getByName(WORKFLOW_NAME, "deployed");
+                return Boolean.TRUE.equals(wd.getDeployed());
+              } catch (Exception e) {
+                return false;
+              }
+            });
+  }
+
+  private void createFailedTestResult(OpenMetadataClient client, TestCase testCase) {
+    CreateTestCaseResult result = new CreateTestCaseResult();
+    result.setTimestamp(System.currentTimeMillis());
+    result.setTestCaseStatus(TestCaseStatus.Failed);
+    result.setResult("Test failed");
+    client.testCaseResults().create(testCase.getFullyQualifiedName(), result);
+  }
+
+  private Task awaitIncidentTask(OpenMetadataClient client, TestCase testCase) {
+    AtomicReference<Task> taskRef = new AtomicReference<>();
+    await()
+        .atMost(PIPELINE_TIMEOUT)
+        .pollInterval(Duration.ofSeconds(2))
+        .until(
+            () -> {
+              Task found = findIncidentTaskForTestCase(client, testCase);
+              boolean started = found != null && found.getWorkflowInstanceId() != null;
+              if (started) {
+                taskRef.set(found);
+              }
+              return started;
+            });
+    return taskRef.get();
+  }
+
+  private Task findIncidentTaskForTestCase(OpenMetadataClient client, TestCase testCase) {
+    ListParams params =
+        new ListParams()
+            .addFilter("category", "Incident")
+            .setFields("assignees,payload,about")
+            .setLimit(100);
+    ListResponse<Task> tasks = client.tasks().list(params);
+
+    return tasks.getData().stream()
+        .filter(
+            task ->
+                task.getAbout() != null
+                    && testCase
+                        .getFullyQualifiedName()
+                        .equals(task.getAbout().getFullyQualifiedName()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private TestCaseResolutionStatus findTcrsOfType(
+      OpenMetadataClient client, UUID stateId, TestCaseResolutionStatusTypes type) {
+    return listTcrsForStateId(client, stateId).stream()
+        .filter(r -> r.getTestCaseResolutionStatusType() == type)
+        .findFirst()
+        .orElse(null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<TestCaseResolutionStatus> listTcrsForStateId(
+      OpenMetadataClient client, UUID stateId) {
+    try {
+      String response =
+          client
+              .getHttpClient()
+              .executeForString(
+                  HttpMethod.GET,
+                  "/v1/dataQuality/testCases/testCaseIncidentStatus/stateId/" + stateId,
+                  null,
+                  RequestOptions.builder().build());
+
+      Map<String, Object> result = JsonUtils.readValue(response, new TypeReference<>() {});
+      List<Object> data = (List<Object>) result.get("data");
+      if (data == null) {
+        return List.of();
+      }
+      return data.stream()
+          .map(d -> JsonUtils.convertValue(d, TestCaseResolutionStatus.class))
+          .toList();
+    } catch (Exception e) {
+      return List.of();
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/lifecycle/handlers/IncidentTcrsSyncHandler.java
@@ -36,6 +36,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.TestCaseRepository;
 import org.openmetadata.service.jdbi3.TestCaseResolutionStatusRepository;
+import org.openmetadata.service.tasks.IncidentWorkflowStages;
 
 /**
  * Mirrors task-first incident lifecycle events into the legacy {@code
@@ -80,10 +81,10 @@ public final class IncidentTcrsSyncHandler {
 
   private static final Map<String, TestCaseResolutionStatusTypes> STAGE_TO_TCRS_STATUS =
       Map.of(
-          "new", TestCaseResolutionStatusTypes.New,
-          "ack", TestCaseResolutionStatusTypes.Ack,
-          "assigned", TestCaseResolutionStatusTypes.Assigned,
-          "resolved", TestCaseResolutionStatusTypes.Resolved);
+          IncidentWorkflowStages.NEW_STAGE_ID, TestCaseResolutionStatusTypes.New,
+          IncidentWorkflowStages.ACK_STAGE_ID, TestCaseResolutionStatusTypes.Ack,
+          IncidentWorkflowStages.ASSIGNED_STAGE_ID, TestCaseResolutionStatusTypes.Assigned,
+          IncidentWorkflowStages.RESOLVED_STAGE_ID, TestCaseResolutionStatusTypes.Resolved);
 
   private static final String TEST_CASE_TYPE = "testCase";
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseResolutionStatusRepository.java
@@ -44,6 +44,8 @@ import org.openmetadata.service.resources.dqtests.TestCaseResolutionStatusMapper
 import org.openmetadata.service.resources.dqtests.TestCaseResolutionStatusResource;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.search.SearchListFilter;
+import org.openmetadata.service.tasks.IncidentWorkflowStages;
+import org.openmetadata.service.tasks.TaskWorkflowLifecycleResolver;
 import org.openmetadata.service.util.EntityUtil;
 import org.openmetadata.service.util.RestUtil;
 import org.openmetadata.service.util.incidentSeverityClassifier.IncidentSeverityClassifierInterface;
@@ -568,7 +570,57 @@ public class TestCaseResolutionStatusRepository
         "Incident task created on test failure: id={}, testCase={}",
         task.getId(),
         fullTestCase.getFullyQualifiedName());
+    advanceAutoAssignedIncident(taskRepository, task.getId(), assignees, updatedBy);
     return task.getId();
+  }
+
+  /**
+   * Moves an incident that was auto-assigned from the test case owners out of the workflow's {@code
+   * new} stage and into {@code assigned}, by driving the same {@code assign} transition a manual
+   * assignment uses.
+   *
+   * <p>Without this the incident stays in {@code New}, and because the TCRS mirror only carries
+   * assignee details on {@code Assigned} records, the Incident Manager renders it as unassigned even
+   * though the task itself has assignees.
+   */
+  private static void advanceAutoAssignedIncident(
+      TaskRepository taskRepository,
+      UUID taskId,
+      List<EntityReference> assignees,
+      String updatedBy) {
+    if (!nullOrEmpty(assignees)) {
+      try {
+        Task current = taskRepository.get(null, taskId, taskRepository.getFields("*"));
+        if (canAdvanceToAssignedStage(current)) {
+          taskRepository.resolveTaskWithWorkflow(
+              current,
+              IncidentWorkflowStages.ASSIGN_TRANSITION_ID,
+              null,
+              null,
+              null,
+              null,
+              updatedBy);
+          LOG.info("Incident task {} auto-advanced to the assigned stage", taskId);
+        } else {
+          LOG.warn(
+              "Incident task {} has assignees but sits at stage '{}' instead of '{}'; it stays New and renders as unassigned",
+              taskId,
+              current.getWorkflowStageId(),
+              IncidentWorkflowStages.NEW_STAGE_ID);
+        }
+      } catch (Exception e) {
+        // Best effort: an incident that fails to advance is still a usable incident sitting in
+        // New, so never fail test result ingestion over it.
+        LOG.warn("Failed to auto-advance incident task {} to the assigned stage", taskId, e);
+      }
+    }
+  }
+
+  private static boolean canAdvanceToAssignedStage(Task task) {
+    return IncidentWorkflowStages.NEW_STAGE_ID.equals(task.getWorkflowStageId())
+        && TaskWorkflowLifecycleResolver.findTransition(
+                task, IncidentWorkflowStages.ASSIGN_TRANSITION_ID)
+            != null;
   }
 
   private void setResolutionMetrics(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/IncidentWorkflowStages.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/IncidentWorkflowStages.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.tasks;
+
+/**
+ * Stage and transition identifiers declared by the {@code TestCaseResolutionTaskWorkflow} seed
+ * definition. Kept in one place so the code paths that mirror or drive that workflow —
+ * {@code IncidentTcrsSyncHandler} and the incident auto-assignment path — cannot drift apart.
+ */
+public final class IncidentWorkflowStages {
+  public static final String NEW_STAGE_ID = "new";
+  public static final String ACK_STAGE_ID = "ack";
+  public static final String ASSIGNED_STAGE_ID = "assigned";
+  public static final String RESOLVED_STAGE_ID = "resolved";
+
+  public static final String ASSIGN_TRANSITION_ID = "assign";
+
+  private IncidentWorkflowStages() {}
+}

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -626,7 +626,9 @@ test.describe(
         ).toBeVisible();
       });
 
-      await test.step('Verify New incident for Consistency test case on table3 DQ tab', async () => {
+      // table3 is given an owner in beforeAll, so the incident raised by the
+      // Consistency failure is auto-assigned on creation instead of opening as New.
+      await test.step('Verify Assigned incident for Consistency test case on table3 DQ tab', async () => {
         await visitDataQualityTab(page, table3);
         await expect(
           page.locator(
@@ -635,7 +637,7 @@ test.describe(
         ).toContainText('Failed');
         await expect(
           page.locator(`[data-testid="${consistencyTestCaseName}-status"]`)
-        ).toContainText('New');
+        ).toContainText('Assigned');
       });
 
       await test.step('Verify Resolved incident chip for Uniqueness test case on table4 DQ tab', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -30,6 +30,7 @@ import {
   addAssigneeFromPopoverWidget,
   assignIncident,
   triggerTestSuitePipelineAndWaitForSuccess,
+  verifyIncidentStatus,
   visitProfilerTab,
 } from '../../utils/incidentManager';
 import { makeRetryRequest } from '../../utils/serviceIngestion';
@@ -879,13 +880,16 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
 
     /**
      * Step: Verify open vs closed
-     * @description Verifies incident counts for Open and Closed after rerun and re-acknowledgement.
+     * @description Verifies incident counts for Open and Closed after the rerun.
      */
     await test.step('Verify open and closed task', async () => {
-      await acknowledgeTask({
+      // table1 has an owner by now, so the rerun's incident is auto-assigned on
+      // creation. Ack is not reachable from the Assigned stage.
+      await verifyIncidentStatus({
         page,
-        testCase: testCaseName,
+        status: 'Assigned',
         table: table1,
+        testCase: testCaseName,
       });
       await page.reload();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -106,6 +106,32 @@ export const visitProfilerTab = async (page: Page, table: TableClass) => {
   await expect(page.getByRole('tab', { name: 'Data Quality' })).toBeVisible();
 };
 
+/**
+ * Asserts a failed test case's incident sits at `status`, then opens the test
+ * case details page. Drives no transition, but leaves the page where
+ * {@link acknowledgeTask} does so callers can go on to the Incident tab.
+ */
+export const verifyIncidentStatus = async (data: {
+  testCase: string;
+  page: Page;
+  table: TableClass;
+  status: string;
+}) => {
+  const { testCase, page, table, status } = data;
+  await visitProfilerTab(page, table);
+  await page.getByRole('tab', { name: 'Data Quality' }).click();
+
+  await expect(
+    page.locator(`[data-testid="status-badge-${testCase}"]`)
+  ).toContainText('Failed');
+
+  await expect(
+    page.locator(`[data-testid="${testCase}-status"]`)
+  ).toContainText(status);
+  await page.getByTestId(testCase).getByText(testCase).click();
+  await waitForAllLoadersToDisappear(page);
+};
+
 export const acknowledgeTask = async (data: {
   testCase: string;
   page: Page;


### PR DESCRIPTION
Cherry-pick of #30594 to `2.0`. Fixes #22967 on the 2.0 line.

Clean cherry-pick of the squashed commit `a829fc8` — no conflicts, no adaptations needed.

## Problem

An incident task created on test failure already inherits its assignees from the test case owners (`TestCaseResolutionStatusRepository.createIncidentTask`), but `TestCaseResolutionTaskWorkflow` always enters `NewStage` and nothing ever advances it — the only edges out of `NewStage` are the `ack`/`assign`/`resolve` transitions a user fires by hand.

Two symptoms follow from that single cause:

- the incident sits in **New** even though it has an assignee
- it renders as **unassigned**, because `IncidentTcrsSyncHandler.buildDetailsForStage` only attaches assignee details to `Assigned` records, and the Incident Manager reads the assignee from `testCaseResolutionStatusDetails.assignee` on the TCRS time series rather than from the task

## Fix

After the incident task is created, if assignees resolved, drive the workflow's own `assign` transition via `resolveTaskWithWorkflow` — the same path a manual assignment takes. The workflow advances to `AssignedStage`, `CreateTask` stamps `workflowStageId=assigned` / `status=InProgress`, and the resulting `postUpdate` makes the TCRS sync emit an `Assigned` record carrying the assignee.

Guarded so it only fires when assignees are non-empty, the task actually sits at stage `new`, and an `assign` transition is available. Best-effort: an incident that fails to advance is still a usable incident in New, so it never fails test-result ingestion.

Incidents with no owners are untouched and stay in New.

## 2.0 verification

The premises the fix relies on were checked against `2.0` rather than assumed:

- `TestCaseResolutionTaskWorkflow.json` on 2.0 has the same shape — `new` stage exposes an `assign` transition, `assigned` stage exists
- `TaskRepository.resolveTaskWithWorkflow` has the same 7-arg signature
- `TaskWorkflowLifecycleResolver.findTransition` is present
- the Playwright premises hold: `DataQualityDashboard.spec.ts` still patches an owner onto table3 in `beforeAll` before the Consistency failure; `IncidentManager.spec.ts` still claims table1 ownership before the pipeline re-run

Build evidence on this branch:

- `mvn -pl openmetadata-service -am install -DskipTests` → BUILD SUCCESS
- `mvn -pl openmetadata-integration-tests test-compile` → BUILD SUCCESS (`AutoAssignIncidentIT.class` produced)
- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:check` → clean

`AutoAssignIncidentIT` covers both directions — owned test case reaches `assigned`/`InProgress` with the owner on the TCRS `Assigned` record, unowned test case stays `new`/`Open` with no `Assigned` record.

## Known limitation (carried over from #30594)

`SetApprovalAssigneesImpl` strips the requester from the assignee list to prevent self-approval and does not add them back for workflow-managed tasks. If the user who triggered the test run is the sole owner, the incident ends up unassigned and stays in New — same as a manual assign behaves today. Not addressed here.
