### PR TITLE
fix(e2e): use data insight setup for KPI widget

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -180,14 +180,15 @@ jobs:
         working-directory: openmetadata-ui/src/main/resources/ui/
         run: |
           if [ "${{ matrix.shardIndex }}" -eq "1" ]; then
-            echo "🔹 Running DataAssetRules-only tests on shard 1"
+            echo "🔹 Running dedicated project tests on shard 1"
 
-            # The testMatch pattern ensures only DataAssetRules*.spec.ts files run
+            # Run projects excluded from the common chromium shards.
             npx playwright test \
               --project=setup \
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled \
               --project=Basic \
+              --project="Data Insight" \
               --project=SearchRBAC \
 
           else

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -159,6 +159,7 @@ jobs:
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled \
               --project=Basic \
+              --project="Data Insight" \
               --project=SearchRBAC \
 
           else

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -16,6 +16,27 @@ name: Postgresql PR Playwright E2E Tests
 on:
   merge_group:
   workflow_dispatch:
+  # pull_request resolves the workflow file from the PR's own merge ref, so on
+  # this branch it is the trigger that actually fires. pull_request_target below
+  # is inert here: those runs resolve the default branch's copy, whose gate job
+  # skips same-repo PRs on the assumption that a pull_request run covers them.
+  # Without this trigger that assumption is false and the suite never runs.
+  pull_request:
+    types:
+      - labeled
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths-ignore:
+      - ".github/**"
+      - "openmetadata-dist/**"
+      - "docker/**"
+      - "!docker/development/docker-compose.yml"
+      - "!docker/development/docker-compose-postgres.yml"
+      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
+      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
+      - "openmetadata-ui/src/main/resources/ui/scripts/**"
   pull_request_target:
     types:
       - labeled
