### PR TITLE
Custom Connector per service type, with integration tests (2.0)

### DIFF
--- a/ingestion/src/metadata/utils/importer.py
+++ b/ingestion/src/metadata/utils/importer.py
@@ -130,7 +130,9 @@ def import_from_module(key: str, log_traceback: bool = True) -> Type[Any]:  # no
     try:
         obj = getattr(importlib.import_module(module_name), obj_name)
         return obj  # noqa: RET504, TRY300
-    except (ModuleNotFoundError, ImportError) as err:
+    # AttributeError covers an importable module missing the requested name, e.g. a
+    # typo in a custom connector's `sourcePythonClass`.
+    except (ModuleNotFoundError, ImportError, AttributeError) as err:
         if log_traceback:
             logger.debug(traceback.format_exc())
         raise DynamicImportException(module=module_name, key=obj_name, cause=err)  # noqa: B904

--- a/ingestion/src/metadata/utils/importer.py
+++ b/ingestion/src/metadata/utils/importer.py
@@ -128,11 +128,18 @@ def import_from_module(key: str, log_traceback: bool = True) -> Type[Any]:  # no
     logger.debug("Importing: %s", key)
     module_name, obj_name = key.rsplit(MODULE_SEPARATOR, 1)
     try:
-        obj = getattr(importlib.import_module(module_name), obj_name)
+        module = importlib.import_module(module_name)
+    except (ModuleNotFoundError, ImportError) as err:
+        if log_traceback:
+            logger.debug(traceback.format_exc())
+        raise DynamicImportException(module=module_name, key=obj_name, cause=err)  # noqa: B904
+
+    # Scoped to the lookup alone: an AttributeError raised by the module's own top-level
+    # code must keep its original traceback rather than be reported as a missing name.
+    try:
+        obj = getattr(module, obj_name)
         return obj  # noqa: RET504, TRY300
-    # AttributeError covers an importable module missing the requested name, e.g. a
-    # typo in a custom connector's `sourcePythonClass`.
-    except (ModuleNotFoundError, ImportError, AttributeError) as err:
+    except AttributeError as err:
         if log_traceback:
             logger.debug(traceback.format_exc())
         raise DynamicImportException(module=module_name, key=obj_name, cause=err)  # noqa: B904

--- a/ingestion/tests/integration/custom_connectors/README.md
+++ b/ingestion/tests/integration/custom_connectors/README.md
@@ -1,0 +1,67 @@
+# Custom connector integration tests
+
+One Custom Connector per service type that supports `sourcePythonClass`, each producing a small,
+deterministic set of entities from memory. They reach no external system, so the only requirement
+is a running OpenMetadata server on `http://localhost:8585`.
+
+| Module | Service type | Produces |
+|---|---|---|
+| `custom_database.py` | `CustomDatabase` | database → 2 schemas → 3 tables with columns |
+| `custom_dashboard.py` | `CustomDashboard` | 2 charts + 1 dashboard referencing them |
+| `custom_messaging.py` | `CustomMessaging` | 2 topics with partitions and a message schema |
+| `custom_mlmodel.py` | `CustomMlModel` | 1 model with features, hyper parameters, store |
+| `custom_pipeline.py` | `CustomPipeline` | 1 pipeline with 3 chained tasks |
+| `custom_search.py` | `CustomSearch` | 2 search indexes with typed fields |
+| `custom_storage.py` | `CustomStorage` | root container + child container with a data model |
+| `custom_drive.py` | `CustomDrive` | directory + file, spreadsheet + worksheet |
+
+## Run the tests
+
+```bash
+source env/bin/activate
+cd ingestion
+python -m pytest tests/integration/custom_connectors -q
+```
+
+## Run one connector by hand
+
+The connector modules are plain top-level modules, so put this directory on `PYTHONPATH` and point
+`sourcePythonClass` at `<module>.<Class>`:
+
+```yaml
+source:
+  type: custom-database
+  serviceName: custom_database_demo
+  serviceConnection:
+    config:
+      type: CustomDatabase
+      sourcePythonClass: custom_database.CustomDatabaseSource
+      connectionOptions:
+        databaseName: my_catalog
+  sourceConfig:
+    config:
+      type: DatabaseMetadata
+sink:
+  type: metadata-rest
+  config: {}
+workflowConfig:
+  openMetadataServerConfig:
+    hostPort: http://localhost:8585/api
+    authProvider: openmetadata
+    securityConfig:
+      jwtToken: <ingestion-bot token>
+```
+
+```bash
+PYTHONPATH=ingestion/tests/integration/custom_connectors metadata ingest -c workflow.yaml
+```
+
+`connectionOptions` values are `Dict[str, str]`; numeric options have to be parsed by the connector.
+
+## Writing your own
+
+Subclass `metadata.ingestion.api.steps.Source` and implement `create`, `prepare`, `test_connection`,
+`close` and `_iter`. `_iter` yields `Either(right=<CreateXRequest>)`, starting with the service
+request from `metadata.get_create_service_from_source(...)` so the service exists before its
+children. Subclassing a `*ServiceSource` base instead additionally requires module-level
+`get_connection` and `test_connection` functions next to the class.

--- a/ingestion/tests/integration/custom_connectors/__init__.py
+++ b/ingestion/tests/integration/custom_connectors/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/tests/integration/custom_connectors/conftest.py
+++ b/ingestion/tests/integration/custom_connectors/conftest.py
@@ -1,0 +1,16 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Make the connector modules importable under the same name the workflow resolves."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))

