### PR TITLE
Honour the service filter when listing tables, schemas and stored procedures (2.0)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -20,7 +20,6 @@ import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
@@ -2345,8 +2344,14 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
   void test_listDatabaseSchemasFilteredByService(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
     DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
-    DatabaseSchemaTestFactory.createSimple(ns, service);
-    DatabaseSchemaTestFactory.createSimple(ns, service);
+    Database database =
+        Databases.create().name(ns.prefix("db")).in(service.getFullyQualifiedName()).execute();
+    for (int i = 0; i < 2; i++) {
+      DatabaseSchemas.create()
+          .name(ns.prefix("service_filter_schema_" + i))
+          .in(database.getFullyQualifiedName())
+          .execute();
+    }
 
     ListResponse<DatabaseSchema> response =
         client.databaseSchemas().list(new ListParams().setService(service.getName()).setLimit(50));

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DatabaseSchemaResourceIT.java
@@ -20,6 +20,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DatabaseSchemaTestFactory;
 import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
@@ -2338,5 +2339,22 @@ public class DatabaseSchemaResourceIT extends BaseEntityIT<DatabaseSchema, Creat
     assertTrue(
         schemas.stream().noneMatch(s -> s.getName().startsWith("temp")),
         "Excluded schemas should not appear in results");
+  }
+
+  @Test
+  void test_listDatabaseSchemasFilteredByService(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchemaTestFactory.createSimple(ns, service);
+    DatabaseSchemaTestFactory.createSimple(ns, service);
+
+    ListResponse<DatabaseSchema> response =
+        client.databaseSchemas().list(new ListParams().setService(service.getName()).setLimit(50));
+
+    assertEquals(2, response.getData().size());
+    assertTrue(
+        response.getData().stream()
+            .allMatch(
+                schema -> schema.getFullyQualifiedName().startsWith(service.getName() + ".")));
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StoredProcedureResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/StoredProcedureResourceIT.java
@@ -596,4 +596,31 @@ public class StoredProcedureResourceIT
     request.setName(ns.prefix("invalid_stored_proc"));
     return request;
   }
+
+  @Test
+  void test_listStoredProceduresFilteredByService(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    StoredProcedureCode code =
+        new StoredProcedureCode()
+            .withCode(
+                "CREATE OR REPLACE PROCEDURE p() AS $$ BEGIN RETURN; END; $$ LANGUAGE plpgsql;")
+            .withLanguage(StoredProcedureLanguage.SQL);
+    for (int i = 0; i < 2; i++) {
+      CreateStoredProcedure request = new CreateStoredProcedure();
+      request.setName(ns.prefix("service_filter_proc_" + i));
+      request.setDatabaseSchema(schema.getFullyQualifiedName());
+      request.setStoredProcedureCode(code);
+      client.storedProcedures().create(request);
+    }
+
+    ListResponse<StoredProcedure> response =
+        client.storedProcedures().list(new ListParams().setService(service.getName()).setLimit(50));
+
+    assertEquals(2, response.getData().size());
+    assertTrue(
+        response.getData().stream()
+            .allMatch(proc -> proc.getFullyQualifiedName().startsWith(service.getName() + ".")));
+  }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableResourceIT.java
@@ -6452,4 +6452,26 @@ public class TableResourceIT extends BaseEntityIT<Table, CreateTable> {
         idTagsProfile.getTags().isEmpty(), "Tags must be present even when profile requested");
     assertNotNull(idTagsProfile.getProfile(), "Profile must be present when profile requested");
   }
