### PR TITLE
Fixes 30387: Hydrate data product references before search indexing

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -2337,13 +2337,15 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
     }
 
     DataProduct dataProduct =
-        SdkClients.adminClient()
-            .dataProducts()
-            .create(
-                new CreateDataProduct()
-                    .withName(ns.prefix("minimal_data_product"))
-                    .withDescription("Data product for minimal reference PATCH test")
-                    .withDomains(List.of(testDomain().getFullyQualifiedName())));
+        ns.trackRoot(
+            Entity.DATA_PRODUCT,
+            SdkClients.adminClient()
+                .dataProducts()
+                .create(
+                    new CreateDataProduct()
+                        .withName(ns.prefix("minimal_data_product"))
+                        .withDescription("Data product for minimal reference PATCH test")
+                        .withDomains(List.of(testDomain().getFullyQualifiedName()))));
     T entity = createEntity(createMinimalRequest(ns));
 
     EntityReference domainReference =

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseEntityIT.java
@@ -33,11 +33,13 @@ import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.it.util.UpdateType;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.api.domains.CreateDataProduct;
 import org.openmetadata.schema.api.policies.CreatePolicy;
 import org.openmetadata.schema.api.teams.CreateRole;
 import org.openmetadata.schema.api.teams.CreateUser;
 import org.openmetadata.schema.auth.JWTAuthMechanism;
 import org.openmetadata.schema.auth.JWTTokenExpiry;
+import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.entity.policies.Policy;
 import org.openmetadata.schema.entity.policies.accessControl.Rule;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
@@ -45,6 +47,7 @@ import org.openmetadata.schema.entity.teams.Role;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ApiStatus;
 import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.api.BulkOperationResult;
@@ -165,6 +168,7 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   protected boolean supportsDomains = true;
   protected boolean supportsPatchDomains = true; // Can domains be changed via PATCH after creation?
   protected boolean supportsDataProducts = true;
+  protected boolean supportsDataProductAssetsSearch = true;
   protected boolean supportsDataContract = false;
   protected boolean supportsSoftDelete = true;
   protected boolean supportsCustomExtension = true;
@@ -1938,7 +1942,6 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   // TODO: patch_entityUpdatesOutsideASession
 
   // Phase 5: DataProducts/Domain Tests
-  // TODO: patch_dataProducts_200_ok
   // TODO: patch_dataProducts_multipleOperations_200
   // Note: patchWrongDataProducts is covered by patch_invalidDataProducts_4xx
   // Note: patchWrongDomainId is covered by patch_entityWithInvalidDomain_4xx
@@ -2324,9 +2327,92 @@ public abstract class BaseEntityIT<T extends EntityInterface, K> {
   // ===================================================================
 
   @Test
-  void patch_dataProducts_200(TestNamespace ns) {
-    if (!supportsDataProducts || !supportsDomains || !supportsPatch) return;
-    // DataProduct tests require creating a DataProduct first, skipping for now
+  void patch_dataProducts_200(TestNamespace ns) throws Exception {
+    if (!supportsDataProducts
+        || !supportsDomains
+        || !supportsPatchDomains
+        || !supportsPatch
+        || !supportsSearchIndex) {
+      return;
+    }
+
+    DataProduct dataProduct =
+        SdkClients.adminClient()
+            .dataProducts()
+            .create(
+                new CreateDataProduct()
+                    .withName(ns.prefix("minimal_data_product"))
+                    .withDescription("Data product for minimal reference PATCH test")
+                    .withDomains(List.of(testDomain().getFullyQualifiedName())));
+    T entity = createEntity(createMinimalRequest(ns));
+
+    EntityReference domainReference =
+        new EntityReference()
+            .withId(testDomain().getId())
+            .withType(testDomain().getEntityReference().getType())
+            .withName(testDomain().getName())
+            .withFullyQualifiedName(testDomain().getFullyQualifiedName());
+    entity.setDomains(List.of(domainReference));
+    T entityWithDomain = patchEntity(entity.getId().toString(), entity);
+
+    EntityReference minimalDataProductReference =
+        new EntityReference()
+            .withId(dataProduct.getId())
+            .withType(dataProduct.getEntityReference().getType());
+    entityWithDomain.setDataProducts(List.of(minimalDataProductReference));
+    T updated = patchEntity(entityWithDomain.getId().toString(), entityWithDomain);
+
+    OpenMetadataClient client = SdkClients.adminClient();
+    String entityJson =
+        client
+            .getHttpClient()
+            .executeForString(
+                HttpMethod.GET, getResourcePath() + updated.getId() + "?fields=dataProducts", null);
+    JsonNode apiDataProducts = MAPPER.readTree(entityJson).path("dataProducts");
+    assertTrue(apiDataProducts.isArray(), "Entity API must return dataProducts");
+    assertEquals(1, apiDataProducts.size());
+    assertEquals(dataProduct.getId().toString(), apiDataProducts.path(0).path("id").asText());
+    assertEquals(
+        dataProduct.getFullyQualifiedName(),
+        apiDataProducts.path(0).path("fullyQualifiedName").asText());
+
+    Awaitility.await("Wait for minimal data product PATCH to update search-backed assets")
+        .atMost(Duration.ofSeconds(60))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              JsonNode indexedDataProducts =
+                  MAPPER
+                      .readTree(searchForEntity(updated.getId().toString()))
+                      .path("hits")
+                      .path("hits")
+                      .path(0)
+                      .path("_source")
+                      .path("dataProducts");
+              assertTrue(indexedDataProducts.isArray(), "Search document must have dataProducts");
+              assertEquals(1, indexedDataProducts.size());
+              assertEquals(
+                  dataProduct.getId().toString(), indexedDataProducts.path(0).path("id").asText());
+              assertEquals(
+                  dataProduct.getFullyQualifiedName(),
+                  indexedDataProducts.path(0).path("fullyQualifiedName").asText());
+
+              if (supportsDataProductAssetsSearch) {
+                String assetsJson =
+                    client
+                        .getHttpClient()
+                        .executeForString(
+                            HttpMethod.GET,
+                            "/v1/dataProducts/" + dataProduct.getId() + "/assets?limit=10&offset=0",
+                            null);
+                JsonNode assets = MAPPER.readTree(assetsJson);
+                assertEquals(1, assets.path("paging").path("total").asInt());
+                assertEquals(
+                    updated.getId().toString(), assets.path("data").path(0).path("id").asText());
+              }
+            });
   }
 
   @Test

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -78,6 +78,7 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
     supportsTags = true;
     supportsDomains = true;
     supportsDataProducts = true;
