### PR TITLE
perf(ui): R4 residual — passive scroll listeners, lazy state init, hoist localStorage read

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/MathEquationComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/MathEquation/MathEquationComponent.tsx
@@ -31,7 +31,9 @@ export const MathEquationComponent: FC<NodeViewProps> = ({
   const inputRef = useRef<TextAreaRef>(null);
   const equation = node.attrs.math_equation;
 
-  const [isEditing, setIsEditing] = useState(Boolean(node.attrs.isEditing));
+  const [isEditing, setIsEditing] = useState(() =>
+    Boolean(node.attrs.isEditing)
+  );
 
   const handleSaveEquation = () => {
     updateAttributes({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/hooks/useDataProductListingData.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/hooks/useDataProductListingData.tsx
@@ -36,8 +36,8 @@ import {
 
 export const useDataProductListingData = (): ListingData<DataProduct> => {
   const { dataProductBasePath } = useMarketplaceStore();
-  const filterKeys = useMemo(() => DATAPRODUCT_DEFAULT_QUICK_FILTERS, []);
-  const filterConfigs = useMemo(() => DATAPRODUCT_FILTERS, []);
+  const filterKeys = DATAPRODUCT_DEFAULT_QUICK_FILTERS;
+  const filterConfigs = DATAPRODUCT_FILTERS;
 
   const getDomains = useCallback(
     (dataProduct: DataProduct) => dataProduct.domains || [],

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityHeatmap/useScrollIndicator.hook.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityHeatmap/useScrollIndicator.hook.ts
@@ -81,7 +81,7 @@ export const useScrollIndicator = (
     };
 
     if (container) {
-      container.addEventListener('scroll', handleScroll);
+      container.addEventListener('scroll', handleScroll, { passive: true });
     }
     window.addEventListener('resize', checkScroll);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NavBar/NavBar.tsx
@@ -108,7 +108,7 @@ const NavBar = () => {
     handleDeleteEntityWebsocketResponse
   );
   handleDeleteEntityResponseRef.current = handleDeleteEntityWebsocketResponse;
-  const Logo = useMemo(() => brandClassBase.getMonogram().src, []);
+  const Logo = brandClassBase.getMonogram().src;
   const [showVersionMissMatchAlert, setShowVersionMissMatchAlert] =
     useState(false);
   const location = useCustomLocation();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/Execution/Execution.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Pipeline/Execution/Execution.component.tsx
@@ -51,10 +51,10 @@ const ExecutionsTab = ({ pipelineFQN, tasks }: ExecutionProps) => {
   const [searchValue, setSearchValue] = useState<string>('');
   const [executions, setExecutions] = useState<Array<PipelineStatus>>();
   const [datesSelected, setDatesSelected] = useState<boolean>(false);
-  const [startTime, setStartTime] = useState(
+  const [startTime, setStartTime] = useState(() =>
     getEpochMillisForPastDays(EXECUTION_FILTER_RANGE.last365days.days)
   );
-  const [endTime, setEndTime] = useState(getCurrentMillis());
+  const [endTime, setEndTime] = useState(() => getCurrentMillis());
   const [isClickedCalendar, setIsClickedCalendar] = useState(false);
   const [status, setStatus] = useState(MenuOptions.all);
   const [isLoading, setIsLoading] = useState(true);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/UserTab/UserTab.component.tsx
@@ -199,10 +199,7 @@ export const UserTab = ({
     }
   }, [currentTeam, pageSize, pagingCursor]);
 
-  const isTeamDeleted = useMemo(
-    () => currentTeam.deleted ?? false,
-    [currentTeam]
-  );
+  const isTeamDeleted = currentTeam.deleted ?? false;
 
   const columns: ColumnsType<User> = useMemo(() => {
     const tabColumns: ColumnsType<User> = [

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useGridEditController.ts
@@ -300,7 +300,7 @@ export function useGridEditController({
     if (gridContainer) {
       gridContainer
         .querySelector('.rdg')
-        ?.addEventListener('scroll', highlightSelectedRange);
+        ?.addEventListener('scroll', highlightSelectedRange, { passive: true });
 
       return () => {
         gridContainer

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MyDataPage/MyDataPage.component.tsx
@@ -87,7 +87,10 @@ const MyDataPage = () => {
   const [personaPreferences, setPersonaPreferences] = useState<
     PersonaPreferences[]
   >([]);
-  const storageData = localStorage.getItem(LOGGED_IN_USER_STORAGE_KEY);
+  const storageData = useMemo(
+    () => localStorage.getItem(LOGGED_IN_USER_STORAGE_KEY),
+    []
+  );
 
   const loggedInUserName = useMemo(() => {
     return currentUser?.name ?? '';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/SignUpPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/SignUpPage.tsx
@@ -50,7 +50,7 @@ const SignUp = () => {
   } = useApplicationStore();
 
   const [loading, setLoading] = useState<boolean>(false);
-  const OMDLogo = useMemo(() => brandClassBase.getMonogram().svg, []);
+  const OMDLogo = brandClassBase.getMonogram().svg;
 
   const handleCreateNewUser: FormProps['onFinish'] = async (data) => {
     setLoading(true);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVUtilsClassBase.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSVUtilsClassBase.tsx
@@ -1088,7 +1088,10 @@ const InlineBulkEditReferencePickerEditor = ({
 
     updatePosition();
     window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('scroll', updatePosition, {
+      capture: true,
+      passive: true,
+    });
 
     return () => {
       window.removeEventListener('resize', updatePosition);
@@ -1370,7 +1373,10 @@ const InlineCustomPropertiesEditor = ({
 
     updatePosition();
     window.addEventListener('resize', updatePosition);
-    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('scroll', updatePosition, {
+      capture: true,
+      passive: true,
+    });
 
     return () => {
       window.removeEventListener('resize', updatePosition);


### PR DESCRIPTION
Finishes the smaller **R4** re-render items (the bigger R4 piece — functional setState + memoized column arrays — merged in #31002).

## Changes
- **Passive scroll listeners** — mark 4 scroll listeners `{ passive: true }` (`useScrollIndicator.hook`, `useGridEditController`, `CSVUtilsClassBase` ×2) so scrolling isn't blocked waiting on the handler.
- **Lazy state init** — `Execution` (`startTime`/`endTime`) and `MathEquation` (`isEditing`) use lazy initialisers, so the init expressions aren't evaluated on every render.
- **localStorage out of render** — `MyDataPage` (the landing page) read `localStorage.getItem` synchronously in the render body on every render; wrapped in `useMemo` so it runs once.
- **Drop trivial `useMemo` wrappers** — `useDataProductListingData` (memoised module constants), `NavBar`/`SignUpPage` (memoised a cheap brand-logo getter), `UserTab` (memoised a boolean primitive). These memos added overhead without preventing any recompute.

## Testing
- Jest: affected suites (Execution, MyDataPage, NavBar, SignUp, UserTab, DataProduct) pass.
- `lint:base` 0 errors; `tsc --noEmit` no new errors (one pre-existing `SignUpPage` type error is untouched).

Part of the UI Quality Audit — open-metadata/openmetadata-collate#5442, R4 under open-metadata/openmetadata-collate#5447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)