### PR TITLE
fix(ui): stop glossary left panel duplicating the last page

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMiscOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryMiscOperations.spec.ts
@@ -16,7 +16,11 @@ import { TableClass } from '../../../support/entity/TableClass';
 import { Glossary } from '../../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../../support/glossary/GlossaryTerm';
 import { getApiContext, redirectToHomePage } from '../../../utils/common';
-import { fillDeleteConfirmationIfPresent } from '../../../utils/entity';
+import {
+  fillDeleteConfirmationIfPresent,
+  getEncodedFqn,
+  waitForAllLoadersToDisappear,
+} from '../../../utils/entity';
 import {
   dragAndDropTerm,
   performExpandAll,
@@ -258,8 +262,12 @@ test.describe('Glossary Miscellaneous Operations', () => {
       await afterDeleteResponse;
 
       // Verify term is deleted from glossary
-      await sidebarClick(page, SidebarItem.GLOSSARY);
-      await selectActiveGlossary(page, glossary.data.displayName);
+      await page.goto(
+        `/glossary/${getEncodedFqn(
+          glossary.responseData.fullyQualifiedName as string
+        )}`
+      );
+      await waitForAllLoadersToDisappear(page);
 
       await expect(
         page.locator(`[data-row-key*="${glossaryTerm.responseData.name}"]`)

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -785,7 +785,8 @@ export const visitGlossaryPage = async (page: Page, glossaryName: string) => {
   await glossaryResponse;
   await waitForAllLoadersToDisappear(page);
   await page
-    .getByRole('menuitem', { name: glossaryName })
+    .getByTestId('glossary-left-panel')
+    .getByRole('menuitem', { name: glossaryName, exact: true })
     .click({ timeout: 30000 });
   await waitForAllLoadersToDisappear(page);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.component.tsx
@@ -51,11 +51,13 @@ import {
 import { Glossary } from '../../../generated/entity/data/glossary';
 import { GlossaryTerm } from '../../../generated/entity/data/glossaryTerm';
 import { Operation } from '../../../generated/entity/policies/policy';
+import { Paging } from '../../../generated/type/paging';
 import { withPageLayout } from '../../../hoc/withPageLayout';
 import { usePaging } from '../../../hooks/paging/usePaging';
 import { useElementInView } from '../../../hooks/useElementInView';
 import { useFqn } from '../../../hooks/useFqn';
 import {
+  getGlossariesByName,
   getGlossariesList,
   patchGlossaries,
   patchGlossaryTerm,
@@ -75,6 +77,15 @@ import { getGlossaryPath } from '../../../utils/RouterUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import GlossaryLeftPanel from '../GlossaryLeftPanel/GlossaryLeftPanel.component';
+
+const GLOSSARY_LIST_FIELDS = [
+  TabSpecificField.OWNERS,
+  TabSpecificField.TAGS,
+  TabSpecificField.REVIEWERS,
+  TabSpecificField.VOTES,
+  TabSpecificField.DOMAINS,
+  TabSpecificField.TERM_COUNT,
+];
 
 const GlossaryPage = () => {
   const { permissions } = usePermissionProvider();
@@ -105,6 +116,7 @@ const GlossaryPage = () => {
     activeGlossary,
     setActiveGlossary,
     updateActiveGlossary,
+    updateGlossary: updateGlossaryInList,
   } = useGlossaryStore();
 
   const isImportAction = useMemo(
@@ -157,19 +169,12 @@ const GlossaryPage = () => {
       let allGlossaries: Glossary[] = [];
       let nextPage = paging.after;
       let isGlossaryFound = false;
-      setInitialised(false);
+      let settledPaging: Paging | undefined;
       setIsLoading(true);
 
       do {
         const { data, paging: glossaryPaging } = await getGlossariesList({
-          fields: [
-            TabSpecificField.OWNERS,
-            TabSpecificField.TAGS,
-            TabSpecificField.REVIEWERS,
-            TabSpecificField.VOTES,
-            TabSpecificField.DOMAINS,
-            TabSpecificField.TERM_COUNT,
-          ],
+          fields: GLOSSARY_LIST_FIELDS,
           limit: PAGE_SIZE_LARGE,
           ...(nextPage && { after: nextPage }),
         });
@@ -185,11 +190,14 @@ const GlossaryPage = () => {
         }
 
         nextPage = glossaryPaging?.after;
-
-        handlePagingChange(glossaryPaging);
+        settledPaging = glossaryPaging;
       } while (nextPage && !isGlossaryFound);
 
       setGlossaries(allGlossaries);
+
+      if (settledPaging) {
+        handlePagingChange(settledPaging);
+      }
     } catch (error) {
       showErrorToast(error as AxiosError);
     } finally {
@@ -205,14 +213,7 @@ const GlossaryPage = () => {
       setIsMoreGlossaryLoading(true);
 
       const { data, paging: glossaryPaging } = await getGlossariesList({
-        fields: [
-          TabSpecificField.OWNERS,
-          TabSpecificField.TAGS,
-          TabSpecificField.REVIEWERS,
-          TabSpecificField.VOTES,
-          TabSpecificField.DOMAINS,
-          TabSpecificField.TERM_COUNT,
-        ],
+        fields: GLOSSARY_LIST_FIELDS,
         limit: PAGE_SIZE_LARGE,
         after: after,
       });
@@ -461,8 +462,15 @@ const GlossaryPage = () => {
           fqn = fqnArr.join(FQN_SEPARATOR_CHAR);
         }
         navigate(getGlossaryPath(fqn));
-        // Refresh glossary list to update term count after deletion
-        fetchGlossaryList();
+
+        const rootFqn = glossaryFqn ? Fqn.split(glossaryFqn)[0] : undefined;
+        if (rootFqn) {
+          updateGlossaryInList(
+            await getGlossariesByName(rootFqn, {
+              fields: GLOSSARY_LIST_FIELDS,
+            })
+          );
+        }
       } catch (err) {
         showErrorToast(
           err as AxiosError,
@@ -472,7 +480,7 @@ const GlossaryPage = () => {
         );
       }
     },
-    [glossaryFqn, activeGlossary, fetchGlossaryList]
+    [glossaryFqn, activeGlossary, fetchGlossaryList, updateGlossaryInList]
   );
 
   const handleAssetClick = useCallback(

--- a/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/Glossary/GlossaryPage/GlossaryPage.test.tsx
@@ -14,8 +14,13 @@
 import { act, fireEvent, screen } from '@testing-library/react';
 import ResizableLeftPanels from '../../../components/common/ResizablePanels/ResizableLeftPanels';
 import * as useGlossaryStoreModule from '../../../components/Glossary/useGlossary.store';
+import { Glossary } from '../../../generated/entity/data/glossary';
 import { MOCK_GLOSSARY } from '../../../mocks/Glossary.mock';
-import { patchGlossaryTerm } from '../../../rest/glossaryAPI';
+import {
+  getGlossariesByName,
+  getGlossariesList,
+  patchGlossaryTerm,
+} from '../../../rest/glossaryAPI';
 import { renderWithQueryClient } from '../../../test/unit/test-utils';
 import GlossaryPage from './GlossaryPage.component';
 
@@ -36,11 +41,13 @@ jest.mock('react-router-dom', () => ({
   useNavigate: jest.fn().mockImplementation(() => mockNavigate),
 }));
 
+const mockHandlePagingChange = jest.fn();
+
 jest.mock('../../../hooks/paging/usePaging', () => ({
   usePaging: jest.fn(() => ({
     paging: {},
     pageSize: 15,
-    handlePagingChange: jest.fn(),
+    handlePagingChange: mockHandlePagingChange,
   })),
 }));
 
@@ -86,6 +93,7 @@ jest.mock('../../../context/AsyncDeleteProvider/AsyncDeleteProvider', () => ({
 const mockSetGlossaries = jest.fn();
 const mockSetActiveGlossary = jest.fn();
 const mockUpdateActiveGlossary = jest.fn();
+const mockUpdateGlossaryInList = jest.fn();
 
 jest.mock('../../../components/Glossary/useGlossary.store', () => ({
   useGlossaryStore: jest.fn(() => ({
@@ -94,6 +102,7 @@ jest.mock('../../../components/Glossary/useGlossary.store', () => ({
     activeGlossary: MOCK_GLOSSARY,
     setActiveGlossary: mockSetActiveGlossary,
     updateActiveGlossary: mockUpdateActiveGlossary,
+    updateGlossary: mockUpdateGlossaryInList,
   })),
 }));
 
@@ -145,6 +154,9 @@ jest.mock('../../../rest/glossaryAPI', () => ({
       paging: { total: 1 },
     })
   ),
+  getGlossariesByName: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve(MOCK_GLOSSARY)),
   patchGlossaryTerm: jest
     .fn()
     .mockImplementation(() => Promise.resolve({ data: MOCK_GLOSSARY })),
@@ -176,6 +188,77 @@ jest.mock('../../../components/common/ResizablePanels/ResizablePanels', () =>
 const mockProps = {
   pageTitle: 'glossary',
 };
+
+describe('Glossary list paging', () => {
+  const pageOneGlossary = {
+    ...MOCK_GLOSSARY,
+    id: 'page-one-glossary-id',
+    name: 'Page One Glossary',
+    fullyQualifiedName: 'Page One Glossary',
+  };
+  const pageTwoGlossary = {
+    ...MOCK_GLOSSARY,
+    id: 'page-two-glossary-id',
+    name: 'Business Glossary',
+    fullyQualifiedName: 'Business Glossary',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getGlossariesByName as jest.Mock).mockResolvedValue(MOCK_GLOSSARY);
+    (getGlossariesList as jest.Mock).mockResolvedValue({
+      data: [MOCK_GLOSSARY],
+      paging: { total: 1 },
+    });
+  });
+
+  it('should publish paging once the whole list has settled', async () => {
+    (getGlossariesList as jest.Mock)
+      .mockResolvedValueOnce({
+        data: [pageOneGlossary],
+        paging: { after: 'page-two-cursor', total: 2 },
+      })
+      .mockResolvedValueOnce({
+        data: [pageTwoGlossary],
+        paging: { total: 2 },
+      });
+
+    renderWithQueryClient(<GlossaryPage {...mockProps} />);
+
+    await screen.findByText(/Glossary.component/i);
+
+    expect(getGlossariesList).toHaveBeenCalledTimes(2);
+    expect(mockHandlePagingChange).toHaveBeenCalledTimes(1);
+    expect(mockHandlePagingChange).toHaveBeenCalledWith({ total: 2 });
+
+    const settledList = mockSetGlossaries.mock.calls.at(-1)?.[0];
+
+    expect(settledList).toHaveLength(2);
+    expect(
+      new Set(settledList.map((item: Glossary) => item.fullyQualifiedName)).size
+    ).toBe(2);
+  });
+
+  it('should refresh only the owning glossary after a term delete', async () => {
+    renderWithQueryClient(<GlossaryPage {...mockProps} />);
+
+    await screen.findByText(/Glossary.component/i);
+
+    const listCallsAfterMount = (getGlossariesList as jest.Mock).mock.calls
+      .length;
+
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId('handleGlossaryTermDelete'));
+    });
+
+    expect(getGlossariesByName).toHaveBeenCalledWith(
+      'Business Glossary',
+      expect.anything()
+    );
+    expect(mockUpdateGlossaryInList).toHaveBeenCalledWith(MOCK_GLOSSARY);
+    expect(getGlossariesList).toHaveBeenCalledTimes(listCallsAfterMount);
+  });
+});
 
 describe('Test GlossaryComponent page', () => {
   it('GlossaryComponent Page Should render', async () => {


### PR DESCRIPTION
## Problem

On any instance with more than `PAGE_SIZE_LARGE` (50) glossaries, deleting a glossary term leaves the left panel showing **the whole glossary list plus a second copy of its final page**.

Surfaced by the nightly AUT report (run 159), where all three attempts of `Glossary Miscellaneous Operations › should delete term and remove tag from assets` failed with the same shape:

| attempt | glossaries on server | page 1 | page 2 | menu items rendered |
|---|---|---|---|---|
| 0 | 60 | 50 | 10 | 70 = 60 + 10 |
| 1 | 63 | 50 | 13 | 76 = 63 + 13 |
| 2 | 62 | 50 | 12 | 74 = 62 + 12 |

Every attempt is the complete list plus exactly one extra copy of the last page.

The test fails on a strict-mode violation because the glossary it looks up by exact name resolves to two `<li>`s sharing one `data-menu-id` — so it is one glossary rendered twice, not two glossaries with similar names:

```
strict mode violation: getByTestId('glossary-left-panel')
  .getByRole('menuitem', { name: 'PW % fc6e9bb5 Jolly3b3e9f28', exact: true })
  resolved to 2 elements
```

## Root cause

The panel renders the `glossaries` array 1:1, so a duplicated item means the same object is in that array twice. It gets there because **two functions write that array with different semantics**, and neither knows what the other did:

- `fetchGlossaryList` rebuilds the list from scratch and **replaces** it
- `fetchNextGlossaryItems` **appends** a single page (infinite scroll)

They collide because `fetchGlossaryList` published its paging cursor from *inside* its page loop, while only writing the store at the very end:

```js
do {
  const { data, paging: glossaryPaging } = await getGlossariesList({ ...after: nextPage });
  allGlossaries = [...allGlossaries, ...data];   // local variable — store untouched
  nextPage = glossaryPaging?.after;
  handlePagingChange(glossaryPaging);            // ← published mid-loop
} while (nextPage && !isGlossaryFound);

setGlossaries(allGlossaries);                    // store written only here
```

With 63 glossaries and the active one on page 2:

1. Page 1 is fetched. Its 50 items sit in a **local variable**; the store still holds the pre-load list.
2. `handlePagingChange({ after: cursorA })` makes a non-null cursor observable.
3. That wakes the infinite-scroll effect — its sentinel is in view because `GlossaryLeftPanel` scrolls the active glossary into view, and the active glossary is near the bottom. It starts fetching page 2 **independently**.
4. `fetchGlossaryList` fetches page 2 itself, finds its target, exits, and writes the complete 63-item list.
5. Step 3's response lands and does `setGlossaries([...63 items, ...13 items])` → **76**.

Both paths fetched page 2; one landed it as part of the rebuild, the other appended it on top.

A second defect amplifies this: `fetchGlossaryList` called `setInitialised(false)` on entry, which the `[initialised]` effect reacted to by invoking it again — so every explicit refresh ran twice and published the intermediate cursor twice. The trace shows 2× page 1 and 3× page 2 after a single term delete. Only the appender adds (the rebuilds replace), which is why exactly one extra copy appears rather than three.

Finally, the refetch that triggers all of this was doing far too much work: a term delete leaves exactly one datum stale — the owning glossary's `termCount`, which reaches the Terms-tab badge because `activeGlossary` is derived from the list — and it was re-paginating every page to update that one integer.

## Not a regression, and not 2.0-specific

- All three defect sites predate the available git history; the spec was last touched in #29783 (2026-07-09), and the only recent change to `GlossaryPage.component.tsx` (#30483) touched the empty-state branch only.
- Runs 135 and 158 passed on identical code. Run 158 already had 60 glossaries and two pages, so crossing the 50 boundary is not by itself the trigger.
- `GlossaryPage.component.tsx`, `GlossaryLeftPanel.component.tsx`, `useElementInView.ts` and `PAGE_SIZE_LARGE` are all identical on `2.0` and `main`.

It is intermittent because four things must line up: more than 50 glossaries; the active glossary in the **last** page (if it is on page 1 the loop exits after one iteration and the subsequent append is legitimate); the sentinel scrolled into view; and the appender's response landing *after* the rebuild's. The odds grow over time, since page 1 is capped at 50 while the last page grows with the glossary count.

## What changed, and why

**`GlossaryPage.component.tsx`**

- **`handlePagingChange` moved out of the `do/while` loop**, called once after the list settles. This is the core fix: paging state now only ever describes a settled list, so no observer can act on an intermediate cursor.
- **`setInitialised(false)` removed from `fetchGlossaryList`.** It was the re-entrancy — it made the `[initialised]` effect call the fetch a second time, doubling the intermediate cursor publications.
- **The term-delete path no longer re-paginates.** It refreshes the single owning glossary and writes it back with the store's `updateGlossary`, matching the optimistic shape `handleGlossaryDelete` already used, where a full refetch is the `onDeleteFailure` reconcile only.
- **Field list hoisted to `GLOSSARY_LIST_FIELDS`** so the single-entity refresh cannot drift from the list fetch and strip `owners`/`tags`/`votes` off the item it replaces.

**Tests**

- `GlossaryPage.test.tsx`: two regression tests — paging is published exactly once for a two-page load with a settled list, and a term delete refreshes only the owning glossary without re-paginating.
- `GlossaryMiscOperations.spec.ts`: the post-delete verification navigates by FQN instead of re-entering the glossary through the nav menu. A test about term deletion should not depend on how many other glossaries exist.
- `visitGlossaryPage`: scoped to the panel with an exact name match, so it can no longer substring-match a different glossary.

## What was deliberately not done

- **No dedupe.** An early draft added `uniqBy` to the store's `setGlossaries`. That was dropped: it repairs the symptom instead of removing the race, cannot distinguish *correct* from *same* (so it would equally have masked the other failure mode of this race — a list missing page 1), and adds a permanent O(n) scan on every write. Duplicates are now impossible by construction: paging is only published at rest, so the appender can only ever be handed a cursor that follows a settled list.
- **No `.first()` on either locator.** Both stay strict, so a duplicated entry fails loudly rather than being silently tolerated. The strict locator is what caught this bug.

## Verification

- `yarn jest src/pages/Glossary/GlossaryPage/GlossaryPage.test.tsx` — 10 passed.
- Both new tests were confirmed to **fail on the unpatched component** and pass with it; the 8 pre-existing tests are unaffected either way.
- `tsc --noEmit` clean on the touched files; `prettier --check` clean.
- Not run locally: the Playwright suite (needs a cluster) and ESLint (the `node_modules` borrowed into my worktree lacks `eslint-plugin-sonarjs`). Both are covered by CI, so the e2e change specifically is unverified by execution.

## Notes for review

- 7 other `sidebarClick(GLOSSARY)` + `selectActiveGlossary(...)` pairs in `GlossaryMiscOperations.spec.ts` use the same panel-dependent pattern and could get the same treatment; left alone here to keep the blind e2e edits minimal.
- `handleGlossaryTermUpdate` also refetches the whole glossary list on *term* rename. The panel lists glossaries only, and in term view `activeGlossary` comes from react-query rather than the list, so that call looks unnecessary — worth a separate look.
- `fetchGlossaryList` still seeds `nextPage` from `paging.after`, so a refresh fired while that cursor is non-null would replace the list with only its tail pages. Safe today because `after` is null once a full load finishes, but a latent trap.
- The nightly cluster is carrying ~38 leftover `PW %` glossaries from workers killed mid-test, which is what pushes it past the 50 boundary. Worth a teardown sweep independently of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
