### PR TITLE
perf(ingestion): seek the newest run per pipeline on postgres instead of ranking all history

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -897,12 +897,9 @@ public class IngestionPipelineResourceIT
   }
 
   /**
-   * Lists several pipelines at once with {@code fields=pipelineStatuses}, which is the only way to
-   * exercise the batched top-N-per-entity query with more than one entity. The single-entity read
-   * above binds a one-element hash list, where a per-entity ordering key is indistinguishable from
-   * none — an earlier revision that ordered solely by entity hash passed that test while returning
-   * an arbitrary historical run as each pipeline's latest. Timestamps are interleaved across the two
-   * pipelines so a query that sorts globally rather than per entity cannot pass either.
+   * Needs more than one pipeline: the single-entity read above binds a one-element hash list, where
+   * a query ordered only by entity hash still looks correct. Timestamps are interleaved across the
+   * two pipelines so a globally-sorted query fails too.
    */
   @Test
   void test_listWithPipelineStatusesOrdersEachPipelineNewestFirst(TestNamespace ns)
@@ -931,8 +928,6 @@ public class IngestionPipelineResourceIT
       for (int i = 0; i < 3; i++) {
         String runId = UUID.randomUUID().toString();
         runIds.add(runId);
-        // Interleave the two pipelines' timestamps: p0 gets base+0/2000/4000, p1
-        // base+1000/3000/5000
         PipelineStatus status =
             new PipelineStatus()
                 .withPipelineState(PipelineStatusType.SUCCESS)

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -893,6 +894,74 @@ public class IngestionPipelineResourceIT
     Collections.reverse(expectedNewestFirst);
     List<String> actualRunIds = statuses.stream().map(PipelineStatus::getRunId).toList();
     assertEquals(expectedNewestFirst, actualRunIds);
+  }
+
+  /**
+   * Lists several pipelines at once with {@code fields=pipelineStatuses}, which is the only way to
+   * exercise the batched top-N-per-entity query with more than one entity. The single-entity read
+   * above binds a one-element hash list, where a per-entity ordering key is indistinguishable from
+   * none — an earlier revision that ordered solely by entity hash passed that test while returning
+   * an arbitrary historical run as each pipeline's latest. Timestamps are interleaved across the two
+   * pipelines so a query that sorts globally rather than per entity cannot pass either.
+   */
+  @Test
+  void test_listWithPipelineStatusesOrdersEachPipelineNewestFirst(TestNamespace ns)
+      throws OpenMetadataException {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    OpenMetadataClient client = SdkClients.adminClient();
+    long base = System.currentTimeMillis() - (48L * 60 * 60 * 1000);
+
+    Map<String, List<String>> expectedNewestFirst = new LinkedHashMap<>();
+    for (int p = 0; p < 2; p++) {
+      CreateIngestionPipeline request =
+          new CreateIngestionPipeline()
+              .withName(ns.prefix("list_statuses_order_" + p))
+              .withPipelineType(PipelineType.METADATA)
+              .withService(service.getEntityReference())
+              .withSourceConfig(
+                  new SourceConfig()
+                      .withConfig(
+                          new DatabaseServiceMetadataPipeline().withMarkDeletedTables(true)))
+              .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE));
+      IngestionPipeline pipeline = createEntity(request);
+      String statusPath =
+          "/v1/services/ingestionPipelines/" + pipeline.getFullyQualifiedName() + "/pipelineStatus";
+
+      List<String> runIds = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+        String runId = UUID.randomUUID().toString();
+        runIds.add(runId);
+        // Interleave the two pipelines' timestamps: p0 gets base+0/2000/4000, p1
+        // base+1000/3000/5000
+        PipelineStatus status =
+            new PipelineStatus()
+                .withPipelineState(PipelineStatusType.SUCCESS)
+                .withRunId(runId)
+                .withTimestamp(base + (i * 2000L) + (p * 1000L));
+        client.getHttpClient().execute(HttpMethod.PUT, statusPath, status, PipelineStatus.class);
+      }
+      Collections.reverse(runIds);
+      expectedNewestFirst.put(pipeline.getFullyQualifiedName(), runIds);
+    }
+
+    ListResponse<IngestionPipeline> listed =
+        listEntities(
+            new ListParams()
+                .setFields("pipelineStatuses")
+                .setLimit(1000)
+                .setService(service.getFullyQualifiedName()));
+
+    for (Map.Entry<String, List<String>> expected : expectedNewestFirst.entrySet()) {
+      IngestionPipeline pipeline =
+          listed.getData().stream()
+              .filter(candidate -> expected.getKey().equals(candidate.getFullyQualifiedName()))
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("pipeline missing from list: " + expected));
+      List<String> actual =
+          pipeline.getPipelineStatuses().stream().map(PipelineStatus::getRunId).toList();
+      assertEquals(
+          expected.getValue(), actual, "runs must be newest-first for " + expected.getKey());
+    }
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -494,13 +494,7 @@ public interface EntityTimeSeriesDAO {
     }
   }
 
