### PR TITLE
[ESLint 5/10] Fix jest/no-disabled-tests warnings

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AppRouter/SettingsRouter.test.tsx
@@ -175,6 +175,7 @@ jest.mock('./AdminProtectedRoute', () => ({
   default: jest.fn().mockImplementation(({ children }) => children),
 }));
 
+// eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (route pages not rendered), left skipped
 describe.skip('SettingsRouter', () => {
   it('should render GlobalSettingPage component for exact settings route', async () => {
     render(
@@ -321,6 +322,7 @@ describe.skip('SettingsRouter', () => {
     ).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests -- suite skipped; individual case also fails when enabled
   it.skip('should render CustomPageSettings component for custom page settings route', async () => {
     render(
       <MemoryRouter

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCaseStatusModal/TestCaseStatusModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCaseStatusModal/TestCaseStatusModal.test.tsx
@@ -46,7 +46,7 @@ describe('TestCaseStatusModal component', () => {
     expect(await screen.findByText('label.save')).toBeInTheDocument();
   });
 
-  it.skip('should render test case reason and comment field, if status is resolved', async () => {
+  it('should render test case reason and comment field, if status is resolved', async () => {
     render(
       <TestCaseStatusModal
         {...mockProps}
@@ -78,6 +78,7 @@ describe('TestCaseStatusModal component', () => {
     expect(mockProps.onCancel).toHaveBeenCalled();
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (status option not selectable), left skipped
   it.skip('should call onSubmit function, on click of save button', async () => {
     render(<TestCaseStatusModal {...mockProps} />);
     const submitBtn = await screen.findByText('label.save');

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableQueries/QueryCardExtraOption/QueryCardExtraOption.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableQueries/QueryCardExtraOption/QueryCardExtraOption.test.tsx
@@ -130,6 +130,7 @@ describe('QueryCardExtraOption component test', () => {
     );
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (mock user not pre-voted), left skipped
   it.skip('OnClick of Vote up it should un vote if logged-in user has already up voted', async () => {
     render(<QueryCardExtraOption {...mockProps} />);
 
@@ -156,6 +157,7 @@ describe('QueryCardExtraOption component test', () => {
     );
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (mock user not pre-voted), left skipped
   it.skip('OnClick of Vote down it should un vote if logged-in user has already down voted', async () => {
     render(<QueryCardExtraOption {...mockProps} />);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.test.tsx
@@ -101,6 +101,7 @@ const mockWithAdvanceSearch =
 
 const ComponentWithProvider = mockWithAdvanceSearch(Children);
 
+// eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (provider render errors), left skipped
 describe.skip('AdvanceSearchProvider component', () => {
   it('should render the AdvanceSearchModal as close by default', () => {
     render(<ComponentWithProvider />);

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryUpdateConfirmationModal/GlossaryUpdateConfirmationModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryUpdateConfirmationModal/GlossaryUpdateConfirmationModal.test.tsx
@@ -70,7 +70,7 @@ describe('GlossaryUpdateConfirmationModal component', () => {
     expect(mockOnCancel).toHaveBeenCalled();
   });
 
-  it.skip('should call validation api on clicking on yes, confirm button', async () => {
+  it('should call validation api on clicking on yes, confirm button', async () => {
     const { findByText } = render(
       <GlossaryUpdateConfirmationModal
         glossaryTerm={{} as GlossaryTerm}

--- a/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MlModel/MlModelDetail/MlModelDetail.component.test.tsx
@@ -236,6 +236,7 @@ jest.mock('../../common/CustomPropertyTable/CustomPropertyTable', () => ({
     .mockReturnValue(<p>CustomPropertyTable.component</p>),
 }));
 
+// eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (component render errors), left skipped
 describe.skip('Test MlModel entity detail component', () => {
   it('Should render detail component', async () => {
     const { container } = render(<MlModelDetailComponent {...mockProp} />, {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/NextPreviousWithOffset/NextPreviousWithOffset.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/NextPreviousWithOffset/NextPreviousWithOffset.test.tsx
@@ -82,6 +82,7 @@ describe('NextPreviousWithOffset', () => {
     expect(screen.getByText('10 / label.page')).toBeInTheDocument();
   });
 
+  // eslint-disable-next-line jest/no-disabled-tests -- fails when enabled (dropdown option not rendered), left skipped
   it.skip('should call onShowSizeChange with correct size when page size is changed', async () => {
     const mockOnShowSizeChange = jest.fn();
     const props = {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/UserPage/UserPage.test.tsx
@@ -82,6 +82,7 @@ jest.mock('../../rest/feedsAPI', () => ({
   postFeedById: jest.fn(),
 }));
 
+// eslint-disable-next-line jest/no-disabled-tests -- multiple cases fail when enabled, left skipped
 describe.skip('Test the User Page', () => {
   it('Should call getUserByName  API on load', async () => {
     render(<UserPage />, { wrapper: MemoryRouter });


### PR DESCRIPTION
Fixes #30982. Part of epic #30977.

**Stacked PR 5 of 10** — base branch `ShaileshParmar11/eslint-04-protocols`. Review after the previous PR in the stack. The diff here contains only the *jest/no-disabled-tests* changes.

⚠️ **Stacked, not independent** — this PR merges after #the one below it in the stack; GitHub auto-retargets the base to `main` as each lands. See epic #30977 for the full approach and reviewer caveats.

Behavior-preserving lint cleanup. Verified: target rule(s) → 0, no new warnings (git-stash ESLint before/after), 0 new tsc signatures vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)