### PR TITLE
[ESLint 4/10] Fix clear-text-protocols + secrets warnings

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/APIEndpoint/APIEndpointDetails/APIEndpointDetails.test.tsx
@@ -29,7 +29,9 @@ const mockApiEndpointDetails: APIEndpoint = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://test.com',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   endpointURL: 'http://api.test.com/endpoint',
   requestMethod: APIRequestMethod.Get,
   service: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/CommentCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCardNew/CommentCard.test.tsx
@@ -107,6 +107,7 @@ const createMockPost = (from: string, message: string): Post => ({
 
 const createMockFeed = (): Thread => ({
   id: 'thread-123',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   href: 'http://test',
   threadTs: 1234567890,
   about: '<#E::table::test>',

--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Shared/ActivityFeedActions.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/Shared/ActivityFeedActions.test.tsx
@@ -60,6 +60,7 @@ const createMockFeed = (
   createdBy: string = 'testuser'
 ): Thread => ({
   id: 'thread-123',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://test',
   threadTs: 1234567890,
   about: '<#E::table::test>',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Chart/ChartDetails/ChartDetails.component.test.tsx
@@ -28,6 +28,7 @@ const mockChartDetails: Chart = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   href: 'http://test.com',
   chartType: ChartType.Line,
   service: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DocumentsView/DocumentPreviewPanel.test.tsx
@@ -89,12 +89,15 @@ const fullFile: ContextFile = {
   updatedAt: Date.now() - 60000,
 };
 
+// eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
+const MOCK_FILE_URL = 'http://x';
+
 describe('DocumentPreviewPanel', () => {
   it('renders the preview panel container', () => {
     render(
       <DocumentPreviewPanel
         file={baseFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -106,7 +109,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={baseFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -120,7 +123,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={{ ...baseFile, displayName: 'Report Display Name' }}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -134,7 +137,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={baseFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -146,7 +149,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={baseFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -158,7 +161,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={fullFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -171,7 +174,7 @@ describe('DocumentPreviewPanel', () => {
     render(
       <DocumentPreviewPanel
         file={baseFile}
-        url="http://x"
+        url={MOCK_FILE_URL}
         onClose={jest.fn()}
       />
     );
@@ -183,7 +186,11 @@ describe('DocumentPreviewPanel', () => {
   it('calls onClose when the close button is clicked', () => {
     const onClose = jest.fn();
     render(
-      <DocumentPreviewPanel file={baseFile} url="http://x" onClose={onClose} />
+      <DocumentPreviewPanel
+        file={baseFile}
+        url={MOCK_FILE_URL}
+        onClose={onClose}
+      />
     );
 
     fireEvent.click(screen.getByTestId('close-preview-btn'));

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DashboardDetails/DashboardDetails.component.test.tsx
@@ -28,6 +28,7 @@ const mockDashboardDetails: Dashboard = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   href: 'http://test.com',
   charts: [],
   service: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Dashboard/DataModel/DataModels/DataModelDetails.component.test.tsx
@@ -31,6 +31,7 @@ const mockDataModelData: DashboardDataModel = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://test.com',
   service: {
     id: 'test-service-id',

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetsHeader/DataAssetsHeader.test.tsx
@@ -477,6 +477,7 @@ describe('DataAssetsHeader component', () => {
   });
 
   it('should render source URL button when sourceUrl is present', () => {
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
     const mockSourceUrl = 'http://test-source.com';
 
     render(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductDomainWidget/DataProductDomainWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductDomainWidget/DataProductDomainWidget.test.tsx
@@ -85,6 +85,7 @@ describe('DataProductDomainWidget', () => {
       fullyQualifiedName: 'target',
       displayName: 'Target',
       description: 'should be stripped',
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://ignored',
       deleted: false,
       inherited: false,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsPage/DataProductsPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsPage/DataProductsPage.component.test.tsx
@@ -27,6 +27,7 @@ const mockDataProduct: DataProduct = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   href: 'http://test.com',
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/ApplicationSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/ApplicationSummary.mock.ts
@@ -28,6 +28,7 @@ export const mockApplicationEntityDetails: App = {
   version: 0.1,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/apps/app-id-101',
   permission: Permissions.All,
   runtime: {},

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/DashboardSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/DashboardSummary.mock.ts
@@ -37,9 +37,11 @@ export const mockDashboardEntityDetails: Dashboard = {
       description: '',
       displayName: 'Are you an ethnic minority in your city?',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
       href: 'http://openmetadata-server:8585/api/v1/charts/eba9c260-4036-4c57-92fe-6c6e3d703bda',
     },
   ],
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://openmetadata-server:8585/api/v1/dashboards/2edaff89-b1d4-47b6-a081-d72f08e1def9',
   followers: [],
   service: {
@@ -48,6 +50,7 @@ export const mockDashboardEntityDetails: Dashboard = {
     name: 'sample_superset',
     fullyQualifiedName: 'sample_superset',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://openmetadata-server:8585/api/v1/services/dashboardServices/38ae6d66-7086-4e00-b2d6-cabd2b951993',
   },
   serviceType: DashboardServiceType.Superset,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/DomainSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/DomainSummary.mock.ts
@@ -31,6 +31,7 @@ export const mockDomainEntityDetails: Domain = {
   version: 0.1,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/domains/123e4567-e89b-12d3-a456-426614174000',
   owners: [
     {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/GlossarySummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/GlossarySummary.mock.ts
@@ -22,6 +22,7 @@ export const mockGlossaryEntityDetails: Glossary = {
   version: 0.1,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://openmetadata-server:8585/api/v1/glossaries/glossary-id-123',
   tags: [],
   owners: [

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/MlModelSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/MlModelSummary.mock.ts
@@ -45,6 +45,7 @@ export const mockMlModelEntityDetails: Mlmodel = {
             fullyQualifiedName: 'sample_data.ecommerce_db.shopify.fact_sale',
             description:
               'The fact table captures the value of products sold or returned.',
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/tables/148e01f8-817a-4094-aa39-970746e3427e',
           },
         },
@@ -67,6 +68,7 @@ export const mockMlModelEntityDetails: Mlmodel = {
             fullyQualifiedName: 'sample_data.ecommerce_db.shopify.raw_customer',
             description:
               'This is a raw customers table as represented in our online DB. ',
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/tables/e2e27b89-9eda-441f-afe4-3c9b780e9e15',
           },
         },
@@ -81,6 +83,7 @@ export const mockMlModelEntityDetails: Mlmodel = {
             fullyQualifiedName: 'sample_data.ecommerce_db.shopify.raw_customer',
             description:
               'This is a raw customers table as represented in our online DB. This contains personal.',
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/tables/e2e27b89-9eda-441f-afe4-3c9b780e9e15',
           },
         },
@@ -113,9 +116,11 @@ export const mockMlModelEntityDetails: Mlmodel = {
     id: '43523452345345325423452345',
     type: '',
   },
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   server: 'http://my-server.ai',
   tags: [],
   followers: [],
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/mlmodels/e42a5d43-36fd-4636-ae89-5bcc6a61542e',
   deleted: false,
 };
@@ -141,6 +146,7 @@ export const mockMlModelEntityDetails1: Mlmodel = {
   },
   tags: [],
   followers: [],
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/mlmodels/b849cc70-ceda-4f2a-8de2-022a5c7f78a6',
   deleted: false,
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/PipelineSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/PipelineSummary.mock.ts
@@ -45,6 +45,7 @@ export const mockPipelineEntityDetails: Pipeline = {
     },
   ],
   deleted: false,
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://openmetadata-server:8585/api/v1/pipelines/b35f7a53-16a9-4ed1-9223-801c3d75674f',
   followers: [],
   tags: [],
@@ -54,6 +55,7 @@ export const mockPipelineEntityDetails: Pipeline = {
     name: 'sample_airflow',
     fullyQualifiedName: 'sample_airflow',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://openmetadata-server:8585/api/v1/services/pipelineServices/d1c5f7b4-dc61-4336-a4b1-a27e0b97d791',
   },
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TableSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TableSummary.mock.ts
@@ -30,6 +30,7 @@ export const mockTableEntityDetails: Table = {
   version: 0.2,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/tables/8dd1f238-6ba0-46c6-a091-7db81f2a6bed',
   columns: [
     {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TagSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TagSummary.mock.ts
@@ -22,6 +22,7 @@ export const mockTagEntityDetails: Tag = {
   version: 0.1,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://openmetadata-server:8585/api/v1/tags/tag-id-456',
   deprecated: false,
   classification: {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TopicSummary.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/mocks/TopicSummary.mock.ts
@@ -28,6 +28,7 @@ export const mockTopicEntityDetails: Topic = {
   version: 0.1,
   updatedAt: 1672627828429,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://openmetadata-server:8585/api/v1/topics/67e1dbbb-054c-4833-ba28-f95d71f0826f',
   deleted: false,
   service: {
@@ -36,6 +37,7 @@ export const mockTopicEntityDetails: Topic = {
     name: 'sample_kafka',
     fullyQualifiedName: 'sample_kafka',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://openmetadata-server:8585/api/v1/services/messagingServices/5d6f73f0-1811-49c8-8d1d-7a478ffd8177',
   },
   partitions: 0,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermReferencesModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/GlossaryTermReferencesModal.test.tsx
@@ -105,6 +105,7 @@ describe('GlossaryTermReferencesModal', () => {
     await act(async () => {
       fireEvent.change(nameInputs[0], { target: { value: 'BBC' } });
       fireEvent.change(endpointInputs[0], {
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test input fixture, not a network call
         target: { value: 'http://www.bbc.co.uk' },
       });
 
@@ -112,6 +113,7 @@ describe('GlossaryTermReferencesModal', () => {
     });
 
     expect(mockOnSave).toHaveBeenCalledWith([
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test expectation fixture, not a network call
       { name: 'BBC', endpoint: 'http://www.bbc.co.uk' },
     ]);
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.mock.ts
@@ -176,6 +176,7 @@ export const QUICK_LINK_MOCK_DATA = {
   fullyQualifiedName: 'QuickLink_AOJs37ZW',
   displayName: 'OpenMetadata Docs updated',
   description: 'Quick Link for OpenMetadata Website updated.',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/contextCenter/pages/fea97e8c-b2ac-4103-b827-29530d1292ad',
   changeDescription: {
     fieldsAdded: [
@@ -205,6 +206,7 @@ export const QUICK_LINK_MOCK_DATA = {
         'Amundsen is one of the OSS Data Catalogs that was developed by Lyft and was open-sourced in October 2019. It quickly became popular for solving data discovery and data governance challenges. However, in recent years, Amundsen’s development and growth have slowed down considerably. Without an active community and no clear roadmap to address the emerging needs, the users of Amundsen are looking for alternatives in the OSS space.\n\nOpenMetadata is redefining the modern metadata platform with a bold vision. We have built a centralized metadata repository based on metadata specifications and APIs from the ground up. It is the foundation for innovation with several applications, such as Discovery, Collaboration, Governance, Data Quality, and Data Insights going beyond passive Data Catalogs. Learn more about OpenMetadata’s journey so far here.',
       displayName: 'Rupesh Chavan',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/users/fcc81c9c-1ca2-4ab6-a44f-722c436c7aa8',
     },
   ],

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePages/KnowledgePages.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePages/KnowledgePages.mock.ts
@@ -90,6 +90,7 @@ export const MOCK_KNOWLEDGE_PAGES = [
     version: 0.6,
     updatedAt: 1705640284779,
     updatedBy: 'shilpa',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/contextCenter/pages/2c0e3122-5699-472a-9634-241595a9a400',
     changeDescription: {
       fieldsAdded: [],
@@ -119,6 +120,7 @@ export const MOCK_KNOWLEDGE_PAGES = [
     version: 0.2,
     updatedAt: 1705656839361,
     updatedBy: 'sachin',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/contextCenter/pages/8d383887-7b41-4ba4-b7e4-5f775df842d0',
     changeDescription: {
       fieldsAdded: [

--- a/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Metric/MetricDetails/MetricDetails.test.tsx
@@ -28,6 +28,7 @@ const mockMetricDetails: Metric = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://test.com',
   metricType: MetricType.Percentage,
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.test.tsx
@@ -110,6 +110,7 @@ const mockData = {
     storage: 's3://path-to-pickle',
     imageRepository: 'https://docker.hub.com/image',
   },
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   server: 'http://my-server.ai',
   href: 'http://localhost:8585/api/v1/mlmodels/1b561c2d-f449-4640-b893-94077cf1c35b',
   followers: [],

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelFeaturesList.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelFeaturesList.test.tsx
@@ -105,6 +105,7 @@ const mockData = {
     storage: 's3://path-to-pickle',
     imageRepository: 'https://docker.hub.com/image',
   },
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   server: 'http://my-server.ai',
   href: 'http://localhost:8585/api/v1/mlmodels/b2374223-3725-4b05-abe7-d51566e5c317',
   followers: [],

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.test.tsx
@@ -277,6 +277,7 @@ jest.mock('../../../common/TestConnection/TestConnection', () =>
 jest.mock('../../../../rest/ingestionPipelineAPI', () => ({
   getPipelineServiceHostIp: jest.fn().mockReturnValue({
     data: {
+      // eslint-disable-next-line sonarjs/no-hardcoded-ip -- mock IP fixture
       ip: '192.168.0.1',
     },
     status: 200,
@@ -667,6 +668,7 @@ describe('ServiceConfig', () => {
   it('should not display host ip if status is is not 200', async () => {
     (getPipelineServiceHostIp as jest.Mock).mockImplementationOnce(() => ({
       data: {
+        // eslint-disable-next-line sonarjs/no-hardcoded-ip -- mock IP fixture
         ip: '192.168.0.1',
       },
       status: 201,
@@ -793,6 +795,7 @@ describe('ServiceConfig', () => {
       expect.objectContaining({
         i18nKey: 'message.airflow-host-ip-address',
         values: expect.objectContaining({
+          // eslint-disable-next-line sonarjs/no-hardcoded-ip -- mock IP fixture
           hostIp: '192.168.0.1',
         }),
       }),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/EmbeddedConnectionConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/EmbeddedConnectionConfigForm.test.tsx
@@ -233,6 +233,7 @@ jest.mock('../../../common/TestConnection/TestConnection', () =>
 
 jest.mock('../../../../rest/ingestionPipelineAPI', () => ({
   getPipelineServiceHostIp: jest.fn().mockReturnValue({
+    // eslint-disable-next-line sonarjs/no-hardcoded-ip -- test fixture / mock IP
     data: { ip: '192.168.0.1' },
     status: 200,
   }),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConnectionDetails/ServiceConnectionDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConnectionDetails/ServiceConnectionDetails.test.tsx
@@ -72,6 +72,7 @@ jest.mock('../../../../utils/SearchServiceUtils', () => ({
 
 const databaseSchema = {
   hostPort: 'localhost:5432',
+  // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
   password: 'testPassword',
   username: 'testUsername',
   database: 'test_db',
@@ -97,6 +98,7 @@ const pipelineSchema = {
 const metaDataSchema = {
   type: MetadataServiceType.Atlas,
   username: 'AtlasUsername',
+  // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
   password: 'AtlasPassword',
   hostPort: 'localhost:5432',
   projectName: 'AtlasProject',

--- a/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Topic/TopicDetails/TopicDetails.component.test.tsx
@@ -28,6 +28,7 @@ const mockTopicDetails: Topic = {
   version: 0.1,
   updatedAt: 1234567890,
   updatedBy: 'test-user',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://test.com',
   service: {
     id: 'test-service-id',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.mock.ts
@@ -14,6 +14,7 @@ export const FORM_DATA = {
   type: 'Mysql',
   scheme: 'mysql+pymysql',
   username: 'openmetadata_user',
+  // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
   password: 'openmetadata_password',
   hostPort: 'mysql:3306',
 };
@@ -27,6 +28,7 @@ export const CREATE_WORKFLOW_PAYLOAD = {
         type: 'Mysql',
         scheme: 'mysql+pymysql',
         username: 'openmetadata_user',
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
         password: 'openmetadata_password',
         hostPort: 'mysql:3306',
       },
@@ -45,6 +47,7 @@ export const CREATE_WORKFLOW_PAYLOAD_WITH_RUNNER = {
         type: 'Mysql',
         scheme: 'mysql+pymysql',
         username: 'openmetadata_user',
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
         password: 'openmetadata_password',
         hostPort: 'mysql:3306',
       },
@@ -68,6 +71,7 @@ export const WORKFLOW_DETAILS = {
         type: 'Mysql',
         scheme: 'mysql+pymysql',
         username: 'openmetadata_user',
+        // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
         password: 'openmetadata_password',
         hostPort: 'mysql:3306',
         supportsMetadataExtraction: true,
@@ -114,6 +118,7 @@ export const WORKFLOW_DETAILS = {
   openMetadataServerConnection: {
     clusterName: 'openmetadata',
     type: 'OpenMetadata',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     hostPort: 'http://openmetadata-server:8585/api',
     authProvider: 'openmetadata',
     verifySSL: 'no-ssl',

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.test.tsx
@@ -1097,6 +1097,7 @@ describe('Test Connection Component', () => {
     );
 
     await act(async () => {
+      // eslint-disable-next-line sonarjs/no-hardcoded-ip -- test fixture / mock IP
       render(<TestConnection {...mockProps} hostIp="10.0.0.1" />);
     });
 
@@ -1110,6 +1111,7 @@ describe('Test Connection Component', () => {
 
     expect(
       await screen.findByTestId('connection-timeout-message')
+      // eslint-disable-next-line sonarjs/no-hardcoded-ip -- test fixture / mock IP
     ).toHaveTextContent('10.0.0.1');
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnectionModal/TestConnectionModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnectionModal/TestConnectionModal.test.tsx
@@ -184,6 +184,7 @@ describe('TestConnectionModal', () => {
       <TestConnectionModal
         {...commonProps}
         isConnectionTimeout
+        // eslint-disable-next-line sonarjs/no-hardcoded-ip -- mock IP fixture
         hostIp="10.0.0.1"
         progress={90}
       />

--- a/openmetadata-ui/src/main/resources/ui/src/constants/APICollection.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/APICollection.constants.ts
@@ -74,8 +74,10 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: 'Access to Petstore orders',
       displayName: 'store',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/apiCollections/a5580b17-739b-4f86-b72a-96eb5c59de6f',
     },
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/apiEndpoints/eb95db42-9b0d-46e0-945d-dc6a4e115692',
     owners: [],
     service: {
@@ -86,6 +88,7 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: '',
       displayName: 'pet_api_service',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/services/apiServices/c5d3b9ff-c8b4-4d3c-a695-7e94c798e3f8',
     },
     serviceType: APIServiceType.REST,
@@ -111,8 +114,10 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: 'Access to Petstore orders',
       displayName: 'store',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/apiCollections/a5580b17-739b-4f86-b72a-96eb5c59de6f',
     },
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/apiEndpoints/24f70b58-d285-4f5e-881e-8d27076a3050',
     owners: [],
     service: {
@@ -123,6 +128,7 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: '',
       displayName: 'pet_api_service',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/services/apiServices/c5d3b9ff-c8b4-4d3c-a695-7e94c798e3f8',
     },
     serviceType: APIServiceType.REST,
@@ -189,8 +195,10 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: 'Access to Petstore orders',
       displayName: 'store',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/apiCollections/a5580b17-739b-4f86-b72a-96eb5c59de6f',
     },
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/apiEndpoints/80cebee6-c433-4aca-be10-00835607f434',
     owners: [],
     service: {
@@ -201,6 +209,7 @@ export const API_COLLECTION_API_ENDPOINTS: APIEndpoint[] = [
       description: '',
       displayName: 'pet_api_service',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/services/apiServices/c5d3b9ff-c8b4-4d3c-a695-7e94c798e3f8',
     },
     serviceType: APIServiceType.REST,

--- a/openmetadata-ui/src/main/resources/ui/src/constants/Domain.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/Domain.constants.ts
@@ -68,6 +68,7 @@ export const DOMAIN_DUMMY_DATA: Domain = {
       fullyQualifiedName: 'brittney_thomas3',
       displayName: 'Brittney Thomas',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/users/9a6687fa-8bd5-446c-aa8f-81416c88fe67',
     },
   ],

--- a/openmetadata-ui/src/main/resources/ui/src/constants/mockTourData.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/mockTourData.constants.ts
@@ -2067,6 +2067,7 @@ export const mockSearchData = {
           version: 0.1,
           updatedAt: 1682049945635,
           updatedBy: 'admin',
+          // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
           href: 'http://openmetadata-server:8585/api/v1/tables/9d664bbd-8c9e-4068-9112-9ab0457d4c52',
           tableType: 'Regular',
           columns: [
@@ -2218,6 +2219,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databaseSchemas/be37a61e-fb10-4748-86ab-0714613a42ea',
           },
           database: {
@@ -2228,6 +2230,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databases/0dac7caf-8419-4a0b-a96e-345730b2c0f5',
           },
           service: {
@@ -2236,6 +2239,7 @@ export const mockSearchData = {
             name: 'sample_data',
             fullyQualifiedName: 'sample_data',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/services/databaseServices/f24cd129-f864-45d9-8cce-46a9aecd6846',
           },
           serviceType: 'BigQuery',
@@ -2293,6 +2297,7 @@ export const mockSearchData = {
           version: 0.1,
           updatedAt: 1682049945673,
           updatedBy: 'admin',
+          // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
           href: 'http://openmetadata-server:8585/api/v1/tables/f1f03f22-24d6-4e88-a6bc-6aa0b03f0da0',
           tableType: 'Regular',
           columns: [
@@ -2433,6 +2438,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databaseSchemas/be37a61e-fb10-4748-86ab-0714613a42ea',
           },
           database: {
@@ -2443,6 +2449,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databases/0dac7caf-8419-4a0b-a96e-345730b2c0f5',
           },
           service: {
@@ -2451,6 +2458,7 @@ export const mockSearchData = {
             name: 'sample_data',
             fullyQualifiedName: 'sample_data',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/services/databaseServices/f24cd129-f864-45d9-8cce-46a9aecd6846',
           },
           serviceType: 'BigQuery',
@@ -2512,6 +2520,7 @@ export const mockSearchData = {
           version: 0.1,
           updatedAt: 1682049945868,
           updatedBy: 'admin',
+          // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
           href: 'http://openmetadata-server:8585/api/v1/tables/94edd207-9d60-40cc-aa73-615e8fe20e97',
           tableType: 'Regular',
           columns: [
@@ -2710,6 +2719,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databaseSchemas/be37a61e-fb10-4748-86ab-0714613a42ea',
           },
           database: {
@@ -2720,6 +2730,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databases/0dac7caf-8419-4a0b-a96e-345730b2c0f5',
           },
           service: {
@@ -2728,6 +2739,7 @@ export const mockSearchData = {
             name: 'sample_data',
             fullyQualifiedName: 'sample_data',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/services/databaseServices/f24cd129-f864-45d9-8cce-46a9aecd6846',
           },
           serviceType: 'BigQuery',
@@ -2791,6 +2803,7 @@ export const mockSearchData = {
           version: 0.1,
           updatedAt: 1682049945964,
           updatedBy: 'admin',
+          // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
           href: 'http://openmetadata-server:8585/api/v1/tables/4e3556eb-ac18-456e-b8ba-ea4a42dac422',
           tableType: 'Regular',
           columns: [
@@ -3158,6 +3171,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schema related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databaseSchemas/be37a61e-fb10-4748-86ab-0714613a42ea',
           },
           database: {
@@ -3168,6 +3182,7 @@ export const mockSearchData = {
             description:
               'This **mock** database contains schemas related to shopify sales and orders with related dimension tables.',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/databases/0dac7caf-8419-4a0b-a96e-345730b2c0f5',
           },
           service: {
@@ -3176,6 +3191,7 @@ export const mockSearchData = {
             name: 'sample_data',
             fullyQualifiedName: 'sample_data',
             deleted: false,
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
             href: 'http://openmetadata-server:8585/api/v1/services/databaseServices/f24cd129-f864-45d9-8cce-46a9aecd6846',
           },
           serviceType: 'BigQuery',

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/IngestionListTable.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/IngestionListTable.mock.ts
@@ -68,6 +68,7 @@ export const mockESIngestionData: IngestionPipeline = {
   openMetadataServerConnection: {
     clusterName: 'sandbox-beta',
     type: OpenmetadataType.OpenMetadata,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     hostPort: 'http://openmetadata-server:8585/api',
     authProvider: AuthProvider.Openmetadata,
     verifySSL: VerifySSL.NoSSL,
@@ -116,6 +117,7 @@ export const mockESIngestionData: IngestionPipeline = {
     description: 'Service Used for creating OpenMetadata Ingestion Pipelines.',
     displayName: 'OpenMetadata Service',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/services/databaseServices/d520c9bb-a517-4f1e-8962-d8518de71279',
   },
   pipelineStatuses: {
@@ -128,6 +130,7 @@ export const mockESIngestionData: IngestionPipeline = {
   loggerLevel: LogLevels.Info,
   deployed: true,
   enabled: false,
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/services/ingestionPipelines/5ff66f1c-9809-4333-836e-ba4dadda11f2',
   version: 0.5,
   updatedAt: 1687854372726,

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/IngestionRecentRun.mock.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/IngestionRecentRun.mock.tsx
@@ -49,6 +49,7 @@ export const mockIngestionPipeline = {
   openMetadataServerConnection: {
     clusterName: 'openmetadata',
     type: 'OpenMetadata',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     hostPort: 'http://openmetadata-server:8585/api',
     authProvider: 'openmetadata',
     verifySSL: 'no-ssl',

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/MlModelVersion.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/MlModelVersion.mock.ts
@@ -51,6 +51,7 @@ export const mockMlModelDetails = {
             type: 'table',
             fullyQualifiedName: 'sample_data.ecommerce_db.shopify.fact_sale',
             description: '',
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
             href: 'http://openmetadata-server:8585/api/v1/tables/655888c1-6a55-4730-a0a2-f1aa287301e2',
           },
         },
@@ -71,6 +72,7 @@ export const mockMlModelDetails = {
             type: 'table',
             fullyQualifiedName: 'sample_data.ecommerce_db.shopify.fact_sale',
             description: '',
+            // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
             href: 'http://openmetadata-server:8585/api/v1/tables/655888c1-6a55-4730-a0a2-f1aa287301e2',
           },
         },
@@ -116,6 +118,7 @@ export const mockMlModelDetails = {
     storage: 's3://path-to-pickle',
     imageRepository: 'https://docker.hub.com/image',
   },
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
   server: 'http://my-server.ai',
   followers: [],
   tags: [],

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/SearchIndex.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/SearchIndex.mock.ts
@@ -90,6 +90,7 @@ export const MOCK_SEARCH_INDEX: SearchIndex = {
     name: 'elasticsearch_sample',
     fullyQualifiedName: 'elasticsearch_sample',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/services/storageServices/43bcffa8-89e7-45f5-9518-9247c56a1de7',
   },
   serviceType: SearchServiceType.ElasticSearch,
@@ -106,6 +107,7 @@ export const MOCK_SEARCH_INDEX: SearchIndex = {
       state: State.Confirmed,
     },
   ],
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/searchIndexes/5cb19694-636d-4c8f-93cf-ed6f6a135da7',
   changeDescription: {
     fieldsAdded: [],
@@ -122,6 +124,7 @@ export const MOCK_SEARCH_INDEX: SearchIndex = {
       fullyQualifiedName: 'Design',
       description: "Here' the description for Product Design",
       displayName: 'Product Design ',
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/domains/52fc9c67-78b7-42bf-8147-69278853c230',
     },
   ],

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Service.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Service.mock.ts
@@ -329,6 +329,7 @@ export const MOCK_METADATA_SERVICE: MetadataService = {
       type: MetadataServiceType.Atlas,
       username: 'admin',
       password: '*********',
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock connection URL fixture, not a network call
       hostPort: 'http://ec2-3-15-17-164.us-east-2.compute.amazonaws.com:21000',
       databaseServiceName: ['local_hive_new'],
       messagingServiceName: [],
@@ -348,9 +349,11 @@ export const MOCK_METADATA_SERVICE: MetadataService = {
       fullyQualifiedName: 'mayur',
       displayName: 'Mayur Singal',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/users/7a12b462-36c7-488a-b4c2-9756918704cb',
     },
   ],
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/services/databaseServices/9b09f404-7713-4f04-b7db-95111bac0c59',
   changeDescription: {
     fieldsAdded: [],

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Tags.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Tags.mock.ts
@@ -44,11 +44,13 @@ export const MOCK_TAG_DATA = {
     description: 'advanceSearch',
     displayName: '',
     deleted: false,
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/classifications/16c5865a-8804-4474-a1dd-14ee9da443b2',
   },
   version: 0.1,
   updatedAt: 1704261482857,
   updatedBy: 'ashish',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/tags/e8bc85c8-a87f-471c-872e-46904c5ea888',
   deprecated: false,
   deleted: false,

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Task.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Task.mock.ts
@@ -204,6 +204,7 @@ export const MOCK_ASSIGNEE_DATA = {
                   'Organization under which all the other team hierarchy is created',
                 displayName: 'Organization',
                 deleted: false,
+                // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
                 href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/9efbccd7-3d0b-485d-89c4-ac0f8fc80da5',
               },
             ],

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/Teams.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/Teams.mock.ts
@@ -33,6 +33,7 @@ export const MOCK_CURRENT_TEAM = {
         'Users with Data Consumer role use different data assets for their day to day work.',
       displayName: 'Data Consumer',
       fullyQualifiedName: 'DataConsumer',
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/roles/1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
       id: '1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
       name: 'DataConsumer',
@@ -44,6 +45,7 @@ export const MOCK_CURRENT_TEAM = {
     'Organization under which all the other team hierarchy is created',
   displayName: 'Organization',
   fullyQualifiedName: 'Organization',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/f9578f16-363a-4788-80fb-d05816c9e169',
   id: 'f9578f16-363a-4788-80fb-d05816c9e169',
   inheritedRoles: [],
@@ -57,6 +59,7 @@ export const MOCK_CURRENT_TEAM = {
       description: 'Policy for all the users of an organization.',
       displayName: 'Organization Policy',
       fullyQualifiedName: 'OrganizationPolicy',
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
       href: 'http://sandbox-beta.open-metadata.org/api/v1/policies/09f4480c-ef57-4239-b2aa-c87053ad4f46',
       id: '09f4480c-ef57-4239-b2aa-c87053ad4f46',
       name: 'OrganizationPolicy',
@@ -118,6 +121,7 @@ export const MOCK_TABLE_DATA = [
     defaultRoles: [],
     deleted: false,
     fullyQualifiedName: 'Engineering',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/49d060a2-ad14-48a7-840a-836cd99aaffb',
     id: '49d060a2-ad14-48a7-840a-836cd99aaffb',
     inheritedRoles: [
@@ -127,6 +131,7 @@ export const MOCK_TABLE_DATA = [
           'Users with Data Consumer role use different data assets for their day to day work.',
         displayName: 'Data Consumer',
         fullyQualifiedName: 'DataConsumer',
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://sandbox-beta.open-metadata.org/api/v1/roles/1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         id: '1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         name: 'DataConsumer',
@@ -148,6 +153,7 @@ export const MOCK_TABLE_DATA = [
     defaultRoles: [],
     deleted: false,
     fullyQualifiedName: 'Finance',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/b201a5b2-b0e8-461d-9fa1-cd5212d09eee',
     id: 'b201a5b2-b0e8-461d-9fa1-cd5212d09eee',
     inheritedRoles: [
@@ -157,6 +163,7 @@ export const MOCK_TABLE_DATA = [
           'Users with Data Consumer role use different data assets for their day to day work.',
         displayName: 'Data Consumer',
         fullyQualifiedName: 'DataConsumer',
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://sandbox-beta.open-metadata.org/api/v1/roles/1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         id: '1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         name: 'DataConsumer',
@@ -178,6 +185,7 @@ export const MOCK_TABLE_DATA = [
     defaultRoles: [],
     deleted: false,
     fullyQualifiedName: 'Legal',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/e64afbd0-aab5-4aed-952d-c5a5b8ba06bb',
     id: 'e64afbd0-aab5-4aed-952d-c5a5b8ba06bb',
     inheritedRoles: [
@@ -187,6 +195,7 @@ export const MOCK_TABLE_DATA = [
           'Users with Data Consumer role use different data assets for their day to day work.',
         displayName: 'Legal',
         fullyQualifiedName: 'Legal',
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://sandbox-beta.open-metadata.org/api/v1/roles/1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         id: '1497b0cf-cb5f-42c2-8e13-3ab68b90bfa0',
         name: 'Legal',

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/TestCase.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/TestCase.mock.ts
@@ -251,6 +251,7 @@ export const MOCK_TEST_CASE_RESOLUTION_STATUS = [
         'sample_data.ecommerce_db.shopify.dim_address.zip.column_values_to_be_between',
       description: 'test the number of column in table is between x and y',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
       href: 'http://openmetadata-server:8585/api/v1/dataQuality/testCases/4188c516-0d74-4692-bfe6-1727c58893f9',
     },
   },
@@ -275,6 +276,7 @@ export const MOCK_TEST_CASE_RESOLUTION_STATUS = [
         'sample_data.ecommerce_db.shopify.dim_address.zip.column_values_to_be_between',
       description: 'test the number of column in table is between x and y',
       deleted: false,
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
       href: 'http://openmetadata-server:8585/api/v1/dataQuality/testCases/4188c516-0d74-4692-bfe6-1727c58893f9',
     },
   },
@@ -368,6 +370,7 @@ export const MOCK_TEST_CASE_INCIDENT = {
           'sample_data.ecommerce_db.shopify.dim_address.zip.column_values_to_be_between',
         description: 'test the number of column in table is between x and y',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
         href: 'http://openmetadata-server:8585/api/v1/dataQuality/testCases/4188c516-0d74-4692-bfe6-1727c58893f9',
       },
     },
@@ -392,6 +395,7 @@ export const MOCK_TEST_CASE_INCIDENT = {
           'sample_data.ecommerce_db.shopify.dim_address.zip.column_values_to_be_between',
         description: 'test the number of column in table is between x and y',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
         href: 'http://openmetadata-server:8585/api/v1/dataQuality/testCases/4188c516-0d74-4692-bfe6-1727c58893f9',
       },
     },

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/TestSuite.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/TestSuite.mock.ts
@@ -498,6 +498,7 @@ export const MOCK_TABLE_ROW_INSERTED_COUNT_TO_BE_BETWEEN = {
   version: 0.1,
   updatedAt: 1675211404184,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/dataQuality/testDefinitions/756c7770-0af3-49a9-9905-75a2886e5eec',
   deleted: false,
 };
@@ -563,6 +564,7 @@ export const MOCK_TABLE_COLUMN_NAME_TO_EXIST = {
   version: 0.1,
   updatedAt: 1672236872076,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   href: 'http://sandbox-beta.open-metadata.org/api/v1/dataQuality/testDefinitions/6d4e4673-fd7f-4b37-811e-7645c3c17e93',
   deleted: false,
 };

--- a/openmetadata-ui/src/main/resources/ui/src/mocks/rests/applicationAPI.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/mocks/rests/applicationAPI.mock.ts
@@ -114,6 +114,7 @@ export const mockExternalApplicationData = {
   version: 0.5,
   updatedAt: 1739539645532,
   updatedBy: 'joseph',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://demo.getcollate.io/api/v1/apps/633f579c-512c-4b5f-864b-5664aa56b37f',
   deleted: false,
   developer: 'Collate Inc.',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MlModelPage/MlModelPage.component.test.tsx
@@ -107,6 +107,7 @@ const mockData = {
     storage: 's3://path-to-pickle',
     imageRepository: 'https://docker.hub.com/image',
   },
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
   server: 'http://my-server.ai',
   href: 'http://localhost:8585/api/v1/mlmodels/b2374223-3725-4b05-abe7-d51566e5c317',
   followers: [],

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ResetPassword/ResetPassword.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ResetPassword/ResetPassword.test.tsx
@@ -97,7 +97,9 @@ describe('ResetPassword', () => {
     });
 
     expect(mockHandleResetPassword).toHaveBeenCalledWith({
+      // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
       confirmPassword: 'Password@123',
+      // eslint-disable-next-line sonarjs/no-hardcoded-passwords -- test fixture credential
       password: 'Password@123',
       token: 'token',
       username: 'admin',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.test.tsx
@@ -1221,6 +1221,7 @@ describe('ServiceDetailsPage', () => {
     it('should fetch host IP when airflow is available', async () => {
       (getPipelineServiceHostIp as jest.Mock).mockResolvedValue({
         status: 200,
+        // eslint-disable-next-line sonarjs/no-hardcoded-ip -- test fixture / mock IP
         data: { ip: '192.168.1.1' },
       });
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/mocks/SignupData.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/mocks/SignupData.mock.ts
@@ -27,6 +27,7 @@ export const mockCreateUser = {
     updatedAt: 1665145804919,
     updatedBy: 'test.user',
     email: 'test.user@test.com',
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
     href: 'http://sandbox-beta.open-metadata.org/api/v1/users/911d4be4-6ebf-48a0-9016-43a2cf716428',
     isAdmin: false,
     profile: {
@@ -41,6 +42,7 @@ export const mockCreateUser = {
         name: 'Engineering',
         fullyQualifiedName: 'Engineering',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
         href: 'http://sandbox-beta.open-metadata.org/api/v1/teams/606c1d33-213b-4626-a619-0e4cef9f5069',
       },
     ],
@@ -55,6 +57,7 @@ export const mockCreateUser = {
           'Users with Data Consumer role use different data assets for their day to day work.',
         displayName: 'Data Consumer',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
         href: 'http://sandbox-beta.open-metadata.org/api/v1/roles/4509b668-2882-45c3-90e1-4551043f8cbd',
       },
     ],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ClassificationUtils.test.tsx
@@ -59,6 +59,7 @@ describe('ClassificationUtils', () => {
         provider: ProviderType.User,
         fullyQualifiedName: 'test.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'test-user',
@@ -89,6 +90,7 @@ describe('ClassificationUtils', () => {
         provider: ProviderType.System,
         fullyQualifiedName: 'tier.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'system',
@@ -119,6 +121,7 @@ describe('ClassificationUtils', () => {
         provider: ProviderType.System,
         fullyQualifiedName: 'system.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'system',
@@ -149,6 +152,7 @@ describe('ClassificationUtils', () => {
         provider: ProviderType.User,
         fullyQualifiedName: 'disabled.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'test-user',
@@ -175,6 +179,7 @@ describe('ClassificationUtils', () => {
         description: 'Minimal description',
         fullyQualifiedName: 'minimal.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'test-user',
@@ -212,6 +217,7 @@ describe('ClassificationUtils', () => {
         provider: ProviderType.User,
         fullyQualifiedName: 'versioned.classification',
         deleted: false,
+        // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
         href: 'http://test.com',
         updatedAt: 1234567890,
         updatedBy: 'test-user',
@@ -358,6 +364,7 @@ describe('ClassificationUtils', () => {
           description: 'Test description',
           fullyQualifiedName: 'test.classification',
           deleted: false,
+          // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a real network call
           href: 'http://test.com',
           updatedAt: 1234567890,
           updatedBy: 'test-user',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataAssetsHeader.utils.test.tsx
@@ -330,6 +330,7 @@ describe('Tests for DataAssetsHeaderUtils', () => {
 
     expect(JSON.stringify(assetData.extraInfo)).toContain('label.server');
     expect(JSON.stringify(assetData.extraInfo)).toContain(
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
       'http://my-server.ai'
     );
 
@@ -374,6 +375,7 @@ describe('Tests for DataAssetsHeaderUtils', () => {
       'label.server'
     );
     expect(JSON.stringify(assetWithNoExtraData.extraInfo)).not.toContain(
+      // eslint-disable-next-line sonarjs/no-clear-text-protocols -- test fixture URL, not a network call
       'http://my-server.ai'
     );
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SSOUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SSOUtils.test.ts
@@ -3033,6 +3033,7 @@ describe('parseSamlMetadataXml', () => {
   it('should parse Okta metadata correctly', () => {
     const result = parseSamlMetadataXml(OKTA_METADATA);
 
+    // eslint-disable-next-line sonarjs/no-clear-text-protocols -- SAML entityId identifier, not a network call
     expect(result.entityId).toBe('http://www.okta.com/exk123456');
     expect(result.ssoLoginUrl).toBe(
       'https://dev-123456.okta.com/app/openmetadata/exk123456/sso/saml'

--- a/openmetadata-ui/src/main/resources/ui/src/utils/mocks/EntityUtils.mock.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/mocks/EntityUtils.mock.ts
@@ -28,6 +28,7 @@ export const entityWithoutNameAndDescHighlight = {
   version: 0.2,
   updatedAt: 1672668265493,
   updatedBy: 'admin',
+  // eslint-disable-next-line sonarjs/no-clear-text-protocols -- mock API URL fixture, not a network call
   href: 'http://openmetadata-server:8585/api/v1/tables/8dd1f238-6ba0-46c6-a091-7db81f2a6bed',
   columns: [
     {


### PR DESCRIPTION
Fixes #30981. Part of epic #30977.

**Stacked PR 4 of 10** — base branch `ShaileshParmar11/eslint-03-react`. Review after the previous PR in the stack. The diff here contains only the *clear-text-protocols + secrets* changes.

⚠️ **Stacked, not independent** — this PR merges after #the one below it in the stack; GitHub auto-retargets the base to `main` as each lands. See epic #30977 for the full approach and reviewer caveats.

Behavior-preserving lint cleanup. Verified: target rule(s) → 0, no new warnings (git-stash ESLint before/after), 0 new tsc signatures vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)