### PR TITLE
Fixes #17204: register Postgres usage source errors so the run does not report success on failure

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
@@ -79,16 +79,23 @@ class PostgresUsageSource(PostgresQueryParserSource, UsageSource):
                 yield TableQueries(queries=queries)
 
         except Exception as err:
+            # Record the failure on the workflow status, not just in the logs, so a
+            # source error surfaces as a failed run rather than a silent success.
+            stack_trace = traceback.format_exc()
+            query_source = self.service_connection.queryStatementSource or "pg_stat_statements"
+            error_message = (
+                f"Source usage processing error for service [{self.config.serviceName}] "
+                f"while reading query logs from [{query_source}]: {err}"
+            )
             if query:
                 logger.debug(f"###### USAGE QUERY #######\n{query}\n##########################")
-            logger.debug(traceback.format_exc())
-            # Register every source failure (connection, missing pg_stat_statements,
-            # permissions, ...) so the run does not report Errors: 0 / Success 100%.
+            logger.debug(stack_trace)
+            logger.error(error_message)
             self.status.failed(
                 StackTraceError(
                     name="Usage",
-                    error=f"Source Usage failed due to - {err}",
-                    stackTrace=traceback.format_exc(),
+                    error=error_message,
+                    stackTrace=stack_trace,
                 )
             )
 

--- a/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
+++ b/ingestion/src/metadata/ingestion/source/database/postgres/usage.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from typing import Iterable  # noqa: UP035
 
 from sqlalchemy import text