@@ -38,13 +59,21 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: playwright-ci-pr-postgresql-${{ github.event.pull_request.number || github.run_id }}
+  # Keyed by event too, so a pull_request run and a pull_request_target run for
+  # the same PR never cancel each other — one skips, the other does the work.
+  group: playwright-ci-pr-postgresql-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
+    # Fork PRs stay on the pull_request_target route, where the default
+    # branch's gate demands a "safe to test" label before handing over the
+    # cloud-connector secrets a pull_request run on a fork cannot read.
+    if: >-
+      ${{ !github.event.pull_request.draft &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.3.4

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -16,27 +16,6 @@ name: Postgresql PR Playwright E2E Tests
 on:
   merge_group:
   workflow_dispatch:
-  # pull_request resolves the workflow file from the PR's own merge ref, so on
-  # this branch it is the trigger that actually fires. pull_request_target below
-  # is inert here: those runs resolve the default branch's copy, whose gate job
-  # skips same-repo PRs on the assumption that a pull_request run covers them.
-  # Without this trigger that assumption is false and the suite never runs.
-  pull_request:
-    types:
-      - labeled
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-    paths-ignore:
-      - ".github/**"
-      - "openmetadata-dist/**"
-      - "docker/**"
-      - "!docker/development/docker-compose.yml"
-      - "!docker/development/docker-compose-postgres.yml"
-      - "openmetadata-ui/src/main/resources/ui/playwright/doc-generator/**"
-      - "openmetadata-ui/src/main/resources/ui/playwright/docs/**"
-      - "openmetadata-ui/src/main/resources/ui/scripts/**"
   pull_request_target:
     types:
       - labeled
@@ -59,21 +38,13 @@ permissions:
   pull-requests: write
 
 concurrency:
-  # Keyed by event too, so a pull_request run and a pull_request_target run for
-  # the same PR never cancel each other — one skips, the other does the work.
-  group: playwright-ci-pr-postgresql-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  group: playwright-ci-pr-postgresql-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Fork PRs stay on the pull_request_target route, where the default
-    # branch's gate demands a "safe to test" label before handing over the
-    # cloud-connector secrets a pull_request run on a fork cannot read.
-    if: >-
-      ${{ !github.event.pull_request.draft &&
-          (github.event_name != 'pull_request' ||
-           github.event.pull_request.head.repo.full_name == github.repository) }}
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.3.4
@@ -180,15 +151,14 @@ jobs:
         working-directory: openmetadata-ui/src/main/resources/ui/
         run: |
           if [ "${{ matrix.shardIndex }}" -eq "1" ]; then
-            echo "🔹 Running dedicated project tests on shard 1"
+            echo "🔹 Running DataAssetRules-only tests on shard 1"
 
-            # Run projects excluded from the common chromium shards.
+            # The testMatch pattern ensures only DataAssetRules*.spec.ts files run
             npx playwright test \
               --project=setup \
               --project=DataAssetRulesEnabled \
               --project=DataAssetRulesDisabled \
               --project=Basic \
-              --project="Data Insight" \
               --project=SearchRBAC \
 
           else

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -12,10 +12,8 @@
  */
 import { expect, Page, test as base } from '@playwright/test';
 import { SearchIndex } from '../../../src/enums/search.enum';
-import {
-  DataInsightChart,
-  KpiTargetType,
-} from '../../../src/generated/api/dataInsight/kpi/createKpiRequest';
+import { KPI_DATA } from '../../constant/dataInsight';
+import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
@@ -34,7 +32,9 @@ import {
   verifyWidgetFooterViewMore,
   verifyWidgetHeaderNavigation,
 } from '../../utils/customizeLandingPage';
+import { addKpi, deleteKpiRequest } from '../../utils/dataInsight';
 import { followEntity, waitForAllLoadersToDisappear } from '../../utils/entity';
+import { sidebarClick } from '../../utils/sidebar';
 import {
   verifyActivityFeedFilters,
   verifyDataFilters,
@@ -133,6 +133,9 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   for (const dp of testDataProducts) {
     await dp.create(apiContext);
   }
+
+  // Delete all existing KPIs before running the test
+  await deleteKpiRequest(apiContext);
 
   // Set default persona for admin user
   await apiContext.patch(`/api/v1/users/${adminUser.responseData.id}`, {
@@ -336,39 +339,13 @@ test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
   test.slow(true);
 
   await test.step('Add KPI', async () => {
-    const currentDate = new Date();
-    const startDate = new Date(
-      currentDate.getFullYear(),
-      currentDate.getMonth() - 1,
-      Math.min(
-        currentDate.getDate(),
-        new Date(currentDate.getFullYear(), currentDate.getMonth(), 0).getDate()
-      )
-    );
+    await waitForAllLoadersToDisappear(page);
 
-    startDate.setHours(0, 0, 0, 0);
-    currentDate.setHours(23, 59, 59, 999);
+    await sidebarClick(page, SidebarItem.DATA_INSIGHT);
+    await page.getByRole('menuitem', { name: 'KPIs' }).click();
 
-    const { apiContext, afterAction } = await getApiContext(page);
-
-    try {
-      const response = await apiContext.put('/api/v1/kpi', {
-        data: {
-          name: 'playwright-kpi-widget-number',
-          displayName: 'Playwright KPI Widget',
-          description: 'Playwright KPI widget test',
-          dataInsightChart: DataInsightChart.NumberOfDataAssetWithOwnerKpi,
-          startDate: startDate.valueOf(),
-          endDate: currentDate.valueOf(),
-          targetValue: 100,
-          metricType: KpiTargetType.Number,
-        },
-      });
-
-      expect(response.ok()).toBeTruthy();
-    } finally {
-      await afterAction();
-    }
+    await page.getByTestId('add-kpi-btn').click();
+    await addKpi(page, KPI_DATA[1]);
   });
 
   await redirectToHomePage(page);
@@ -432,10 +409,28 @@ test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
 
     await expect(kpiWidgetContent).toBeVisible();
 
-    await expect(
-      widget.locator('.recharts-responsive-container')
-    ).toBeVisible();
-    await expect(widget.locator('.recharts-area')).toBeVisible();
+    // Check if there's either a chart or empty state
+    const hasChart = await widget
+      .locator('.recharts-responsive-container')
+      .isVisible()
+      .catch(() => false);
+
+    const hasEmptyState = await widget
+      .locator('[data-testid="widget-empty-state"]')
+      .isVisible()
+      .catch(() => false);
+
+    expect(hasChart || hasEmptyState).toBeTruthy();
+
+    if (hasChart) {
+      // If chart exists, verify it's rendered properly
+      await expect(
+        widget.locator('.recharts-responsive-container')
+      ).toBeVisible();
+
+      // Verify chart elements are present
+      await expect(widget.locator('.recharts-area')).toBeVisible();
+    }
   });
 
   await test.step('Test widget customization', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -335,7 +335,7 @@ test('My Data Widget', async ({ page }) => {
   });
 });
 
-test('KPI Widget', async ({ page }) => {
+test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
   test.slow(true);
 
   await test.step('Add KPI', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -12,8 +12,10 @@
  */
 import { expect, Page, test as base } from '@playwright/test';
 import { SearchIndex } from '../../../src/enums/search.enum';
-import { KPI_DATA } from '../../constant/dataInsight';
-import { SidebarItem } from '../../constant/sidebar';
+import {
+  DataInsightChart,
+  KpiTargetType,
+} from '../../../src/generated/api/dataInsight/kpi/createKpiRequest';
 import { DataProduct } from '../../support/domain/DataProduct';
 import { Domain } from '../../support/domain/Domain';
 import { EntityDataClass } from '../../support/entity/EntityDataClass';
@@ -32,9 +34,7 @@ import {
   verifyWidgetFooterViewMore,
   verifyWidgetHeaderNavigation,
 } from '../../utils/customizeLandingPage';
-import { addKpi, deleteKpiRequest } from '../../utils/dataInsight';
 import { followEntity, waitForAllLoadersToDisappear } from '../../utils/entity';
-import { sidebarClick } from '../../utils/sidebar';
 import {
   verifyActivityFeedFilters,
   verifyDataFilters,
@@ -133,9 +133,6 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   for (const dp of testDataProducts) {
     await dp.create(apiContext);
   }
-
-  // Delete all existing KPIs before running the test
-  await deleteKpiRequest(apiContext);
 
   // Set default persona for admin user
   await apiContext.patch(`/api/v1/users/${adminUser.responseData.id}`, {
@@ -339,13 +336,39 @@ test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
   test.slow(true);
 
   await test.step('Add KPI', async () => {
-    await waitForAllLoadersToDisappear(page);
+    const currentDate = new Date();
+    const startDate = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth() - 1,
+      Math.min(
+        currentDate.getDate(),
+        new Date(currentDate.getFullYear(), currentDate.getMonth(), 0).getDate()
+      )
+    );
 
-    await sidebarClick(page, SidebarItem.DATA_INSIGHT);
-    await page.getByRole('menuitem', { name: 'KPIs' }).click();
+    startDate.setHours(0, 0, 0, 0);
+    currentDate.setHours(23, 59, 59, 999);
 
-    await page.getByTestId('add-kpi-btn').click();
-    await addKpi(page, KPI_DATA[1]);
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      const response = await apiContext.put('/api/v1/kpi', {
+        data: {
+          name: 'playwright-kpi-widget-number',
+          displayName: 'Playwright KPI Widget',
+          description: 'Playwright KPI widget test',
+          dataInsightChart: DataInsightChart.NumberOfDataAssetWithOwnerKpi,
+          startDate: startDate.valueOf(),
+          endDate: currentDate.valueOf(),
+          targetValue: 100,
+          metricType: KpiTargetType.Number,
+        },
+      });
+
+      expect(response.ok()).toBeTruthy();
+    } finally {
+      await afterAction();
+    }
   });
 
   await redirectToHomePage(page);
@@ -409,28 +432,10 @@ test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
 
     await expect(kpiWidgetContent).toBeVisible();
 
-    // Check if there's either a chart or empty state
-    const hasChart = await widget
-      .locator('.recharts-responsive-container')
-      .isVisible()
-      .catch(() => false);
-
-    const hasEmptyState = await widget
-      .locator('[data-testid="widget-empty-state"]')
-      .isVisible()
-      .catch(() => false);
-
-    expect(hasChart || hasEmptyState).toBeTruthy();
-
-    if (hasChart) {
-      // If chart exists, verify it's rendered properly
-      await expect(
-        widget.locator('.recharts-responsive-container')
-      ).toBeVisible();
-
-      // Verify chart elements are present
-      await expect(widget.locator('.recharts-area')).toBeVisible();
-    }
+    await expect(
+      widget.locator('.recharts-responsive-container')
+    ).toBeVisible();
+    await expect(widget.locator('.recharts-area')).toBeVisible();
   });
 
   await test.step('Test widget customization', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -409,28 +409,10 @@ test('KPI Widget', { tag: '@data-insight' }, async ({ page }) => {
 
     await expect(kpiWidgetContent).toBeVisible();
 
-    // Check if there's either a chart or empty state
-    const hasChart = await widget
-      .locator('.recharts-responsive-container')
-      .isVisible()
-      .catch(() => false);
-
-    const hasEmptyState = await widget
-      .locator('[data-testid="widget-empty-state"]')
-      .isVisible()
-      .catch(() => false);
-
-    expect(hasChart || hasEmptyState).toBeTruthy();
-
-    if (hasChart) {
-      // If chart exists, verify it's rendered properly
-      await expect(
-        widget.locator('.recharts-responsive-container')
-      ).toBeVisible();
-
-      // Verify chart elements are present
-      await expect(widget.locator('.recharts-area')).toBeVisible();
-    }
+    await expect(
+      widget.locator('.recharts-responsive-container')
+    ).toBeVisible();
+    await expect(widget.locator('.recharts-area')).toBeVisible();
   });
 
   await test.step('Test widget customization', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
@@ -28,26 +28,21 @@ export const deleteKpiRequest = async (apiRequest: APIRequestContext) => {
 
 export const addKpi = async (page: Page, data: KPIData) => {
   const currentDate = new Date();
-  const month =
-    currentDate.getMonth() + 1 < 10
-      ? `0${currentDate.getMonth() + 1}`
-      : currentDate.getMonth() + 1;
-  const date =
-    currentDate.getDate() < 10
-      ? `0${currentDate.getDate()}`
-      : currentDate.getDate();
-
-  const startDate = `${currentDate.getFullYear()}-${month}-${date}`;
-  currentDate.setDate(currentDate.getDate() + 1);
-  const nextMonth =
-    currentDate.getMonth() + 1 < 10
-      ? `0${currentDate.getMonth() + 1}`
-      : currentDate.getMonth() + 1;
-  const nextDate =
-    currentDate.getDate() < 10
-      ? `0${currentDate.getDate()}`
-      : currentDate.getDate();
-  const endDate = `${currentDate.getFullYear()}-${nextMonth}-${nextDate}`;
+  const previousMonthDate = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth() - 1,
+    Math.min(
+      currentDate.getDate(),
+      new Date(currentDate.getFullYear(), currentDate.getMonth(), 0).getDate()
+    )
+  );
+  const formatDate = (date: Date) =>
+    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+      2,
+      '0'
+    )}-${String(date.getDate()).padStart(2, '0')}`;
+  const startDate = formatDate(previousMonthDate);
+  const endDate = formatDate(currentDate);
 
   await page.click('#chartType');
   await page.click(`.ant-select-dropdown [title="${data.dataInsightChart}"]`);

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataInsight.ts
@@ -28,21 +28,26 @@ export const deleteKpiRequest = async (apiRequest: APIRequestContext) => {
 
 export const addKpi = async (page: Page, data: KPIData) => {
   const currentDate = new Date();
-  const previousMonthDate = new Date(
-    currentDate.getFullYear(),
-    currentDate.getMonth() - 1,
-    Math.min(
-      currentDate.getDate(),
-      new Date(currentDate.getFullYear(), currentDate.getMonth(), 0).getDate()
-    )
-  );
-  const formatDate = (date: Date) =>
-    `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
-      2,
-      '0'
-    )}-${String(date.getDate()).padStart(2, '0')}`;
-  const startDate = formatDate(previousMonthDate);
-  const endDate = formatDate(currentDate);
+  const month =
+    currentDate.getMonth() + 1 < 10
+      ? `0${currentDate.getMonth() + 1}`
+      : currentDate.getMonth() + 1;
+  const date =
+    currentDate.getDate() < 10
+      ? `0${currentDate.getDate()}`
+      : currentDate.getDate();
+
+  const startDate = `${currentDate.getFullYear()}-${month}-${date}`;
+  currentDate.setDate(currentDate.getDate() + 1);
+  const nextMonth =
+    currentDate.getMonth() + 1 < 10
+      ? `0${currentDate.getMonth() + 1}`
+      : currentDate.getMonth() + 1;
+  const nextDate =
+    currentDate.getDate() < 10
+      ? `0${currentDate.getDate()}`
+      : currentDate.getDate();
+  const endDate = `${currentDate.getFullYear()}-${nextMonth}-${nextDate}`;
 
   await page.click('#chartType');
   await page.click(`.ant-select-dropdown [title="${data.dataInsightChart}"]`);


### PR DESCRIPTION
### Describe your changes:

- Restore the same-repository `pull_request` trigger, event-scoped concurrency, and fork-safe build condition from `820dab2cce`.
- Tag the KPI widget test with `@data-insight`.
- Run the existing Data Insight Playwright project in shard 1 of the PostgreSQL PR workflow.
- Require the KPI chart and area to become visible using Playwright web-first assertions.
- Do not accept the KPI empty state after the Data Insight setup has populated results.

#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] No explanatory code comments were required for this change.
- [x] For JSON Schema changes: not applicable.

### Testing
- Parsed `.github/workflows/playwright-postgresql-e2e.yml` as YAML.
- `prettier --check playwright/e2e/Flow/CustomizeWidgets.spec.ts`
- `eslint --no-error-on-unmatched-pattern playwright/e2e/Flow/CustomizeWidgets.spec.ts`
- `git diff --check`
- Playwright test not run as requested.