+    supportsDataProductAssetsSearch = false;
     supportsSoftDelete = true;
     supportsPatch = true;
     supportsOwners = true;

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermResourceIT.java
@@ -75,6 +75,7 @@ public class GlossaryTermResourceIT extends BaseEntityIT<GlossaryTerm, CreateGlo
     // GlossaryTerm export is done through Glossary endpoint, not GlossaryTerm endpoint
     // The Glossary export (/v1/glossaries/name/{name}/export) exports all terms in that glossary
     supportsImportExport = false;
+    supportsDataProductAssetsSearch = false;
     supportsListHistoryByTimestamp = true;
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
@@ -65,6 +65,7 @@ public class TagResourceIT extends BaseEntityIT<Tag, CreateTag> {
   {
     supportsFollowers = false; // Tags don't support followers
     supportsTags = false; // Tags don't support tags on themselves
+    supportsDataProductAssetsSearch = false;
     supportsListHistoryByTimestamp = true;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -8277,6 +8277,12 @@ public abstract class EntityRepository<T extends EntityInterface> {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Validates each data product and hydrates the supplied reference in place.
+   *
+   * <p>Lifecycle handlers receive these references before relationships are reloaded, so search
+   * indexing requires a fully populated reference at this stage.
+   */
   public final void validateDataProducts(List<EntityReference> dataProducts) {
     if (!supportsDataProducts) {
       throw new IllegalArgumentException(CatalogExceptionMessage.invalidField(FIELD_DATA_PRODUCTS));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -8284,7 +8284,9 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
     if (!nullOrEmpty(dataProducts)) {
       for (EntityReference dataProduct : dataProducts) {
-        getEntityReferenceById(DATA_PRODUCT, dataProduct.getId(), NON_DELETED);
+        EntityReference validatedDataProduct =
+            getEntityReferenceById(DATA_PRODUCT, dataProduct.getId(), NON_DELETED);
+        EntityUtil.copy(validatedDataProduct, dataProduct);
       }
     }
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #30387

I fixed minimal Data Product PATCH handling by hydrating validated `id`/`type` references before lifecycle indexing, so search-backed Assets update without requiring a reindex.
The inherited `BaseEntityIT` regression uses the SDK patch flow and verifies the entity API, raw search document, and Data Product Assets API for searchable entity types.
No index mappings were changed.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered

- PATCH an entity with a minimal Data Product reference containing only `id` and `type`
- Verify the API returns the hydrated Data Product reference
- Verify the raw entity search document contains the hydrated reference
- Verify searchable entity types appear through the Data Product Assets API

#### Unit tests

- [ ] I added unit tests for the new/changed logic.
- Not added; the behavior is covered by the inherited backend integration regression.

#### Backend integration tests

- [x] I added integration tests in `openmetadata-integration-tests/` for the changed behavior.
- Files updated: `BaseEntityIT.java`, `GlossaryResourceIT.java`, `GlossaryTermResourceIT.java`, and `TagResourceIT.java`
- `mvn -pl openmetadata-integration-tests -Pmysql-elasticsearch,integration-lane-parallel -Dit.test='*IT#patch_dataProducts_200' verify` — 59 tests, 0 failures, 0 errors

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

- Automated backend build and integration verification only.
- `mvn -pl openmetadata-service -am -DskipTests install`
- `mvn -pl openmetadata-service,openmetadata-integration-tests spotless:check`

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable; this PR has no JSON Schema changes.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