+
+  @Test
+  void test_listTablesFilteredByService(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
+    for (int i = 0; i < 3; i++) {
+      CreateTable request = new CreateTable();
+      request.setName(ns.prefix("service_filter_table_" + i));
+      request.setDatabaseSchema(schema.getFullyQualifiedName());
+      request.setColumns(List.of(ColumnBuilder.of("id", "BIGINT").build()));
+      client.tables().create(request);
+    }
+
+    ListResponse<Table> response =
+        client.tables().list(new ListParams().setService(service.getName()).setLimit(50));
+
+    assertEquals(3, response.getData().size());
+    assertTrue(
+        response.getData().stream()
+            .allMatch(table -> table.getFullyQualifiedName().startsWith(service.getName() + ".")));
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/DatabaseSchemaResource.java
@@ -138,6 +138,11 @@ public class DatabaseSchemaResource
           @QueryParam("fields")
           String fieldsParam,
       @Parameter(
+              description = "Filter schemas by database service name",
+              schema = @Schema(type = "string", example = "snowflakeWestCoast"))
+          @QueryParam("service")
+          String serviceParam,
+      @Parameter(
               description = "Filter schemas by database name",
               schema = @Schema(type = "string", example = "customerDatabase"))
           @QueryParam("database")
@@ -185,6 +190,9 @@ public class DatabaseSchemaResource
           @DefaultValue("include")
           RegexMode regexMode) {
     ListFilter filter = new ListFilter(include).addQueryParam("database", databaseParam);
+    if (serviceParam != null) {
+      filter.addQueryParam("service", serviceParam);
+    }
     if (regexFilterByFqn) {
       filter.addQueryParam("regexFilterByFqn", true);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/StoredProcedureResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/StoredProcedureResource.java
@@ -92,6 +92,11 @@ public class StoredProcedureResource
           @QueryParam("fields")
           String fieldsParam,
       @Parameter(
+              description = "Filter stored procedures by database service name",
+              schema = @Schema(type = "string", example = "snowflakeWestCoast"))
+          @QueryParam("service")
+          String serviceParam,
+      @Parameter(
               description = "Filter stored procedures by database schema",
               schema = @Schema(type = "string", example = "customerDatabaseSchema"))
           @QueryParam("databaseSchema")
@@ -120,6 +125,9 @@ public class StoredProcedureResource
           Include include) {
     ListFilter filter =
         new ListFilter(include).addQueryParam("databaseSchema", databaseSchemaParam);
+    if (serviceParam != null) {
+      filter.addQueryParam("service", serviceParam);
+    }
     return listInternal(uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/databases/TableResource.java
@@ -195,6 +195,11 @@ public class TableResource extends EntityResource<Table, TableRepository> {
           @QueryParam("fields")
           String fieldsParam,
       @Parameter(
+              description = "Filter tables by database service name",
+              schema = @Schema(type = "string", example = "snowflakeWestCoast"))
+          @QueryParam("service")
+          String serviceParam,
+      @Parameter(
               description = "Filter tables by database fully qualified name",
               schema = @Schema(type = "string", example = "snowflakeWestCoast.financeDB"))
           @QueryParam("database")
@@ -264,6 +269,9 @@ public class TableResource extends EntityResource<Table, TableRepository> {
           @DefaultValue("include")
           RegexMode regexMode) {
     ListFilter filter = new ListFilter(include);
+    if (serviceParam != null) {
+      filter.addQueryParam("service", serviceParam);
+    }
     if (databaseParam != null) {
       filter.addQueryParam("database", databaseParam);
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/ListFilterTest.java
@@ -521,4 +521,25 @@ class ListFilterTest {
     assertTrue(condition.contains(":folderIdParam"), condition);
     assertEquals(hostile, filter.getQueryParam("folderIdParam"));
   }
+
+  @Test
+  void test_getServiceCondition_filtersDatabaseHierarchyTables() {
+    // The database hierarchy below `databases` is FQN-prefixed by the service, so the
+    // generic service condition applies to it unchanged.
+    List<String> tableNames =
+        List.of("table_entity", "database_schema_entity", "stored_procedure_entity");
+    for (String tableName : tableNames) {
+      ListFilter filter =
+          new ListFilter(Include.NON_DELETED).addQueryParam("service", "my_service");
+      assertEquals(tableName + ".fqnHash LIKE :serviceHash", filter.getServiceCondition(tableName));
+      assertEquals(
+          FullyQualifiedName.buildHash("my_service") + ".%",
+          filter.getQueryParams().get("serviceHash"));
+    }
+  }
+
+  @Test
+  void test_getServiceCondition_absentServiceYieldsNoCondition() {
+    assertEquals("", new ListFilter(Include.NON_DELETED).getServiceCondition("table_entity"));
+  }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #30900

Cherry-pick of #30902 onto `2.0`. Commits `81acfa9001` and `d6f617ea63` applied cleanly with no conflicts; the resulting patches are byte-identical to the originals.

`GET /v1/tables?service=X`, `/v1/databaseSchemas?service=X` and `/v1/storedProcedures?service=X` returned every entity in the instance rather than the ones under `X`. The three resources never declared a `service` `@QueryParam`, and JAX-RS discards an undeclared query parameter silently, so the caller got a 200 with unfiltered results.

The filtering machinery was already present: `ListFilter.getCondition()` calls `getServiceCondition()` unconditionally for every entity, resolving to `fqnHash LIKE '<hash(service)>.%'`, which is correct here because these FQNs are service-prefixed. `ListParams.setService()` in the Java SDK has always sent the parameter. Only the plumbing that feeds the filter was missing.

Two lines per resource: declare the parameter, forward it into the filter. `ListFilter` is unchanged. Includes a regression IT per resource and unit tests covering the condition and bind value for `table_entity`, `database_schema_entity` and `stored_procedure_entity`.

Verified on this branch: `mvn -pl openmetadata-service test -Dtest=ListFilterTest` → 40 tests pass, and `mvn -pl openmetadata-integration-tests test-compile` → BUILD SUCCESS.

#
### Type of change:
- [x] Bug fix