### PR TITLE
fix(tests): stop the Glue pipeline unit test calling the real AWS API

### DIFF
--- a/ingestion/tests/unit/topology/pipeline/test_gluepipeline.py
+++ b/ingestion/tests/unit/topology/pipeline/test_gluepipeline.py
@@ -356,6 +356,11 @@ class GluePipelineUnitTest(TestCase):
         mock_metadata.get_entity_reference.return_value = mock_table_ref
         self.gluepipeline.metadata = mock_metadata
 
+        # Without this the resolver calls the real AWS Glue API, which a try/except
+        # swallows only after the request blocks — indefinitely if egress is dropped.
+        self.gluepipeline.glue = MagicMock()
+        self.gluepipeline.glue.get_connection.return_value = {"Connection": {"ConnectionProperties": {}}}
+
         lineage_details = {"sources": [], "targets": []}
         jdbc_ref = JDBCRef(
             connection_name="Redshift - Jdbc connection",


### PR DESCRIPTION
## The problem

The Python unit-test job has been timing out. On a single run, `Unit Tests & Static Checks (3.12)` finished in 18 minutes while `(3.10)` and `(3.11)` were cancelled at exactly 60 minutes — the job's `timeout-minutes`. The log shows the run parked at `99%` and then `Error: The operation was canceled.`, with `pytest` still listed among the orphan processes at teardown.

## The cause

`test_resolve_jdbc_entities_wildcard_fallback` mocks the metadata client but not the Glue one. `self.glue` is the real boto3 client built in `setUp`, so `_resolve_jdbc_entities` reaches `_resolve_glue_connection`, which issues a genuine `glue.get_connection(...)` call over botocore.

That call sits inside a `try/except`, so the test reports green either way — but only *after* the request completes. Where egress to AWS is refused it fails quickly; where it is silently dropped, the socket sits in `SYN_SENT` and the test blocks indefinitely.

CI runs pytest under xdist with `--dist loadfile`, so one file belongs to one worker. That worker never returns, the other thirteen go idle, and the controller waits until the job limit kills the run. Nothing names the test, because worker output is buffered through `tee`.

## Evidence

Reproduced locally with CI's exact flags. The run parks at 99% with 13 workers `[pytest-xdist idle]` and one `[pytest-xdist running]`, and that worker holds:

```
TCP 192.168.50.79:55732 -> 52.36.154.217:443 (SYN_SENT)
   = ec2-52-36-154-217.us-west-2.compute.amazonaws.com
```

Re-running with `-o faulthandler_timeout=150` dumps the stuck worker and names it:

```
tests/unit/topology/pipeline/test_gluepipeline.py:365
  test_resolve_jdbc_entities_wildcard_fallback
    → gluepipeline/metadata.py:339  _resolve_jdbc_entities
    → gluepipeline/metadata.py:377  _resolve_glue_connection
      → botocore/endpoint.py → urllib3 → real HTTPS
```

## The fix

Mock the Glue client so the resolver gets an empty connection. The assertion is unchanged and still exercises what the test is named for: an unresolved connection falls back to the wildcard service search.

Measured on the same machine — `test_gluepipeline.py` alone:

| | Result |
|---|---|
| before | still blocking when a 10-minute timeout killed it |
| after | **6 passed in 0.6s** |

## Note

This is one instance of a wider issue: a sweep of `tests/unit` with a guard that fails on real client construction or socket use found **249 violations**, of which **19 tests genuinely reach the network** — Azure, Bitbucket and AWS. Most tolerate the failure and only cost time; this one blocks. The others are worth addressing separately, along with a `faulthandler_timeout` default so a future hang names itself instead of burning a 60-minute job.