--- a/ingestion/tests/integration/custom_connectors/custom_dashboard.py
+++ b/ingestion/tests/integration/custom_connectors/custom_dashboard.py
@@ -1,0 +1,129 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Dashboard connector yielding a deterministic in-memory dashboard.
+
+``DataModelType`` has no vendor-neutral member, so a custom connector has to
+borrow one; ``SupersetDataModel`` is used here.
+"""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createChart import CreateChartRequest
+from metadata.generated.schema.api.data.createDashboard import CreateDashboardRequest
+from metadata.generated.schema.api.data.createDashboardDataModel import (
+    CreateDashboardDataModelRequest,
+)
+from metadata.generated.schema.api.services.createDashboardService import (
+    CreateDashboardServiceRequest,
+)
+from metadata.generated.schema.entity.data.chart import ChartType
+from metadata.generated.schema.entity.data.dashboard import DashboardType
+from metadata.generated.schema.entity.data.dashboardDataModel import DataModelType
+from metadata.generated.schema.entity.data.table import Column, DataType
+from metadata.generated.schema.entity.services.connections.dashboard.customDashboardConnection import (
+    CustomDashboardConnection,
+)
+from metadata.generated.schema.entity.services.dashboardService import (
+    DashboardServiceType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+CHARTS: list[tuple[str, ChartType, str]] = [
+    ("revenue_by_month", ChartType.Line, "Monthly revenue trend"),
+    ("orders_by_region", ChartType.Bar, "Order counts split by sales region"),
+]
+
+DATA_MODEL = "my_revenue_model"
+DASHBOARD_NAME = "my_sales_overview"
+
+
+class CustomDashboardSource(Source):
+    """Yields two charts, a data model and one dashboard referencing both."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomDashboardSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomDashboardConnection):
+            raise InvalidSourceException(f"Expected CustomDashboardConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateDashboardServiceRequest(
+                name=service_name,
+                serviceType=DashboardServiceType.CustomDashboard,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Dashboard Demo",
+                description="Reporting served by the custom dashboard connector",
+            )
+        )
+        for chart_name, chart_type, chart_description in CHARTS:
+            yield Either(
+                right=CreateChartRequest(
+                    name=chart_name,
+                    displayName=chart_name.replace("_", " ").title(),
+                    description=chart_description,
+                    chartType=chart_type,
+                    service=service_name,
+                    sourceUrl=f"https://dashboards.example.com/chart/{chart_name}",
+                )
+            )
+        yield Either(
+            right=CreateDashboardDataModelRequest(
+                name=DATA_MODEL,
+                displayName="My Revenue Model",
+                description="Semantic model backing the sales overview",
+                service=service_name,
+                dataModelType=DataModelType.SupersetDataModel,
+                sql="SELECT day, sum(total_amount) AS revenue FROM orders GROUP BY day",
+                columns=[
+                    Column(name="day", dataType=DataType.DATE, description="Calendar day"),
+                    Column(name="revenue", dataType=DataType.DECIMAL, description="Revenue for the day"),
+                ],
+            )
+        )
+        yield Either(
+            right=CreateDashboardRequest(
+                name=DASHBOARD_NAME,
+                displayName="My Sales Overview",
+                description="Dashboard produced by the custom dashboard connector",
+                dashboardType=DashboardType.Dashboard,
+                service=service_name,
+                charts=[f"{service_name}.{chart_name}" for chart_name, _, _ in CHARTS],
+                dataModels=[f"{service_name}.model.{DATA_MODEL}"],
+                sourceUrl=f"https://dashboards.example.com/dashboard/{DASHBOARD_NAME}",
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/custom_database.py
+++ b/ingestion/tests/integration/custom_connectors/custom_database.py
@@ -1,0 +1,225 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Database connector yielding a deterministic in-memory catalog."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.classification.createClassification import (
+    CreateClassificationRequest,
+)
+from metadata.generated.schema.api.classification.createTag import CreateTagRequest
+from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
+from metadata.generated.schema.api.data.createDatabaseSchema import (
+    CreateDatabaseSchemaRequest,
+)
+from metadata.generated.schema.api.data.createStoredProcedure import (
+    CreateStoredProcedureRequest,
+)
+from metadata.generated.schema.api.data.createTable import CreateTableRequest
+from metadata.generated.schema.api.services.createDatabaseService import (
+    CreateDatabaseServiceRequest,
+)
+from metadata.generated.schema.entity.data.storedProcedure import (
+    Language,
+    StoredProcedureCode,
+)
+from metadata.generated.schema.entity.data.table import Column, DataType, TableType
+from metadata.generated.schema.entity.services.connections.database.customDatabaseConnection import (
+    CustomDatabaseConnection,
+)
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseServiceType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.generated.schema.type.tagLabel import (
+    LabelType,
+    State,
+    TagLabel,
+    TagSource,
+)
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
+from metadata.ingestion.models.ometa_lineage import OMetaFQNLineageRequest
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+DEFAULT_DATABASE = "my_catalog"
+CLASSIFICATION = "CustomConnectorTier"
+TAG = "Gold"
+TAG_FQN = f"{CLASSIFICATION}.{TAG}"
+
+SCHEMAS: dict[str, tuple[str, dict[str, tuple[str, list[tuple[str, DataType, str]]]]]] = {
+    "my_schema": (
+        "Landing schema for operational tables",
+        {
+            "customers": (
+                "One row per customer account",
+                [
+                    ("customer_id", DataType.BIGINT, "Surrogate key of the customer"),
+                    ("email", DataType.VARCHAR, "Primary contact address"),
+                    ("created_at", DataType.TIMESTAMP, "Account creation instant, UTC"),
+                ],
+            ),
+            "orders": (
+                "One row per placed order",
+                [
+                    ("order_id", DataType.BIGINT, "Surrogate key of the order"),
+                    ("customer_id", DataType.BIGINT, "References customers.customer_id"),
+                    ("total_amount", DataType.DECIMAL, "Order total in account currency"),
+                ],
+            ),
+        },
+    ),
+    "my_other_schema": (
+        "Curated schema for reporting aggregates",
+        {
+            "daily_revenue": (
+                "Revenue aggregated per calendar day",
+                [
+                    ("day", DataType.DATE, "Calendar day of the aggregate"),
+                    ("revenue", DataType.DECIMAL, "Summed order total for the day"),
+                ],
+            ),
+        },
+    ),
+}
+
+LINEAGE_FROM = "my_schema.orders"
+LINEAGE_TO = "my_other_schema.daily_revenue"
+STORED_PROCEDURE = "refresh_daily_revenue"
+
+
+class CustomDatabaseSource(Source):
+    """Yields a tagged catalog of databases, schemas, tables, a stored procedure and lineage."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+        options = self.service_connection.connectionOptions
+        self.database_name = (options.root or {}).get("databaseName", DEFAULT_DATABASE) if options else DEFAULT_DATABASE
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomDatabaseSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomDatabaseConnection):
+            raise InvalidSourceException(f"Expected CustomDatabaseConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateDatabaseServiceRequest(
+                name=service_name,
+                serviceType=DatabaseServiceType.CustomDatabase,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Database Demo",
+                description="Catalog served by the custom database connector",
+            )
+        )
+        yield Either(
+            right=OMetaTagAndClassification(
+                fqn=TAG_FQN,
+                classification_request=CreateClassificationRequest(
+                    name=CLASSIFICATION,
+                    description="Tiering applied by the custom database connector",
+                ),
+                tag_request=CreateTagRequest(
+                    classification=CLASSIFICATION,
+                    name=TAG,
+                    description="Curated, business-critical asset",
+                ),
+            )
+        )
+        yield Either(
+            right=CreateDatabaseRequest(
+                name=self.database_name,
+                service=service_name,
+                displayName=self.database_name.replace("_", " ").title(),
+                description="Catalog produced by the custom database connector",
+            )
+        )
+        database_fqn = f"{service_name}.{self.database_name}"
+        tag_label = TagLabel(
+            tagFQN=TAG_FQN,
+            source=TagSource.Classification,
+            labelType=LabelType.Automated,
+            state=State.Confirmed,
+        )
+        for schema_name, (schema_description, tables) in SCHEMAS.items():
+            yield Either(
+                right=CreateDatabaseSchemaRequest(
+                    name=schema_name,
+                    database=database_fqn,
+                    displayName=schema_name.replace("_", " ").title(),
+                    description=schema_description,
+                )
+            )
+            schema_fqn = f"{database_fqn}.{schema_name}"
+            for table_name, (table_description, columns) in tables.items():
+                yield Either(
+                    right=CreateTableRequest(
+                        name=table_name,
+                        databaseSchema=schema_fqn,
+                        displayName=table_name.replace("_", " ").title(),
+                        description=table_description,
+                        tableType=TableType.Regular,
+                        tags=[tag_label],
+                        columns=[
+                            Column(
+                                name=column_name,
+                                dataType=data_type,
+                                dataLength=64,
+                                description=column_description,
+                            )
+                            for column_name, data_type, column_description in columns
+                        ],
+                    )
+                )
+        yield Either(
+            right=CreateStoredProcedureRequest(
+                name=STORED_PROCEDURE,
+                databaseSchema=f"{database_fqn}.my_other_schema",
+                displayName="Refresh Daily Revenue",
+                description="Rebuilds the daily revenue aggregate",
+                storedProcedureCode=StoredProcedureCode(
+                    language=Language.SQL,
+                    code=f"INSERT INTO {LINEAGE_TO} SELECT day, sum(total_amount) FROM {LINEAGE_FROM} GROUP BY day",
+                ),
+            )
+        )
+        # Lineage resolves both ends by FQN, so the buffered tables must be committed first.
+        yield Either(right=Barrier(reason="tables must exist before lineage"))
+        yield Either(
+            right=OMetaFQNLineageRequest(
+                from_entity_fqn=f"{database_fqn}.{LINEAGE_FROM}",
+                from_entity_type="table",
+                to_entity_fqn=f"{database_fqn}.{LINEAGE_TO}",
+                to_entity_type="table",
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/custom_drive.py
+++ b/ingestion/tests/integration/custom_connectors/custom_drive.py
@@ -1,0 +1,137 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Drive connector yielding a deterministic in-memory drive tree.
+
+``customDriveConnection.json`` does not declare ``sourcePythonClass``; it only
+survives because the schema sets ``additionalProperties: true``, so the UI cannot
+configure this connector today.
+"""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createDirectory import CreateDirectoryRequest
+from metadata.generated.schema.api.data.createFile import CreateFileRequest
+from metadata.generated.schema.api.data.createSpreadsheet import (
+    CreateSpreadsheetRequest,
+)
+from metadata.generated.schema.api.data.createWorksheet import CreateWorksheetRequest
+from metadata.generated.schema.api.services.createDriveService import (
+    CreateDriveServiceRequest,
+)
+from metadata.generated.schema.entity.data.directory import DirectoryType
+from metadata.generated.schema.entity.data.file import FileType
+from metadata.generated.schema.entity.data.table import Column, DataType
+from metadata.generated.schema.entity.services.connections.drive.customDriveConnection import (
+    CustomDriveConnection,
+)
+from metadata.generated.schema.entity.services.driveService import DriveServiceType
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+DIRECTORY_NAME = "my_directory"
+FILE_NAME = "my_report.csv"
+SPREADSHEET_NAME = "my_spreadsheet"
+WORKSHEET_NAME = "my_worksheet"
+
+
+class CustomDriveSource(Source):
+    """Yields one directory with a file, and one spreadsheet with a worksheet."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomDriveSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomDriveConnection):
+            raise InvalidSourceException(f"Expected CustomDriveConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateDriveServiceRequest(
+                name=service_name,
+                serviceType=DriveServiceType.CustomDrive,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Drive Demo",
+                description="Shared drive served by the custom drive connector",
+            )
+        )
+        yield Either(
+            right=CreateDirectoryRequest(
+                name=DIRECTORY_NAME,
+                service=service_name,
+                displayName="My Directory",
+                description="Folder produced by the custom drive connector",
+                directoryType=DirectoryType.Folder,
+                path=f"/{DIRECTORY_NAME}",
+                numberOfFiles=1,
+            )
+        )
+        yield Either(
+            right=CreateFileRequest(
+                name=FILE_NAME,
+                service=service_name,
+                directory=f"{service_name}.{DIRECTORY_NAME}",
+                displayName="My Report",
+                description="Daily revenue export",
+                fileType=FileType.CSV,
+                mimeType="text/csv",
+                fileExtension="csv",
+                path=f"/{DIRECTORY_NAME}/{FILE_NAME}",
+                size=2048,
+            )
+        )
+        yield Either(
+            right=CreateSpreadsheetRequest(
+                name=SPREADSHEET_NAME,
+                service=service_name,
+                displayName="My Spreadsheet",
+                description="Workbook produced by the custom drive connector",
+                path=f"/{SPREADSHEET_NAME}",
+                size=4096,
+            )
+        )
+        yield Either(
+            right=CreateWorksheetRequest(
+                name=WORKSHEET_NAME,
+                spreadsheet=f"{service_name}.{SPREADSHEET_NAME}",
+                displayName="My Worksheet",
+                description="Revenue tab of the workbook",
+                rowCount=100,
+                columnCount=2,
+                columns=[
+                    Column(name="day", dataType=DataType.DATE, description="Calendar day"),
+                    Column(name="revenue", dataType=DataType.DECIMAL, description="Revenue for the day"),
+                ],
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/custom_messaging.py
+++ b/ingestion/tests/integration/custom_connectors/custom_messaging.py
@@ -1,0 +1,137 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Messaging connector yielding deterministic in-memory topics."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createTopic import CreateTopicRequest
+from metadata.generated.schema.api.services.createMessagingService import (
+    CreateMessagingServiceRequest,
+)
+from metadata.generated.schema.entity.data.topic import (
+    CleanupPolicy,
+    TopicSampleData,
+)
+from metadata.generated.schema.entity.data.topic import (
+    Topic as TopicEntity,
+)
+from metadata.generated.schema.entity.services.connections.messaging.customMessagingConnection import (
+    CustomMessagingConnection,
+)
+from metadata.generated.schema.entity.services.messagingService import (
+    MessagingServiceType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.generated.schema.type.schema import (
+    DataTypeTopic,
+    FieldModel,
+    SchemaType,
+    Topic,
+)
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.models.ometa_topic_data import OMetaTopicSampleData
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+TOPICS: list[tuple[str, str, int, int]] = [
+    ("my_orders_topic", "Order lifecycle events", 3, 2),
+    ("my_clickstream_topic", "Raw page view events", 6, 3),
+]
+
+SAMPLE_MESSAGES = [
+    '{"event_id": "evt-1", "event_ts": 1700000000000}',
+    '{"event_id": "evt-2", "event_ts": 1700000060000}',
+]
+
+
+class CustomMessagingSource(Source):
+    """Yields two topics with a message schema and sample data."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomMessagingSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomMessagingConnection):
+            raise InvalidSourceException(f"Expected CustomMessagingConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateMessagingServiceRequest(
+                name=service_name,
+                serviceType=MessagingServiceType.CustomMessaging,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Messaging Demo",
+                description="Event streams served by the custom messaging connector",
+            )
+        )
+        for topic_name, topic_description, partitions, replication in TOPICS:
+            yield Either(
+                right=CreateTopicRequest(
+                    name=topic_name,
+                    service=service_name,
+                    displayName=topic_name.replace("_", " ").title(),
+                    description=topic_description,
+                    partitions=partitions,
+                    replicationFactor=replication,
+                    retentionSize=1024.0,
+                    maximumMessageSize=1048576,
+                    cleanupPolicies=[CleanupPolicy.delete],
+                    messageSchema=Topic(
+                        schemaType=SchemaType.JSON,
+                        schemaFields=[
+                            FieldModel(
+                                name="event_id",
+                                dataType=DataTypeTopic.STRING,
+                                description="Unique event identifier",
+                            ),
+                            FieldModel(
+                                name="event_ts",
+                                dataType=DataTypeTopic.LONG,
+                                description="Event time in epoch millis",
+                            ),
+                        ],
+                    ),
+                )
+            )
+        # Sample data is attached to a persisted Topic, so the buffer must be committed first.
+        yield Either(right=Barrier(reason="topics must exist before sample data"))
+        for topic_name, _, _, _ in TOPICS:
+            topic = self.metadata.get_by_name(entity=TopicEntity, fqn=f"{service_name}.{topic_name}")
+            if topic:
+                yield Either(
+                    right=OMetaTopicSampleData(
+                        topic=topic,
+                        sample_data=TopicSampleData(messages=SAMPLE_MESSAGES),
+                    )
+                )

