### PR TITLE
Fixes #30973: key BigQuery dataset and table object caches per schema

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -113,9 +113,15 @@ from metadata.utils import fqn
 from metadata.utils.credentials import GOOGLE_CREDENTIALS
 from metadata.utils.helpers import retry_with_docker_host
 from metadata.utils.logger import ingestion_logger
+from metadata.utils.lru_cache import LRUCache
 from metadata.utils.sqlalchemy_utils import is_complex_type
 from metadata.utils.tag_utils import get_ometa_tag_and_classification, get_tag_label
 from metadata.utils.tag_utils import get_tag_labels as fetch_tag_labels_om
+
+# The databaseSchema node runs multi-threaded, so these caches are shared across schemas
+# being processed concurrently and must be keyed by the fully qualified name.
+DATASET_OBJ_CACHE_SIZE = 512
+TABLE_OBJ_CACHE_SIZE = 2048
 
 _bigquery_table_types = {
     "BASE TABLE": TableType.Regular,
@@ -241,8 +247,8 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         self.incremental = incremental_configuration
         self.incremental_table_processor: Optional[BigQueryIncrementalTableProcessor] = None  # noqa: UP045
 
-        self._current_schema_tables = {}
-        self._current_dataset_obj = None
+        self._table_obj_cache: LRUCache = LRUCache(capacity=TABLE_OBJ_CACHE_SIZE)
+        self._dataset_obj_cache: LRUCache = LRUCache(capacity=DATASET_OBJ_CACHE_SIZE)
         self._policy_tag_cache = {}
         self._taxonomy_cache = {}
         self._taxonomy_to_tags = {}
@@ -366,8 +372,6 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         database = self.context.get().database
         dataset_ref = f"{database}.{schema_name}"
 
-        self._current_schema_tables.clear()
-        self._current_dataset_obj = None
         self._prefetch_table_ddls(schema_name)
         clear_constraint_cache_for_schema(database, schema_name)
 
@@ -416,11 +420,19 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         return super().get_table_description(schema_name=schema_name, table_name=table_name, inspector=inspector)
 
     def get_dataset_obj(self, schema_name: str):
-        """Get dataset object with per-schema caching"""
-        if self._current_dataset_obj is None:
-            database = self.context.get().database
-            self._current_dataset_obj = self.client.get_dataset(f"{database}.{schema_name}")
-        return self._current_dataset_obj
+        """Get dataset object with per-schema caching.
+
+        Keyed by `project.dataset`: the schema node emits tags and the schema entity before
+        its table child node runs, so a cache that is not keyed hands one schema's
+        description and labels to the next one.
+        """
+        dataset_ref = f"{self.context.get().database}.{schema_name}"
+        if dataset_ref in self._dataset_obj_cache:
+            return self._dataset_obj_cache.get(dataset_ref)
+
+        dataset_obj = self.client.get_dataset(dataset_ref)
+        self._dataset_obj_cache.put(dataset_ref, dataset_obj)
+        return dataset_obj
 
     def yield_life_cycle_data(self, _) -> Iterable[Either[OMetaLifeCycleData]]:
         """
@@ -742,16 +754,17 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         yield Either(right=database_schema_request_obj)
 
     def get_table_obj(self, table_name: str):
-        if table_name in self._current_schema_tables:
-            return self._current_schema_tables[table_name]
-
         schema_name = self.context.get().database_schema
         database = self.context.get().database
-        logger.debug(f"Fetching table object for {database}.{schema_name}.{table_name} using BigQuery API")
+        cache_key = f"{database}.{schema_name}.{table_name}"
+        if cache_key in self._table_obj_cache:
+            return self._table_obj_cache.get(cache_key)
+
+        logger.debug(f"Fetching table object for {cache_key} using BigQuery API")
         bq_table_fqn = fqn._build(database, schema_name, table_name)
         table_obj = self.client.get_table(bq_table_fqn)
 
-        self._current_schema_tables[table_name] = table_obj
+        self._table_obj_cache.put(cache_key, table_obj)
         return table_obj
 
     def yield_table_tags(self, table_name_and_type: Tuple[str, str]):  # noqa: UP006

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -428,8 +428,12 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         """
         database = self.context.get().database  # pyright: ignore[reportAttributeAccessIssue]
         dataset_ref = f"{database}.{schema_name}"
-        if dataset_ref in self._dataset_obj_cache:
+        try:
+            # Read in one locked operation: a check-then-get would let a concurrent
+            # eviction drop the key in between and raise on the read.
             return self._dataset_obj_cache.get(dataset_ref)
+        except KeyError:
+            pass
 
         dataset_obj = self.client.get_dataset(dataset_ref)  # pyright: ignore[reportOptionalMemberAccess]
         self._dataset_obj_cache.put(dataset_ref, dataset_obj)
@@ -758,8 +762,10 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         schema_name = self.context.get().database_schema
         database = self.context.get().database
         cache_key = f"{database}.{schema_name}.{table_name}"
-        if cache_key in self._table_obj_cache:
+        try:
             return self._table_obj_cache.get(cache_key)
+        except KeyError:
+            pass
 
         logger.debug(f"Fetching table object for {cache_key} using BigQuery API")
         bq_table_fqn = fqn._build(database, schema_name, table_name)

--- a/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/bigquery/metadata.py
@@ -426,11 +426,12 @@ class BigquerySource(LifeCycleQueryMixin, CommonDbSourceService, MultiDBSource):
         its table child node runs, so a cache that is not keyed hands one schema's
         description and labels to the next one.
         """
-        dataset_ref = f"{self.context.get().database}.{schema_name}"
+        database = self.context.get().database  # pyright: ignore[reportAttributeAccessIssue]
+        dataset_ref = f"{database}.{schema_name}"
         if dataset_ref in self._dataset_obj_cache:
             return self._dataset_obj_cache.get(dataset_ref)
 
-        dataset_obj = self.client.get_dataset(dataset_ref)
+        dataset_obj = self.client.get_dataset(dataset_ref)  # pyright: ignore[reportOptionalMemberAccess]
         self._dataset_obj_cache.put(dataset_ref, dataset_obj)
         return dataset_obj
 

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -63,6 +63,7 @@ from metadata.ingestion.source.database.bigquery.queries import (
     BIGQUERY_LIFE_CYCLE_QUERY,
     BIGQUERY_LIFE_CYCLE_QUERY_BY_REGION,
 )
+from metadata.utils.lru_cache import LRUCache
 
 mock_bq_config = {
     "source": {
@@ -988,6 +989,17 @@ class TestBigqueryRegionAwareQueries:
         assert "creation_time as created_at" in query
 
 
+class _EvictedOnReadCache(LRUCache):
+    """An LRUCache whose entries vanish between the lookup and the read.
+
+    Stands in for another ingestion thread evicting the key in that window, which is not
+    reproducible deterministically with real threads.
+    """
+
+    def get(self, key):
+        raise KeyError(key)
+
+
 class TestBigqueryPerSchemaCaching:
     """
     The dataset/table object caches must be keyed per schema.
@@ -1110,3 +1122,27 @@ class TestBigqueryPerSchemaCaching:
         descriptions = {schema: self.bq_source.get_schema_description(schema) for schema in schemas}
 
         assert descriptions == {schema: self.DATASETS[schema][0] for schema in schemas}
+
+    def test_dataset_obj_survives_entry_evicted_before_read(self):
+        """
+        LRUCache locks each operation separately, so a concurrent put that triggers
+        eviction can drop the key after we looked it up but before we read it. Reading
+        must fall back to a fetch rather than raising KeyError at the caller.
+        """
+        self.bq_source._dataset_obj_cache = _EvictedOnReadCache(capacity=8)
+        self.bq_source._dataset_obj_cache.put(f"{MOCK_DB_NAME}.clean_mac", object())
+
+        dataset_obj = self.bq_source.get_dataset_obj("clean_mac")
+
+        assert dataset_obj.description == "Clean MAC data"
+
+    def test_table_obj_survives_entry_evicted_before_read(self):
+        """Same eviction window as the dataset cache, for the table object cache."""
+        self.bq_source.context.get().__dict__["database_schema"] = "clean_mac"
+        self.bq_source.client.get_table.return_value = SimpleNamespace(labels={}, description="events")
+        self.bq_source._table_obj_cache = _EvictedOnReadCache(capacity=8)
+        self.bq_source._table_obj_cache.put(f"{MOCK_DB_NAME}.clean_mac.events", object())
+
+        table_obj = self.bq_source.get_table_obj(table_name="events")
+
+        assert table_obj.description == "events"

--- a/ingestion/tests/unit/topology/database/test_bigquery.py
+++ b/ingestion/tests/unit/topology/database/test_bigquery.py
@@ -16,7 +16,8 @@ bigquery unit tests
 # pylint: disable=line-too-long
 import types
 from copy import deepcopy
-from typing import Dict  # noqa: UP035
+from types import SimpleNamespace
+from typing import ClassVar, Dict  # noqa: UP035
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -788,7 +789,7 @@ class TestBigqueryRegionAwareQueries:
         mock_dataset = Mock()
         mock_dataset.location = location
         self.bq_source.client.get_dataset.return_value = mock_dataset
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
 
     # --- get_stored_procedures ---
 
@@ -823,7 +824,7 @@ class TestBigqueryRegionAwareQueries:
     def test_get_stored_procedures_falls_back_when_location_unavailable(self):
         """When client.get_dataset raises, falls back to dataset-scoped query and returns results."""
         self.bq_source.client.get_dataset.side_effect = Exception("permission denied")
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
         sp_row = {"name": "my_proc", "definition": "BEGIN END", "language": "SQL"}
         mock_engine, mock_conn = self._make_engine_mock([sp_row])
         self.bq_source.engine = mock_engine
@@ -838,7 +839,7 @@ class TestBigqueryRegionAwareQueries:
     def test_get_stored_procedures_returns_empty_when_dataset_not_found(self):
         """When both client.get_dataset and SQL execution fail, returns empty without a producer failure."""
         self.bq_source.client.get_dataset.side_effect = Exception("404 Not found")
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
         mock_engine = MagicMock()
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = Exception("404 Not found in location US")
@@ -913,7 +914,7 @@ class TestBigqueryRegionAwareQueries:
     def test_prefetch_table_ddls_falls_back_when_location_unavailable(self):
         """When client.get_dataset raises, falls back to dataset-scoped query and populates cache."""
         self.bq_source.client.get_dataset.side_effect = Exception("permission denied")
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
         ddl_row = Mock()
         ddl_row.table_name = "my_table"
         ddl_row.ddl = "CREATE TABLE my_table (id INT64)"
@@ -929,7 +930,7 @@ class TestBigqueryRegionAwareQueries:
     def test_prefetch_table_ddls_cache_empty_when_dataset_not_found(self):
         """When both client.get_dataset and SQL execution fail, cache stays empty and no exception propagates."""
         self.bq_source.client.get_dataset.side_effect = Exception("404 Not found")
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
         mock_engine = MagicMock()
         mock_conn = MagicMock()
         mock_conn.execute.side_effect = Exception("404 Not found in location US")
@@ -979,9 +980,133 @@ class TestBigqueryRegionAwareQueries:
     def test_life_cycle_query_falls_back_when_location_unavailable(self):
         """When client.get_dataset raises, falls back to the dataset-scoped created-only query."""
         self.bq_source.client.get_dataset.side_effect = Exception("permission denied")
-        self.bq_source._current_dataset_obj = None
+        self.bq_source._dataset_obj_cache.clear()
 
         query = self.bq_source.get_life_cycle_query()
 
         assert "TABLE_STORAGE" not in query
         assert "creation_time as created_at" in query
+
+
+class TestBigqueryPerSchemaCaching:
+    """
+    The dataset/table object caches must be keyed per schema.
+
+    The databaseSchema topology node emits tags and the schema entity *before* its table
+    child node runs, so a cache that is only invalidated by the table producer hands the
+    previous dataset's description and labels to the next schema.
+    """
+
+    # dataset_id -> (description, labels)
+    DATASETS: ClassVar[dict] = {
+        "clean_identity_resolution": ("Clean Identity Resolution data", {"tier": "bronze"}),
+        "clean_mac": ("Clean MAC data", {"tier": "silver"}),
+        "clean_recon": ("Clean recon data", {"tier": "gold"}),
+    }
+
+    def setup_method(self):
+        self._patchers = [
+            patch("metadata.ingestion.source.database.bigquery.metadata.BigquerySource._test_connection"),
+            patch("metadata.ingestion.source.database.bigquery.metadata.BigquerySource.set_project_id"),
+            patch(
+                "metadata.ingestion.source.database.bigquery.connection.BigQueryConnection._get_client",
+                return_value=Mock(),
+            ),
+        ]
+        for p in self._patchers:
+            p.start()
+
+        metadata = OpenMetadata(
+            OpenMetadataConnection.model_validate(mock_bq_config["workflowConfig"]["openMetadataServerConfig"])
+        )
+        self.bq_source = BigquerySource.create(mock_bq_config["source"], metadata)
+        self.bq_source.context.get().__dict__["database_service"] = MOCK_DATABASE_SERVICE.name.root
+        self.bq_source.context.get().__dict__["database"] = MOCK_DB_NAME
+        # The table node repopulates the dataset cache after invalidating it (DDL prefetch here;
+        # the lifecycle and stored-procedure stages do the same), which is what strands the
+        # previous schema's dataset in the cache for the next schema.
+        self.bq_source.source_config.includeDDL = True
+        self.bq_source.source_config.includeTags = True
+
+        self.bq_source.client = Mock()
+        self.bq_source.client.get_dataset.side_effect = self._get_dataset
+        self.bq_source.client.list_tables.return_value = []
+
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.all.return_value = []
+        self.bq_source.engine = MagicMock()
+        self.bq_source.engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        self.bq_source.engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    def teardown_method(self):
+        for p in self._patchers:
+            p.stop()
+
+    def _get_dataset(self, dataset_ref: str):
+        description, labels = self.DATASETS[dataset_ref.rsplit(".", maxsplit=1)[-1]]
+        return SimpleNamespace(description=description, labels=labels, location="US")
+
+    def _walk_schema_then_tables(self, schema_name: str):
+        """Mimic the topology: schema stages first, then the table node producer."""
+        self.bq_source.context.get().__dict__["database_schema"] = schema_name
+        dataset_for_tags = self.bq_source.get_dataset_obj(schema_name)
+        description = self.bq_source.get_schema_description(schema_name)
+        list(self.bq_source.query_table_names_and_types(schema_name))
+        return description, dataset_for_tags.labels
+
+    def test_each_schema_gets_its_own_description(self):
+        """Descriptions must not shift onto the following schema."""
+        ingested = {schema: self._walk_schema_then_tables(schema)[0] for schema in self.DATASETS}
+
+        assert ingested == {schema: desc for schema, (desc, _) in self.DATASETS.items()}
+
+    def test_each_schema_gets_its_own_dataset_labels(self):
+        """Dataset labels feed schema tags; a stale dataset object invents tags that do not exist."""
+        ingested = {schema: self._walk_schema_then_tables(schema)[1] for schema in self.DATASETS}
+
+        assert ingested == {schema: labels for schema, (_, labels) in self.DATASETS.items()}
+
+    def test_dataset_obj_is_fetched_once_per_schema(self):
+        """The cache must still spare repeat API calls for the same schema."""
+        for _ in range(3):
+            self.bq_source.get_dataset_obj("clean_mac")
+
+        assert self.bq_source.client.get_dataset.call_count == 1
+
+    def test_table_obj_cache_is_scoped_per_schema(self):
+        """Same-named tables in different schemas must not share a cached table object."""
+        table_objs = {}
+        for schema in ("clean_mac", "clean_recon"):
+            self.bq_source.context.get().__dict__["database_schema"] = schema
+            self.bq_source.client.get_table.return_value = SimpleNamespace(
+                labels={"schema": schema}, description=f"{schema} events"
+            )
+            table_objs[schema] = self.bq_source.get_table_obj(table_name="events")
+
+        assert table_objs["clean_mac"].labels == {"schema": "clean_mac"}
+        assert table_objs["clean_recon"].labels == {"schema": "clean_recon"}
+
+    def test_table_obj_is_fetched_once_per_table(self):
+        """The cache must still spare repeat API calls for the same schema and table."""
+        self.bq_source.context.get().__dict__["database_schema"] = "clean_mac"
+        self.bq_source.client.get_table.return_value = SimpleNamespace(labels={}, description="events")
+
+        for _ in range(3):
+            self.bq_source.get_table_obj(table_name="events")
+
+        assert self.bq_source.client.get_table.call_count == 1
+
+    def test_interleaved_schemas_keep_their_own_description(self):
+        """
+        The schema node is multi-threaded, so two schemas can be in flight at once.
+        Interleaving their stages must not let one schema's dataset serve the other.
+        """
+        schemas = ["clean_mac", "clean_recon"]
+
+        for schema in schemas:
+            self.bq_source.context.get().__dict__["database_schema"] = schema
+            self.bq_source.get_dataset_obj(schema)
+
+        descriptions = {schema: self.bq_source.get_schema_description(schema) for schema in schemas}
+
+        assert descriptions == {schema: self.DATASETS[schema][0] for schema in schemas}


### PR DESCRIPTION
### Describe your changes:

Fixes #30973

I keyed the BigQuery `get_dataset_obj` and `get_table_obj` caches by fully qualified name because both were effectively unkeyed, so every database schema was ingested with the *previous* dataset's description and labels.

`get_dataset_obj` was documented as "per-schema caching" but held a single slot with no key — once `_current_dataset_obj` was set it ignored `schema_name` entirely. Its only invalidation lived in `query_table_names_and_types()`, the **table** node's producer, which runs *after* the `databaseSchema` node has already emitted that schema's tags and description; the table/stored-procedure stage then refilled the slot with the current schema, so the next schema read the previous one's dataset object. Regression from #25471.

Both caches now use the existing thread-safe bounded `LRUCache` (`metadata/utils/lru_cache.py`), and the manual invalidations are gone: they caused the off-by-one and, being unsynchronized instance attributes, could wipe a concurrent thread's entry while the schema node runs `threads=True`. `get_table_obj` is keyed by `project.dataset.table` (was bare `table_name`), so same-named tables in different schemas no longer share a cached object. Fixing the keying rather than moving the reset earlier is deliberate — moving it would leave the thread-safety hole. The per-call API savings the original optimization added are preserved: `get_dataset` is still called exactly once per schema.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (2 files, one connector).

#
### Tests:

#### Use cases covered
- Ingesting a BigQuery project with multiple datasets stores each schema's own description, instead of the previous dataset's
- Ingesting with `includeTags` stores each schema's own dataset labels, instead of inheriting tags that do not exist on that dataset in BigQuery
- Two schemas in flight concurrently (the schema node is multi-threaded) keep their own descriptions
- Two same-named tables in different schemas keep their own labels
- Repeat lookups for the same schema/table still hit the cache (no extra BigQuery API calls)

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files updated: `ingestion/tests/unit/topology/database/test_bigquery.py` — new `TestBigqueryPerSchemaCaching` (6 tests)
- Each of the 4 bug tests was confirmed failing before the fix, with the exact off-by-one shift, e.g. `clean_mac` → `"Clean Identity Resolution data"` and `clean_recon` → `"Clean MAC data"`. The 2 remaining tests guard the caching behaviour itself so a future "just drop the cache" fix cannot regress the API-call savings.
- Also updated 6 pre-existing tests that set `_current_dataset_obj = None` to call `_dataset_obj_cache.clear()`; left alone they would have become silent no-ops that stop invalidating.
- Coverage: **100% of the changed lines** (`__init__` cache setup, `get_dataset_obj`, `get_table_obj`) are covered — verified with `--cov-report=term-missing`. Module-wide coverage of `bigquery/metadata.py` is 38%, which is pre-existing and unchanged by this PR.
- `test_bigquery.py`: 32 passed. All four BigQuery test files: 81 passed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
Not added — the fix is in per-schema cache keying, which the unit tests cover deterministically by driving the real `BigquerySource` through the topology call order. An integration test would need a live multi-dataset BigQuery project.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
No live BigQuery run — I do not have access to the reporter's project. Verification was a standalone reproduction script that drives the real `BigquerySource` through the topology's call order (schema stages → table producer) against a mocked `bigquery.Client`:

1. Before the fix: 4/5 schemas received the wrong description, reproducing the reporter's screenshot value-for-value.
2. After the fix: 0/5 wrong, and `client.get_dataset` is called exactly once per schema.
3. Also confirmed the buggy behaviour returns by temporarily reinstating the unkeyed lookup, so the new tests are known to fail against the old code.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable, no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

#
### Notes for the reviewer

Two related items I deliberately left out of this PR, happy to fold either in:

- `_table_ddl_cache` has the identical defect — keyed by bare `table_name` and `clear()`ed per schema — so at `threads > 1` it can serve one schema's DDL for a same-named table in another. Outside the reported symptoms; same one-line keying change.
- `BIGQUERY_SCHEMA_DESCRIPTION` in `bigquery/queries.py` is the correct pre-#25471 SQL lookup and is now dead code.

Deploying this fix stops new corruption, but existing wrong values need one re-ingestion with Override Metadata enabled to be rewritten. The phantom tags will **not** clear themselves — `overrideMetadata` deliberately skips REMOVE operations on `tags`, so already-attached wrong tags need a manual cleanup pass.