### PR TITLE
test(ui): let core-component mocks fall through to the real module

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationFormItemV2.test.tsx
@@ -99,6 +99,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   Grid.Item = GridItem;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: ({
       onPress,
       children,
@@ -114,9 +116,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     Card,
     Divider: () => <hr />,
     Grid,
+
     Input: ({
       onChange,
       value,
@@ -137,7 +141,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
         onChange={(e) => onChange?.(e.target.value)}
       />
     ),
+
     Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+
     Typography: ({
       children,
       as: Tag = 'span',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/DestinationSelectItemV2/DestinationSelectItemV2.test.tsx
@@ -99,9 +99,12 @@ jest.mock('@openmetadata/ui-core-components', () => {
   Grid.Item = GridItem;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Alert: ({ title, variant }: { title: ReactNode; variant?: string }) => (
       <div data-testid={`alert-${variant}`}>{title}</div>
     ),
+
     Button: ({
       onPress,
       children,
@@ -117,7 +120,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     Grid,
+
     Input: ({
       onChange,
       value,
@@ -143,7 +148,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
         />
       </div>
     ),
+
     Select: SelectBase,
+
     Toggle: ({
       onChange,
       isSelected,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItemV2/TeamAndUserSelectItemV2/TeamAndUserSelectItemV2.test.tsx
@@ -24,6 +24,8 @@ import TeamAndUserSelectItemV2 from './TeamAndUserSelectItemV2';
 import { TeamAndUserSelectItemV2Props } from './TeamAndUserSelectItemV2.interface';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   BadgeWithButton: ({
     children,
     onButtonClick,
@@ -40,6 +42,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     </span>
   ),
+
   Checkbox: ({
     isSelected,
     'data-testid': tid,
@@ -54,6 +57,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       type="checkbox"
     />
   ),
+
   Input: ({
     onChange,
     value,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Classifications/ClassificationDetails/ClassificationDetails.test.tsx
@@ -24,6 +24,8 @@ import ClassificationDetails from './ClassificationDetails';
 const mockNavigate = jest.fn();
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: ({
     children,
     onClick,
@@ -39,6 +41,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Tooltip: ({
     children,
     title,
@@ -50,6 +53,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   TooltipTrigger: ({
     children,
     className,
@@ -57,6 +61,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     className?: string;
   }) => <button className={className}>{children}</button>,
+
   Badge: ({
     children,
     'data-testid': testId,
@@ -64,6 +69,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     'data-testid'?: string;
   }) => <span data-testid={testId}>{children}</span>,
+
   Toggle: ({
     isSelected,
     onChange,
@@ -84,13 +90,17 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       toggle
     </button>
   ),
+
   SlideoutMenu: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+
   Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+
   EmptyPlaceholder: ({ title }: { title?: string }) => (
     <div data-testid="empty-tags-placeholder">{title}</div>
   ),
+
   Typography: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArticleDetailHeader/ArticleDetailHeader.test.tsx
@@ -130,12 +130,16 @@ jest.mock(
 );
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   Box: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Button: jest.fn(
     ({
       children,
@@ -151,6 +155,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -168,10 +173,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Card: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Dot: jest.fn(() => <span>·</span>),
+
   Dropdown: Object.assign(
     jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -209,7 +217,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Skeleton: jest.fn(() => <div data-testid="skeleton" />),
+
   Tabs: Object.assign(
     jest.fn(
       ({
@@ -231,12 +241,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Tooltip: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   TooltipTrigger: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextCenterHeader/ContextCenterHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextCenterHeader/ContextCenterHeader.test.tsx
@@ -20,10 +20,14 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Breadcrumbs: jest.fn(() => <nav data-testid="title-breadcrumb" />),
+
   Button: jest.fn(
     ({
       children,
@@ -33,9 +37,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onClick?: () => void;
     }) => <button onClick={onClick}>{children}</button>
   ),
+
   Card: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Input: jest.fn(
     ({
       onChange,
@@ -56,6 +62,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateFolderModal/CreateFolderModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateFolderModal/CreateFolderModal.test.tsx
@@ -26,6 +26,8 @@ jest.mock('rest/assetAPI', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn(
     ({
       children,
@@ -49,6 +51,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Dialog: Object.assign(
     jest.fn(
       ({
@@ -75,6 +78,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )),
     }
   ),
+
   Input: jest.fn(
     ({
       value,
@@ -95,13 +99,16 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   Modal: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   ModalOverlay: jest.fn(
     ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
       isOpen ? <div data-testid="modal-overlay">{children}</div> : null
   ),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.test.tsx
@@ -89,18 +89,24 @@ jest.mock('antd', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Alert: jest.fn(({ title }: { title: string }) => (
     <div role="alert">{title}</div>
   )),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   BadgeWithButton: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   Box: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Button: jest.fn(
     ({
       children,
@@ -110,12 +116,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onClick?: () => void;
     }) => <button onClick={onClick}>{children}</button>
   ),
+
   ButtonUtility: jest.fn(({ onClick }: { onClick?: () => void }) => (
     <button onClick={onClick}>x</button>
   )),
+
   Card: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Dialog: Object.assign(
     jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -126,8 +135,10 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )),
     }
   ),
+
   Dot: jest.fn(() => <span />),
   FieldTypes: { TEXT: 'text', SELECT: 'select' },
+
   FormField: ({
     control,
     name,
@@ -141,9 +152,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
 
     return <>{children(controller)}</>;
   },
+
   FormItemLabel: jest.fn(({ label }: { label: React.ReactNode }) => (
     <label>{label}</label>
   )),
+
   getField: (fieldProp: {
     name: string;
     label: React.ReactNode;
@@ -194,6 +207,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
 
     return <MockField />;
   },
+
   HookForm: ({
     form,
     children,
@@ -211,6 +225,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </form>
     </FormProvider>
   ),
+
   Input: jest.fn(
     ({
       'data-testid': testId,
@@ -228,13 +243,16 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   Modal: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   ModalOverlay: jest.fn(
     ({ children, isOpen }: { children: React.ReactNode; isOpen?: boolean }) =>
       isOpen ? <div>{children}</div> : null
   ),
+
   Select: Object.assign(
     jest.fn(
       ({
@@ -249,6 +267,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Item: jest.fn(({ label }: { label: string }) => <option>{label}</option>),
     }
   ),
+
   TextArea: jest.fn(
     ({
       'data-testid': testId,
@@ -266,12 +285,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   Tooltip: jest.fn(({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   )),
+
   TooltipTrigger: jest.fn(({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   )),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentFolderView.test.tsx
@@ -116,6 +116,8 @@ jest.mock('../../../components/common/DeleteModal/DeleteModal', () =>
 );
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn(
     ({
       children,
@@ -125,9 +127,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onClick?: (e: React.MouseEvent) => void;
     }) => <button onClick={onClick}>{children}</button>
   ),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span data-testid="badge">{children}</span>
   )),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -143,14 +147,19 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Card: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div data-testid="card">{children}</div>
   )),
+
   Dot: jest.fn(() => <div data-testid="dot">dot</div>),
+
   FileIcon: jest.fn(({ type }: { type: string }) => (
     <span data-testid={`file-icon-${type}`} />
   )),
+
   Skeleton: jest.fn(() => <div data-testid="skeleton" />),
+
   Tree: Object.assign(
     jest.fn(
       ({
@@ -190,6 +199,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.test.tsx
@@ -16,6 +16,8 @@ import { ContextFile } from '../../../generated/entity/data/contextFile';
 import DocumentPreviewPanel from './DocumentPreviewPanel.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: jest.fn(
     ({
       children,
@@ -31,6 +33,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -44,6 +47,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Card: jest.fn(
     ({
       children,
@@ -53,9 +57,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       'data-testid'?: string;
     }) => <div data-testid={testId}>{children}</div>
   ),
+
   FileIcon: jest.fn(({ type }: { type: string }) => (
     <span data-testid={`file-icon-${type}`} />
   )),
+
   Typography: jest.fn(
     ({
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentsView.test.tsx
@@ -47,6 +47,8 @@ jest.mock('react-aria-components', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: jest.fn(
     ({
       children,
@@ -62,6 +64,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   Button: jest.fn(
     ({
       children,
@@ -77,6 +80,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -90,6 +94,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Card: jest.fn(
     ({
       children,
@@ -99,6 +104,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       'data-testid'?: string;
     }) => <div data-testid={testId}>{children}</div>
   ),
+
   Dropdown: {
     Root: jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -134,10 +140,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )
     ),
   },
+
   Dot: jest.fn(() => <span>·</span>),
+
   EmptyPlaceholder: jest.fn(({ title }: { title?: React.ReactNode }) => (
     <div data-testid="empty-placeholder">{title}</div>
   )),
+
   Checkbox: jest.fn(
     ({
       onChange,
@@ -147,16 +156,21 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       'aria-label'?: string;
     }) => <input aria-label={ariaLabel} type="checkbox" onChange={onChange} />
   ),
+
   FileIcon: jest.fn(({ type }: { type: string }) => (
     <span data-testid={`file-icon-${type}`} />
   )),
+
   Skeleton: jest.fn(() => <div data-testid="skeleton" />),
+
   Tooltip: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   TooltipTrigger: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/MemoriesView/MemoriesView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/MemoriesView/MemoriesView.test.tsx
@@ -27,9 +27,12 @@ jest.mock('../../../assets/svg/edit-new.svg', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   Box: jest.fn(
     ({
       children,
@@ -38,6 +41,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       children: React.ReactNode;
     } & React.HTMLAttributes<HTMLDivElement>) => <div {...rest}>{children}</div>
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -51,10 +55,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       <button data-testid={testId} disabled={isDisabled} onClick={onClick} />
     )
   ),
+
   Dot: jest.fn(() => <span />),
+
   EmptyPlaceholder: jest.fn(({ title }: { title?: React.ReactNode }) => (
     <div data-testid="empty-placeholder">{title}</div>
   )),
+
   Dropdown: {
     Root: jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -72,13 +79,17 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )
     ),
   },
+
   Skeleton: jest.fn(() => <div data-testid="skeleton" />),
+
   Tooltip: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   TooltipTrigger: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.test.tsx
@@ -33,6 +33,8 @@ let mockOnDropFiles: ((files: FileList) => void) | undefined;
 let mockOnSizeLimitExceed: ((files: FileList) => void) | undefined;
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn(
     ({
       children,
@@ -48,6 +50,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({ onClick, tooltip }: { onClick?: () => void; tooltip?: string }) => (
       <button aria-label={tooltip} onClick={onClick}>
@@ -55,6 +58,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Dialog: Object.assign(
     jest.fn(
       ({
@@ -82,6 +86,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Header: jest.fn(({ title }: { title: string }) => <div>{title}</div>),
     }
   ),
+
   FileUpload: Object.assign(
     jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
@@ -122,6 +127,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   FileUploadDropZone: jest.fn(
     ({
       onDropFiles,
@@ -136,10 +142,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       return <div data-testid="drop-zone" />;
     }
   ),
+
   getReadableFileSize: jest.fn((size: number) => `${size} bytes`),
+
   Modal: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   ModalOverlay: jest.fn(
     ({ children, isOpen }: { children: React.ReactNode; isOpen: boolean }) =>
       isOpen ? <div data-testid="modal-overlay">{children}</div> : null

--- a/openmetadata-ui/src/main/resources/ui/src/components/CopyLinkButton/CopyLinkButton.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/CopyLinkButton/CopyLinkButton.test.tsx
@@ -24,6 +24,8 @@ jest.mock('../../hooks/useClipBoard', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -33,7 +35,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Tooltip: jest.fn().mockImplementation(({ children }) => <>{children}</>),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionContentBody.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionContentBody.test.tsx
@@ -16,6 +16,8 @@ import AssetSelectionContentBody, {
 } from './AssetSelectionContentBody';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: ({
     children,
     onScroll,
@@ -29,7 +31,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   Divider: () => <div data-testid="divider" />,
+
   Typography: ({
     children,
     onClick,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionDrawer.test.tsx
@@ -16,6 +16,8 @@ import { AssetSelectionDrawer } from './AssetSelectionDrawer';
 import { useAssetSelectionState } from './useAssetSelectionState';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   SlideoutMenu: Object.assign(
     ({
       isOpen,
@@ -61,6 +63,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionFooter.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionFooter.test.tsx
@@ -16,6 +16,8 @@ import AssetSelectionFooter, {
 } from './AssetSelectionFooter';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: ({
     children,
     'data-testid': testId,
@@ -23,6 +25,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     'data-testid'?: string;
   }) => <div data-testid={testId}>{children}</div>,
+
   Button: ({
     children,
     onClick,
@@ -44,9 +47,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Divider: ({ 'data-testid': testId }: { 'data-testid'?: string }) => (
     <div data-testid={testId ?? 'divider'} />
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/AssetsSelectionModal/AssetSelectionModal.test.tsx
@@ -47,10 +47,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Dialog: MockDialog,
+
     Modal: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="modal">{children}</div>
     ),
+
     ModalOverlay: ({
       children,
       isOpen,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractDetailTab/ContractDetail.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ContractDetailTab/ContractDetail.test.tsx
@@ -43,12 +43,16 @@ import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import { ContractDetail } from './ContractDetail';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest.fn(({ children }: { children?: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   BadgeWithIcon: jest.fn(({ children }: { children?: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   Box: jest.fn(
     ({
       children,
@@ -64,6 +68,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   Button: jest.fn(
     ({
       children,
@@ -81,6 +86,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -90,6 +96,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       [key: string]: unknown;
     }) => <button onClick={onClick} {...rest} />
   ),
+
   Card: Object.assign(
     jest.fn(
       ({
@@ -118,6 +125,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )),
     }
   ),
+
   Divider: jest.fn(
     ({
       className,
@@ -135,6 +143,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   Dropdown: (() => {
     const OnActionCtx = React.createContext<
       ((key: string) => void) | undefined
@@ -190,6 +199,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Separator: jest.fn(() => <hr />),
     };
   })(),
+
   Tooltip: jest.fn(
     ({
       children,
@@ -203,9 +213,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   TooltipTrigger: jest.fn(({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   )),
+
   Typography: jest.fn(
     ({
       as: Tag = 'span',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataContract/ODCSImportModal/ODCSImportModal.test.tsx
@@ -36,12 +36,16 @@ import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import ContractImportModal from './ODCSImportModal.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   BadgeWithIcon: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
+
   Box: jest.fn(
     ({
       children,
@@ -57,6 +61,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   Button: jest.fn(
     ({
       children,
@@ -74,6 +79,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   ButtonUtility: jest.fn(
     ({
       onClick,
@@ -83,6 +89,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       [key: string]: unknown;
     }) => <button onClick={onClick} {...rest} />
   ),
+
   Card: Object.assign(
     jest.fn(
       ({
@@ -105,6 +112,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )),
     }
   ),
+
   FileUploadDropZone: jest.fn(
     ({
       accept,
@@ -152,6 +160,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       );
     }
   ),
+
   Dialog: Object.assign(
     jest.fn(
       ({
@@ -181,13 +190,16 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )),
     }
   ),
+
   Modal: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   ModalOverlay: jest.fn(
     ({ children, isOpen }: { children: React.ReactNode; isOpen?: boolean }) =>
       isOpen ? <div data-testid="modal-overlay">{children}</div> : null
   ),
+
   RadioButton: jest.fn(
     ({
       value,
@@ -209,6 +221,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       />
     )
   ),
+
   RadioGroup: jest.fn(
     ({
       children,
@@ -260,6 +273,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       );
     }
   ),
+
   Select: jest.fn(
     ({
       items,
@@ -285,6 +299,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </select>
     )
   ),
+
   Typography: jest.fn(
     ({
       as: Tag = 'span',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceGreetingBanner/MarketplaceGreetingBanner.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceGreetingBanner/MarketplaceGreetingBanner.test.tsx
@@ -28,6 +28,8 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Typography: ({
     as: Element = 'div',
     children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
@@ -109,7 +109,12 @@ jest.mock('@openmetadata/ui-core-components', () => {
     children?: React.ReactNode;
   } & Record<string, unknown>) => <span {...rest}>{children}</span>;
 
-  return { Input, SelectPopover, Typography };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Input,
+    SelectPopover,
+    Typography,
+  };
 });
 
 jest.mock('@untitledui/icons', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TableDiffFields.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/TableDiffFields.test.tsx
@@ -38,7 +38,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const actual = jest.requireActual('@openmetadata/ui-core-components');
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     ...actual,
+
     getField: (config: {
       name?: string;
       props?: { options?: Array<{ id: string; isDisabled?: boolean }> };

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddToBundleSuiteModal/AddToBundleSuiteModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddToBundleSuiteModal/AddToBundleSuiteModal.test.tsx
@@ -126,6 +126,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: ({
       children,
       onPress,
@@ -141,10 +143,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     Dialog: MockDialog,
+
     Modal: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="modal">{children}</div>
     ),
+
     ModalOverlay: ({
       children,
       isOpen,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataStatisticWidget/DataStatisticWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/DataStatisticWidget/DataStatisticWidget.test.tsx
@@ -18,6 +18,8 @@ import { DataStatisticWidgetProps } from '../../DataQuality.interface';
 import DataStatisticWidget from './DataStatisticWidget.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Skeleton: ({
     width,
     height,
@@ -29,6 +31,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Loading...
     </div>
   ),
+
   Typography: ({
     children,
     className,
@@ -40,6 +43,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </span>
   ),
+
   Button: ({
     children,
     ...props
@@ -51,6 +55,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Divider: ({ className }: { className?: string }) => (
     <hr className={className} />
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusAreaChartWidget/TestCaseStatusAreaChartWidget.test.tsx
@@ -55,6 +55,8 @@ jest.mock('../../../../assets/svg/ic-warning-2.svg', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Skeleton: ({
     width,
     height,
@@ -66,6 +68,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Loading...
     </div>
   ),
+
   Tooltip: ({
     children,
     title,
@@ -73,6 +76,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     title?: string;
   }) => <div title={title ?? ''}>{children}</div>,
+
   Typography: ({
     children,
     className,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DataQualityDashboard.test.tsx
@@ -42,6 +42,8 @@ const mockSearchQuery = jest.fn().mockResolvedValue({
 });
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: ({
     children,
     className,
@@ -51,12 +53,14 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Card: ({
     children,
     className,
   }: React.PropsWithChildren<{ className?: string }>) => (
     <div className={className}>{children}</div>
   ),
+
   Grid: Object.assign(
     ({
       children,
@@ -79,9 +83,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Tooltip: ({ children }: React.PropsWithChildren<Record<string, unknown>>) => (
     <>{children}</>
   ),
+
   TooltipTrigger: ({
     children,
   }: React.PropsWithChildren<Record<string, unknown>>) => <>{children}</>,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DqDashboardSectionContent.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DqDashboardSectionContent.test.tsx
@@ -27,7 +27,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
     </div>
   );
 
-  return { Grid };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Grid,
+  };
 });
 
 jest.mock('../../../utils/ObservabilityRouterClassBase', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityHeatmap/DimensionalityHeatmap.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityHeatmap/DimensionalityHeatmap.component.test.tsx
@@ -22,6 +22,8 @@ const Wrapper = ({ children }: { children: React.ReactNode }) => (
 );
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Typography: ({
     as: Component = 'span',
     children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/DimensionalityTab/DimensionalityTab.test.tsx
@@ -34,10 +34,13 @@ const PRESET_RANGE = {
 };
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Select: Object.assign(
     jest.fn().mockImplementation(() => <div data-testid="dimension-select" />),
     { Item: jest.fn() }
   ),
+
   Skeleton: jest.fn().mockImplementation(() => <div data-testid="skeleton" />),
   Table: jest.fn(),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/FailedTestCaseSampleData/FailedTestCaseSampleData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/FailedTestCaseSampleData/FailedTestCaseSampleData.test.tsx
@@ -83,6 +83,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: jest
       .fn()
       .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -90,7 +92,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
           {children}
         </button>
       )),
+
     Table: TableMock,
+
     Typography: ({ children }: React.PropsWithChildren<unknown>) => (
       <span>{children}</span>
     ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/Severity/InlineSeverity.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/Severity/InlineSeverity.test.tsx
@@ -92,6 +92,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Dropdown: {
       Root: ({
         children,
@@ -123,6 +125,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       Item: DropdownItem,
       Separator: () => <hr data-testid="dropdown-separator" />,
     },
+
     Typography: ({
       as: Component = 'span',
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineTestCaseIncidentStatus.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseStatus/InlineTestCaseIncidentStatus.test.tsx
@@ -107,6 +107,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Box: ({
       children,
       className,
@@ -127,6 +129,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </div>
     ),
+
     Button: React.forwardRef<
       HTMLButtonElement,
       React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -151,6 +154,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </button>
       )
     ),
+
     ButtonUtility: ({
       icon: Icon,
       onClick,
@@ -164,7 +168,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {Icon ? <Icon /> : null}
       </button>
     ),
+
     Divider: () => <hr />,
+
     Dropdown: {
       Root: ({
         children,
@@ -201,6 +207,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       Item: DropdownItem,
       Separator: () => <hr data-testid="dropdown-separator" />,
     },
+
     Input: ({
       onChange,
       placeholder,
@@ -217,6 +224,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {...props}
       />
     ),
+
     Label: ({
       children,
       isRequired,
@@ -229,6 +237,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {isRequired && <span> *</span>}
       </label>
     ),
+
     Popover: ({
       children,
       containerClassName,
@@ -242,6 +251,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </div>
     ),
+
     PopoverTrigger: ({
       children,
       isOpen,
@@ -270,6 +280,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       );
     },
+
     TextArea: ({
       onChange,
       value,
@@ -293,6 +304,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {...props}
       />
     ),
+
     Typography: ({
       as: Component = 'span',
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCaseListTableHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCaseListTableHeader.test.tsx
@@ -15,12 +15,15 @@ import { act } from 'react';
 import { TestCaseListTableHeader } from './TestCaseListTableHeader.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: ({
     children,
     'data-testid': testId,
   }: React.PropsWithChildren<{ 'data-testid'?: string }>) => (
     <div data-testid={testId}>{children}</div>
   ),
+
   Input: ({
     value,
     placeholder,
@@ -37,6 +40,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onChange={(e) => onChange?.(e.target.value)}
     />
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuiteListPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuiteListPanel.test.tsx
@@ -71,6 +71,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const Tabs = Object.assign(TabsComponent, { List, Item });
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Box: ({
       children,
       className,
@@ -84,6 +86,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </div>
     ),
+
     Input: ({
       placeholder,
       value,
@@ -100,6 +103,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         onChange={(e) => onChange(e.target.value)}
       />
     ),
+
     Tabs,
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuites.test.tsx
@@ -273,6 +273,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }) => <Component {...props}>{children}</Component>;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Box: MockBox,
     EmptyPlaceholder: MockEmptyPlaceholder,
     Input: MockInput,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuitesTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuiteList/TestSuitesTable.test.tsx
@@ -166,6 +166,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }) => <Component {...props}>{children}</Component>;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Box: MockBox,
     EmptyPlaceholder: MockEmptyPlaceholder,
     Table: MockTable,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestSuite/TestSuitePipelineTab/TestSuitePipelineTab.test.tsx
@@ -163,6 +163,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }) => <Component {...props}>{children}</Component>;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: jest
       .fn()
       .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -170,6 +172,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           {children}
         </button>
       )),
+
     Table: MockTable,
     TableCard: MockTableCard,
     Tooltip: MockTooltip,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
@@ -93,6 +93,8 @@ jest.mock('antd', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn().mockImplementation(
     ({
       children,
@@ -110,6 +112,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </button>
     )
   ),
+
   Typography: jest
     .fn()
     .mockImplementation(({ as: Component = 'span', children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/KeyProfileMetrics/KeyProfileMetrics.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/KeyProfileMetrics/KeyProfileMetrics.test.tsx
@@ -16,12 +16,15 @@ import { ColumnProfile } from '../../../../generated/entity/data/table';
 import { KeyProfileMetrics } from './KeyProfileMetrics.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Tooltip: ({
     children,
     title,
   }: React.PropsWithChildren<{ title?: string }>) => (
     <div title={title}>{children}</div>
   ),
+
   TooltipTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataObservability/DataObservabilityTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataObservability/DataObservabilityTab.test.tsx
@@ -57,7 +57,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
     </button>
   );
 
-  return { Tabs };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Tabs,
+  };
 });
 
 const mockNavigate = jest.fn();

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataObservability/TabFilters/TabFilters.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataObservability/TabFilters/TabFilters.test.tsx
@@ -79,6 +79,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   };
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Button,
     Dropdown,
     Tooltip,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.test.tsx
@@ -232,18 +232,22 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Box: MockBox,
     Button: MockButton,
     EmptyPlaceholder: MockEmptyPlaceholder,
     Skeleton: () => <span data-testid="skeleton">Loading...</span>,
     Table: MockTable,
+
     Tooltip: ({
       children,
       title,
     }: React.PropsWithChildren<{ title?: string }>) => (
       <div title={title}>{children}</div>
     ),
+
     TooltipTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+
     Typography: ({
       children,
       className,
@@ -253,6 +257,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </span>
     ),
+
     Dropdown: {
       Root: DropdownRoot,
       Popover: DropdownPopover,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/ProfilerStateWrapper/ProfilerStateWrapper.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/ProfilerStateWrapper/ProfilerStateWrapper.test.tsx
@@ -14,6 +14,7 @@ import { render, screen } from '@testing-library/react';
 import ProfilerStateWrapper from './ProfilerStateWrapper.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Skeleton: () => <div data-testid="skeleton">Loading...</div>,
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -81,7 +81,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Table,
+
     Typography: ({ children }: { children: React.ReactNode }) => (
       <span>{children}</span>
     ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/QualityTab/QualityTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/QualityTab/QualityTab.test.tsx
@@ -46,7 +46,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
   MockTabs.List = MockTabList;
   MockTabs.Item = MockTabItem;
 
-  return { Tabs: MockTabs };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Tabs: MockTabs,
+  };
 });
 
 import { render, screen } from '@testing-library/react';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableQueries/TableQueries.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableQueries/TableQueries.test.tsx
@@ -31,11 +31,14 @@ import TableQueries from './TableQueries';
 import { TableQueriesProp } from './TableQueries.interface';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (
       <button {...props}>{children}</button>
     )),
+
   Dropdown: {
     Root: jest.fn().mockImplementation(({ children, ...props }) => (
       <div data-testid="dropdown" {...props}>
@@ -56,6 +59,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )),
   },
+
   Typography: jest
     .fn()
     .mockImplementation(({ as: Component = 'span', children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.test.tsx
@@ -101,10 +101,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }) => <div data-testid={testId}>{label}</div>;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Autocomplete,
+
     Avatar: (props: Record<string, unknown>) => (
       <div data-testid="avatar" {...props} />
     ),
+
     Box: ({
       children,
       ...props
@@ -112,7 +115,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
       children?: ReactNode;
       [key: string]: unknown;
     }) => <div {...props}>{children}</div>,
+
     Dot: (props: Record<string, unknown>) => <span {...props} />,
+
     Button: ({
       children,
       onPress,
@@ -141,6 +146,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     FieldTypes: {
       COVER_IMAGE_UPLOAD: 'cover_image_upload',
       DESCRIPTION: 'description',
@@ -155,6 +161,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       USER_TEAM_SELECT: 'user_team_select',
       USER_TEAM_SELECT_INPUT: 'user_team_select_input',
     },
+
     FormField: <TFieldValues extends FieldValues = FieldValues>({
       control,
       name,
@@ -184,8 +191,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
         rules={rules}
       />
     ),
+
     FormItemLabel: ({ label }: { label: ReactNode }) => <div>{label}</div>,
     HintText: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+
     HookForm: ({
       children,
       onSubmit,
@@ -204,6 +213,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </form>
     ),
+
     getField: (field: {
       id?: string;
       name: string;
@@ -217,6 +227,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {field.label}
       </div>
     ),
+
     Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
     TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.test.tsx
@@ -47,7 +47,9 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Avatar: () => <div data-testid="avatar" />,
+
   Badge: ({
     children,
     'data-testid': dataTestId,
@@ -55,6 +57,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children?: ReactNode;
     'data-testid'?: string;
   }) => <span data-testid={dataTestId}>{children}</span>,
+
   Box: ({
     children,
     direction: _direction,
@@ -64,12 +67,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     direction?: string;
     [key: string]: unknown;
   }) => <div {...props}>{children}</div>,
+
   Divider: ({ label }: { label?: ReactNode }) => (
     <div role="separator">{label}</div>
   ),
+
   Typography: ({ children }: { children?: ReactNode }) => (
     <span>{children}</span>
   ),
+
   Button: ({
     children,
     onPress,
@@ -77,15 +83,18 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: ReactNode;
     onPress?: () => void;
   }) => <button onClick={onPress}>{children}</button>,
+
   DatePicker: ({ 'aria-label': label }: { 'aria-label'?: string }) => (
     <div data-testid={`${label}-date-picker`} />
   ),
+
   FieldTypes: {
     MULTI_SELECT: 'multi_select',
     SELECT: 'select',
     TEXT: 'text',
     USER_TEAM_SELECT_INPUT: 'user_team_select_input',
   },
+
   FormField: <TFieldValues extends FieldValues = FieldValues>({
     children,
     control,
@@ -110,7 +119,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       rules={rules}
     />
   ),
+
   FormItemLabel: ({ label }: { label: ReactNode }) => <div>{label}</div>,
+
   getField: (field: {
     label?: ReactNode;
     name: string;
@@ -127,7 +138,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {field.label}
     </div>
   ),
+
   HintText: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+
   Input: ({
     hint,
     inputDataTestId,
@@ -157,6 +170,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {hint}
     </label>
   ),
+
   TimePicker: ({ 'aria-label': label }: { 'aria-label'?: string }) => (
     <div data-testid={`${label}-time-picker`} />
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/components/DomainTreeView.test.tsx
@@ -41,17 +41,23 @@ let capturedCallbacks: {
 // ---------------------------------------------------------------------------
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Avatar: jest.fn(() => null),
+
   Badge: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span data-testid="badge">{children}</span>
   )),
+
   Box: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   )),
-  Tree: jest.fn(), // implementation configured per-test in beforeEach
+
+  // implementation configured per-test in beforeEach
+  Tree: jest.fn(),
 }));
 
 jest.mock('../../common/ResizablePanels/ResizableLeftPanels', () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.test.tsx
@@ -43,6 +43,8 @@ const defaultProps = {
 };
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -62,6 +64,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Dropdown: {
     Root: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
     Popover: jest
@@ -80,19 +83,23 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         <li data-key={key}>{children}</li>
       )),
   },
+
   Tooltip: jest
     .fn()
     .mockImplementation(({ children, title }) => (
       <div title={title as string}>{children}</div>
     )),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children, as: Tag = 'span', className }) => (
       <Tag className={className}>{children}</Tag>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -112,6 +119,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Tabs: Object.assign(
     jest
       .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomNodeV1.test.tsx
@@ -152,6 +152,8 @@ const setColumnsInCurrentPagesMock = jest.fn((updater) => {
 });
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -173,6 +175,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         />
       )
     ),
+
   BadgeWithIcon: jest
     .fn()
     .mockImplementation(({ children, iconLeading: Icon }) => (
@@ -181,11 +184,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </span>
     )),
+
   Box: jest.fn().mockImplementation(({ children, className, ...props }) => (
     <div className={className} {...props}>
       {children}
     </div>
   )),
+
   Breadcrumbs: jest
     .fn()
     .mockImplementation(({ items, 'data-testid': testId }) => {
@@ -209,6 +214,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </div>
       );
     }),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -222,6 +228,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Typography: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/VirtualColumnList.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/NodeChildren/VirtualColumnList.component.test.tsx
@@ -20,6 +20,8 @@ import VirtualColumnList, {
 } from './VirtualColumnList.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityVersionTimeLine/BulkImportVersionSummary/BulkImportVersionSummary.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityVersionTimeLine/BulkImportVersionSummary/BulkImportVersionSummary.test.tsx
@@ -18,6 +18,8 @@ import {
 import { BulkImportVersionSummary } from './BulkImportVersionSummary.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, 'data-testid': testId }) => (
@@ -25,6 +27,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Dialog: Object.assign(
     jest
       .fn()
@@ -51,6 +54,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         .mockImplementation(({ children }) => <div>{children}</div>),
     }
   ),
+
   Typography: jest
     .fn()
     .mockImplementation(
@@ -58,7 +62,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         <Tag data-testid={testId}>{children}</Tag>
       )
     ),
+
   Modal: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   ModalOverlay: jest
     .fn()
     .mockImplementation(({ children, isOpen }) =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/LineageTab/LineageTabContent.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/LineageTab/LineageTabContent.test.tsx
@@ -35,6 +35,8 @@ jest.mock('@untitledui/icons', () => ({
 
 // Mock react-i18next
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -42,12 +44,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Tooltip: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   Breadcrumbs: jest
     .fn()
     .mockImplementation(
@@ -81,6 +86,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         );
       }
     ),
+
   Typography: jest
     .fn()
     .mockImplementation(({ as: Component = 'span', children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
@@ -39,6 +39,8 @@ jest.mock('../common/Loader/Loader', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: ({
     children,
     onPress,
@@ -52,6 +54,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Checkbox: ({
     isSelected,
     onChange,
@@ -72,6 +75,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {label}
     </label>
   ),
+
   Input: ({
     value,
     onChange,
@@ -88,9 +92,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onChange={(event) => onChange(event.target.value)}
     />
   ),
+
   Popover: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
+
   PopoverTrigger: ({
     isOpen,
     onOpenChange,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/SortingDropDown.test.tsx
@@ -16,11 +16,14 @@ import { MemoryRouter } from 'react-router-dom';
 import SortingDropDown from './SortingDropDown';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (
       <button {...props}>{children}</button>
     )),
+
   Dropdown: {
     Root: jest.fn().mockImplementation(({ children, ...props }) => (
       <div data-testid="dropdown" {...props}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreSearchCard/ExploreSearchCard.test.tsx
@@ -95,6 +95,8 @@ jest.mock('../../common/DomainDisplay/DomainDisplay.component', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -102,6 +104,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Breadcrumbs: jest.fn(({ items = [] }) => (
     <nav data-testid="breadcrumbs">
       {items.map(
@@ -127,7 +130,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       )}
     </nav>
   )),
+
   Card: jest.fn(({ children, ...props }) => <div {...props}>{children}</div>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ as: Component = 'span', children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.test.tsx
@@ -168,6 +168,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Alert,
     Box,
     Button,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.test.tsx
@@ -28,6 +28,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const React = require('react');
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Autocomplete: Object.assign(
       ({ children, ...props }: Record<string, unknown>) =>
         React.createElement('div', props, children),
@@ -36,19 +38,23 @@ jest.mock('@openmetadata/ui-core-components', () => {
           React.createElement('div', props, label),
       }
     ),
+
     Badge: ({ children, ...props }: Record<string, unknown>) =>
       React.createElement('span', props, children),
+
     BadgeWithIcon: ({
       children,
       iconLeading: _iconLeading,
       ...props
     }: Record<string, unknown>) => React.createElement('span', props, children),
+
     Button: ({
       children,
       iconLeading: _iconLeading,
       ...props
     }: Record<string, unknown>) =>
       React.createElement('button', props, children),
+
     Select: Object.assign(
       ({ children, ...props }: Record<string, unknown>) =>
         React.createElement('select', props, children),
@@ -57,10 +63,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
           React.createElement('option', props, label),
       }
     ),
+
     Tooltip: ({ children, ...props }: Record<string, unknown>) =>
       React.createElement('span', props, children),
+
     TooltipTrigger: ({ children, ...props }: Record<string, unknown>) =>
       React.createElement('span', props, children),
+
     Typography: ({ children, ...props }: Record<string, unknown>) =>
       React.createElement('span', props, children),
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/TermsRowEditor.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/TermsRowEditor.test.tsx
@@ -31,6 +31,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const React = require('react');
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Autocomplete: Object.assign(
       ({
         children,
@@ -56,6 +58,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           React.createElement('div', { 'data-testid': `option-${id}` }, label),
       }
     ),
+
     Button: ({
       children,
       iconLeading: _iconLeading,
@@ -63,6 +66,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       ...props
     }: Record<string, unknown>) =>
       React.createElement('button', { ...props, onClick }, children),
+
     Select: Object.assign(
       ({
         children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManager.test.tsx
@@ -195,9 +195,12 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Box: ({ children }: { children?: React.ReactNode }) => (
       <div>{children}</div>
     ),
+
     EmptyPlaceholder: ({
       title,
       description,
@@ -210,6 +213,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         <span>{description}</span>
       </div>
     ),
+
     Dropdown: {
       Root: DropdownRoot,
       Popover: jest
@@ -224,9 +228,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
           <div data-testid={`date-field-item-${id}`}>{label}</div>
         )),
     },
+
     Skeleton: jest
       .fn()
       .mockImplementation(() => <div data-testid="skeleton" />),
+
     Button: jest
       .fn()
       .mockImplementation(
@@ -238,6 +244,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           </button>
         )
       ),
+
     Table: TableMock,
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManagerTable.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/IncidentManager/IncidentManagerTable.component.test.tsx
@@ -77,16 +77,20 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
     EmptyPlaceholder: jest.fn().mockImplementation(({ title, description }) => (
       <div data-testid="empty-placeholder">
         <span>{title}</span>
         <span>{description}</span>
       </div>
     )),
+
     Skeleton: jest
       .fn()
       .mockImplementation(() => <div data-testid="skeleton" />),
+
     Table: TableMock,
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.test.tsx
@@ -37,16 +37,20 @@ const mockProps: KnowledgeCardProps = {
 };
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest
     .fn()
     .mockImplementation(({ children }) => (
       <span data-testid="badge">{children}</span>
     )),
+
   Box: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (
       <div {...props}>{children}</div>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(({ children, onClick, 'data-testid': testId }) => (
@@ -54,12 +58,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Card: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (
       <div {...props}>{children}</div>
     )),
+
   Dot: jest.fn().mockReturnValue(<span data-testid="dot" />),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children, ...props }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/QuickLinkFormModal/QuickLinkFormModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/QuickLinkFormModal/QuickLinkFormModal.test.tsx
@@ -44,7 +44,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }) => <div data-testid={testId}>{label}</div>;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Autocomplete,
+
     Button: ({
       children,
       onClick,
@@ -52,6 +54,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       children: ReactNode;
       onClick?: () => void;
     }) => <button onClick={onClick}>{children}</button>,
+
     Dialog: Object.assign(
       ({ children }: { children: ReactNode }) => (
         <div data-testid="dialog">{children}</div>
@@ -68,6 +71,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         ),
       }
     ),
+
     FieldTypes: {
       ASYNC_SELECT: 'ASYNC_SELECT',
       DESCRIPTION: 'DESCRIPTION',
@@ -76,6 +80,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
       TEXT: 'TEXT',
       TEXTAREA: 'TEXTAREA',
     },
+
     FormField: <TFieldValues extends FieldValues = FieldValues>({
       control,
       name,
@@ -105,8 +110,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
         rules={rules}
       />
     ),
+
     FormItemLabel: ({ label }: { label: ReactNode }) => <div>{label}</div>,
     HintText: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+
     HookForm: ({
       children,
       form,
@@ -129,6 +136,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </form>
       </FormProvider>
     ),
+
     getField: ({
       name,
       type,
@@ -163,9 +171,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
 
       return <div data-testid={testId ?? name} />;
     },
+
     Modal: ({ children }: { children: ReactNode }) => (
       <div data-testid="modal">{children}</div>
     ),
+
     ModalOverlay: ({
       children,
       isOpen,

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeGraph3D/KnowledgeGraph3D.test.tsx
@@ -116,6 +116,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   Select.Item = SelectItem;
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Badge,
     Button,
     ButtonGroup,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/IconColorModal/IconColorModal.test.tsx
@@ -25,6 +25,8 @@ type MockFieldProp = {
 };
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -34,6 +36,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Dialog: Object.assign(
     jest.fn().mockImplementation(({ children, title }) => (
       <div role="dialog">
@@ -50,14 +53,18 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         .mockImplementation(({ children }) => <div>{children}</div>),
     }
   ),
+
   Modal: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   ModalOverlay: jest
     .fn()
     .mockImplementation(({ children, isOpen }) =>
       isOpen ? <div>{children}</div> : null
     ),
+
   FieldTypes: { COLOR_PICKER: 'color_picker', ICON_PICKER: 'icon_picker' },
   HelperTextType: { ALERT: 'alert', TOOLTIP: 'tooltip' },
+
   HookForm: ({
     children,
     form,
@@ -80,6 +87,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </form>
     </FormProvider>
   ),
+
   getField: (field: MockFieldProp) => {
     const testId = field.props?.['data-testid'] ?? field.id ?? field.name;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchedData/SearchedData.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchedData/SearchedData.test.tsx
@@ -114,6 +114,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const actual = jest.requireActual('@openmetadata/ui-core-components');
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     ...actual,
     Badge: ({ children }: PropsWithChildren) => <div>{children}</div>,
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentOverflowMenu.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentOverflowMenu.test.tsx
@@ -22,6 +22,8 @@ const mockMenuAction: { current?: (key: string) => void } = {};
 const mockOpenChange: { current?: (open: boolean) => void } = {};
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Dropdown: {
     Root: ({
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/Steps/ScheduleIntervalV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/Steps/ScheduleIntervalV1.test.tsx
@@ -61,6 +61,8 @@ jest.mock('./ScheduleSelectionCards', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: ({
     children,
     color,
@@ -85,6 +87,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Card: ({
     children,
     className,
@@ -96,6 +99,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   Grid: Object.assign(
     ({ children, ...rest }: Record<string, unknown>) => (
       <div data-testid={rest['data-testid'] as string}>
@@ -110,6 +114,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Select: Object.assign(
     ({
       items,
@@ -140,6 +145,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Item: ({ children }: { children: React.ReactNode }) => <>{children}</>,
     }
   ),
+
   TimePicker: ({
     value,
     onChange,
@@ -161,6 +167,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       }}
     />
   ),
+
   Input: ({
     value,
     onChange,
@@ -182,6 +189,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onChange={(e) => onChange?.(e.target.value)}
     />
   ),
+
   Typography: ({
     children,
     className,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionWorkflowForm/ProfileSampleConfigField.test.tsx
@@ -78,6 +78,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: ({
       children,
       onClick,
@@ -94,8 +96,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     Card: CardMock,
     Grid: GridMock,
+
     Input: ({
       'data-testid': testId,
       value,
@@ -115,7 +119,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
         onChange={(e) => onChange?.(e.target.value)}
       />
     ),
+
     Select: SelectMock,
+
     Typography: ({
       children,
       className,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/AdminPermissionDebugger/AdminPermissionDebugger.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/AdminPermissionDebugger/AdminPermissionDebugger.component.tsx
@@ -11,7 +11,6 @@
  *  limitations under the License.
  */
 
-import { Typography as CoreTypography } from '@openmetadata/ui-core-components';
 import {
   Button,
   Typography as CoreTypography,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Users/CreateUser/CreateUser.test.tsx
@@ -62,6 +62,8 @@ jest.mock('../../../../rest/rolesAPIV1', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -69,10 +71,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Tooltip: jest.fn().mockImplementation(({ children }) => <>{children}</>),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(({ icon, onClick, 'data-testid': testId }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionList/TestDefinitionList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/TestLibrary/TestDefinitionList/TestDefinitionList.test.tsx
@@ -82,19 +82,24 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
     EmptyPlaceholder: jest.fn().mockImplementation(({ title, description }) => (
       <div data-testid="empty-placeholder">
         <span>{title}</span>
         <span>{description}</span>
       </div>
     )),
+
     Popover: jest
       .fn()
       .mockImplementation(({ children }) => <div>{children}</div>),
+
     PopoverTrigger: jest
       .fn()
       .mockImplementation(({ children }) => <div>{children}</div>),
+
     Button: jest
       .fn()
       .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -102,6 +107,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           {children}
         </button>
       )),
+
     ButtonUtility: jest
       .fn()
       .mockImplementation(
@@ -111,15 +117,19 @@ jest.mock('@openmetadata/ui-core-components', () => {
           </button>
         )
       ),
+
     FeaturedIcon: jest
       .fn()
       .mockImplementation(({ icon }) => <span>{icon}</span>),
+
     Typography: jest
       .fn()
       .mockImplementation(({ children }) => <span>{children}</span>),
+
     Skeleton: jest
       .fn()
       .mockImplementation(() => <div data-testid="skeleton" />),
+
     Table: TableMock,
     defaultColors: { gray: { 50: '#fafafa' } },
   };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.test.tsx
@@ -19,6 +19,8 @@ import CardinalityDistributionChart, {
 } from './CardinalityDistributionChart.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: ({
     children,
     ...props

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/EmptyCanvasMessage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/EmptyCanvasMessage.test.tsx
@@ -27,9 +27,12 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Card: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="empty-canvas-card">{children}</div>
   ),
+
   Typography: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/WorkflowHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/WorkflowHeader.test.tsx
@@ -25,6 +25,8 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: ({
     children,
     ...rest
@@ -32,6 +34,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     [key: string]: unknown;
   }) => <span {...rest}>{children}</span>,
+
   Button: ({
     children,
     onPress,
@@ -45,9 +48,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Card: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="workflow-header">{children}</div>
   ),
+
   Dialog: ({
     children,
     title,
@@ -55,8 +60,10 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     title?: string;
   }) => <div data-title={title}>{children}</div>,
+
   Input: ({ label }: { label?: string }) => <input aria-label={label} />,
   Modal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+
   ModalOverlay: ({
     children,
     isOpen,
@@ -64,6 +71,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     isOpen: boolean;
   }) => (isOpen ? <>{children}</> : null),
+
   Tooltip: ({
     children,
     title,
@@ -75,9 +83,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+
   Typography: ({
     children,
     ...rest

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/ConditionBuilder/ConditionBuilder.test.tsx
@@ -135,7 +135,15 @@ jest.mock('@openmetadata/ui-core-components', () => {
     }
   );
 
-  return { Autocomplete, Button, Card, Input, Select, Toggle };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Autocomplete,
+    Button,
+    Card,
+    Input,
+    Select,
+    Toggle,
+  };
 });
 
 jest.mock('react-i18next', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/MetadataFormSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/MetadataFormSection.test.tsx
@@ -84,7 +84,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
     );
   };
 
-  return { Input, TextArea };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Input,
+    TextArea,
+  };
 });
 
 jest.mock('../../../../contexts/WorkflowModeContext', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/SchemaBasedNodeForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/SchemaBasedNodeForm.test.tsx
@@ -69,7 +69,13 @@ jest.mock('@openmetadata/ui-core-components', () => {
     className?: string;
   }) => <span className={props.className}>{props.children}</span>;
 
-  return { Input, TextArea, Toggle, Typography };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Input,
+    TextArea,
+    Toggle,
+    Typography,
+  };
 });
 
 jest.mock('react-i18next', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/SinkTaskForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/WorkflowBuilder/forms/SinkTaskForm.test.tsx
@@ -97,7 +97,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
 
   const SelectWithItem = Object.assign(Select, { Item: SelectItem });
 
-  return { Input, Select: SelectWithItem };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Input,
+    Select: SelectWithItem,
+  };
 });
 
 jest.mock('../../../../contexts/WorkflowModeContext', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AnnouncementsWidget/AnnouncementItemV3.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AnnouncementsWidget/AnnouncementItemV3.test.tsx
@@ -27,6 +27,8 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: ({
     children,
     className,
@@ -54,6 +56,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   Typography: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/AnnouncementsWidget/AnnouncementsWidgetV3Body.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/AnnouncementsWidget/AnnouncementsWidgetV3Body.test.tsx
@@ -20,6 +20,8 @@ jest.mock('react-i18next', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: ({
     children,
     className,
@@ -33,9 +35,11 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   Typography: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),
+
   Button: ({
     children,
     onClick,
@@ -49,6 +53,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   ButtonUtility: ({
     isDisabled,
     onClick,
@@ -67,6 +72,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       onClick={onClick}
     />
   ),
+
   Skeleton: () => <span data-testid="skeleton" />,
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/CopyToClipboardButton/CopyToClipboardButton.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/CopyToClipboardButton/CopyToClipboardButton.test.tsx
@@ -15,14 +15,18 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CopyToClipboardButton } from './CopyToClipboardButton';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Tooltip: jest.fn().mockImplementation(({ children, title }) => (
     <div data-testid="tooltip" data-title={title}>
       {children}
     </div>
   )),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(({ icon, onClick, 'data-testid': testId }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteModal/DeleteModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/DeleteModal/DeleteModal.test.tsx
@@ -15,6 +15,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { DeleteModal } from './DeleteModal';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -24,6 +26,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Dialog: Object.assign(
     jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
     {
@@ -32,6 +35,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         .mockImplementation(({ children }) => <div>{children}</div>),
     }
   ),
+
   Grid: Object.assign(
     jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
     {
@@ -40,13 +44,16 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         .mockImplementation(({ children }) => <div>{children}</div>),
     }
   ),
+
   FeaturedIcon: jest.fn().mockReturnValue(<div data-testid="featured-icon" />),
   Modal: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   ModalOverlay: jest
     .fn()
     .mockImplementation(({ children, isOpen }) =>
       isOpen ? <div>{children}</div> : null
     ),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.test.tsx
@@ -27,18 +27,23 @@ jest.mock('react-router-dom', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: jest.fn().mockImplementation((props) => (
     <div className={props.className} data-testid={props['data-testid']}>
       {props.children}
     </div>
   )),
+
   Button: jest.fn().mockImplementation((props) => (
     <button data-testid={props['data-testid']} onClick={props.onPress}>
       {props.children}
     </button>
   )),
+
   Divider: jest.fn().mockImplementation(() => <hr />),
   Tooltip: jest.fn().mockImplementation((props) => props.children),
+
   Typography: jest
     .fn()
     .mockImplementation((props) => <span>{props.children}</span>),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
@@ -29,6 +29,8 @@ import { CsvJobsTray } from './CsvJobsTray.component';
 import { CSV_JOBS_REFRESH_EVENT } from './CsvJobsTray.constants';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityTitleSection/EntityTitleSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityTitleSection/EntityTitleSection.test.tsx
@@ -17,14 +17,18 @@ import { EntityType } from '../../../enums/entity.enum';
 import { EntityTitleSection } from './EntityTitleSection';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn().mockImplementation(({ children, onClick, ...props }) => (
     <button onClick={onClick} {...props}>
       {children}
     </button>
   )),
+
   Tooltip: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaFields/AuthSelectField/AuthSelectField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaFields/AuthSelectField/AuthSelectField.test.tsx
@@ -17,6 +17,8 @@ import React from 'react';
 import AuthSelectField from './AuthSelectField';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Typography: ({
     children,
     as: Tag = 'span',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/FormBuilderV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/FormBuilderV1.test.tsx
@@ -29,6 +29,8 @@ const mockFormatFormDataForRender = jest.fn(
 );
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest.fn(
     ({
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreArrayField.test.tsx
@@ -21,6 +21,8 @@ jest.mock('@untitledui/icons', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   HintText: jest.fn(
     ({
       children,
@@ -30,6 +32,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       isInvalid?: boolean;
     }) => <div data-invalid={String(Boolean(isInvalid))}>{children}</div>
   ),
+
   Label: jest.fn(
     ({
       children,
@@ -44,6 +47,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       </div>
     )
   ),
+
   Tooltip: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreBooleanField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreBooleanField.test.tsx
@@ -16,6 +16,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import CoreBooleanField from './CoreBooleanField';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Toggle: jest.fn(
     ({
       isDisabled,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreOneOfField.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/fields/CoreOneOfField.test.tsx
@@ -17,9 +17,12 @@ import React from 'react';
 import CoreOneOfField from './CoreOneOfField';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Box: jest.fn(({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   )),
+
   Select: Object.assign(
     jest.fn(
       ({
@@ -75,6 +78,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Typography: jest.fn(
     ({
       children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/templates/FormBuilderV1Templates.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/templates/FormBuilderV1Templates.test.tsx
@@ -44,6 +44,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const AccordionItemContext = ActualReact.createContext(undefined);
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Accordion: jest.fn(({ children }: { children: React.ReactNode }) => {
       const [expandedItem, setExpandedItem] = ActualReact.useState(
         undefined as string | undefined
@@ -55,6 +57,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </AccordionContext.Provider>
       );
     }),
+
     AccordionHeader: jest.fn(({ children }: { children: React.ReactNode }) => {
       const { expandedItem, setExpandedItem } =
         ActualReact.useContext(AccordionContext);
@@ -70,6 +73,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </button>
       );
     }),
+
     AccordionItem: jest.fn(
       ({ children, id }: { children: React.ReactNode; id: string }) => (
         <AccordionItemContext.Provider value={id}>
@@ -77,6 +81,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </AccordionItemContext.Provider>
       )
     ),
+
     AccordionPanel: jest.fn(
       ({ children, ...props }: { children: React.ReactNode }) => {
         const { expandedItem } = ActualReact.useContext(AccordionContext);
@@ -87,6 +92,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         ) : null;
       }
     ),
+
     Button: jest.fn(
       ({
         children,
@@ -111,6 +117,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </button>
       )
     ),
+
     Input: jest.fn(
       ({
         id,
@@ -139,6 +146,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     Typography: jest.fn(
       ({
         children,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/widgets/FormBuilderV1Widgets.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilderV1/widgets/FormBuilderV1Widgets.test.tsx
@@ -106,9 +106,12 @@ jest.mock('@openmetadata/ui-core-components', () => {
   }
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Box: jest.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
+
     Button: jest.fn(
       ({
         children,
@@ -124,6 +127,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </button>
       )
     ),
+
     FileTrigger: jest.fn(
       ({
         children,
@@ -142,6 +146,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     HintText: jest.fn(
       ({
         children,
@@ -151,6 +156,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         isInvalid?: boolean;
       }) => <div data-invalid={String(Boolean(isInvalid))}>{children}</div>
     ),
+
     Label: jest.fn(
       ({
         children,
@@ -165,6 +171,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     RadioButton: jest.fn(
       ({
         hint,
@@ -182,6 +189,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </label>
       )
     ),
+
     RadioGroup: jest.fn(
       ({
         children,
@@ -202,9 +210,11 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     Typography: jest.fn(({ children }: { children: React.ReactNode }) => (
       <span>{children}</span>
     )),
+
     Checkbox: jest.fn(
       ({
         hint,
@@ -229,6 +239,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </button>
       )
     ),
+
     Input: jest.fn(
       ({
         autoFocus,
@@ -270,6 +281,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     Select: Object.assign(
       jest.fn(
         ({
@@ -326,6 +338,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         ),
       }
     ),
+
     TextArea: jest.fn(
       ({
         autoFocus,
@@ -363,6 +376,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       )
     ),
+
     PasswordInput: jest.fn(MockPasswordInput),
   };
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderBreadcrumb/HeaderBreadcrumb.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/HeaderBreadcrumb/HeaderBreadcrumb.test.tsx
@@ -30,6 +30,8 @@ let capturedOnAction: ((id: string) => void) | undefined;
 let capturedAutoCollapse: boolean | undefined;
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Breadcrumbs: jest.fn(
     ({
       items,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LineageSection/LineageSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LineageSection/LineageSection.test.tsx
@@ -17,6 +17,8 @@ import { showErrorToast } from '../../../utils/ToastUtils';
 import LineageSection from './LineageSection';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -35,7 +37,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Divider: jest.fn().mockImplementation(() => <hr />),
+
   Typography: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/LogViewerModal/LogViewerModal.test.tsx
@@ -73,6 +73,8 @@ jest.mock('@melloware/react-logviewer', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   ModalOverlay: ({
     children,
     isOpen,
@@ -80,7 +82,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: ReactNode;
     isOpen: boolean;
   }) => (isOpen ? <div data-testid="modal-overlay">{children}</div> : null),
+
   Modal: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+
   CloseButton: ({
     onPress,
     theme,
@@ -94,7 +98,9 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       close
     </button>
   ),
+
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+
   TooltipTrigger: ({
     children,
     onPress,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ManageMenuButton/ManageMenuButton.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ManageMenuButton/ManageMenuButton.test.tsx
@@ -15,9 +15,12 @@ import React from 'react';
 import ManageMenuButton, { ManageMenuItem } from './ManageMenuButton.component';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Typography: ({ children }: { children?: React.ReactNode }) => (
     <span>{children}</span>
   ),
+
   Dropdown: {
     Root: ({ children }: { children?: React.ReactNode }) => (
       <div data-testid="dropdown-root">{children}</div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/OwnerLabel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/OwnerLabel/OwnerLabel.test.tsx
@@ -30,14 +30,18 @@ const mockTeamOwner = [
 ];
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children, 'data-testid': testId }) => (
       <span data-testid={testId}>{children}</span>
     )),
+
   Button: jest
     .fn()
     .mockImplementation(({ children }) => <button>{children}</button>),
+
   Dropdown: {
     Root: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
     Popover: jest

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TagSuggestion/TagSuggestion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TagSuggestion/TagSuggestion.test.tsx
@@ -152,7 +152,10 @@ jest.mock('@openmetadata/ui-core-components', () => {
     supportingText?: string;
   }) => ({ id, label, supportingText });
 
-  return { Autocomplete };
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Autocomplete,
+  };
 });
 
 describe('TagSuggestion', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AuditLogsPage/AuditLogsPage.test.tsx
@@ -24,11 +24,14 @@ import { showErrorToast } from '../../utils/ToastUtils';
 import AuditLogsPage from './AuditLogsPage';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest
     .fn()
     .mockImplementation(({ children, 'data-testid': testId }) => (
       <span data-testid={testId}>{children}</span>
     )),
+
   Breadcrumbs: jest.fn().mockImplementation(({ items }) => (
     <nav data-testid="breadcrumbs">
       {items?.map((item: { id: string; label?: string }) => (
@@ -36,6 +39,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ))}
     </nav>
   )),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -45,6 +49,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -55,11 +60,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Card: jest
     .fn()
     .mockImplementation(({ children, 'data-testid': testId }) => (
       <div data-testid={testId}>{children}</div>
     )),
+
   Input: jest
     .fn()
     .mockImplementation(({ value, onChange, inputDataTestId, placeholder }) => (
@@ -70,6 +77,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         onChange={(e) => onChange?.(e.target.value)}
       />
     )),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/CustomPropertiesPageV1/CustomPropertiesPageV1.test.tsx
@@ -34,6 +34,8 @@ jest.mock('../../utils/useRequiredParams', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, 'data-testid': testId }) => (
@@ -41,14 +43,19 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   Card: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   Tooltip: jest.fn().mockImplementation(({ children }) => <>{children}</>),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(({ icon, onClick, 'data-testid': testId }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IncidentManager/IncidentManagerPage.test.tsx
@@ -15,18 +15,23 @@ import incidentManagerClassBase from './IncidentManagerClassBase';
 import IncidentManagerPage from './IncidentManagerPage';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Popover: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   PopoverTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick }) => (
       <button onClick={onClick}>{children}</button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -36,12 +41,15 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ as: Component = 'span', children, ...props }) => (
       <Component {...props}>{children}</Component>
     )),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.test.tsx
@@ -44,13 +44,18 @@ const renderPage = () =>
   );
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Avatar: jest
     .fn()
     .mockImplementation(({ initials }) => <span>{initials}</span>),
+
   Badge: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(
@@ -63,6 +68,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -72,20 +78,25 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   EmptyPlaceholder: jest
     .fn()
     .mockImplementation(({ title }: { title?: string }) => (
       <div data-testid="metric-empty-placeholder">{title}</div>
     )),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Input: jest
     .fn()
     .mockImplementation(({ placeholder, value, onChange }) => (
       <input placeholder={placeholder} value={value} onChange={onChange} />
     )),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   Dropdown: {
     DotsButton: jest
       .fn()
@@ -116,6 +127,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     Root: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
     Separator: jest.fn().mockImplementation(() => <hr />),
   },
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/NotificationListPage/NotificationListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/NotificationListPage/NotificationListPage.test.tsx
@@ -29,13 +29,17 @@ import { descriptionTableObject } from '../../utils/TableColumn.util';
 import NotificationListPage from './NotificationListPage';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Popover: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   PopoverTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -43,6 +47,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -52,10 +57,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/ObservabilityAlertsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/ObservabilityAlertsPage.test.tsx
@@ -152,6 +152,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Table: MockTable,
     TableCard: MockTableCard,
     Box: Passthrough,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/components/ObservabilityAlertsTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ObservabilityAlertsPage/components/ObservabilityAlertsTable.test.tsx
@@ -124,6 +124,8 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+
     Button: jest
       .fn()
       .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -131,6 +133,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           {children}
         </button>
       )),
+
     Box: MockBox,
     EmptyPlaceholder: MockEmptyPlaceholder,
     Table: MockTable,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/OntologyExplorerPage/OntologyExplorerPage.test.tsx
@@ -17,11 +17,14 @@ import OntologyExplorerPage from './OntologyExplorerPage';
 const mockOntologyExplorer = jest.fn();
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: jest
     .fn()
     .mockImplementation(({ children, 'data-testid': testId }) => (
       <span data-testid={testId}>{children}</span>
     )),
+
   Box: jest
     .fn()
     .mockImplementation(
@@ -39,13 +42,16 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </div>
       )
     ),
+
   Card: jest
     .fn()
     .mockImplementation(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
+
   Dot: jest.fn().mockImplementation(() => <span data-testid="stats-dot" />),
   Skeleton: jest.fn().mockImplementation(() => <div data-testid="skeleton" />),
+
   Typography: jest
     .fn()
     .mockImplementation(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/PlatformLineage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PlatformLineage/PlatformLineage.test.tsx
@@ -54,17 +54,21 @@ jest.mock('@openmetadata/ui-core-components', () => {
   GridMock.Item = jest.fn(({ children }: GridProps) => <div>{children}</div>);
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     Grid: GridMock,
+
     Tooltip: jest
       .fn()
       .mockImplementation(({ children }: { children: React.ReactNode }) => (
         <div>{children}</div>
       )),
+
     TooltipTrigger: jest
       .fn()
       .mockImplementation(({ children }: { children: React.ReactNode }) => (
         <span>{children}</span>
       )),
+
     ButtonUtility: jest
       .fn()
       .mockImplementation(({ children, onClick, 'data-testid': testId }) => (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesListPage/PoliciesListPage.test.tsx
@@ -18,13 +18,17 @@ import { POLICY_LIST_WITH_PAGING } from '../../RolesPage/Roles.mock';
 import PoliciesListPage from './PoliciesListPage';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Popover: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   PopoverTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -32,6 +36,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -41,10 +46,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesListPage/RolesListPage.test.tsx
@@ -17,13 +17,17 @@ import { ROLES_LIST_WITH_PAGING } from '../Roles.mock';
 import RolesListPage from './RolesListPage';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Popover: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   PopoverTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick, isDisabled, ...rest }) => (
@@ -31,6 +35,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         {children}
       </button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -40,10 +45,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagPage/TagPage.test.tsx
@@ -24,11 +24,14 @@ import TagPage from './TagPage';
 const render = renderWithQueryClient;
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick }) => (
       <button onClick={onClick}>{children}</button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -38,6 +41,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   Dialog: Object.assign(
     jest.fn().mockImplementation(({ children, title }) => (
       <div role="dialog">
@@ -54,16 +58,20 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         .mockImplementation(({ children }) => <div>{children}</div>),
     }
   ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
   Modal: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   ModalOverlay: jest
     .fn()
     .mockImplementation(({ children, isOpen }) =>
       isOpen ? <div>{children}</div> : null
     ),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/ClassificationFormDrawer.test.tsx
@@ -21,6 +21,8 @@ jest.mock('./TagsForm', () => {
 });
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   SlideoutMenu: Object.assign(
     ({
       isOpen,
@@ -64,6 +66,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Button: ({
     children,
     onClick,
@@ -84,6 +87,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagFormDrawer.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagFormDrawer.test.tsx
@@ -21,6 +21,8 @@ jest.mock('./TagsForm', () => {
 });
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   SlideoutMenu: Object.assign(
     ({
       isOpen,
@@ -64,6 +66,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       ),
     }
   ),
+
   Button: ({
     children,
     onClick,
@@ -84,6 +87,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsForm.test.tsx
@@ -52,10 +52,12 @@ jest.mock('@openmetadata/ui-core-components', () => {
   );
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     FieldTypes,
     HelperTextType,
     Box: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     Avatar: () => <div data-testid="avatar" />,
+
     FormItemLabel: ({
       label,
       tooltip,
@@ -71,6 +73,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {tooltip}
       </span>
     ),
+
     IconPickerField: ({
       value,
       onChange,
@@ -86,6 +89,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         onChange={(e) => onChange?.(e.target.value)}
       />
     ),
+
     Tooltip: ({
       children,
       title,
@@ -97,6 +101,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </div>
     ),
+
     TooltipTrigger: ({
       children,
       className,
@@ -104,11 +109,14 @@ jest.mock('@openmetadata/ui-core-components', () => {
       children: React.ReactNode;
       className?: string;
     }) => <button className={className}>{children}</button>,
+
     HintText: ({ children }: { children: React.ReactNode }) => (
       <span>{children}</span>
     ),
+
     Toggle,
     Grid: GridComponent,
+
     HookForm: ({
       children,
       onSubmit,
@@ -120,6 +128,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </form>
     ),
+
     FormField: ({
       name,
       children,
@@ -142,6 +151,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         },
         fieldState: { invalid: false },
       }),
+
     getField: (fieldProp: {
       id?: string;
       name: string;

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/TagsPage.test.tsx
@@ -242,6 +242,8 @@ jest.mock('../../utils/TagsUtils', () => ({
 }));
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Badge: ({
     children,
     'data-testid': testId,
@@ -255,6 +257,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </span>
   ),
+
   Typography: ({
     children,
     className,
@@ -268,6 +271,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </Tag>
   ),
+
   Button: ({
     children,
     onClick,
@@ -289,6 +293,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </button>
   ),
+
   Tooltip: ({
     children,
     title,
@@ -300,6 +305,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       {children}
     </div>
   ),
+
   TooltipTrigger: ({
     children,
     className,
@@ -307,6 +313,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: React.ReactNode;
     className?: string;
   }) => <button className={className}>{children}</button>,
+
   Toggle: ({
     isSelected,
     onChange,
@@ -327,6 +334,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       toggle
     </button>
   ),
+
   SlideoutMenu: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/FeedbackApprovalTask.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/FeedbackApprovalTask.test.tsx
@@ -18,6 +18,8 @@ import { MOCK_TASK_RECOGNIZER_FEEDBACK } from '../../../mocks/Task.mock';
 import FeedbackApprovalTask from './FeedbackApprovalTask';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   BadgeWithDot: ({
     children,
     'data-testid': testId,
@@ -25,6 +27,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
     children: ReactNode;
     'data-testid'?: string;
   }) => <span data-testid={testId}>{children}</span>,
+
   Grid: Object.assign(
     ({
       children,
@@ -43,6 +46,7 @@ jest.mock('@openmetadata/ui-core-components', () => ({
       Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     }
   ),
+
   Typography: ({
     children,
     'data-testid': testId,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TaskPayloadSchemaFields.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TasksPage/shared/TaskPayloadSchemaFields.test.tsx
@@ -31,10 +31,13 @@ import { JsonSchemaObject } from '../../../rest/taskFormSchemasAPI';
 import TaskPayloadSchemaFields from './TaskPayloadSchemaFields';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: ({ children }: any) => <div>{children}</div>,
+
   Button: ({ children, onPress }: any) => (
     <button onClick={onPress}>{children}</button>
   ),
+
   Typography: ({ children }: any) => <span>{children}</span>,
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TestSuiteDetailsPage/TestSuiteDetailsPage.test.tsx
@@ -34,7 +34,9 @@ jest.mock('@openmetadata/ui-core-components', () => {
   const actual = jest.requireActual('@openmetadata/ui-core-components');
 
   return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
     ...actual,
+
     Button: ({
       children,
       onPress,
@@ -52,6 +54,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </button>
     ),
+
     DialogTrigger: ({
       children,
       isOpen,
@@ -88,6 +91,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         </div>
       );
     },
+
     Dialog: Object.assign(
       ({
         children,
@@ -121,6 +125,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         ),
       }
     ),
+
     Modal: ({
       children,
       className,
@@ -134,6 +139,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
         {children}
       </div>
     ),
+
     ModalOverlay: ({
       children,
       isOpen,
@@ -150,6 +156,7 @@ jest.mock('@openmetadata/ui-core-components', () => {
           {children}
         </div>
       ) : null,
+
     Tabs: (() => {
       const TabsRoot = ({
         children,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserListPage/UserListPageV1.test.tsx
@@ -23,18 +23,23 @@ import { MOCK_EMPTY_USER_DATA, MOCK_USER_DATA } from './MockUserPageData';
 import UserListPageV1 from './UserListPageV1';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
   Box: jest.fn().mockImplementation(({ children }) => <div>{children}</div>),
+
   Popover: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   PopoverTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <div>{children}</div>),
+
   Button: jest
     .fn()
     .mockImplementation(({ children, onClick }) => (
       <button onClick={onClick}>{children}</button>
     )),
+
   ButtonUtility: jest
     .fn()
     .mockImplementation(
@@ -44,10 +49,13 @@ jest.mock('@openmetadata/ui-core-components', () => ({
         </button>
       )
     ),
+
   FeaturedIcon: jest.fn().mockImplementation(({ icon }) => <span>{icon}</span>),
+
   Typography: jest
     .fn()
     .mockImplementation(({ children }) => <span>{children}</span>),
+
   defaultColors: { gray: { 50: '#fafafa' } },
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/CSV/CSV.utils.test.tsx
@@ -56,14 +56,18 @@ import {
 } from './CSVPureUtils';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+
   Tooltip: jest.fn().mockImplementation(({ children, title }) => (
     <div data-testid="tooltip" title={title}>
       {children}
     </div>
   )),
+
   TooltipTrigger: jest
     .fn()
     .mockImplementation(({ children }) => <>{children}</>),
+
   Typography: jest
     .fn()
     .mockImplementation(

--- a/tooling/antd-codemods/__tests__/core-mock-require-actual.test.js
+++ b/tooling/antd-codemods/__tests__/core-mock-require-actual.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { defineInlineTest } = require('jscodeshift/dist/testUtils');
+const transform = require('../transforms/core-mock-require-actual');
+
+const t = (name, input, expected) =>
+  defineInlineTest(transform, {}, input, expected, name);
+
+t(
+  'spreads requireActual into an expression-body factory',
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  Typography: jest.fn(),
+}));`,
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+  Typography: jest.fn()
+}));`
+);
+
+t(
+  'spreads requireActual into a block-body factory',
+  `jest.mock('@openmetadata/ui-core-components', () => {
+  return { Typography: jest.fn() };
+});`,
+  `jest.mock('@openmetadata/ui-core-components', () => {
+  return {
+    ...jest.requireActual('@openmetadata/ui-core-components'),
+    Typography: jest.fn()
+  };
+});`
+);
+
+// The spread goes first so explicit overrides still take precedence - that is
+// the whole point of the mock.
+t(
+  'keeps explicit overrides winning over the real module',
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  Button: 'MockButton',
+  Typography: 'MockTypography',
+}));`,
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+  Button: 'MockButton',
+  Typography: 'MockTypography'
+}));`
+);
+
+t(
+  'leaves a mock that already spreads requireActual untouched',
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+  Typography: jest.fn(),
+}));`,
+  `jest.mock('@openmetadata/ui-core-components', () => ({
+  ...jest.requireActual('@openmetadata/ui-core-components'),
+  Typography: jest.fn(),
+}));`
+);
+
+t(
+  'leaves mocks of other modules untouched',
+  `jest.mock('antd', () => ({ Button: jest.fn() }));`,
+  `jest.mock('antd', () => ({ Button: jest.fn() }));`
+);
+
+// A module-factory mock with no object literal (e.g. returning a variable)
+// cannot be safely extended, so it is left for a human.
+t(
+  'leaves a factory that does not return an object literal untouched',
+  `jest.mock('@openmetadata/ui-core-components', () => mockModule);`,
+  `jest.mock('@openmetadata/ui-core-components', () => mockModule);`
+);

--- a/tooling/antd-codemods/transforms/core-mock-require-actual.js
+++ b/tooling/antd-codemods/transforms/core-mock-require-actual.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Makes `jest.mock('@openmetadata/ui-core-components', factory)` fall through
+ * to the real module for anything the factory does not override.
+ *
+ * A factory mock replaces the module *wholesale*, so any export the factory
+ * omits comes back `undefined`. That turns every component sweep into a
+ * tripwire: Typography and Button happened to already be listed in these
+ * mocks, but the layout sweep introduces `Grid`/`Box`, and `Grid.Item` then
+ * throws "Cannot read properties of undefined (reading 'Item')" - 416 times
+ * across 22 suites on the first run.
+ *
+ * Spreading `jest.requireActual` first keeps every explicit override intact
+ * while letting unlisted exports resolve to the real implementation, so future
+ * sweeps stop breaking unrelated tests.
+ *
+ * jscodeshift -t transforms/core-mock-require-actual.js <path> --parser=tsx
+ */
+
+const CORE_MODULE = '@openmetadata/ui-core-components';
+
+module.exports = function transform(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let changed = false;
+
+  root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: 'jest' },
+        property: { type: 'Identifier', name: 'mock' },
+      },
+    })
+    .forEach((path) => {
+      const [moduleArg, factory] = path.node.arguments;
+
+      const isCore =
+        moduleArg &&
+        (moduleArg.type === 'StringLiteral' || moduleArg.type === 'Literal') &&
+        moduleArg.value === CORE_MODULE;
+
+      if (!isCore || !factory) {
+        return;
+      }
+      if (
+        factory.type !== 'ArrowFunctionExpression' &&
+        factory.type !== 'FunctionExpression'
+      ) {
+        return;
+      }
+
+      // Locate the object literal the factory returns, in either shape:
+      //   () => ({ ... })        - expression body
+      //   () => { return {...} } - block body
+      let obj = null;
+      if (factory.body.type === 'ObjectExpression') {
+        obj = factory.body;
+      } else if (factory.body.type === 'BlockStatement') {
+        const ret = factory.body.body.find(
+          (s) => s.type === 'ReturnStatement' && s.argument
+        );
+        if (ret && ret.argument.type === 'ObjectExpression') {
+          obj = ret.argument;
+        }
+      }
+
+      if (!obj) {
+        return;
+      }
+
+      // Already spreading requireActual for this module - leave it alone.
+      const alreadySpread = obj.properties.some((p) => {
+        if (p.type !== 'SpreadElement' && p.type !== 'SpreadProperty') {
+          return false;
+        }
+        const a = p.argument;
+
+        return (
+          a &&
+          a.type === 'CallExpression' &&
+          a.callee.type === 'MemberExpression' &&
+          a.callee.object.name === 'jest' &&
+          a.callee.property.name === 'requireActual'
+        );
+      });
+
+      if (alreadySpread) {
+        return;
+      }
+
+      const spread = j.spreadElement(
+        j.callExpression(
+          j.memberExpression(
+            j.identifier('jest'),
+            j.identifier('requireActual')
+          ),
+          [j.stringLiteral(CORE_MODULE)]
+        )
+      );
+
+      // First position: explicit overrides that follow must still win.
+      obj.properties.unshift(spread);
+      changed = true;
+    });
+
+  return changed ? root.toSource({ quote: 'single' }) : fileInfo.source;
+};
+
+module.exports.parser = 'tsx';


### PR DESCRIPTION
## Why

`jest.mock('@openmetadata/ui-core-components', factory)` replaces the module **wholesale**, so any export the factory omits comes back `undefined`.

**124** test files mock it that way; only **6** spread `jest.requireActual`. That makes every component sweep a tripwire for suites that never referenced the new component.

Typography and Button escaped it only because those names were already listed in the mocks. The layout sweep introduces `Grid`/`Box`, and `Grid.Item` immediately throws `Cannot read properties of undefined (reading 'Item')`:

| | failing |
|---|---|
| before | **22 suites / 267 tests** |
| after | **4 suites / 5 tests** |

## What

A new codemod (`transforms/core-mock-require-actual.js`, 6 tests) spreads `jest.requireActual` as the **first** property, so explicit overrides still win while unlisted exports resolve to the real implementation. Applied across **121** files.

It deliberately leaves alone: mocks already spreading `requireActual`, mocks of other modules, and factories that don't return an object literal.

## Also included

Merges a duplicate `CoreTypography` import in `AdminPermissionDebugger`. esbuild and tsc both accept it — TypeScript tolerates re-importing the same symbol from the same module — so nothing was broken. But jscodeshift's spec-compliant parser rejects the file, which blocks every codemod run over it.

## Verification

- 121 files transformed, prettier + eslint clean
- Full suite: **1154/1155 suites, 13,641 tests passing**
- The single failure (`ExploreTree`) is test-isolation flake, not this change: it passes standalone both with and without the fix (17/17 each), contains no core-components mock at all, and wasn't among the failures in either earlier full-suite run.

## Why it's split out

This is independently valuable and self-contained. The layout sweep that surfaced it needs more work — core `Box` is always a flex container, so mapping `Col` → `Box` makes every column its own flex container. That's being reworked separately.

Collate has the same defect in **188** files; the same transform applies there once Collate unparks.