--- a/ingestion/tests/integration/custom_connectors/custom_mlmodel.py
+++ b/ingestion/tests/integration/custom_connectors/custom_mlmodel.py
@@ -1,0 +1,119 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom MlModel connector yielding a deterministic in-memory model."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createMlModel import CreateMlModelRequest
+from metadata.generated.schema.api.services.createMlModelService import (
+    CreateMlModelServiceRequest,
+)
+from metadata.generated.schema.entity.data.mlmodel import (
+    FeatureType,
+    MlFeature,
+    MlHyperParameter,
+    MlStore,
+)
+from metadata.generated.schema.entity.services.connections.mlmodel.customMlModelConnection import (
+    CustomMlModelConnection,
+)
+from metadata.generated.schema.entity.services.mlmodelService import MlModelServiceType
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+MODEL_NAME = "my_churn_classifier"
+
+
+class CustomMlModelSource(Source):
+    """Yields one ML model with described features, hyper parameters and a model store."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomMlModelSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomMlModelConnection):
+            raise InvalidSourceException(f"Expected CustomMlModelConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateMlModelServiceRequest(
+                name=service_name,
+                serviceType=MlModelServiceType.CustomMlModel,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom MlModel Demo",
+                description="Model registry served by the custom mlmodel connector",
+            )
+        )
+        yield Either(
+            right=CreateMlModelRequest(
+                name=MODEL_NAME,
+                displayName="My Churn Classifier",
+                description="Model produced by the custom mlmodel connector",
+                algorithm="GradientBoostingClassifier",
+                service=service_name,
+                target="churned",
+                mlFeatures=[
+                    MlFeature(
+                        name="tenure_months",
+                        dataType=FeatureType.numerical,
+                        description="Months since the account was opened",
+                        featureSources=[],
+                    ),
+                    MlFeature(
+                        name="plan_tier",
+                        dataType=FeatureType.categorical,
+                        description="Subscription tier at scoring time",
+                        featureSources=[],
+                    ),
+                ],
+                mlHyperParameters=[
+                    MlHyperParameter(
+                        name="n_estimators",
+                        value="200",
+                        description="Number of boosting stages",
+                    ),
+                    MlHyperParameter(
+                        name="max_depth",
+                        value="5",
+                        description="Maximum depth of each tree",
+                    ),
+                ],
+                mlStore=MlStore(
+                    storage="s3://bucket/models/my_churn_classifier",
+                    imageRepository="registry.example.com/models",
+                ),
+                server="https://models.example.com/my_churn_classifier/invocations",
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/custom_pipeline.py
+++ b/ingestion/tests/integration/custom_connectors/custom_pipeline.py
@@ -1,0 +1,136 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Pipeline connector yielding a deterministic in-memory pipeline."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
+from metadata.generated.schema.api.services.createPipelineService import (
+    CreatePipelineServiceRequest,
+)
+from metadata.generated.schema.entity.data.pipeline import (
+    PipelineStatus,
+    StatusType,
+    Task,
+    TaskStatus,
+)
+from metadata.generated.schema.entity.services.connections.pipeline.customPipelineConnection import (
+    CustomPipelineConnection,
+)
+from metadata.generated.schema.entity.services.pipelineService import (
+    PipelineServiceType,
+)
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.generated.schema.type.basic import Timestamp
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+PIPELINE_NAME = "my_daily_etl"
+
+TASKS: list[tuple[str, str, list[str]]] = [
+    ("extract", "Pull yesterday's orders from the source system", []),
+    ("transform", "Aggregate orders into daily revenue", ["extract"]),
+    ("load", "Write the aggregate to the reporting schema", ["transform"]),
+]
+
+# Fixed so the ingested status is reproducible across runs.
+RUN_TIMESTAMP = 1700000000000
+RUN_END_TIMESTAMP = 1700000300000
+
+
+class CustomPipelineSource(Source):
+    """Yields one pipeline with three chained tasks and one execution status."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomPipelineSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomPipelineConnection):
+            raise InvalidSourceException(f"Expected CustomPipelineConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreatePipelineServiceRequest(
+                name=service_name,
+                serviceType=PipelineServiceType.CustomPipeline,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Pipeline Demo",
+                description="Orchestrator served by the custom pipeline connector",
+            )
+        )
+        yield Either(
+            right=CreatePipelineRequest(
+                name=PIPELINE_NAME,
+                displayName="My Daily ETL",
+                description="Pipeline produced by the custom pipeline connector",
+                service=service_name,
+                scheduleInterval="0 2 * * *",
+                concurrency=1,
+                sourceUrl=f"https://orchestrator.example.com/pipelines/{PIPELINE_NAME}",
+                tasks=[
+                    Task(
+                        name=task_name,
+                        displayName=task_name.title(),
+                        description=task_description,
+                        taskType="PythonOperator",
+                        downstreamTasks=downstream,
+                        sourceUrl=f"https://orchestrator.example.com/pipelines/{PIPELINE_NAME}/{task_name}",
+                    )
+                    for task_name, task_description, downstream in TASKS
+                ],
+            )
+        )
+        # Pipeline status is posted against a persisted pipeline.
+        yield Either(right=Barrier(reason="pipeline must exist before its status"))
+        yield Either(
+            right=OMetaPipelineStatus(
+                pipeline_fqn=f"{service_name}.{PIPELINE_NAME}",
+                pipeline_status=PipelineStatus(
+                    timestamp=Timestamp(RUN_TIMESTAMP),
+                    executionStatus=StatusType.Successful,
+                    endTime=Timestamp(RUN_END_TIMESTAMP),
+                    taskStatus=[
+                        TaskStatus(
+                            name=task_name,
+                            executionStatus=StatusType.Successful,
+                            startTime=Timestamp(RUN_TIMESTAMP),
+                            endTime=Timestamp(RUN_END_TIMESTAMP),
+                        )
+                        for task_name, _, _ in TASKS
+                    ],
+                ),
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/custom_search.py
+++ b/ingestion/tests/integration/custom_connectors/custom_search.py
@@ -1,0 +1,109 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Search connector yielding deterministic in-memory search indexes."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createSearchIndex import (
+    CreateSearchIndexRequest,
+)
+from metadata.generated.schema.api.services.createSearchService import (
+    CreateSearchServiceRequest,
+)
+from metadata.generated.schema.entity.data.searchIndex import (
+    DataType,
+    IndexType,
+    SearchIndexField,
+)
+from metadata.generated.schema.entity.services.connections.search.customSearchConnection import (
+    CustomSearchConnection,
+)
+from metadata.generated.schema.entity.services.searchService import SearchServiceType
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+INDEXES: dict[str, tuple[str, list[tuple[str, DataType, str]]]] = {
+    "my_product_index": (
+        "Searchable product catalogue",
+        [
+            ("product_id", DataType.KEYWORD, "Stable product identifier"),
+            ("title", DataType.TEXT, "Analysed product title"),
+            ("price", DataType.DOUBLE, "Current list price"),
+        ],
+    ),
+    "my_customer_index": (
+        "Searchable customer directory",
+        [
+            ("customer_id", DataType.KEYWORD, "Stable customer identifier"),
+            ("signup_date", DataType.DATE, "Date the account was opened"),
+        ],
+    ),
+}
+
+
+class CustomSearchSource(Source):
+    """Yields two search indexes with described, typed fields."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomSearchSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomSearchConnection):
+            raise InvalidSourceException(f"Expected CustomSearchConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateSearchServiceRequest(
+                name=service_name,
+                serviceType=SearchServiceType.CustomSearch,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Search Demo",
+                description="Search cluster served by the custom search connector",
+            )
+        )
+        for index_name, (index_description, fields) in INDEXES.items():
+            yield Either(
+                right=CreateSearchIndexRequest(
+                    name=index_name,
+                    service=service_name,
+                    displayName=index_name.replace("_", " ").title(),
+                    description=index_description,
+                    indexType=IndexType.Index,
+                    fields=[
+                        SearchIndexField(name=field_name, dataType=data_type, description=field_description)
+                        for field_name, data_type, field_description in fields
+                    ],
+                )
+            )

--- a/ingestion/tests/integration/custom_connectors/custom_storage.py
+++ b/ingestion/tests/integration/custom_connectors/custom_storage.py
@@ -1,0 +1,123 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Custom Storage connector yielding a deterministic in-memory container tree."""
+
+from typing import Iterable, Optional  # noqa: UP035
+
+from metadata.generated.schema.api.data.createContainer import CreateContainerRequest
+from metadata.generated.schema.api.services.createStorageService import (
+    CreateStorageServiceRequest,
+)
+from metadata.generated.schema.entity.data.container import (
+    Container,
+    ContainerDataModel,
+    FileFormat,
+)
+from metadata.generated.schema.entity.data.table import Column, DataType
+from metadata.generated.schema.entity.services.connections.storage.customStorageConnection import (
+    CustomStorageConnection,
+)
+from metadata.generated.schema.entity.services.storageService import StorageServiceType
+from metadata.generated.schema.metadataIngestion.workflow import Source as WorkflowSource
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.api.models import Either
+from metadata.ingestion.api.steps import InvalidSourceException, Source
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+ROOT_CONTAINER = "my_bucket"
+CHILD_CONTAINER = "my_prefix"
+
+
+class CustomStorageSource(Source):
+    """Yields a root container and a child container carrying a described data model."""
+
+    def __init__(self, config: WorkflowSource, metadata: OpenMetadata):
+        super().__init__()
+        self.config = config
+        self.metadata = metadata
+        self.service_connection = config.serviceConnection.root.config
+
+    @classmethod
+    def create(
+        cls,
+        config_dict: dict,
+        metadata: OpenMetadata,
+        pipeline_name: Optional[str] = None,  # noqa: UP045
+    ) -> "CustomStorageSource":
+        config: WorkflowSource = WorkflowSource.model_validate(config_dict)
+        connection = config.serviceConnection.root.config
+        if not isinstance(connection, CustomStorageConnection):
+            raise InvalidSourceException(f"Expected CustomStorageConnection, but got {connection}")
+        return cls(config, metadata)
+
+    def prepare(self):
+        """Nothing to prepare"""
+
+    def test_connection(self) -> None:
+        """No external system to reach"""
+
+    def close(self) -> None:
+        """Nothing to close"""
+
+    def _iter(self, *_, **__) -> Iterable[Either]:
+        service_name = self.config.serviceName
+        yield Either(
+            right=CreateStorageServiceRequest(
+                name=service_name,
+                serviceType=StorageServiceType.CustomStorage,
+                connection=self.config.serviceConnection.root,
+                displayName="Custom Storage Demo",
+                description="Object store served by the custom storage connector",
+            )
+        )
+        yield Either(
+            right=CreateContainerRequest(
+                name=ROOT_CONTAINER,
+                service=service_name,
+                displayName="My Bucket",
+                description="Bucket produced by the custom storage connector",
+                prefix="/",
+                fullPath=f"s3://{ROOT_CONTAINER}",
+            )
+        )
+        # parent is an EntityReference by id, so the root container must already be
+        # persisted; the sink writes CreateContainerRequest eagerly, not buffered.
+        parent = self.metadata.get_by_name(entity=Container, fqn=f"{service_name}.{ROOT_CONTAINER}")
+        yield Either(
+            right=CreateContainerRequest(
+                name=CHILD_CONTAINER,
+                service=service_name,
+                displayName="My Prefix",
+                description="Partitioned event data under the bucket",
+                parent=EntityReference(id=parent.id, type="container") if parent else None,
+                prefix=f"/{CHILD_CONTAINER}",
+                fullPath=f"s3://{ROOT_CONTAINER}/{CHILD_CONTAINER}",
+                numberOfObjects=42,
+                size=1024,
+                fileFormats=[FileFormat.parquet],
+                dataModel=ContainerDataModel(
+                    isPartitioned=False,
+                    columns=[
+                        Column(
+                            name="event_id",
+                            dataType=DataType.STRING,
+                            dataLength=64,
+                            description="Unique event identifier",
+                        ),
+                        Column(
+                            name="event_ts",
+                            dataType=DataType.TIMESTAMP,
+                            description="Event time in UTC",
+                        ),
+                    ],
+                ),
+            )
+        )

--- a/ingestion/tests/integration/custom_connectors/test_custom_connectors.py
+++ b/ingestion/tests/integration/custom_connectors/test_custom_connectors.py
@@ -235,10 +235,12 @@ def ingested_service(metadata, workflow_config, sink_config):
 
     def _run(spec: ConnectorSpec) -> tuple[str, MetadataWorkflow]:
         service_name = f"custom_{spec.key}_{uuid.uuid4().hex[:8]}"
+        # Registered before the run: a workflow that fails partway may still have
+        # created the service, and teardown has to reclaim it either way.
+        created.append((spec.service_entity, service_name))
         workflow = MetadataWorkflow.create(build_config(spec, service_name, workflow_config, sink_config))
         workflow.execute()
         workflow.raise_from_status()
-        created.append((spec.service_entity, service_name))
         return service_name, workflow
 
     yield _run

--- a/ingestion/tests/integration/custom_connectors/test_custom_connectors.py
+++ b/ingestion/tests/integration/custom_connectors/test_custom_connectors.py
@@ -1,0 +1,347 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""End-to-end ingestion for one custom connector per service type.
+
+Custom connectors resolve their source class from ``sourcePythonClass`` and read
+no external system, so these need a running OpenMetadata server and nothing else.
+"""
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+import custom_database
+import custom_pipeline
+import pytest
+
+from metadata.generated.schema.entity.data.chart import Chart
+from metadata.generated.schema.entity.data.container import Container
+from metadata.generated.schema.entity.data.dashboard import Dashboard
+from metadata.generated.schema.entity.data.dashboardDataModel import DashboardDataModel
+from metadata.generated.schema.entity.data.database import Database
+from metadata.generated.schema.entity.data.databaseSchema import DatabaseSchema
+from metadata.generated.schema.entity.data.directory import Directory
+from metadata.generated.schema.entity.data.file import File
+from metadata.generated.schema.entity.data.mlmodel import MlModel
+from metadata.generated.schema.entity.data.pipeline import Pipeline, StatusType
+from metadata.generated.schema.entity.data.searchIndex import SearchIndex
+from metadata.generated.schema.entity.data.spreadsheet import Spreadsheet
+from metadata.generated.schema.entity.data.storedProcedure import StoredProcedure
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.entity.data.worksheet import Worksheet
+from metadata.generated.schema.entity.services.dashboardService import DashboardService
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.generated.schema.entity.services.driveService import DriveService
+from metadata.generated.schema.entity.services.messagingService import MessagingService
+from metadata.generated.schema.entity.services.mlmodelService import MlModelService
+from metadata.generated.schema.entity.services.pipelineService import PipelineService
+from metadata.generated.schema.entity.services.searchService import SearchService
+from metadata.generated.schema.entity.services.storageService import StorageService
+from metadata.ingestion.ometa.utils import model_str
+from metadata.workflow.metadata import MetadataWorkflow
+
+
+@dataclass(frozen=True)
+class ConnectorSpec:
+    """One custom connector: how to run it and what it must have produced."""
+
+    key: str
+    source_type: str
+    connection_type: str
+    source_python_class: str
+    source_config_type: str
+    service_entity: type
+    entities: list[tuple[type, str]]
+    checks: dict[str, Callable] = field(default_factory=dict)
+
+
+SPECS = [
+    ConnectorSpec(
+        key="database",
+        source_type="custom-database",
+        connection_type="CustomDatabase",
+        source_python_class="custom_database.CustomDatabaseSource",
+        source_config_type="DatabaseMetadata",
+        service_entity=DatabaseService,
+        entities=[
+            (Database, "my_catalog"),
+            (DatabaseSchema, "my_catalog.my_schema"),
+            (DatabaseSchema, "my_catalog.my_other_schema"),
+            (Table, "my_catalog.my_schema.customers"),
+            (Table, "my_catalog.my_schema.orders"),
+            (Table, "my_catalog.my_other_schema.daily_revenue"),
+            (StoredProcedure, f"my_catalog.my_other_schema.{custom_database.STORED_PROCEDURE}"),
+        ],
+        checks={
+            "my_catalog.my_schema.customers": lambda t: (
+                [model_str(c.name) for c in t.columns] == ["customer_id", "email", "created_at"]
+                and all(c.description for c in t.columns)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="dashboard",
+        source_type="custom-dashboard",
+        connection_type="CustomDashboard",
+        source_python_class="custom_dashboard.CustomDashboardSource",
+        source_config_type="DashboardMetadata",
+        service_entity=DashboardService,
+        entities=[
+            (Chart, "revenue_by_month"),
+            (Chart, "orders_by_region"),
+            (DashboardDataModel, "model.my_revenue_model"),
+            (Dashboard, "my_sales_overview"),
+        ],
+        checks={
+            "model.my_revenue_model": lambda m: (
+                [model_str(c.name) for c in m.columns] == ["day", "revenue"] and all(c.description for c in m.columns)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="messaging",
+        source_type="custom-messaging",
+        connection_type="CustomMessaging",
+        source_python_class="custom_messaging.CustomMessagingSource",
+        source_config_type="MessagingMetadata",
+        service_entity=MessagingService,
+        entities=[(Topic, "my_orders_topic"), (Topic, "my_clickstream_topic")],
+        checks={
+            "my_orders_topic": lambda t: (
+                t.partitions == 3
+                and [model_str(f.name) for f in t.messageSchema.schemaFields] == ["event_id", "event_ts"]
+                and all(f.description for f in t.messageSchema.schemaFields)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="mlmodel",
+        source_type="custom-mlmodel",
+        connection_type="CustomMlModel",
+        source_python_class="custom_mlmodel.CustomMlModelSource",
+        source_config_type="MlModelMetadata",
+        service_entity=MlModelService,
+        entities=[(MlModel, "my_churn_classifier")],
+        checks={
+            "my_churn_classifier": lambda m: (
+                m.algorithm == "GradientBoostingClassifier"
+                and [model_str(f.name) for f in m.mlFeatures] == ["tenure_months", "plan_tier"]
+                and all(f.description for f in m.mlFeatures)
+                and [model_str(h.name) for h in m.mlHyperParameters] == ["n_estimators", "max_depth"]
+                and all(h.description for h in m.mlHyperParameters)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="pipeline",
+        source_type="custom-pipeline",
+        connection_type="CustomPipeline",
+        source_python_class="custom_pipeline.CustomPipelineSource",
+        source_config_type="PipelineMetadata",
+        service_entity=PipelineService,
+        entities=[(Pipeline, "my_daily_etl")],
+        checks={
+            "my_daily_etl": lambda p: (
+                [model_str(t.name) for t in p.tasks] == ["extract", "transform", "load"]
+                and all(t.description for t in p.tasks)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="search",
+        source_type="custom-search",
+        connection_type="CustomSearch",
+        source_python_class="custom_search.CustomSearchSource",
+        source_config_type="SearchMetadata",
+        service_entity=SearchService,
+        entities=[(SearchIndex, "my_product_index"), (SearchIndex, "my_customer_index")],
+        checks={
+            "my_product_index": lambda i: (
+                [model_str(f.name) for f in i.fields] == ["product_id", "title", "price"]
+                and all(f.description for f in i.fields)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="storage",
+        source_type="custom-storage",
+        connection_type="CustomStorage",
+        source_python_class="custom_storage.CustomStorageSource",
+        source_config_type="StorageMetadata",
+        service_entity=StorageService,
+        entities=[(Container, "my_bucket"), (Container, "my_bucket.my_prefix")],
+        checks={
+            "my_bucket.my_prefix": lambda c: (
+                [model_str(col.name) for col in c.dataModel.columns] == ["event_id", "event_ts"]
+                and all(col.description for col in c.dataModel.columns)
+            ),
+        },
+    ),
+    ConnectorSpec(
+        key="drive",
+        source_type="custom-drive",
+        connection_type="CustomDrive",
+        source_python_class="custom_drive.CustomDriveSource",
+        source_config_type="DriveMetadata",
+        service_entity=DriveService,
+        entities=[
+            (Directory, "my_directory"),
+            (File, 'my_directory."my_report.csv"'),
+            (Spreadsheet, "my_spreadsheet"),
+            (Worksheet, "my_spreadsheet.my_worksheet"),
+        ],
+        checks={
+            "my_spreadsheet.my_worksheet": lambda w: (
+                [model_str(c.name) for c in w.columns] == ["day", "revenue"] and all(c.description for c in w.columns)
+            ),
+        },
+    ),
+]
+
+SPEC_BY_KEY = {spec.key: spec for spec in SPECS}
+
+
+def build_config(spec: ConnectorSpec, service_name: str, workflow_config: dict, sink_config: dict) -> dict:
+    return {
+        "source": {
+            "type": spec.source_type,
+            "serviceName": service_name,
+            "serviceConnection": {
+                "config": {
+                    "type": spec.connection_type,
+                    "sourcePythonClass": spec.source_python_class,
+                }
+            },
+            "sourceConfig": {"config": {"type": spec.source_config_type}},
+        },
+        "sink": sink_config,
+        "workflowConfig": workflow_config,
+    }
+
+
+@pytest.fixture
+def ingested_service(metadata, workflow_config, sink_config):
+    """Run one custom connector against a fresh service and clean it up afterwards."""
+    created = []
+
+    def _run(spec: ConnectorSpec) -> tuple[str, MetadataWorkflow]:
+        service_name = f"custom_{spec.key}_{uuid.uuid4().hex[:8]}"
+        workflow = MetadataWorkflow.create(build_config(spec, service_name, workflow_config, sink_config))
+        workflow.execute()
+        workflow.raise_from_status()
+        created.append((spec.service_entity, service_name))
+        return service_name, workflow
+
+    yield _run
+
+    for service_entity, service_name in created:
+        service = metadata.get_by_name(entity=service_entity, fqn=service_name)
+        if service:
+            metadata.delete(entity=service_entity, entity_id=service.id, recursive=True, hard_delete=True)
+
+
+@pytest.mark.parametrize("spec", SPECS, ids=lambda spec: spec.key)
+def test_custom_connector_ingests_entities(spec, metadata, ingested_service):
+    service_name, workflow = ingested_service(spec)
+
+    for entity_type, suffix in spec.entities:
+        fqn = f"{service_name}.{suffix}"
+        entity = metadata.get_by_name(entity=entity_type, fqn=fqn, fields=["*"])
+        assert entity is not None, f"{entity_type.__name__} {fqn} was not ingested"
+        assert model_str(entity.fullyQualifiedName) == fqn
+        assert entity.description, f"{entity_type.__name__} {fqn} lost its description"
+        check = spec.checks.get(suffix)
+        if check:
+            assert check(entity), f"{entity_type.__name__} {fqn} lost fields on the way to the API"
+
+    source_status = workflow.source.get_status()
+    assert source_status.failures == []
+    assert source_status.warnings == []
+    assert workflow.steps[0].get_status().failures == []
+
+
+@pytest.mark.parametrize("spec", SPECS, ids=lambda spec: spec.key)
+def test_custom_connector_describes_its_service(spec, metadata, ingested_service):
+    """A custom connector builds its own service request, so it can set fields the
+    shared get_create_service_from_source helper leaves empty."""
+    service_name, _ = ingested_service(spec)
+
+    service = metadata.get_by_name(entity=spec.service_entity, fqn=service_name)
+    assert service is not None
+    assert service.serviceType.value == spec.connection_type
+    assert service.description, "service description was dropped"
+    assert service.displayName, "service displayName was dropped"
+
+
+def test_custom_database_tags_its_tables(metadata, ingested_service):
+    service_name, _ = ingested_service(SPEC_BY_KEY["database"])
+
+    table = metadata.get_by_name(
+        entity=Table,
+        fqn=f"{service_name}.my_catalog.my_schema.orders",
+        fields=["tags"],
+    )
+    assert [model_str(tag.tagFQN) for tag in table.tags] == [custom_database.TAG_FQN]
+
+
+def test_custom_database_emits_lineage(metadata, ingested_service):
+    """Lineage is resolved by FQN, which only works because the connector yields a
+    Barrier to flush the sink's bulk buffer before the lineage record."""
+    service_name, _ = ingested_service(SPEC_BY_KEY["database"])
+
+    downstream_fqn = f"{service_name}.my_catalog.{custom_database.LINEAGE_TO}"
+    lineage = metadata.client.get(f"/lineage/table/name/{downstream_fqn}?upstreamDepth=1&downstreamDepth=0")
+
+    upstream_names = [node["fullyQualifiedName"] for node in lineage.get("nodes") or []]
+    assert upstream_names == [f"{service_name}.my_catalog.{custom_database.LINEAGE_FROM}"]
+    assert len(lineage.get("upstreamEdges") or []) == 1
+
+
+def test_custom_dashboard_links_charts_and_data_model(metadata, ingested_service):
+    service_name, _ = ingested_service(SPEC_BY_KEY["dashboard"])
+
+    dashboard = metadata.get_by_name(
+        entity=Dashboard,
+        fqn=f"{service_name}.my_sales_overview",
+        fields=["charts", "dataModels"],
+    )
+    assert sorted(model_str(chart.fullyQualifiedName) for chart in dashboard.charts.root) == [
+        f"{service_name}.orders_by_region",
+        f"{service_name}.revenue_by_month",
+    ]
+    assert [model_str(model.fullyQualifiedName) for model in dashboard.dataModels.root] == [
+        f"{service_name}.model.my_revenue_model"
+    ]
+
+
+def test_custom_messaging_attaches_sample_data(metadata, ingested_service):
+    service_name, _ = ingested_service(SPEC_BY_KEY["messaging"])
+
+    topic = metadata.get_by_name(entity=Topic, fqn=f"{service_name}.my_orders_topic")
+    # Sample data is not returned as an entity field; it has its own endpoint.
+    with_sample_data = metadata.get_topic_sample_data(topic)
+    assert with_sample_data.sampleData is not None, "topic sample data was not ingested"
+    assert len(with_sample_data.sampleData.messages) == 2
+
+
+def test_custom_pipeline_records_execution_status(metadata, ingested_service):
+    service_name, _ = ingested_service(SPEC_BY_KEY["pipeline"])
+
+    pipeline_fqn = f"{service_name}.my_daily_etl"
+    statuses = metadata.client.get(
+        f"/pipelines/{pipeline_fqn}/status"
+        f"?startTs={custom_pipeline.RUN_TIMESTAMP - 1}&endTs={custom_pipeline.RUN_END_TIMESTAMP + 1}"
+    )
+    runs = statuses.get("data") or []
+    assert len(runs) == 1
+    assert runs[0]["executionStatus"] == StatusType.Successful.value
+    assert [task["name"] for task in runs[0]["taskStatus"]] == ["extract", "transform", "load"]

--- a/ingestion/tests/unit/test_importer.py
+++ b/ingestion/tests/unit/test_importer.py
@@ -14,6 +14,7 @@ Test import utilities
 """
 
 from unittest import TestCase
+from unittest.mock import patch
 
 import pytest
 
@@ -105,3 +106,12 @@ def test_import_from_module_wraps_missing_attribute() -> None:
         import_from_module("metadata.ingestion.source.database.mysql.metadata.MysqlSourceTypo")
 
     assert "Cannot import metadata.ingestion.source.database.mysql.metadata.MysqlSourceTypo" in str(exc_info.value)
+
+
+def test_import_from_module_does_not_wrap_module_level_attribute_error() -> None:
+    """An AttributeError from the module's own code must keep its traceback."""
+    with (
+        patch("importlib.import_module", side_effect=AttributeError("boom inside the module")),
+        pytest.raises(AttributeError, match="boom inside the module"),
+    ):
+        import_from_module("metadata.ingestion.source.database.mysql.metadata.MysqlSource")

--- a/ingestion/tests/unit/test_importer.py
+++ b/ingestion/tests/unit/test_importer.py
@@ -15,8 +15,11 @@ Test import utilities
 
 from unittest import TestCase
 
+import pytest
+
 from metadata.generated.schema.entity.services.serviceType import ServiceType
 from metadata.utils.importer import (
+    DynamicImportException,
     get_class_name_root,
     get_module_name,
     get_source_module_name,
@@ -87,3 +90,18 @@ class ImporterTest(TestCase):
             import_bulk_sink_type(bulk_sink_type="metadata-usage"),
             MetadataUsageBulkSink,
         )
+
+
+def test_import_from_module_wraps_missing_module() -> None:
+    with pytest.raises(DynamicImportException) as exc_info:
+        import_from_module("metadata.ingestion.source.database.does_not_exist.Nope")
+
+    assert "Cannot import metadata.ingestion.source.database.does_not_exist.Nope" in str(exc_info.value)
+
+
+def test_import_from_module_wraps_missing_attribute() -> None:
+    """A typo in the class part of `sourcePythonClass` must not escape as AttributeError."""
+    with pytest.raises(DynamicImportException) as exc_info:
+        import_from_module("metadata.ingestion.source.database.mysql.metadata.MysqlSourceTypo")
+
+    assert "Cannot import metadata.ingestion.source.database.mysql.metadata.MysqlSourceTypo" in str(exc_info.value)

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServicePureUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServicePureUtils.test.ts
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { StorageServiceType } from '../generated/entity/data/container';
+import { MlModelServiceType } from '../generated/entity/data/mlmodel';
+import { DashboardServiceType } from '../generated/entity/services/dashboardService';
+import { DatabaseServiceType } from '../generated/entity/services/databaseService';
+import { DriveServiceType } from '../generated/entity/services/driveService';
+import { MessagingServiceType } from '../generated/entity/services/messagingService';
+import { PipelineServiceType } from '../generated/entity/services/pipelineService';
+import { SearchServiceType } from '../generated/entity/services/searchService';
+import { shouldTestConnection } from './ServicePureUtils';
+
+describe('shouldTestConnection', () => {
+  it.each([
+    DatabaseServiceType.CustomDatabase,
+    MessagingServiceType.CustomMessaging,
+    DashboardServiceType.CustomDashboard,
+    MlModelServiceType.CustomMlModel,
+    PipelineServiceType.CustomPipeline,
+    StorageServiceType.CustomStorage,
+    SearchServiceType.CustomSearch,
+    DriveServiceType.CustomDrive,
+  ])('should return false for %s', (serviceType) => {
+    expect(shouldTestConnection(serviceType)).toBe(false);
+  });
+
+  it.each([
+    DatabaseServiceType.Mysql,
+    DashboardServiceType.Superset,
+    SearchServiceType.ElasticSearch,
+  ])('should return true for %s', (serviceType) => {
+    expect(shouldTestConnection(serviceType)).toBe(true);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServicePureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServicePureUtils.ts
@@ -30,6 +30,7 @@ import { DriveServiceType } from '../generated/entity/services/driveService';
 import { PipelineType as IngestionPipelineType } from '../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { MessagingServiceType } from '../generated/entity/services/messagingService';
 import { PipelineServiceType } from '../generated/entity/services/pipelineService';
+import { SearchServiceType } from '../generated/entity/services/searchService';
 import { t } from './i18next/LocalUtil';
 import { replaceAllSpacialCharWith_ } from './StringUtils';
 
@@ -66,6 +67,7 @@ export const shouldTestConnection = (serviceType: string) => {
     serviceType !== MlModelServiceType.CustomMlModel &&
     serviceType !== PipelineServiceType.CustomPipeline &&
     serviceType !== StorageServiceType.CustomStorage &&
+    serviceType !== SearchServiceType.CustomSearch &&
     serviceType !== DriveServiceType.CustomDrive
   );
 };


### PR DESCRIPTION
### Describe your changes:

Fixes #30899

Cherry-pick of #30901 onto `2.0`. Commits `2c2c739d69`, `08fad36214`, `35f7e5e72f` applied cleanly with no conflicts; the resulting patches are byte-identical to the originals.

Adds one Custom Connector for each service type whose connection schema carries `sourcePythonClass`, plus `CustomDrive`, and an integration test suite covering all eight. A custom connector reads no external system, so the tests need a running OpenMetadata server and nothing else — no testcontainers.

Between them the connectors exercise the sink paths a minimal connector never reaches: classification and tags, a stored procedure, FQN lineage behind a `Barrier`, a dashboard data model, topic sample data and a pipeline execution status. Every entity, column, field and task carries a description, and each connector builds its own `CreateXServiceRequest` so the service gets a description and displayName.

Two fixes the work surfaced, both included:

- `import_from_module` did not wrap the `AttributeError` `getattr` raises when a module imports but the name is absent, so a typo in the class part of `sourcePythonClass` escaped raw. The import and the lookup are separate `try` blocks so an `AttributeError` from the module body keeps its own traceback.
- `shouldTestConnection` omitted `CustomSearch`, so Custom Search alone offered a Test Connection button.

Verified on this branch: `11 passed` on `tests/unit/test_importer.py`. The integration suite needs a live server, which was unavailable at cherry-pick time; it passed on #30901 against the identical code.

#
### Type of change:
- [x] Improvement
- [x] Bug fix