### PR TITLE
fix(playwright): use API anchor + skeleton wait for hierarchy node clicks

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -684,7 +684,16 @@ test.describe('Context Center Articles', () => {
     const targetArticle =
       listKnowledgeCenter.knowledgePages[MIN_CARDS - 1].displayName;
     const node = await scrollHierarchyToNode(page, targetArticle);
+    const articleLoaded = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+        resp.status() === 200
+    );
     await node.click();
+    await articleLoaded;
+    await expect(
+      page.getByTestId('article-detail-header-skeleton')
+    ).not.toBeVisible();
 
     await expect(page.getByTestId('entity-header-display-name')).toHaveValue(
       targetArticle
@@ -1387,8 +1396,16 @@ test.describe('Context Center Articles', () => {
           page,
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
+        const articleLoaded = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+            resp.status() === 200
+        );
         await node.click();
-        await waitForAllLoadersToDisappear(page);
+        await articleLoaded;
+        await expect(
+          page.getByTestId('article-detail-header-skeleton')
+        ).not.toBeVisible();
         await assertArticleEditorSaved(page);
       });
 
@@ -1453,8 +1470,16 @@ test.describe('Context Center Articles', () => {
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
         await updateDisplayNameResponse;
+        const articleLoaded = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+            resp.status() === 200
+        );
         await node.click();
-        await waitForAllLoadersToDisappear(page);
+        await articleLoaded;
+        await expect(
+          page.getByTestId('article-detail-header-skeleton')
+        ).not.toBeVisible();
         await assertArticleEditorSaved(page);
       });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -684,8 +684,10 @@ test.describe('Context Center Articles', () => {
     const targetArticle =
       listKnowledgeCenter.knowledgePages[MIN_CARDS - 1].displayName;
     const node = await scrollHierarchyToNode(page, targetArticle);
-    const articleLoaded = page.waitForResponse((resp) =>
-      resp.url().includes('/api/v1/contextCenter/pages/name/')
+    const articleLoaded = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+        resp.status() === 200
     );
     await node.click();
     await articleLoaded;
@@ -1394,8 +1396,10 @@ test.describe('Context Center Articles', () => {
           page,
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
-        const articleLoaded = page.waitForResponse((resp) =>
-          resp.url().includes('/api/v1/contextCenter/pages/name/')
+        const articleLoaded = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+            resp.status() === 200
         );
         await node.click();
         await articleLoaded;
@@ -1466,8 +1470,10 @@ test.describe('Context Center Articles', () => {
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
         await updateDisplayNameResponse;
-        const articleLoaded = page.waitForResponse((resp) =>
-          resp.url().includes('/api/v1/contextCenter/pages/name/')
+        const articleLoaded = page.waitForResponse(
+          (resp) =>
+            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
+            resp.status() === 200
         );
         await node.click();
         await articleLoaded;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -684,13 +684,13 @@ test.describe('Context Center Articles', () => {
     const targetArticle =
       listKnowledgeCenter.knowledgePages[MIN_CARDS - 1].displayName;
     const node = await scrollHierarchyToNode(page, targetArticle);
-    const articleLoaded = page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-        resp.status() === 200
+    const articleLoaded = page.waitForResponse((resp) =>
+      resp.url().includes('/api/v1/contextCenter/pages/name/')
     );
     await node.click();
-    await articleLoaded;
+    const articleResponse = await articleLoaded;
+
+    expect(articleResponse.status()).toBe(200);
     await expect(
       page.getByTestId('article-detail-header-skeleton')
     ).not.toBeVisible();
@@ -1396,13 +1396,13 @@ test.describe('Context Center Articles', () => {
           page,
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
-        const articleLoaded = page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-            resp.status() === 200
+        const articleLoaded = page.waitForResponse((resp) =>
+          resp.url().includes('/api/v1/contextCenter/pages/name/')
         );
         await node.click();
-        await articleLoaded;
+        const articleResponse = await articleLoaded;
+
+        expect(articleResponse.status()).toBe(200);
         await expect(
           page.getByTestId('article-detail-header-skeleton')
         ).not.toBeVisible();
@@ -1470,13 +1470,13 @@ test.describe('Context Center Articles', () => {
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
         await updateDisplayNameResponse;
-        const articleLoaded = page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-            resp.status() === 200
+        const articleLoaded = page.waitForResponse((resp) =>
+          resp.url().includes('/api/v1/contextCenter/pages/name/')
         );
         await node.click();
-        await articleLoaded;
+        const articleResponse = await articleLoaded;
+
+        expect(articleResponse.status()).toBe(200);
         await expect(
           page.getByTestId('article-detail-header-skeleton')
         ).not.toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterArticles.spec.ts
@@ -684,10 +684,8 @@ test.describe('Context Center Articles', () => {
     const targetArticle =
       listKnowledgeCenter.knowledgePages[MIN_CARDS - 1].displayName;
     const node = await scrollHierarchyToNode(page, targetArticle);
-    const articleLoaded = page.waitForResponse(
-      (resp) =>
-        resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-        resp.status() === 200
+    const articleLoaded = page.waitForResponse((resp) =>
+      resp.url().includes('/api/v1/contextCenter/pages/name/')
     );
     await node.click();
     await articleLoaded;
@@ -1396,10 +1394,8 @@ test.describe('Context Center Articles', () => {
           page,
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
-        const articleLoaded = page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-            resp.status() === 200
+        const articleLoaded = page.waitForResponse((resp) =>
+          resp.url().includes('/api/v1/contextCenter/pages/name/')
         );
         await node.click();
         await articleLoaded;
@@ -1470,10 +1466,8 @@ test.describe('Context Center Articles', () => {
           DRAFT_ARTICLE_B_DISPLAY_NAME
         );
         await updateDisplayNameResponse;
-        const articleLoaded = page.waitForResponse(
-          (resp) =>
-            resp.url().includes('/api/v1/contextCenter/pages/name/') &&
-            resp.status() === 200
+        const articleLoaded = page.waitForResponse((resp) =>
+          resp.url().includes('/api/v1/contextCenter/pages/name/')
         );
         await node.click();
         await articleLoaded;


### PR DESCRIPTION
### Describe your changes:

I worked on making Playwright tests robust against a race condition in hierarchy node navigation because `waitForAllLoadersToDisappear` could run before the article-fetch loader even appeared, passing immediately and leaving the page still loading when downstream assertions ran.

- Register `page.waitForResponse` for `GET /api/v1/contextCenter/pages/name/` **before** each `node.click()` so no response can be missed
- After the click, await the response, then assert `article-detail-header-skeleton` is not visible (semantic, article-specific wait instead of a generic loader poll)
- Applied to all 3 hierarchy-click locations in `ContextCenterArticles.spec.ts`

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `switching articles does not bleed unsaved content into next article`
- `switching articles does not bleed unsaved title into next article`
- `Left hierarchy pagination and expand collapse actions work`

#### Unit tests
- [ ] Not applicable (test-only change, no production logic changed).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Modified existing Playwright tests to be more robust — `ContextCenterArticles.spec.ts`

#### Manual testing performed
N/A — CI will validate.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.