-  /**
-   * The single newest row per entity. Same shape as {@link #getLatestExtensionsBatch} with N = 1, and
-   * the same trade-off between the two dialects: the MySQL form ranks every historical row for the
-   * requested entities before discarding all but the newest, so its cost tracks total history rather
-   * than the number of entities asked for. Measured on 26 entities holding 52k rows between them,
-   * that is 77ms against 8ms for the Postgres seek below.
-   */
+  /** The single newest row per entity. See {@link #getLatestExtensionsBatch} for the dialect split. */
   @ConnectionAwareSqlQuery(
       value =
           "SELECT entityFQNHash, json FROM (SELECT entityFQNHash, json, "
@@ -527,8 +521,7 @@ public interface EntityTimeSeriesDAO {
     if (entityFQNHashes == null || entityFQNHashes.isEmpty()) {
       return Map.of();
     }
-    // Distinct for the same reason as the overload below: `IN (...)` collapses a repeated hash but
-    // `unnest(ARRAY[...])` yields a row per occurrence. Harmless for this map, wasteful either way.
+    // Distinct because `IN (...)` collapses a repeated hash but `unnest(ARRAY[...])` does not.
     List<FQNHashJsonRow> rows =
         EntityDAO.queryInChunks(
             entityFQNHashes.stream().distinct().toList(),
@@ -543,24 +536,13 @@ public interface EntityTimeSeriesDAO {
   /**
    * Top-N rows per entity, each entity's rows newest-first.
    *
-   * <p>The newest-first order is part of the contract, not a convenience: callers index straight
-   * into the result to get an entity's most recent row. A per-entity ordering key must therefore
-   * appear in the outer ORDER BY — ordering by the entity hash alone leaves rows unordered within an
-   * entity, which silently returns an arbitrary historical row as the newest one.
+   * <p>Newest-first is part of the contract: callers index into the result to get an entity's most
+   * recent row. The outer ORDER BY therefore needs a per-entity key — ordering by hash alone leaves
+   * rows unordered within an entity and silently returns an arbitrary historical row as the newest.
    *
-   * <p>The MySQL form ranks every historical row for the requested entities and then discards all
-   * but the newest N, so its cost grows with total history rather than with N. The Postgres form
-   * asks for the newest N per entity via LATERAL, which lets the planner walk
-   * {@code (entityFQNHash, extension, timestamp)} backwards and stop at N instead of reading that
-   * entity's whole history. Which plan it picks is its own choice — on a small table it may still
-   * sort — so treat this as removing the guaranteed full scan, not as a guaranteed seek.
-   *
-   * <p>MySQL keeps the window form because LATERAL needs MySQL 8.0.14+ and this project declares no
-   * minimum 8.0.x patch level.
-   *
-   * <p>Prefer the {@code (hashes, extension, limit)} overload below. It de-duplicates the hash list,
-   * which the two dialects require to agree: {@code IN (...)} collapses a repeated hash while
-   * {@code unnest(ARRAY[...])} yields one N-row block per occurrence.
+   * <p>The MySQL form ranks all of an entity's history before discarding everything but the newest
+   * N; the Postgres form asks only for N so the planner can stop there. MySQL keeps the window form
+   * because LATERAL needs 8.0.14+ and this project declares no minimum 8.0.x patch level.
    */
   @ConnectionAwareSqlQuery(
       value =
@@ -588,17 +570,14 @@ public interface EntityTimeSeriesDAO {
 
   default Map<String, List<String>> getLatestExtensionsBatch(
       List<String> entityFQNHashes, String extension, int limit) {
-    // "Newest N per entity" has no meaning for N <= 0, so this is always a caller bug. Fail loudly:
-    // returning an empty map instead is indistinguishable from "no entity has any rows", which
-    // surfaces as every pipeline reporting no runs at all, with nothing logged anywhere.
+    // Fail loudly: an empty map here is indistinguishable from "no entity has any rows".
     if (limit <= 0) {
       throw new IllegalArgumentException(
           "limit must be positive to fetch top-N rows, got " + limit);
     }
     Map<String, List<String>> result = new LinkedHashMap<>();
-    // De-duplicate before binding: MySQL's `IN (...)` collapses a repeated hash, whereas the
-    // Postgres form expands one array element per occurrence and would return `limit` rows per
-    // occurrence. Distinct input keeps the two dialects returning the same rows.
+    // Distinct because `IN (...)` collapses a repeated hash but `unnest(ARRAY[...])` does not,
+    // which would return one N-row block per occurrence.
     List<String> distinctHashes =
         entityFQNHashes == null ? List.of() : entityFQNHashes.stream().distinct().toList();
     if (!distinctHashes.isEmpty()) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -512,9 +512,9 @@ public interface EntityTimeSeriesDAO {
       value =
           "SELECT h.hash AS \"entityFQNHash\", x.json AS json "
               + "FROM unnest(ARRAY[<entityFQNHashes>]::varchar[]) AS h(hash) "
-              + "CROSS JOIN LATERAL (SELECT json FROM <table> "
+              + "JOIN LATERAL (SELECT json FROM <table> "
               + "WHERE entityFQNHash = h.hash AND extension = :extension "
-              + "ORDER BY timestamp DESC LIMIT 1) x",
+              + "ORDER BY timestamp DESC LIMIT 1) x ON TRUE",
       connectionType = POSTGRES)
   @RegisterRowMapper(FQNHashJsonRowMapper.class)
   List<FQNHashJsonRow> getLatestExtensionBatch(
@@ -574,9 +574,9 @@ public interface EntityTimeSeriesDAO {
       value =
           "SELECT h.hash AS \"entityFQNHash\", x.json AS json "
               + "FROM unnest(ARRAY[<entityFQNHashes>]::varchar[]) AS h(hash) "
-              + "CROSS JOIN LATERAL (SELECT json, timestamp FROM <table> "
+              + "JOIN LATERAL (SELECT json, timestamp FROM <table> "
               + "WHERE entityFQNHash = h.hash AND extension = :extension "
-              + "ORDER BY timestamp DESC LIMIT :limit) x "
+              + "ORDER BY timestamp DESC LIMIT :limit) x ON TRUE "
               + "ORDER BY h.hash, x.timestamp DESC",
       connectionType = POSTGRES)
   @RegisterRowMapper(FQNHashJsonRowMapper.class)

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityTimeSeriesDAO.java
@@ -494,11 +494,28 @@ public interface EntityTimeSeriesDAO {
     }
   }
 
-  @SqlQuery(
-      "SELECT entityFQNHash, json FROM (SELECT entityFQNHash, json, "
-          + "ROW_NUMBER() OVER (PARTITION BY entityFQNHash ORDER BY timestamp DESC) AS rn "
-          + "FROM <table> WHERE entityFQNHash IN (<entityFQNHashes>) "
-          + "AND extension = :extension) ranked WHERE rn = 1")
+  /**
+   * The single newest row per entity. Same shape as {@link #getLatestExtensionsBatch} with N = 1, and
+   * the same trade-off between the two dialects: the MySQL form ranks every historical row for the
+   * requested entities before discarding all but the newest, so its cost tracks total history rather
+   * than the number of entities asked for. Measured on 26 entities holding 52k rows between them,
+   * that is 77ms against 8ms for the Postgres seek below.
+   */
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT entityFQNHash, json FROM (SELECT entityFQNHash, json, "
+              + "ROW_NUMBER() OVER (PARTITION BY entityFQNHash ORDER BY timestamp DESC) AS rn "
+              + "FROM <table> WHERE entityFQNHash IN (<entityFQNHashes>) "
+              + "AND extension = :extension) ranked WHERE rn = 1",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT h.hash AS \"entityFQNHash\", x.json AS json "
+              + "FROM unnest(ARRAY[<entityFQNHashes>]::varchar[]) AS h(hash) "
+              + "CROSS JOIN LATERAL (SELECT json FROM <table> "
+              + "WHERE entityFQNHash = h.hash AND extension = :extension "
+              + "ORDER BY timestamp DESC LIMIT 1) x",
+      connectionType = POSTGRES)
   @RegisterRowMapper(FQNHashJsonRowMapper.class)
   List<FQNHashJsonRow> getLatestExtensionBatch(
       @Define("table") String table,
@@ -510,9 +527,11 @@ public interface EntityTimeSeriesDAO {
     if (entityFQNHashes == null || entityFQNHashes.isEmpty()) {
       return Map.of();
     }
+    // Distinct for the same reason as the overload below: `IN (...)` collapses a repeated hash but
+    // `unnest(ARRAY[...])` yields a row per occurrence. Harmless for this map, wasteful either way.
     List<FQNHashJsonRow> rows =
         EntityDAO.queryInChunks(
-            entityFQNHashes,
+            entityFQNHashes.stream().distinct().toList(),
             chunk -> getLatestExtensionBatch(getTimeSeriesTableName(), chunk, extension));
     Map<String, String> result = new HashMap<>();
     for (FQNHashJsonRow row : rows) {
@@ -521,12 +540,45 @@ public interface EntityTimeSeriesDAO {
     return result;
   }
 
-  @SqlQuery(
-      "SELECT entityFQNHash, json FROM (SELECT entityFQNHash, json, "
-          + "ROW_NUMBER() OVER (PARTITION BY entityFQNHash ORDER BY timestamp DESC) AS rn "
-          + "FROM <table> WHERE entityFQNHash IN (<entityFQNHashes>) "
-          + "AND extension = :extension) ranked WHERE rn <= :limit "
-          + "ORDER BY entityFQNHash, rn")
+  /**
+   * Top-N rows per entity, each entity's rows newest-first.
+   *
+   * <p>The newest-first order is part of the contract, not a convenience: callers index straight
+   * into the result to get an entity's most recent row. A per-entity ordering key must therefore
+   * appear in the outer ORDER BY — ordering by the entity hash alone leaves rows unordered within an
+   * entity, which silently returns an arbitrary historical row as the newest one.
+   *
+   * <p>The MySQL form ranks every historical row for the requested entities and then discards all
+   * but the newest N, so its cost grows with total history rather than with N. The Postgres form
+   * asks for the newest N per entity via LATERAL, which lets the planner walk
+   * {@code (entityFQNHash, extension, timestamp)} backwards and stop at N instead of reading that
+   * entity's whole history. Which plan it picks is its own choice — on a small table it may still
+   * sort — so treat this as removing the guaranteed full scan, not as a guaranteed seek.
+   *
+   * <p>MySQL keeps the window form because LATERAL needs MySQL 8.0.14+ and this project declares no
+   * minimum 8.0.x patch level.
+   *
+   * <p>Prefer the {@code (hashes, extension, limit)} overload below. It de-duplicates the hash list,
+   * which the two dialects require to agree: {@code IN (...)} collapses a repeated hash while
+   * {@code unnest(ARRAY[...])} yields one N-row block per occurrence.
+   */
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT entityFQNHash, json FROM (SELECT entityFQNHash, json, "
+              + "ROW_NUMBER() OVER (PARTITION BY entityFQNHash ORDER BY timestamp DESC) AS rn "
+              + "FROM <table> WHERE entityFQNHash IN (<entityFQNHashes>) "
+              + "AND extension = :extension) ranked WHERE rn <= :limit "
+              + "ORDER BY entityFQNHash, rn",
+      connectionType = MYSQL)
+  @ConnectionAwareSqlQuery(
+      value =
+          "SELECT h.hash AS \"entityFQNHash\", x.json AS json "
+              + "FROM unnest(ARRAY[<entityFQNHashes>]::varchar[]) AS h(hash) "
+              + "CROSS JOIN LATERAL (SELECT json, timestamp FROM <table> "
+              + "WHERE entityFQNHash = h.hash AND extension = :extension "
+              + "ORDER BY timestamp DESC LIMIT :limit) x "
+              + "ORDER BY h.hash, x.timestamp DESC",
+      connectionType = POSTGRES)
   @RegisterRowMapper(FQNHashJsonRowMapper.class)
   List<FQNHashJsonRow> getLatestExtensionsBatch(
       @Define("table") String table,
@@ -536,14 +588,27 @@ public interface EntityTimeSeriesDAO {
 
   default Map<String, List<String>> getLatestExtensionsBatch(
       List<String> entityFQNHashes, String extension, int limit) {
-    Map<String, List<String>> result = new LinkedHashMap<>();
-    if (entityFQNHashes == null || entityFQNHashes.isEmpty()) {
-      return result;
+    // "Newest N per entity" has no meaning for N <= 0, so this is always a caller bug. Fail loudly:
+    // returning an empty map instead is indistinguishable from "no entity has any rows", which
+    // surfaces as every pipeline reporting no runs at all, with nothing logged anywhere.
+    if (limit <= 0) {
+      throw new IllegalArgumentException(
+          "limit must be positive to fetch top-N rows, got " + limit);
     }
-    List<FQNHashJsonRow> rows =
-        getLatestExtensionsBatch(getTimeSeriesTableName(), entityFQNHashes, extension, limit);
-    for (FQNHashJsonRow row : rows) {
-      result.computeIfAbsent(row.entityFQNHash(), key -> new ArrayList<>()).add(row.json());
+    Map<String, List<String>> result = new LinkedHashMap<>();
+    // De-duplicate before binding: MySQL's `IN (...)` collapses a repeated hash, whereas the
+    // Postgres form expands one array element per occurrence and would return `limit` rows per
+    // occurrence. Distinct input keeps the two dialects returning the same rows.
+    List<String> distinctHashes =
+        entityFQNHashes == null ? List.of() : entityFQNHashes.stream().distinct().toList();
+    if (!distinctHashes.isEmpty()) {
+      List<FQNHashJsonRow> rows =
+          EntityDAO.queryInChunks(
+              distinctHashes,
+              chunk -> getLatestExtensionsBatch(getTimeSeriesTableName(), chunk, extension, limit));
+      for (FQNHashJsonRow row : rows) {
+        result.computeIfAbsent(row.entityFQNHash(), key -> new ArrayList<>()).add(row.json());
+      }
     }
     return result;
   }


### PR DESCRIPTION
Context: open-metadata/openmetadata-collate#5499

Supports #30718 (`GET /v1/services/overview`) — its `ServiceHealthProvider` calls
`getLatestExtensionBatch`, which this PR is the fix for.

### What this changes

Both batched "latest run(s) per pipeline" queries currently rank **every** historical row for the
requested pipelines and then throw all but the newest away. On Postgres they now seek the newest rows
per pipeline instead. MySQL keeps the existing query.

- `getLatestExtensionBatch` (newest 1 per pipeline) — the method `ServiceHealthProvider` uses.
- `getLatestExtensionsBatch` (newest N per pipeline) — used by the `pipelineStatuses` field.
- Both helpers de-duplicate the input list, because `IN (...)` collapses a repeated hash but
  `unnest(ARRAY[...])` returns one block per occurrence.
- The N-variant now throws on a non-positive limit instead of silently returning nothing (Postgres
  used to error, MySQL returned empty — this makes them agree loudly rather than quietly).

### Why

Cost tracked total run history rather than how many pipelines were asked for, so it got slower every
time any pipeline ran. Measured on Postgres:

| | window over all history | Postgres seek |
| --- | --- | --- |
| newest 1, 26 pipelines / 52k rows | 77 ms | **8 ms** |
| newest 5, 253 pipelines / 224k rows | 420 ms | **6 ms** |

### Type of change

- [x] Improvement

### Tests

- New integration test lists **multiple** pipelines with interleaved run timestamps and asserts each
  one's runs come back newest-first. The existing test used a single pipeline, where a per-pipeline
  ordering bug is invisible — an earlier revision of this PR ordered only by pipeline, returning an
  arbitrary historical run as "latest", and passed that test. That bug is what this test pins.
- 218 backend unit tests pass; `spotless:check` clean; integration-test module compiles.
- Verified on a local Postgres with a 253-pipeline / 224k-status-row fixture: identical rows to the
  window query (`EXCEPT ALL` both directions returns nothing), and 0 ordering violations across 1239
  statuses.
- **Not run:** the new integration test needs the full integration environment. Worth confirming in CI.

### Note on scope

This PR originally also added an `excludeStackTraces` flag to the pipeline list endpoint, to cut a
43 MB response down to 2 MB for Collate's landing-page health widget. #30718 solves that better —
it derives health server-side and never serializes the run details at all — so the flag has been
dropped and only the query fix remains.



Closes #31332
