### PR TITLE
perf(ui): functional setState + memoize inline antd columns arrays (R4)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssetRules/DataAssetRules.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssetRules/DataAssetRules.component.tsx
@@ -283,36 +283,36 @@ export const useSemanticsRuleList = ({
   const [deleteSemanticsRule, setDeleteSemanticsRule] =
     useState<SemanticsRule | null>(null);
 
-  const handleSave = async (
-    semanticsRule: SemanticsRule,
-    previousName?: string
-  ) => {
-    // previousName: pass this if editing and the name was changed
-    let updatedSemanticsRules = [...semanticsRules];
+  const handleSave = useCallback(
+    async (semanticsRule: SemanticsRule, previousName?: string) => {
+      // previousName: pass this if editing and the name was changed
+      let updatedSemanticsRules = [...semanticsRules];
 
-    // Remove the old rule if editing and the name has changed
-    if (previousName && previousName !== semanticsRule.name) {
-      updatedSemanticsRules = updatedSemanticsRules.filter(
-        (rule) => rule.name !== previousName
+      // Remove the old rule if editing and the name has changed
+      if (previousName && previousName !== semanticsRule.name) {
+        updatedSemanticsRules = updatedSemanticsRules.filter(
+          (rule) => rule.name !== previousName
+        );
+      }
+
+      // Check if a rule with the new name already exists
+      const existingIndex = updatedSemanticsRules.findIndex(
+        (rule) => rule.name === semanticsRule.name
       );
-    }
 
-    // Check if a rule with the new name already exists
-    const existingIndex = updatedSemanticsRules.findIndex(
-      (rule) => rule.name === semanticsRule.name
-    );
+      if (existingIndex > -1) {
+        // Replace the existing rule
+        updatedSemanticsRules[existingIndex] = semanticsRule;
+      } else {
+        // Add as new rule in the beginning
+        updatedSemanticsRules.unshift(semanticsRule);
+      }
 
-    if (existingIndex > -1) {
-      // Replace the existing rule
-      updatedSemanticsRules[existingIndex] = semanticsRule;
-    } else {
-      // Add as new rule in the beginning
-      updatedSemanticsRules.unshift(semanticsRule);
-    }
-
-    await onSemanticsRuleChange(updatedSemanticsRules);
-    setAddEditSemanticsRule(null);
-  };
+      await onSemanticsRuleChange(updatedSemanticsRules);
+      setAddEditSemanticsRule(null);
+    },
+    [semanticsRules, onSemanticsRuleChange]
+  );
 
   const handleAddDataAssetRule = () => {
     setAddEditSemanticsRule({

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssetRules/DataAssetRules.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssetRules/DataAssetRules.component.tsx
@@ -331,33 +331,36 @@ export const useSemanticsRuleList = ({
     setDeleteSemanticsRule(null);
   };
 
-  const columns = [
-    {
-      title: t('label.name'),
-      dataIndex: 'name',
-      className: 'col-name',
-    },
-    {
-      title: t('label.description'),
-      dataIndex: 'description',
-      className: 'col-description',
-      render: (description: string) => (
-        <RichTextEditorPreviewerNew markdown={description} />
-      ),
-    },
-    {
-      title: t('label.enabled'),
-      dataIndex: 'enabled',
-      render: (enabled: boolean, record: SemanticsRule) => (
-        <Switch
-          checked={enabled}
-          onChange={() => {
-            handleSave({ ...record, enabled: !enabled });
-          }}
-        />
-      ),
-    },
-  ];
+  const columns = useMemo(
+    () => [
+      {
+        title: t('label.name'),
+        dataIndex: 'name',
+        className: 'col-name',
+      },
+      {
+        title: t('label.description'),
+        dataIndex: 'description',
+        className: 'col-description',
+        render: (description: string) => (
+          <RichTextEditorPreviewerNew markdown={description} />
+        ),
+      },
+      {
+        title: t('label.enabled'),
+        dataIndex: 'enabled',
+        render: (enabled: boolean, record: SemanticsRule) => (
+          <Switch
+            checked={enabled}
+            onChange={() => {
+              handleSave({ ...record, enabled: !enabled });
+            }}
+          />
+        ),
+      },
+    ],
+    [t, handleSave]
+  );
 
   const dataAssetRuleList = useMemo(() => {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/AddIngestion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/AddIngestion/AddIngestion.component.tsx
@@ -204,7 +204,7 @@ const AddIngestion = forwardRef<AddIngestionHandle, AddIngestionProps>(
     };
 
     const handleSubmit = (data: IngestionWorkflowData) => {
-      setWorkflowData({ ...data, displayName: workflowData?.displayName });
+      setWorkflowData((prev) => ({ ...data, displayName: prev?.displayName }));
       handleNext(2);
     };
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
@@ -419,9 +419,7 @@ const Services = ({ serviceName }: ServicesProps) => {
               markdown={highlightSearchText(description, searchTerm)}
             />
           ) : (
-            <span className="text-grey-muted">
-              {t('label.no-description')}
-            </span>
+            <span className="text-grey-muted">{t('label.no-description')}</span>
           ),
       },
       {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Services.tsx
@@ -382,63 +382,68 @@ const Services = ({ serviceName }: ServicesProps) => {
     []
   );
 
-  const columns: ColumnsType<ServicesType> = [
-    {
-      title: t('label.name'),
-      dataIndex: TABLE_COLUMNS_KEYS.NAME,
-      key: TABLE_COLUMNS_KEYS.NAME,
-      width: 200,
-      sorter: getColumnSorter<ServicesType, 'name'>('name'),
-      render: (name, record) => (
-        <div className="d-flex gap-2 items-center">
-          {getServiceLogoElement(record, 'w-4')}
-          <Link
-            className="max-two-lines"
-            data-testid={`service-name-${name}`}
-            to={getServiceDetailsPath(
-              record.fullyQualifiedName ?? record.name,
-              serviceName
-            )}>
-            {stringToHTML(
-              highlightSearchText(getEntityName(record), searchTerm)
-            )}
-          </Link>
-        </div>
-      ),
-    },
-    {
-      title: t('label.description'),
-      dataIndex: TABLE_COLUMNS_KEYS.DESCRIPTION,
-      key: TABLE_COLUMNS_KEYS.DESCRIPTION,
-      width: 200,
-      render: (description) =>
-        description ? (
-          <RichTextEditorPreviewerNew
-            className="max-two-lines"
-            markdown={highlightSearchText(description, searchTerm)}
-          />
-        ) : (
-          <span className="text-grey-muted">{t('label.no-description')}</span>
+  const columns: ColumnsType<ServicesType> = useMemo(
+    () => [
+      {
+        title: t('label.name'),
+        dataIndex: TABLE_COLUMNS_KEYS.NAME,
+        key: TABLE_COLUMNS_KEYS.NAME,
+        width: 200,
+        sorter: getColumnSorter<ServicesType, 'name'>('name'),
+        render: (name, record) => (
+          <div className="d-flex gap-2 items-center">
+            {getServiceLogoElement(record, 'w-4')}
+            <Link
+              className="max-two-lines"
+              data-testid={`service-name-${name}`}
+              to={getServiceDetailsPath(
+                record.fullyQualifiedName ?? record.name,
+                serviceName
+              )}>
+              {stringToHTML(
+                highlightSearchText(getEntityName(record), searchTerm)
+              )}
+            </Link>
+          </div>
         ),
-    },
-    {
-      title: t('label.type'),
-      dataIndex: TABLE_COLUMNS_KEYS.SERVICE_TYPE,
-      key: TABLE_COLUMNS_KEYS.SERVICE_TYPE,
-      width: 200,
-      filterDropdown: ColumnFilter,
-      filterIcon: columnFilterIcon,
-      filtered: !isEmpty(serviceTypeFilter),
-      filteredValue: serviceTypeFilter,
-      filters: serviceTypeFilters,
-      render: (serviceType) => (
-        <span className="font-normal text-grey-body">
-          {stringToHTML(highlightSearchText(serviceType, searchTerm))}
-        </span>
-      ),
-    },
-    ...ownerTableObject<ServicesType>(),
-  ];
+      },
+      {
+        title: t('label.description'),
+        dataIndex: TABLE_COLUMNS_KEYS.DESCRIPTION,
+        key: TABLE_COLUMNS_KEYS.DESCRIPTION,
+        width: 200,
+        render: (description) =>
+          description ? (
+            <RichTextEditorPreviewerNew
+              className="max-two-lines"
+              markdown={highlightSearchText(description, searchTerm)}
+            />
+          ) : (
+            <span className="text-grey-muted">
+              {t('label.no-description')}
+            </span>
+          ),
+      },
+      {
+        title: t('label.type'),
+        dataIndex: TABLE_COLUMNS_KEYS.SERVICE_TYPE,
+        key: TABLE_COLUMNS_KEYS.SERVICE_TYPE,
+        width: 200,
+        filterDropdown: ColumnFilter,
+        filterIcon: columnFilterIcon,
+        filtered: !isEmpty(serviceTypeFilter),
+        filteredValue: serviceTypeFilter,
+        filters: serviceTypeFilters,
+        render: (serviceType) => (
+          <span className="font-normal text-grey-body">
+            {stringToHTML(highlightSearchText(serviceType, searchTerm))}
+          </span>
+        ),
+      },
+      ...ownerTableObject<ServicesType>(),
+    ],
+    [t, serviceName, searchTerm, serviceTypeFilter, serviceTypeFilters]
+  );
 
   const serviceCardRenderer = (service: ServicesType) => {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/AddServicePage/AddServicePage.component.tsx
@@ -199,7 +199,7 @@ const AddServicePage = () => {
   };
 
   const handleServiceCategoryChange = (category: ServiceCategory) => {
-    setShowErrorMessage({ ...showErrorMessage, serviceType: false });
+    setShowErrorMessage((prev) => ({ ...prev, serviceType: false }));
     setServiceConfig((prev) => ({
       ...prev,
       serviceType: '',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/EmbeddedAddServicePage/EmbeddedAddServicePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/EmbeddedAddServicePage/EmbeddedAddServicePage.component.tsx
@@ -246,7 +246,7 @@ const EmbeddedAddServicePage = () => {
   };
 
   const handleServiceCategoryChange = (category: ServiceCategory) => {
-    setShowErrorMessage({ ...showErrorMessage, serviceType: false });
+    setShowErrorMessage((prev) => ({ ...prev, serviceType: false }));
     setServiceConfig((prev) => ({
       ...prev,
       serviceType: '',

--- a/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/IntakeForms/IntakeFormsPage.tsx
@@ -182,12 +182,15 @@ const IntakeFormsPage = () => {
       initialValue: null,
     });
 
-  const columns = [
-    { id: 'entityType', name: t('label.entity-type') },
-    { id: 'formFields', name: t('label.field-plural') },
-    { id: 'enabled', name: t('label.enabled') },
-    { id: 'actions', name: t('label.action-plural') },
-  ];
+  const columns = useMemo(
+    () => [
+      { id: 'entityType', name: t('label.entity-type') },
+      { id: 'formFields', name: t('label.field-plural') },
+      { id: 'enabled', name: t('label.enabled') },
+      { id: 'actions', name: t('label.action-plural') },
+    ],
+    [t]
+  );
 
   const renderAddButton = () => {
     if (allEntityTypesCovered) {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/PoliciesPage/PoliciesDetailPage/PoliciesDetailPage.tsx
@@ -164,7 +164,7 @@ const PoliciesDetailPage = () => {
     const patch = compare(policy, { ...policy, description });
     try {
       const data = await patchPolicy(patch, policy.id);
-      setPolicy({ ...policy, description: data.description });
+      setPolicy((prev) => ({ ...prev, description: data.description }));
     } catch (error) {
       showErrorToast(error as AxiosError);
     }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/RolesPage/RolesDetailPage/RolesDetailPage.tsx
@@ -146,7 +146,7 @@ const RolesDetailPage = () => {
     const patch = compare(role, { ...role, description });
     try {
       const data = await patchRole(patch, role.id);
-      setRole({ ...role, description: data.description });
+      setRole((prev) => ({ ...prev, description: data.description }));
     } catch (error) {
       showErrorToast(error as AxiosError);
     }


### PR DESCRIPTION
## What
Re-render hygiene batch (R4 from the UI quality audit).

**Functional setState** — 5 `setX(prev => ...)` conversions where the updater read current state from the closure (stale-state risk + unnecessary closure dep):
- `RolesDetailPage` (`setRole`), `PoliciesDetailPage` (`setPolicy`)
- `EmbeddedAddServicePage` & `AddServicePage` (`setShowErrorMessage`)
- `AddIngestion` (`setWorkflowData`)

**Memoize inline antd `columns` arrays** — 3 sites building a fresh array each render, forcing the `Table` to re-diff every column on every render. Wrapped in `useMemo` with correct deps:
- `Services.tsx`, `DataAssetRules.component.tsx`, `IntakeForms/IntakeFormsPage.tsx`

## Behavior
No behavior change — mechanical, identity-stability only.

## Verification
- `eslint` on all 8 changed files: **0 errors** (remaining warnings are pre-existing sonarjs/exhaustive-deps at untouched lines; no new ones at edit sites).
- exhaustive-deps validates each memoized `columns` dep list.

Ref: open-metadata/openmetadata-collate#5442 (R4, sub-issue #5447)

🤖 Generated with [Claude Code](https://claude.com/claude-code)