### PR TITLE
Fixes #30545: stop addDataModel from wiping asset certification

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableDataModelCertificationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableDataModelCertificationIT.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.type.AssetCertification;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.DataModel;
+import org.openmetadata.schema.type.TagLabel;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+
+/**
+ * Regression for issue #30545: {@code PUT /v1/tables/{id}/dataModel} (the endpoint every dbt
+ * ingestion calls once per manifest node) wipes the table's certification.
+ *
+ * <p>{@code TableRepository.addDataModel} deletes every {@code tag_usage} row for the table with the
+ * prefix-agnostic {@code deleteTagsByTarget} and then re-applies only {@code table.getTags()}, which
+ * deliberately excludes certification-classification tags because certification is surfaced as its
+ * own entity field. The certification row is deleted but never re-applied.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class TableDataModelCertificationIT {
+
+  private static final String CERTIFICATION_GOLD = "Certification.Gold";
+  private static final String CERTIFICATION_PREFIX = "Certification.";
+  private static final String CERTIFICATION_FIELDS = "certification,tags";
+
+  @Test
+  void addDataModel_withoutTags_preservesCertification(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String existingTagFqn = SharedEntities.get().PII_SENSITIVE_TAG_LABEL.getTagFQN();
+    Table table = createCertifiedTable(client, ns, "dm_cert_no_tags", existingTagFqn);
+
+    client
+        .tables()
+        .updateDataModel(
+            table.getId().toString(),
+            new DataModel().withModelType(DataModel.ModelType.DBT).withTags(List.of()));
+
+    Table reloaded = client.tables().get(table.getId().toString(), CERTIFICATION_FIELDS);
+    assertNotNull(
+        reloaded.getCertification(),
+        "addDataModel with an empty tag list removed the table certification");
+    assertEquals(
+        CERTIFICATION_GOLD,
+        reloaded.getCertification().getTagLabel().getTagFQN(),
+        "certification changed");
+    assertTrue(
+        reloaded.getTags().stream().anyMatch(t -> existingTagFqn.equals(t.getTagFQN())),
+        () -> "pre-existing classification tag was dropped; tags=" + reloaded.getTags());
+  }
+
+  @Test
+  void addDataModel_withTags_preservesCertification(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String existingTagFqn = SharedEntities.get().PII_SENSITIVE_TAG_LABEL.getTagFQN();
+    String dbtTagFqn = SharedEntities.get().PERSONAL_DATA_TAG_LABEL.getTagFQN();
+    Table table = createCertifiedTable(client, ns, "dm_cert_with_tags", existingTagFqn);
+
+    client
+        .tables()
+        .updateDataModel(
+            table.getId().toString(),
+            new DataModel()
+                .withModelType(DataModel.ModelType.DBT)
+                .withTags(List.of(classificationTag(dbtTagFqn))));
+
+    Table reloaded = client.tables().get(table.getId().toString(), CERTIFICATION_FIELDS);
+    assertNotNull(
+        reloaded.getCertification(), "addDataModel with dbt tags removed the table certification");
+    assertEquals(
+        CERTIFICATION_GOLD,
+        reloaded.getCertification().getTagLabel().getTagFQN(),
+        "certification changed");
+    assertTrue(
+        reloaded.getTags().stream().anyMatch(t -> dbtTagFqn.equals(t.getTagFQN())),
+        () -> "dbt tag was not applied; tags=" + reloaded.getTags());
+    assertTrue(
+        reloaded.getTags().stream().noneMatch(t -> t.getTagFQN().startsWith(CERTIFICATION_PREFIX)),
+        () -> "certification leaked into the tags array; tags=" + reloaded.getTags());
+  }
+
+  private static Table createCertifiedTable(
+      OpenMetadataClient client, TestNamespace ns, String base, String existingTagFqn) {
+    Database database =
+        client
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName(ns.prefix(base + "_db"))
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    DatabaseSchema schema =
+        client
+            .databaseSchemas()
+            .create(
+                new CreateDatabaseSchema()
+                    .withName(ns.prefix(base + "_schema"))
+                    .withDatabase(database.getFullyQualifiedName()));
+    Table table =
+        client
+            .tables()
+            .create(
+                new CreateTable()
+                    .withName(ns.prefix(base))
+                    .withDatabaseSchema(schema.getFullyQualifiedName())
+                    .withColumns(
+                        List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)))
+                    .withTags(List.of(classificationTag(existingTagFqn))));
+
+    long now = System.currentTimeMillis();
+    table.setCertification(
+        new AssetCertification()
+            .withTagLabel(classificationTag(CERTIFICATION_GOLD))
+            .withAppliedDate(now)
+            .withExpiryDate(now + Duration.ofDays(30).toMillis()));
+    Table certified = client.tables().update(table.getId().toString(), table);
+    assertNotNull(certified.getCertification(), "test setup failed to certify the table");
+    return certified;
+  }
+
+  private static TagLabel classificationTag(String tagFqn) {
+    return new TagLabel()
+        .withTagFQN(tagFqn)
+        .withSource(TagLabel.TagSource.CLASSIFICATION)
+        .withLabelType(TagLabel.LabelType.MANUAL);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -7108,6 +7108,13 @@ public interface CollectionDAO {
         @Bind("tagFQNPrefix") String tagFQNPrefix,
         @BindFQN("targetFQNHash") String targetFQNHash);
 
+    @SqlUpdate(
+        "DELETE FROM tag_usage WHERE targetFQNHash = :targetFQNHash AND NOT (source = :source AND tagFQN LIKE :tagFQNPrefix)")
+    void deleteTagsByTargetExcludingPrefix(
+        @Bind("source") int source,
+        @Bind("tagFQNPrefix") String tagFQNPrefix,
+        @BindFQN("targetFQNHash") String targetFQNHash);
+
     @SqlUpdate("DELETE FROM tag_usage WHERE targetFQNHash IN (<targetFQNHashes>)")
     void deleteTagsByTargetsInternal(@BindListFQN("targetFQNHashes") List<String> targetFQNs);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -6175,6 +6175,25 @@ public abstract class EntityRepository<T extends EntityInterface> {
     daoCollection.tagUsageDAO().applyTagsBatchMultiTarget(certTagsByTarget);
   }
 
+  /**
+   * Certification is stored as a {@code tag_usage} row but is surfaced as its own entity field, so
+   * every tags read path filters it out. A caller that wipes tags with the prefix-agnostic
+   * {@code deleteTagsByTarget} and re-applies from {@code entity.getTags()} would therefore drop the
+   * certification permanently (issue #30545). Use this instead when replacing an entity's tags
+   * outside the {@code EntityUpdater} path.
+   */
+  protected void deleteTagsPreservingCertification(String entityFQN) {
+    String certClassification = getCertificationClassification();
+    if (certClassification == null) {
+      daoCollection.tagUsageDAO().deleteTagsByTarget(entityFQN);
+    } else {
+      daoCollection
+          .tagUsageDAO()
+          .deleteTagsByTargetExcludingPrefix(
+              TagLabel.TagSource.CLASSIFICATION.ordinal(), certClassification + ".%", entityFQN);
+    }
+  }
+
   protected void deleteCertificationTag(String entityFQN) {
     String certClassification = getCertificationClassification();
     if (certClassification == null) return;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TableRepository.java
@@ -1426,7 +1426,7 @@ public class TableRepository extends EntityRepository<Table> {
 
     List<TagLabel> mergedTableTags =
         mergeTagsWithIncomingPrecedence(table.getTags(), dataModel.getTags());
-    daoCollection.tagUsageDAO().deleteTagsByTarget(table.getFullyQualifiedName());
+    deleteTagsPreservingCertification(table.getFullyQualifiedName());
     table.setTags(mergedTableTags);
     applyTags(table);
 


### PR DESCRIPTION
### Describe your changes:

Fixes #30545

`TableRepository.addDataModel` replaced the table's tags with the prefix-agnostic
`deleteTagsByTarget` and then re-applied only `table.getTags()`, which deliberately excludes
certification-classification tags because certification is surfaced as its own entity field.
Since 1.13 stores certification in `tag_usage`, the certification row was inside the delete and
outside the re-apply, so every dbt ingestion run silently dropped it — even for models with no
tags, because the delete is unconditional. I narrowed the delete so it skips the certification
classification prefix, which leaves the existing row untouched (keeping its `appliedAt`,
`appliedBy` and `expiryDate`) while still removing every non-certification row, so the
mutually-exclusive Tier swap that #26220 added the delete for keeps working.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Small change, but two decisions worth flagging for review:

- **Narrow the delete rather than capture-and-re-apply.** The issue suggested either. Re-applying
  through `applyCertification` would reset `appliedAt` to now and rebuild the `TagLabelMetadata`;
  excluding the prefix leaves the row byte-identical. New DAO method
  `TagUsageDAO.deleteTagsByTargetExcludingPrefix` mirrors the existing
  `deleteTagsByPrefixAndTarget`/`deleteTagsByPrefixAndTargets` already used by
  `applyCertificationBatch`, so the SQL shape is not new.
- **Helper on `EntityRepository`, not inlined in `TableRepository`.** `deleteTagsPreservingCertification`
  is `protected` and falls back to the plain delete when no certification classification is
  configured. `EntityUpdater.updateTagsForImport` (`EntityRepository.java:9337`) has the same
  wipe-and-reapply shape and looks vulnerable in the same way, but I have not written a test for
  the CSV-import path, so it is left alone here rather than changed on inspection.

No schema, migration, or API-contract change; `PUT /v1/tables/{id}/dataModel` request and response
are unchanged.

#
### Tests:

#### Use cases covered
- dbt ingestion runs against a certified table whose dbt model carries no tags (`tags: []`, the
  common case) → certification survives
- dbt ingestion runs against a certified table whose dbt model carries tags → certification
  survives and the dbt tags are applied
- Pre-existing non-certification tags on the table are still reconciled, not dropped
- Certification does not leak into the `tags` array of the response
- A mutually-exclusive tag arriving via the data model (`Tier.Tier1` → `Tier.Tier2`) still swaps
  rather than colliding — the behaviour #26220 added the delete for

#### Unit tests
No unit test added. The fix is a SQL-level guarantee (which rows a `DELETE` matches); a mock of
`TagUsageDAO` could only assert that a different method name was called, which is the
mock-wiring-not-behaviour test the repo guidance warns against. Covered by the integration test
below instead, which runs against a real database.

No jacoco figure quoted: the three changed call sites in `EntityRepository`, `CollectionDAO` and
`TableRepository` are reached only from the integration-test module, so
`mvn jacoco:report -pl openmetadata-service` reports them uncovered with or without this PR.

#### Backend integration tests
- [x] Added `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TableDataModelCertificationIT.java`

Two tests, both failing before the fix and passing after (issue number referenced in the class
javadoc):

```
# before (main)
Tests run: 2, Failures: 2
AssertionFailedError: addDataModel with an empty tag list removed the table certification
  ==> expected: not <null>
AssertionFailedError: addDataModel with dbt tags removed the table certification
  ==> expected: not <null>

# after
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

Command: `mvn test -pl openmetadata-integration-tests -Dtest=TableDataModelCertificationIT`

#### Ingestion integration tests
- [x] Not applicable — no ingestion changes. The dbt source and sink are correct: the `DataModel`
  schema has no `certification` property, so no ingestion-side change could have prevented this.

#### Playwright (UI) tests
- [x] Not applicable — no UI changes.

#### Manual testing performed
Against a local Docker stack, first on unpatched `main` (revision `1ae5a62953`) and then on this
branch, using `curl` only — no ingestion involved, to confirm the endpoint itself is the cause:

1. Created a database service / database / schema / table, tagged the table `PII.Sensitive` as a
   control, and set `Certification.Gold` via `PATCH /v1/tables/{id}`.
2. Sent the single call the dbt sink makes per manifest node:
   `PUT /v1/tables/{id}/dataModel` with `{"modelType":"DBT", ..., "tags":[]}`.
3. Read back `GET /v1/tables/{id}?fields=certification,tags`.

On `main`: `certification` became `null` while `tags` still held `PII.Sensitive`, the entity
version stayed at `0.2`, `GET /v1/tables/{id}/versions` contained no entry for the removal, and
`table_search_index` still served the Gold badge — i.e. the loss was silent, matching the report.
Repeated with `tags: null`, `tags` omitted, and `tags` populated: all four wiped the
certification, confirming no payload shape avoids it.

On this branch, all four cases preserve `Certification.Gold`, the populated case additionally
applies `PersonalData.Personal`, the `Tier.Tier1` → `Tier.Tier2` swap still works, and
certification remains editable afterwards (`PATCH` to `Silver`, then removal, then a further
`PUT /dataModel` with no resurrection).

Known residual, pre-existing and out of scope: `addDataModel` never notifies `SearchRepository`,
so a *tag* it adds is invisible in Explore until a reindex. Certification is now consistent
between REST and search; the general case deserves its own issue.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema changes.
- [x] For UI changes: not applicable — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

Bug fix
- [x] I have added a test that covers the exact scenario we are fixing. Issue number is referenced
  in the test class javadoc for future reference.