-from sqlalchemy.exc import OperationalError
 
 from metadata.generated.schema.entity.services.ingestionPipelines.status import (
     StackTraceError,
@@ -79,7 +78,12 @@ class PostgresUsageSource(PostgresQueryParserSource, UsageSource):
             if queries:
                 yield TableQueries(queries=queries)
 
-        except OperationalError as err:
+        except Exception as err:
+            if query:
+                logger.debug(f"###### USAGE QUERY #######\n{query}\n##########################")
+            logger.debug(traceback.format_exc())
+            # Register every source failure (connection, missing pg_stat_statements,
+            # permissions, ...) so the run does not report Errors: 0 / Success 100%.
             self.status.failed(
                 StackTraceError(
                     name="Usage",
@@ -87,12 +91,6 @@ class PostgresUsageSource(PostgresQueryParserSource, UsageSource):
                     stackTrace=traceback.format_exc(),
                 )
             )
-
-        except Exception as err:
-            if query:
-                logger.debug(f"###### USAGE QUERY #######\n{query}\n##########################")
-            logger.error(f"Source usage processing error - {err}")
-            logger.debug(traceback.format_exc())
 
     def get_filters(self) -> str:
         if filter_condition := self.source_config.filterCondition:  # pyright: ignore[reportAttributeAccessIssue]

--- a/ingestion/tests/integration/postgres/test_usage.py
+++ b/ingestion/tests/integration/postgres/test_usage.py
@@ -7,9 +7,6 @@ from metadata.generated.schema.entity.services.databaseService import DatabaseSe
 from metadata.generated.schema.metadataIngestion.databaseServiceQueryUsagePipeline import (
     DatabaseUsageConfigType,
 )
-from metadata.generated.schema.metadataIngestion.workflow import (
-    OpenMetadataWorkflowConfig,
-)
 from metadata.ingestion.lineage.sql_lineage import search_cache
 from metadata.ingestion.source.database.postgres.usage import PostgresUsageSource
 from metadata.workflow.metadata import MetadataWorkflow
@@ -76,37 +73,31 @@ def test_usage_delete_usage(
     run_workflow(UsageWorkflow, usage_config)
 
 
-def test_usage_registers_failing_query_source(postgres_container, workflow_config):
+def test_usage_registers_failing_query_source(postgres_container, metadata):
     """
     When the usage query fails against the source (here the configured query
     source does not exist), the failure must be registered on the source status
     instead of the run reporting Errors: 0 / Success 100% (#17204).
     """
     url = make_url(postgres_container.get_connection_url())
-    config = {
-        "source": {
-            "type": "postgres-usage",
-            "serviceName": "test_usage_17204",
-            "serviceConnection": {
-                "config": {
-                    "type": "Postgres",
-                    "username": url.username,
-                    "authType": {"password": url.password},
-                    "hostPort": f"{url.host}:{url.port}",
-                    "database": url.database,
-                    "queryStatementSource": "nonexistent_query_source_17204",
-                }
-            },
-            "sourceConfig": {"config": {"type": "DatabaseUsage", "queryLogDuration": 1}},
+    source_config = {
+        "type": "postgres-usage",
+        "serviceName": "test_usage_17204",
+        "serviceConnection": {
+            "config": {
+                "type": "Postgres",
+                "username": url.username,
+                "authType": {"password": url.password},
+                "hostPort": f"{url.host}:{url.port}",
+                "database": url.database,
+                "queryStatementSource": "nonexistent_query_source_17204",
+            }
         },
-        "sink": {"type": "metadata-rest", "config": {}},
-        "workflowConfig": workflow_config,
+        "sourceConfig": {"config": {"type": "DatabaseUsage", "queryLogDuration": 1}},
     }
-    parsed = OpenMetadataWorkflowConfig.model_validate(config)
     with patch("metadata.ingestion.source.database.postgres.usage.PostgresUsageSource.test_connection"):
-        source = PostgresUsageSource.create(config["source"], parsed.workflowConfig.openMetadataServerConfig)
+        source = PostgresUsageSource.create(source_config, metadata)
 
     list(source._iter())
 
-    assert len(source.status.failures) >= 1
-    assert "nonexistent_query_source_17204" in str(source.status.failures[0].error)
+    assert any("nonexistent_query_source_17204" in str(failure.error) for failure in source.status.failures)

--- a/ingestion/tests/integration/postgres/test_usage.py
+++ b/ingestion/tests/integration/postgres/test_usage.py
@@ -1,10 +1,17 @@
+from unittest.mock import patch
+
 import pytest
+from sqlalchemy.engine.url import make_url
 
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.metadataIngestion.databaseServiceQueryUsagePipeline import (
     DatabaseUsageConfigType,
 )
+from metadata.generated.schema.metadataIngestion.workflow import (
+    OpenMetadataWorkflowConfig,
+)
 from metadata.ingestion.lineage.sql_lineage import search_cache
+from metadata.ingestion.source.database.postgres.usage import PostgresUsageSource
 from metadata.workflow.metadata import MetadataWorkflow
 from metadata.workflow.usage import UsageWorkflow
 
@@ -67,3 +74,39 @@ def test_usage_delete_usage(
     metadata.delete(DatabaseService, db_service.id, hard_delete=True, recursive=True)
     run_workflow(MetadataWorkflow, ingestion_config)
     run_workflow(UsageWorkflow, usage_config)
+
+
+def test_usage_registers_failing_query_source(postgres_container, workflow_config):
+    """
+    When the usage query fails against the source (here the configured query
+    source does not exist), the failure must be registered on the source status
+    instead of the run reporting Errors: 0 / Success 100% (#17204).
+    """
+    url = make_url(postgres_container.get_connection_url())
+    config = {
+        "source": {
+            "type": "postgres-usage",
+            "serviceName": "test_usage_17204",
+            "serviceConnection": {
+                "config": {
+                    "type": "Postgres",
+                    "username": url.username,
+                    "authType": {"password": url.password},
+                    "hostPort": f"{url.host}:{url.port}",
+                    "database": url.database,
+                    "queryStatementSource": "nonexistent_query_source_17204",
+                }
+            },
+            "sourceConfig": {"config": {"type": "DatabaseUsage", "queryLogDuration": 1}},
+        },
+        "sink": {"type": "metadata-rest", "config": {}},
+        "workflowConfig": workflow_config,
+    }
+    parsed = OpenMetadataWorkflowConfig.model_validate(config)
+    with patch("metadata.ingestion.source.database.postgres.usage.PostgresUsageSource.test_connection"):
+        source = PostgresUsageSource.create(config["source"], parsed.workflowConfig.openMetadataServerConfig)
+
+    list(source._iter())
+
+    assert len(source.status.failures) >= 1
+    assert "nonexistent_query_source_17204" in str(source.status.failures[0].error)


### PR DESCRIPTION
### Describe your changes:

Related to #17204 (for postgres connector)

`PostgresUsageSource.process_table_query` registered a failure only for `OperationalError` (added after this issue was filed) and swallowed every other exception with a log line. So a common source error that is not an `OperationalError`, such as `pg_stat_statements` not being installed or the configured `queryStatementSource` not existing, was logged but never registered, and the run reported Errors: 0 / Success 100% while collecting nothing.

I merged the two exception handlers into a single `except Exception` that records the failure via `self.status.failed(...)`, so any source error during usage (connection, missing extension, permissions, ...) surfaces on the workflow status. The `OperationalError` case is still covered by the same handler.

Scope note: the same swallow pattern exists one level up in `postgres/query_parser.py` (the ingest-all-databases branch) and in the shared `usage_source.py` base plus the trino, snowflake and timescale usage sources. I kept this change to the reproduced path to limit blast radius, and those are worth a follow-up if we want the fix framework-wide (the issue is labeled `ingestion-framework`).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A (localized error-handling change).

#
### Tests:

#### Use cases covered
- A postgres-usage run whose query fails against the source (here a non-existent `queryStatementSource`) registers the failure on the source status instead of reporting success.

#### Unit tests
- [x] Not applicable as a unit test. The behavior is only meaningful against a real Postgres executing the real query, so it is covered by the integration test below rather than mocking the connection and query internals.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Added `test_usage_registers_failing_query_source` to `ingestion/tests/integration/postgres/test_usage.py`. Using the shared `postgres_container`, it builds a real `PostgresUsageSource` pointed at a non-existent `queryStatementSource`, drives the source, and asserts the failure is registered on `status.failures`.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Reproduced end-to-end against a real Postgres before and after the change, driving the actual `PostgresUsageSource`:

```
BEFORE
  missing pg_stat_statements / bad query source -> status.failures: 0  (Errors: 0 / Success 100%)
  bad auth (OperationalError)                    -> status.failures: 1

AFTER
  missing pg_stat_statements / bad query source -> status.failures: 1
  bad auth (OperationalError)                    -> status.failures: 1   (still registered)
```

Existing Postgres unit tests pass (22).

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
