### PR TITLE
fix(ui): stop ColumnGrid rows remounting mid-edit (focus loss)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
@@ -2162,7 +2162,6 @@ const ColumnGrid: React.FC<ColumnGridProps> = ({
       columnGridListing.loading,
       columnGridListing.isSelected,
       t,
-      columnGridListing.handleSelect,
       columnGridListing.expandedRows,
       columnGridListing.expandedStructRows,
       pendingRefetchRowIds,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/ColumnGrid.component.tsx
@@ -1938,50 +1938,6 @@ const ColumnGrid: React.FC<ColumnGridProps> = ({
   handleSelectRef.current = selectWithDescendants;
 
   // Set up data table with custom row component
-  const CustomTableRow = useCallback(
-    (props: Record<string, unknown>) => {
-      const { entity, isSelected, tableColumns } = props as {
-        entity: ColumnGridRowData;
-        isSelected: boolean;
-        tableColumns: { id: string }[];
-      };
-
-      const isChildRow = Boolean(entity.parentId || entity.isStructChild);
-      const isParentExpanded =
-        columnGridListing.expandedRows.has(entity.id) ||
-        columnGridListing.expandedStructRows.has(entity.id);
-      const showParentChildColors = isChildRow || isParentExpanded;
-
-      return (
-        <ColumnGridTableRow
-          columnWidthPercent={COLUMN_WIDTH_PERCENT}
-          entity={entity}
-          isPendingRefetch={pendingRefetchRowIds.has(entity.id)}
-          isRecentlyUpdated={recentlyUpdatedRowIds.has(entity.id)}
-          isSelected={isSelected}
-          renderColumnNameCell={renderColumnNameCellFinal}
-          renderDescriptionCell={renderDescriptionCellAdapter}
-          renderGlossaryTermsCell={renderGlossaryTermsCellAdapter}
-          renderPathCell={renderPathCellAdapter}
-          renderTagsCell={renderTagsCellAdapter}
-          showParentChildColors={showParentChildColors}
-          tableColumns={tableColumns}
-        />
-      );
-    },
-    [
-      columnGridListing.expandedRows,
-      columnGridListing.expandedStructRows,
-      pendingRefetchRowIds,
-      recentlyUpdatedRowIds,
-      renderColumnNameCellFinal,
-      renderPathCellAdapter,
-      renderDescriptionCellAdapter,
-      renderTagsCellAdapter,
-      renderGlossaryTermsCellAdapter,
-    ]
-  );
-
   // Filter entities to show only selected ones when viewSelectedOnly is true
   const filteredEntities = useMemo(() => {
     if (viewSelectedOnly) {
@@ -2171,13 +2127,26 @@ const ColumnGrid: React.FC<ColumnGridProps> = ({
               );
             }
 
+            const isChildRow = Boolean(entity.parentId || entity.isStructChild);
+            const isParentExpanded =
+              columnGridListing.expandedRows.has(entity.id) ||
+              columnGridListing.expandedStructRows.has(entity.id);
+
             return (
-              <CustomTableRow
+              <ColumnGridTableRow
+                columnWidthPercent={COLUMN_WIDTH_PERCENT}
                 entity={entity}
+                isPendingRefetch={pendingRefetchRowIds.has(entity.id)}
+                isRecentlyUpdated={recentlyUpdatedRowIds.has(entity.id)}
                 isSelected={columnGridListing.isSelected(entity.id)}
                 key={entity.id}
+                renderColumnNameCell={renderColumnNameCellFinal}
+                renderDescriptionCell={renderDescriptionCellAdapter}
+                renderGlossaryTermsCell={renderGlossaryTermsCellAdapter}
+                renderPathCell={renderPathCellAdapter}
+                renderTagsCell={renderTagsCellAdapter}
+                showParentChildColors={isChildRow || isParentExpanded}
                 tableColumns={tableColumns}
-                onSelect={columnGridListing.handleSelect}
               />
             );
           }}
@@ -2194,7 +2163,15 @@ const ColumnGrid: React.FC<ColumnGridProps> = ({
       columnGridListing.isSelected,
       t,
       columnGridListing.handleSelect,
-      CustomTableRow,
+      columnGridListing.expandedRows,
+      columnGridListing.expandedStructRows,
+      pendingRefetchRowIds,
+      recentlyUpdatedRowIds,
+      renderColumnNameCellFinal,
+      renderPathCellAdapter,
+      renderDescriptionCellAdapter,
+      renderTagsCellAdapter,
+      renderGlossaryTermsCellAdapter,
     ]
   );
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/components/ColumnGridTableRow.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ColumnBulkOperations/ColumnGrid/components/ColumnGridTableRow.test.tsx
@@ -1,0 +1,146 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ColumnGridRowData } from '../ColumnGrid.interface';
+import { ColumnGridTableRow } from './ColumnGridTableRow';
+
+jest.mock('@openmetadata/ui-core-components', () => ({
+  Table: {
+    Row: ({
+      children,
+      columns,
+      ...props
+    }: {
+      children: (col: { id: string }) => React.ReactNode;
+      columns: { id: string }[];
+      [key: string]: unknown;
+    }) => (
+      <div
+        data-row-type={props['data-row-type'] as string}
+        data-testid={props['data-testid'] as string}>
+        {columns.map((col) => (
+          <React.Fragment key={col.id}>{children(col)}</React.Fragment>
+        ))}
+      </div>
+    ),
+    Cell: ({
+      children,
+      ...props
+    }: {
+      children: React.ReactNode;
+      [key: string]: unknown;
+    }) => <div data-testid={props['data-testid'] as string}>{children}</div>,
+  },
+}));
+
+jest.mock('../../../../components/common/Loader/Loader', () =>
+  jest.fn().mockImplementation(() => <span data-testid="loader">loader</span>)
+);
+
+const mockEntity = {
+  id: 'col-1',
+  columnName: 'test_col',
+  dataType: 'VARCHAR',
+} as ColumnGridRowData;
+
+const mockTableColumns = [
+  { id: 'columnName' },
+  { id: 'path' },
+  { id: 'description' },
+  { id: 'dataType' },
+  { id: 'tags' },
+  { id: 'glossaryTerms' },
+];
+
+const renderProps = {
+  renderColumnNameCell: jest.fn(() => <span>name</span>),
+  renderPathCell: jest.fn(() => <span>path</span>),
+  renderDescriptionCell: jest.fn(() => <span>desc</span>),
+  renderTagsCell: jest.fn(() => <span>tags</span>),
+  renderGlossaryTermsCell: jest.fn(() => <span>glossary</span>),
+};
+
+describe('ColumnGridTableRow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the row and delegates each cell to its render adapter', () => {
+    render(
+      <ColumnGridTableRow
+        entity={mockEntity}
+        isSelected={false}
+        tableColumns={mockTableColumns}
+        {...renderProps}
+      />
+    );
+
+    expect(screen.getByTestId('column-row-test_col')).toBeInTheDocument();
+    expect(screen.getByTestId('column-name-cell')).toBeInTheDocument();
+    expect(screen.getByTestId('column-description-cell')).toBeInTheDocument();
+    expect(renderProps.renderColumnNameCell).toHaveBeenCalledWith(mockEntity);
+    expect(renderProps.renderDescriptionCell).toHaveBeenCalledWith(mockEntity);
+    expect(renderProps.renderTagsCell).toHaveBeenCalledWith(mockEntity);
+    expect(renderProps.renderGlossaryTermsCell).toHaveBeenCalledWith(
+      mockEntity
+    );
+    // dataType is rendered from the entity directly, not via an adapter.
+    expect(screen.getByText('VARCHAR')).toBeInTheDocument();
+  });
+
+  it('shows the refetch loader on the column-name cell when isPendingRefetch', () => {
+    render(
+      <ColumnGridTableRow
+        isPendingRefetch
+        entity={mockEntity}
+        isSelected={false}
+        tableColumns={[{ id: 'columnName' }]}
+        {...renderProps}
+      />
+    );
+
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('marks the row as parent or child based on the entity', () => {
+    const { rerender } = render(
+      <ColumnGridTableRow
+        entity={mockEntity}
+        isSelected={false}
+        tableColumns={mockTableColumns}
+        {...renderProps}
+      />
+    );
+
+    expect(screen.getByTestId('column-row-test_col')).toHaveAttribute(
+      'data-row-type',
+      'parent'
+    );
+
+    rerender(
+      <ColumnGridTableRow
+        showParentChildColors
+        entity={{ ...mockEntity, parentId: 'p1' } as ColumnGridRowData}
+        isSelected={false}
+        tableColumns={mockTableColumns}
+        {...renderProps}
+      />
+    );
+
+    expect(screen.getByTestId('column-row-test_col')).toHaveAttribute(
+      'data-row-type',
+      'child'
+    );
+  });
+});


### PR DESCRIPTION
## Description

In the Column Bulk Operations grid, the row map rendered `<CustomTableRow>` — a component defined **inside** `ColumnGrid` via `useCallback`:

```tsx
const CustomTableRow = useCallback((props) => { ... }, [/* 9 deps */]);
// ...
<CustomTableRow entity={entity} key={entity.id} ... />
```

`useCallback` does **not** stabilise a component *type*. Its identity changed whenever any of its nine deps changed (`expandedRows`, `expandedStructRows`, `pendingRefetchRowIds`, `recentlyUpdatedRowIds`, and the five render adapters). React then saw a **new element type** at each row position and unmounted/remounted **every row** — destroying focus (and selection/scroll) on an input the user was actively editing. This is the "inputs lose focus mid-edit" bug.

## Fix

Inline the already-extracted, module-level `<ColumnGridTableRow>` directly in the row map. Its type is stable, so React reconciles rows **by key** and updates props in place instead of remounting — the editing input keeps focus. The nine former closure values move onto the enclosing `useMemo` (warning-neutral: 12 `exhaustive-deps` warnings before and after). Also drops a dead `onSelect` prop the wrapper received but never forwarded.

## Type of change

- [x] Bug fix (correctness — focus loss during inline edit)

## Tests

- **Added** `ColumnGridTableRow.test.tsx` (the extracted row component was previously untested): cell-adapter delegation, the pending-refetch loader, and parent/child row typing — **3 tests pass**.
- `eslint` 0 errors (no new warnings — 12 `exhaustive-deps` before and after), `tsc --noEmit` 0 errors, `CustomTableRow` fully removed.
- The grid render path is additionally exercised by the existing `ColumnBulkOperations` Playwright specs.

> Note: the focus-preservation behaviour itself is an E2E concern; a dedicated Playwright assertion (type in a cell → mutate a former dep like `expandedRows` → focus survives) is a good follow-up in `ColumnBulkOperations.spec.ts`.

Ref: open-metadata/openmetadata-collate#5442