### PR TITLE
fix(test): simplify SearchExport tray step for AUT 2.0

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -427,52 +427,20 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
 
     const jobId = await startAsyncExport(page);
 
-      await test.step('Jobs tray surfaces the export job', async () => {
-        // PR #30615 added a useEffect that calls setOpen(true) when a job
-        // reaches a terminal state, auto-opening the tray and hiding the
-        // launcher button ({!open && !isEmpty(visibleJobs) && ...} renders
-        // nothing once open=true).
-        //
-        // Race: right after startAsyncExport, visibleJobs may still be
-        // empty (socket event not yet received), so neither the launcher
-        // nor the tray has rendered yet. A bare click() on the launcher
-        // fails during this window.
-        //
-        // Fix: wait for whichever surface appears first, then open the tray
-        // only if it has not already been auto-opened.
-        const launcherButton = page.getByRole('button', {
-          name: /Background jobs|jobs running/,
-        });
-        const trayPopover = page.locator('.csv-jobs-tray-popover');
-
-        // Block until the launcher (job in progress) or the tray (job
-        // completed and auto-opened by the useEffect) is in the DOM.
-        await expect(launcherButton.or(trayPopover)).toBeVisible();
-
-        // Open the tray only if it has not already been auto-opened.
-        // When the job finished fast, the tray is already visible and the
-        // launcher is gone from the DOM — clicking it would throw.
-        if (!(await trayPopover.isVisible())) {
-          await launcherButton.click();
-        }
+    await test.step('Jobs tray auto-opens and surfaces the export job', async () => {
+      await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible({
+        timeout: 30_000,
+      });
 
       await expect(page.getByText(/Exporting|Exported/).first()).toBeVisible();
     });
 
     await test.step('Download from the tray serves the job result CSV', async () => {
-      // The Download button only renders once the async job finishes, so waiting
-      // blind on it spent up to 90s of the test budget before the download waits
-      // even started -- the remainder then ran out mid-wait and surfaced as
-      // "Target page, context or browser has been closed". Poll the job over the
-      // API first (the same way fetchCompletedExportCsv does), so a stalled job is
-      // named as such and the UI waits that follow are short.
-      await waitForExportJobCompleted(page.request, jobId);
-
       const downloadButton = page
         .getByRole('button', { name: 'Download' })
         .first();
 
-      await expect(downloadButton).toBeVisible();
+      await expect(downloadButton).toBeVisible({ timeout: 90_000 });
 
       const resultResponsePromise = page.waitForResponse(
         (response) =>


### PR DESCRIPTION
## Summary

Fixes `SearchExport.spec.ts:411 › Export queues a background job and downloads from the jobs tray` failing in the AUT 1.x → 2.0 nightly.

- **Auto-open tray**: The tray now opens automatically when a job starts or reaches a terminal state. The old conditional `launcherButton.or(trayPopover)` + gated-click logic is replaced with a direct `expect('.csv-jobs-tray-popover').toBeVisible()`.
- **Remove API polling**: Dropped `waitForExportJobCompleted(page.request, jobId)` which was calling `csvAsyncJobs` with `page.request` (cookies, no bearer token) and getting a 401 that manifested as `TypeError: jobs.find is not a function`. Since the tray auto-opens and the Download button appears once the job completes, polling the API separately is unnecessary — `expect(downloadButton).toBeVisible({ timeout: 90_000 })` is sufficient.

## Test plan
- [ ] AUT 2.0 nightly: `SearchExport › Export queues a background job and downloads from the jobs tray` passes
- [ ] Other SearchExport tests unaffected (they use `fetchCompletedExportCsv` with an authenticated `apiContext`, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)