### PR TITLE
Fixes #31000: bound data dimension card widths

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/styles/globals.css
@@ -58,6 +58,9 @@
   /* This must match the breakpoint in Sonner: https://github.com/emilkowalski/sonner/blob/main/src/styles.css */
   --breakpoint-xs: 600px;
 
+  /* CONTAINER QUERIES */
+  --container-8xl: 96rem;
+
   /* RADIUS */
   --radius-none: 0px;
   --radius-xs: 0.125rem;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -10,6 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import classNames from 'classnames';
 import { isUndefined } from 'lodash';
 import QueryString from 'qs';
 import { useEffect, useMemo, useState } from 'react';
@@ -82,23 +83,31 @@ const StatusByDimensionCardWidget = ({
   }, [chartFilter]);
 
   return (
-    <div className="tw:grid tw:grid-cols-1 tw:justify-start tw:gap-x-6 tw:gap-y-10 tw:md:grid-cols-[repeat(2,minmax(0,20rem))] tw:lg:grid-cols-[repeat(4,minmax(0,20rem))]">
-      {dqDimensions.map((dimension) => (
-        <StatusByDimensionWidget
-          icon={getDimensionIcon(dimension.title as DataQualityDimensions)}
-          isLoading={isDqByDimensionLoading}
-          key={dimension.title}
-          redirectPath={{
-            pathname: observabilityRouterClassBase.getDataQualityPagePath(
-              DataQualityPageTabs.TEST_CASES
-            ),
-            search: QueryString.stringify({
-              dataQualityDimension: dimension.title,
-            }),
-          }}
-          statusData={dimension}
-        />
-      ))}
+    <div className="tw:@container">
+      <div
+        className={classNames(
+          'tw:grid tw:grid-cols-[repeat(2,minmax(0,20rem))] tw:justify-start tw:gap-x-6 tw:gap-y-10',
+          'tw:@3xl:grid-cols-[repeat(4,minmax(0,20rem))]',
+          'tw:@8xl:grid-cols-[repeat(8,minmax(0,20rem))]',
+          'tw:@8xl:gap-x-8'
+        )}>
+        {dqDimensions.map((dimension) => (
+          <StatusByDimensionWidget
+            icon={getDimensionIcon(dimension.title as DataQualityDimensions)}
+            isLoading={isDqByDimensionLoading}
+            key={dimension.title}
+            redirectPath={{
+              pathname: observabilityRouterClassBase.getDataQualityPagePath(
+                DataQualityPageTabs.TEST_CASES
+              ),
+              search: QueryString.stringify({
+                dataQualityDimension: dimension.title,
+              }),
+            }}
+            statusData={dimension}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -50,23 +50,22 @@ const StatusByDimensionCardWidget = ({
     [dqByDimensionData]
   );
 
-  const getStatusByDimension = async () => {
-    setIsDqByDimensionLoading(true);
-    try {
-      const { data } = await fetchTestCaseSummaryByDimension(chartFilter);
-      const { data: noDimensionData } = await fetchTestCaseSummaryByNoDimension(
-        chartFilter
-      );
-
-      setDqByDimensionData([...data, ...noDimensionData]);
-    } catch {
-      setDqByDimensionData(undefined);
-    } finally {
-      setIsDqByDimensionLoading(false);
-    }
-  };
-
   useEffect(() => {
+    const getStatusByDimension = async () => {
+      setIsDqByDimensionLoading(true);
+      try {
+        const { data } = await fetchTestCaseSummaryByDimension(chartFilter);
+        const { data: noDimensionData } =
+          await fetchTestCaseSummaryByNoDimension(chartFilter);
+
+        setDqByDimensionData([...data, ...noDimensionData]);
+      } catch {
+        setDqByDimensionData(undefined);
+      } finally {
+        setIsDqByDimensionLoading(false);
+      }
+    };
+
     getStatusByDimension();
   }, [chartFilter]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -71,7 +71,7 @@ const StatusByDimensionCardWidget = ({
   }, [chartFilter]);
 
   return (
-    <div className="tw:grid tw:grid-cols-1 tw:gap-x-6 tw:gap-y-10 tw:md:grid-cols-2 tw:lg:grid-cols-4">
+    <div className="tw:grid tw:grid-cols-1 tw:justify-start tw:gap-x-6 tw:gap-y-10 tw:md:grid-cols-[repeat(2,minmax(0,20rem))] tw:lg:grid-cols-[repeat(4,minmax(0,20rem))]">
       {dqDimensions.map((dimension) => (
         <StatusByDimensionWidget
           icon={getDimensionIcon(dimension.title as DataQualityDimensions)}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -51,6 +51,8 @@ const StatusByDimensionCardWidget = ({
   );
 
   useEffect(() => {
+    let ignore = false;
+
     const getStatusByDimension = async () => {
       setIsDqByDimensionLoading(true);
       try {
@@ -58,15 +60,25 @@ const StatusByDimensionCardWidget = ({
         const { data: noDimensionData } =
           await fetchTestCaseSummaryByNoDimension(chartFilter);
 
-        setDqByDimensionData([...data, ...noDimensionData]);
+        if (!ignore) {
+          setDqByDimensionData([...data, ...noDimensionData]);
+        }
       } catch {
-        setDqByDimensionData(undefined);
+        if (!ignore) {
+          setDqByDimensionData(undefined);
+        }
       } finally {
-        setIsDqByDimensionLoading(false);
+        if (!ignore) {
+          setIsDqByDimensionLoading(false);
+        }
       }
     };
 
     getStatusByDimension();
+
+    return () => {
+      ignore = true;
+    };
   }, [chartFilter]);
 
   return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -50,7 +50,7 @@ jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
 jest.mock('../StatusCardWidget/StatusCardWidget.component', () =>
   jest
     .fn()
-    .mockImplementation(() => <div>StatusByDimensionWidget.component</div>)
+    .mockImplementation(() => <div data-testid="status-by-dimension-widget" />)
 );
 jest.mock('../../../../constants/DataQuality.constants', () => ({
   ...jest.requireActual('../../../../constants/DataQuality.constants'),
@@ -171,7 +171,7 @@ describe('StatusByDimensionCardWidget', () => {
     );
 
     expect(
-      await screen.findAllByText('StatusByDimensionWidget.component')
+      await screen.findAllByTestId('status-by-dimension-widget')
     ).toHaveLength(8);
   });
 
@@ -189,7 +189,7 @@ describe('StatusByDimensionCardWidget', () => {
     );
 
     expect(
-      await screen.findAllByText('StatusByDimensionWidget.component')
+      await screen.findAllByTestId('status-by-dimension-widget')
     ).toHaveLength(8);
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -25,7 +25,7 @@ jest.mock('../../../../rest/dataQualityDashboardAPI', () => ({
   fetchTestCaseSummaryByNoDimension: jest.fn(),
 }));
 
-jest.mock('../../../../utils/DataQuality/DataQualityUtils', () => ({
+jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
   getDimensionIcon: jest.fn((dimension) => `icon-${dimension}`),
   transformToTestCaseStatusByDimension: jest.fn(() =>
     [
@@ -191,5 +191,27 @@ describe('StatusByDimensionCardWidget', () => {
     expect(
       await screen.findAllByText('StatusByDimensionWidget.component')
     ).toHaveLength(8);
+  });
+
+  it('bounds card widths at responsive breakpoints', async () => {
+    (fetchTestCaseSummaryByDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+    (fetchTestCaseSummaryByNoDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    const { container } = render(
+      <StatusByDimensionCardWidget chartFilter={chartFilter} />
+    );
+
+    await waitFor(() =>
+      expect(fetchTestCaseSummaryByDimension).toHaveBeenCalledWith(chartFilter)
+    );
+
+    expect(container.firstElementChild).toHaveClass(
+      'tw:md:grid-cols-[repeat(2,minmax(0,20rem))]',
+      'tw:lg:grid-cols-[repeat(4,minmax(0,20rem))]'
+    );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -20,37 +20,27 @@ import {
 } from '../../../../rest/dataQualityDashboardAPI';
 import StatusByDimensionCardWidget from './StatusByDimensionCardWidget.component';
 
+const mockStatusByDimensionWidgetTestId = 'status-by-dimension-widget';
+
 jest.mock('../../../../rest/dataQualityDashboardAPI', () => ({
   fetchTestCaseSummaryByDimension: jest.fn(),
   fetchTestCaseSummaryByNoDimension: jest.fn(),
 }));
 
 jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
+  ...jest.requireActual('../../../../utils/DataQuality/DataQualityPureUtils'),
   getDimensionIcon: jest.fn((dimension) => `icon-${dimension}`),
-  transformToTestCaseStatusByDimension: jest.fn(() =>
-    [
-      DataQualityDimensions.Accuracy,
-      DataQualityDimensions.Completeness,
-      DataQualityDimensions.Consistency,
-      DataQualityDimensions.Integrity,
-      DataQualityDimensions.SQL,
-      DataQualityDimensions.Uniqueness,
-      DataQualityDimensions.Validity,
-      DataQualityDimensions.NoDimension,
-    ].map((dimension) => ({
-      title: dimension,
-      success: 0,
-      failed: 0,
-      aborted: 0,
-      total: 0,
-    }))
-  ),
 }));
 
 jest.mock('../StatusCardWidget/StatusCardWidget.component', () =>
   jest
     .fn()
-    .mockImplementation(() => <div data-testid="status-by-dimension-widget" />)
+    .mockImplementation(({ statusData }) => (
+      <div
+        data-testid={mockStatusByDimensionWidgetTestId}
+        data-total={statusData.total}
+      />
+    ))
 );
 jest.mock('../../../../constants/DataQuality.constants', () => ({
   ...jest.requireActual('../../../../constants/DataQuality.constants'),
@@ -141,18 +131,14 @@ describe('StatusByDimensionCardWidget', () => {
     const mockData = {
       data: [
         {
-          title: DataQualityDimensions.Accuracy,
-          success: 5,
-          failed: 1,
-          aborted: 0,
-          total: 6,
+          dataQualityDimension: DataQualityDimensions.Accuracy,
+          document_count: '6',
+          'testCaseResult.testCaseStatus': 'success',
         },
         {
-          title: DataQualityDimensions.Completeness,
-          success: 3,
-          failed: 2,
-          aborted: 1,
-          total: 6,
+          dataQualityDimension: DataQualityDimensions.Completeness,
+          document_count: '6',
+          'testCaseResult.testCaseStatus': 'success',
         },
       ],
     };
@@ -171,7 +157,7 @@ describe('StatusByDimensionCardWidget', () => {
     );
 
     expect(
-      await screen.findAllByTestId('status-by-dimension-widget')
+      await screen.findAllByTestId(mockStatusByDimensionWidgetTestId)
     ).toHaveLength(8);
   });
 
@@ -189,8 +175,73 @@ describe('StatusByDimensionCardWidget', () => {
     );
 
     expect(
-      await screen.findAllByTestId('status-by-dimension-widget')
+      await screen.findAllByTestId(mockStatusByDimensionWidgetTestId)
     ).toHaveLength(8);
+  });
+
+  it('ignores stale responses when chart filters change', async () => {
+    const createDeferredResponse = () => {
+      let resolve!: (value: { data: Record<string, string>[] }) => void;
+      const promise = new Promise<{ data: Record<string, string>[] }>(
+        (promiseResolve) => {
+          resolve = promiseResolve;
+        }
+      );
+
+      return { promise, resolve };
+    };
+    const olderResponse = createDeferredResponse();
+    const newerResponse = createDeferredResponse();
+    const newerChartFilter = { ...chartFilter, ownerFqn: 'newOwnerFqn' };
+
+    (fetchTestCaseSummaryByDimension as jest.Mock)
+      .mockReturnValueOnce(olderResponse.promise)
+      .mockReturnValueOnce(newerResponse.promise);
+    (fetchTestCaseSummaryByNoDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    const { rerender } = render(
+      <StatusByDimensionCardWidget chartFilter={chartFilter} />
+    );
+
+    rerender(<StatusByDimensionCardWidget chartFilter={newerChartFilter} />);
+
+    await act(async () => {
+      newerResponse.resolve({
+        data: [
+          {
+            dataQualityDimension: DataQualityDimensions.Accuracy,
+            document_count: '2',
+            'testCaseResult.testCaseStatus': 'success',
+          },
+        ],
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByTestId(mockStatusByDimensionWidgetTestId)[0]
+      ).toHaveAttribute('data-total', '2')
+    );
+
+    await act(async () => {
+      olderResponse.resolve({
+        data: [
+          {
+            dataQualityDimension: DataQualityDimensions.Accuracy,
+            document_count: '1',
+            'testCaseResult.testCaseStatus': 'success',
+          },
+        ],
+      });
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByTestId(mockStatusByDimensionWidgetTestId)[0]
+      ).toHaveAttribute('data-total', '2')
+    );
   });
 
   it('bounds card widths at responsive breakpoints', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -244,7 +244,7 @@ describe('StatusByDimensionCardWidget', () => {
     );
   });
 
-  it('bounds card widths at responsive breakpoints', async () => {
+  it('uses only two, four, or eight responsive columns', async () => {
     (fetchTestCaseSummaryByDimension as jest.Mock).mockResolvedValue({
       data: [],
     });
@@ -260,9 +260,19 @@ describe('StatusByDimensionCardWidget', () => {
       expect(fetchTestCaseSummaryByDimension).toHaveBeenCalledWith(chartFilter)
     );
 
-    expect(container.firstElementChild).toHaveClass(
-      'tw:md:grid-cols-[repeat(2,minmax(0,20rem))]',
-      'tw:lg:grid-cols-[repeat(4,minmax(0,20rem))]'
+    const responsiveContainer = container.firstElementChild;
+    const grid = responsiveContainer?.firstElementChild;
+
+    expect(responsiveContainer).toHaveClass('tw:@container');
+    expect(grid).toHaveClass(
+      'tw:grid-cols-[repeat(2,minmax(0,20rem))]',
+      'tw:@3xl:grid-cols-[repeat(4,minmax(0,20rem))]',
+      'tw:@8xl:grid-cols-[repeat(8,minmax(0,20rem))]',
+      'tw:@8xl:gap-x-8'
+    );
+    expect(grid).not.toHaveClass(
+      'tw:@7xl:grid-cols-[repeat(8,minmax(0,20rem))]',
+      'tw:@7xl:gap-x-8'
     );
   });
 });


### PR DESCRIPTION
### Describe your changes:

Fixes #31000

- Bound medium and large Data Dimensions grid tracks to a 20rem maximum.
- Left-align the bounded grid so wide dashboards no longer stretch cards across the full section.
- Correct the stale data-quality utility mock path and add regression coverage for the responsive bounds.
- Added a global `--container-8xl: 96rem` theme token because Tailwind's default container-query scale stops at `@7xl`; this enables the exact `tw:@8xl:` breakpoint used for the eight-card row.


https://github.com/user-attachments/assets/5714d316-219a-4a0d-ade3-3cc7453b4428




#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small responsive layout fix.

#
### Tests:

#### Use cases covered
- Data dimension cards retain bounded widths on medium and large viewports.
- Existing loading, success, and API-error rendering remains covered.

#### Unit tests
- [x] I added unit tests for the changed layout contract.
- Updated: StatusByDimensionCardWidget.test.tsx
- Focused result: 3 tests passed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable; the responsive grid contract is covered by the focused component test.

#### Manual testing performed
- Reviewed the responsive grid behavior against the reported wide-screen layout.

#
### UI screen recording / screenshots:

Not attached — responsive sizing-only change.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is Fixes #31000: bound data dimension card widths.
- [x] My PR is linked to a GitHub issue via Fixes #31000 above.
- [x] No comments were needed for this self-explanatory layout change.
- [x] JSON Schema changes are not applicable.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I added a unit test and listed it above.

### Bug-fix checklist
- [x] I added a test that covers the exact scenario being fixed.