### PR TITLE
fix(e2e): seed data for KPI widget assertion

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -32,7 +32,11 @@ import {
   verifyWidgetFooterViewMore,
   verifyWidgetHeaderNavigation,
 } from '../../utils/customizeLandingPage';
-import { addKpi, deleteKpiRequest } from '../../utils/dataInsight';
+import {
+  addKpi,
+  deleteKpiRequest,
+  runDataInsightApplication,
+} from '../../utils/dataInsight';
 import { followEntity, waitForAllLoadersToDisappear } from '../../utils/entity';
 import { sidebarClick } from '../../utils/sidebar';
 import {
@@ -338,6 +342,16 @@ test('My Data Widget', async ({ page }) => {
 test('KPI Widget', async ({ page }) => {
   test.slow(true);
 
+  await test.step('Populate Data Insights data', async () => {
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await runDataInsightApplication(page, apiContext);
+    } finally {
+      await afterAction();
+    }
+  });
+
   await test.step('Add KPI', async () => {
     await waitForAllLoadersToDisappear(page);
 
@@ -409,28 +423,10 @@ test('KPI Widget', async ({ page }) => {
 
     await expect(kpiWidgetContent).toBeVisible();
 
-    // Check if there's either a chart or empty state
-    const hasChart = await widget
-      .locator('.recharts-responsive-container')
-      .isVisible()
-      .catch(() => false);
-
-    const hasEmptyState = await widget
-      .locator('[data-testid="widget-empty-state"]')
-      .isVisible()
-      .catch(() => false);
-
-    expect(hasChart || hasEmptyState).toBeTruthy();
-
-    if (hasChart) {
-      // If chart exists, verify it's rendered properly
-      await expect(
-        widget.locator('.recharts-responsive-container')
-      ).toBeVisible();
-
-      // Verify chart elements are present
-      await expect(widget.locator('.recharts-area')).toBeVisible();
-    }
+    await expect(
+      widget.locator('.recharts-responsive-container')
+    ).toBeVisible();
+    await expect(widget.locator('.recharts-area')).toBeVisible();
   });
 
   await test.step('Test widget customization', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/dataInsightApp.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/dataInsightApp.ts
@@ -10,9 +10,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test as setup } from '@playwright/test';
+import { test as setup } from '@playwright/test';
 import { TableClass } from '../support/entity/TableClass';
 import { getApiContext, redirectToHomePage } from '../utils/common';
+import { runDataInsightApplication } from '../utils/dataInsight';
 
 // use the admin user to login
 setup.use({
@@ -56,65 +57,7 @@ setup(
       }
     );
 
-    await expect(
-      await apiContext.patch(
-        `/api/v1/apps/marketplace/name/DataInsightsApplication`,
-        {
-          data: [
-            {
-              op: 'replace',
-              path: '/appConfiguration/batchSize',
-              value: 1000,
-            },
-            {
-              op: 'replace',
-              path: '/appConfiguration/recreateDataAssetsIndex',
-              value: false,
-            },
-            {
-              op: 'replace',
-              path: '/appConfiguration/backfillConfiguration/enabled',
-              value: false,
-            },
-          ],
-          headers: {
-            'Content-Type': 'application/json-patch+json',
-          },
-        }
-      )
-    ).toBeOK();
-
-    await apiContext.post('/api/v1/apps/trigger/DataInsightsApplication');
-
-    // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for pipeline run to start before polling status
-    await page.waitForTimeout(2000);
-
-    await expect
-      .poll(
-        async () => {
-          const response = await apiContext
-            .get(
-              '/api/v1/apps/name/DataInsightsApplication/status?offset=0&limit=1'
-            )
-            .then((res) => res.json());
-
-          return response.data[0].status;
-        },
-        {
-          // Custom expect message for reporting, optional.
-          message: 'Wait for the Data Insight Application run to be successful',
-          ...(process.env.PLAYWRIGHT_IS_OSS
-            ? {
-                timeout: 120_000,
-                intervals: [5_000, 10_000],
-              }
-            : {
-                timeout: 5400_000,
-                intervals: [300_000, 300_000, 120_000],
-              }),
-        }
-      )
-      .toEqual(expect.stringMatching(/(success|failed|partialSuccess)/));
+    await runDataInsightApplication(page, apiContext);
 
     await table.delete(apiContext);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { APIRequestContext, Page } from '@playwright/test';
+import { APIRequestContext, expect, Page } from '@playwright/test';
 import { KPIData } from '../constant/dataInsight.interface';
 import { descriptionBox } from './common';
 
@@ -24,6 +24,72 @@ export const deleteKpiRequest = async (apiRequest: APIRequestContext) => {
       );
     }
   }
+};
+
+export const runDataInsightApplication = async (
+  page: Page,
+  apiRequest: APIRequestContext
+) => {
+  await expect(
+    await apiRequest.patch(
+      '/api/v1/apps/marketplace/name/DataInsightsApplication',
+      {
+        data: [
+          {
+            op: 'replace',
+            path: '/appConfiguration/batchSize',
+            value: 1000,
+          },
+          {
+            op: 'replace',
+            path: '/appConfiguration/recreateDataAssetsIndex',
+            value: false,
+          },
+          {
+            op: 'replace',
+            path: '/appConfiguration/backfillConfiguration/enabled',
+            value: false,
+          },
+        ],
+        headers: {
+          'Content-Type': 'application/json-patch+json',
+        },
+      }
+    )
+  ).toBeOK();
+
+  await expect(
+    await apiRequest.post('/api/v1/apps/trigger/DataInsightsApplication')
+  ).toBeOK();
+
+  // eslint-disable-next-line playwright/no-wait-for-timeout -- wait for pipeline run to start before polling status
+  await page.waitForTimeout(2000);
+
+  await expect
+    .poll(
+      async () => {
+        const response = await apiRequest
+          .get(
+            '/api/v1/apps/name/DataInsightsApplication/status?offset=0&limit=1'
+          )
+          .then((res) => res.json());
+
+        return response.data[0].status;
+      },
+      {
+        message: 'Wait for the Data Insight Application run to be successful',
+        ...(process.env.PLAYWRIGHT_IS_OSS
+          ? {
+              timeout: 120_000,
+              intervals: [5_000, 10_000],
+            }
+          : {
+              timeout: 5_400_000,
+              intervals: [300_000, 300_000, 120_000],
+            }),
+      }
+    )
+    .toEqual(expect.stringMatching(/(success|partialSuccess)/));
 };
 
 export const addKpi = async (page: Page, data: KPIData) => {


### PR DESCRIPTION
### Describe your changes:

This fixes the KPI widget Playwright setup on the 1.13 branch.

The KPI results endpoint builds the Owner KPI series from the Data Insights report index. Creating the KPI definition does not populate that index, and the 1.13 Chromium lane does not run the separate Data Insight setup project. Tagging the test with `@data-insight` would therefore exclude it from that lane instead of fixing it.

This change keeps the test in the Chromium project and:

- extracts the existing Data Insights application setup into a reusable helper;
- runs that setup before creating and checking the KPI;
- requires the application run to finish successfully or partially successfully;
- replaces the instantaneous `isVisible()` branch with direct web-first assertions for the chart container and `.recharts-area` data series.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] No explanatory code comments were required for this change.
- [x] For JSON Schema changes: not applicable.

### Testing
- `yarn ui-checkstyle:playwright:changed playwright/e2e/Flow/CustomizeWidgets.spec.ts playwright/e2e/dataInsightApp.ts playwright/utils/dataInsight.ts`
- `yarn prettier --check playwright/e2e/Flow/CustomizeWidgets.spec.ts playwright/e2e/dataInsightApp.ts playwright/utils/dataInsight.ts`
- `yarn eslint playwright/e2e/Flow/CustomizeWidgets.spec.ts playwright/e2e/dataInsightApp.ts playwright/utils/dataInsight.ts`
- `git diff --check`
- Full `yarn tsc:check` remains blocked by pre-existing errors in unrelated UI source files; it reported no diagnostics for the three changed Playwright files.
- Playwright test not run for this update.
