### PR TITLE
Cherry-pick #30822 to 2.0: stop GlossaryPagination nested-search hang from eating shard budget

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryPagination.spec.ts
@@ -71,15 +71,13 @@ test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   });
 
   test('should check for glossary term search', async ({ page }) => {
-    test.slow(true);
-
     await glossary.visitEntityPage(page);
 
     // Wait for terms to load
     await page.getByTestId('glossary-terms-table').waitFor();
 
     // Test 1: Search for specific term
-    const searchInput = page.getByPlaceholder(/search.*term/i);
+    const searchInput = page.getByTestId('search-glossary-terms-input');
     const searchResponse = page.waitForResponse(
       '**/api/v1/glossaryTerms/search?*'
     );
@@ -125,8 +123,6 @@ test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
   });
 
   test('should check for nested glossary term search', async ({ page }) => {
-    test.slow(true);
-
     // Navigate to glossary
     await glossary.visitEntityPage(page);
 
@@ -138,11 +134,19 @@ test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       `[data-testid="glossary-terms-table"] >> text="${parentTerm.responseData.displayName}"`
     );
 
-    // Click on Terms tab to see child terms
+    // Click on Terms tab to see child terms and wait for the tab body to
+    // mount — the search input below only exists once `GlossaryTermTab`
+    // renders, and filling it before the mount silently misses the input
+    // (the `waitForResponse` then hangs to the test-level timeout).
     await page.click('[data-testid="terms"]');
+    await page
+      .getByTestId('glossary-terms-scroll-container')
+      .waitFor({ state: 'visible' });
 
-    // Test 1: Search within parent term for child terms
-    const searchInput = page.getByPlaceholder(/search.*term/i);
+    // Test 1: Search within parent term for child terms — use the specific
+    // testid rather than a placeholder regex; the regex previously matched
+    // an ambiguous input, causing the fill to hit the wrong element.
+    const searchInput = page.getByTestId('search-glossary-terms-input');
     const searchRes1 = page.waitForResponse('**/api/v1/glossaryTerms/search?*');
     await searchInput.fill('ChildSearchTerm');
     await searchRes1;
@@ -192,7 +196,7 @@ test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     // Wait for terms to load
     await page.getByTestId('glossary-terms-table').waitFor();
 
-    const searchInput = page.getByPlaceholder(/search.*term/i);
+    const searchInput = page.getByTestId('search-glossary-terms-input');
 
     // Search with lowercase
     const lowerRes = page.waitForResponse('**/api/v1/glossaryTerms/search?*');
@@ -244,7 +248,7 @@ test.describe('Glossary tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
     // Wait for terms to load
     await page.getByTestId('glossary-terms-table').waitFor();
 
-    const searchInput = page.getByPlaceholder(/search.*term/i);
+    const searchInput = page.getByTestId('search-glossary-terms-input');
 
     // Search for a term that doesn't exist
     const noResultsRes = page.waitForResponse(


### PR DESCRIPTION
Cherry-pick of #30822 (`1ebcdcb610`) onto `2.0`. Applied cleanly, no conflicts.

## Why

`should check for nested glossary term search` is hard-failing on the 2.0 Automated Upgrade Tests. It burned all three attempts (3 × ~3.0 min) in `AUT PostgreSQL 1.11.13 ➡ 2.0` run [30816454253](https://github.com/open-metadata/openmetadata-nightly/actions/runs/30816454253), and recurs on MySQL.

```
Test timeout of 180000ms exceeded.
Error: page.waitForResponse: Test timeout of 180000ms exceeded.
waiting for response "**/api/v1/glossaryTerms?*"
> 170 |     const clearRes1 = page.waitForResponse('**/api/v1/glossaryTerms?*');
```

`main` has carried the fix since 2026-08-03; `2.0` was never updated, so it still has all four `getByPlaceholder(/search.*term/i)` locators and `test.slow(true)`.

## What the fix does

- Waits for `[data-testid="glossary-terms-scroll-container"]` after clicking the Terms tab — `GlossaryTermTab` mounts lazily, and the fill was landing before the child-terms input existed.
- Replaces the ambiguous `getByPlaceholder(/search.*term/i)` with `getByTestId('search-glossary-terms-input')` in all four tests.
- Drops `test.slow(true)`, which tripled the per-test budget to 180 s and is what let the hang consume the shard.

Worth noting: because the fill never landed, `clear()` was a no-op on an already-empty input, so React suppressed the change event and no request ever fired. The assertions before it passed vacuously — the parent's 5 children are all named `ChildSearchTerm*`, so an unfiltered table is indistinguishable from a filtered one. This fix makes the test actually exercise nested search for the first time.

## Verification on 2.0

Both testids the fix depends on are present in 2.0's UI, so the change is semantically valid here:

- `search-glossary-terms-input` — `GlossaryTermTab.component.tsx:1259`
- `glossary-terms-scroll-container` — `GlossaryTermTab.component.tsx:1795`

After this cherry-pick, `GlossaryPagination.spec.ts` is byte-identical to `main`'s version (`git diff origin/main HEAD -- <file>` is empty), which is the same file that passed CI on #30822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)