### PR TITLE
Fixes 31009: make the related-terms "+N" badge expandable

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelatedTerms.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryTermRelatedTerms.spec.ts
@@ -345,4 +345,69 @@ test.describe('Glossary Term — Related Terms', () => {
       await afterAction();
     }
   });
+
+  test('should reveal the related terms hidden behind the overflow toggle', async ({
+    page,
+  }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    const parentTerm = new GlossaryTerm(glossary);
+    // Seven related terms against a five-badge display limit, so two stay hidden.
+    const relatedTerms = Array.from(
+      { length: 7 },
+      () => new GlossaryTerm(glossary)
+    );
+
+    try {
+      await glossary.create(apiContext);
+      await parentTerm.create(apiContext);
+
+      for (const term of relatedTerms) {
+        await term.create(apiContext);
+      }
+
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
+      await selectActiveGlossaryTerm(page, parentTerm.data.displayName);
+
+      await addRelatedTermsByRelationType(page, [
+        { relationTypeLabel: 'Related To', terms: relatedTerms },
+      ]);
+
+      const container = page.getByTestId('related-term-container');
+      const toggle = page.getByTestId('related-terms-toggle-relatedTo');
+      const names = relatedTerms.map(
+        (term) => term.responseData?.displayName ?? term.data.displayName
+      );
+      // Count by name rather than position — the server does not guarantee the
+      // order relations come back in, so which two are hidden is not fixed.
+      const countVisibleTerms = async () => {
+        const visibility = await Promise.all(
+          names.map((name) => container.getByTestId(name).isVisible())
+        );
+
+        return visibility.filter(Boolean).length;
+      };
+
+      await expect(toggle).toBeVisible();
+
+      expect(await countVisibleTerms()).toBe(5);
+
+      await toggle.click();
+
+      expect(await countVisibleTerms()).toBe(7);
+
+      await toggle.click();
+
+      expect(await countVisibleTerms()).toBe(5);
+    } finally {
+      for (const term of relatedTerms) {
+        await term.delete(apiContext);
+      }
+
+      await parentTerm.delete(apiContext);
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.interface.ts
@@ -10,9 +10,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { ReactNode } from 'react';
 import { GlossaryTerm } from '../../../../generated/entity/data/glossaryTerm';
 import { EntityReference } from '../../../../generated/entity/type';
 import { VersionStatus } from '../../../../utils/EntityVersionUtils.interface';
+
+export interface BadgeListProps {
+  items: ReactNode[];
+  testId: string;
+}
 
 export interface TermItem {
   value: string;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.test.tsx
@@ -10,15 +10,37 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
+import { GlossaryTerm } from '../../../../generated/entity/data/glossaryTerm';
+import { TermRelation } from '../../../../generated/type/termRelation';
 import {
   MOCKED_GLOSSARY_TERMS,
   MOCK_PERMISSIONS,
 } from '../../../../mocks/Glossary.mock';
 import RelatedTerms from './RelatedTerms';
 
+const buildRelatedTerms = (
+  count: number,
+  relationType = 'relatedTo',
+  prefix = 'Related Term'
+): TermRelation[] =>
+  Array.from({ length: count }, (_, index) => ({
+    relationType,
+    term: {
+      deleted: false,
+      description: '',
+      displayName: `${prefix} ${index}`,
+      fullyQualifiedName: `Customer.${prefix} ${index}`,
+      id: `${prefix}-${index}`,
+      name: `${prefix} ${index}`,
+      type: 'glossaryTerm',
+    },
+  }));
+
+const RELATED_TO_TOGGLE = 'related-terms-toggle-relatedTo';
+
 const mockContext = {
-  data: MOCKED_GLOSSARY_TERMS[2],
+  data: MOCKED_GLOSSARY_TERMS[2] as GlossaryTerm,
   onUpdate: jest.fn(),
   isVersionView: false,
   permissions: MOCK_PERMISSIONS,
@@ -158,5 +180,76 @@ describe('RelatedTerms', () => {
     const { getByTestId } = render(<RelatedTerms />);
 
     expect(getByTestId('edit-button')).toBeInTheDocument();
+  });
+});
+
+describe('RelatedTerms overflow', () => {
+  beforeEach(() => {
+    mockContext.permissions = MOCK_PERMISSIONS;
+  });
+
+  it('should hide the related terms beyond the visible limit behind a toggle', () => {
+    mockContext.data = {
+      ...MOCKED_GLOSSARY_TERMS[2],
+      relatedTerms: buildRelatedTerms(8),
+    };
+    const { getByTestId, getByText, queryByText } = render(<RelatedTerms />);
+
+    expect(getByText('Related Term 4')).toBeInTheDocument();
+    expect(queryByText('Related Term 5')).toBeNull();
+    expect(getByTestId(RELATED_TO_TOGGLE)).toBeInTheDocument();
+  });
+
+  it('should reveal every related term when the toggle is clicked', () => {
+    mockContext.data = {
+      ...MOCKED_GLOSSARY_TERMS[2],
+      relatedTerms: buildRelatedTerms(8),
+    };
+    const { getByTestId, getByText } = render(<RelatedTerms />);
+
+    fireEvent.click(getByTestId(RELATED_TO_TOGGLE));
+
+    expect(getByText('Related Term 5')).toBeInTheDocument();
+    expect(getByText('Related Term 7')).toBeInTheDocument();
+  });
+
+  it('should collapse back to the visible limit when the toggle is clicked again', () => {
+    mockContext.data = {
+      ...MOCKED_GLOSSARY_TERMS[2],
+      relatedTerms: buildRelatedTerms(8),
+    };
+    const { getByTestId, queryByText } = render(<RelatedTerms />);
+    const toggle = getByTestId(RELATED_TO_TOGGLE);
+
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(queryByText('Related Term 7')).toBeNull();
+  });
+
+  it('should not render a toggle when the related terms fit within the limit', () => {
+    mockContext.data = {
+      ...MOCKED_GLOSSARY_TERMS[2],
+      relatedTerms: buildRelatedTerms(5),
+    };
+    const { queryByTestId } = render(<RelatedTerms />);
+
+    expect(queryByTestId(RELATED_TO_TOGGLE)).toBeNull();
+  });
+
+  it('should give each relation type its own independent toggle', () => {
+    mockContext.data = {
+      ...MOCKED_GLOSSARY_TERMS[2],
+      relatedTerms: [
+        ...buildRelatedTerms(7, 'relatedTo', 'Related'),
+        ...buildRelatedTerms(7, 'synonymOf', 'Synonym'),
+      ],
+    };
+    const { getByTestId, getByText, queryByText } = render(<RelatedTerms />);
+
+    fireEvent.click(getByTestId(RELATED_TO_TOGGLE));
+
+    expect(getByText('Related 6')).toBeInTheDocument();
+    expect(queryByText('Synonym 6')).toBeNull();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTerms/tabs/RelatedTerms.tsx
@@ -12,7 +12,6 @@
  */
 
 import {
-  Badge,
   BadgeWithIcon,
   Button,
   Tooltip,
@@ -20,7 +19,6 @@ import {
   Typography,
 } from '@openmetadata/ui-core-components';
 import { groupBy, isEmpty } from 'lodash';
-import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -62,6 +60,7 @@ import {
 import { useGenericContext } from '../../../Customization/GenericProvider/GenericContext';
 import { DEFAULT_GLOSSARY_TERM_RELATION_TYPES_FALLBACK } from '../../../OntologyExplorer/OntologyExplorer.constants';
 import {
+  BadgeListProps,
   RelatedTermTagButtonProps,
   RelationEditRow,
   TermsRowEditorProps,
@@ -69,16 +68,27 @@ import {
 import TermsRowEditor from './TermsRowEditor.component';
 const MAX_VISIBLE_BADGES = 5;
 
-const BadgeList: React.FC<{ items: ReactNode[] }> = ({ items }) => {
+const BadgeList: React.FC<BadgeListProps> = ({ items, testId }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
   const hiddenCount = Math.max(0, items.length - MAX_VISIBLE_BADGES);
 
+  const handleToggle = useCallback(() => setIsExpanded((prev) => !prev), []);
+
   return (
-    <div className="tw:flex tw:flex-wrap tw:mt-2 tw:gap-1">
-      {items.slice(0, MAX_VISIBLE_BADGES)}
+    <div className="tw:flex tw:flex-wrap tw:items-center tw:mt-2 tw:gap-1">
+      {isExpanded ? items : items.slice(0, MAX_VISIBLE_BADGES)}
       {hiddenCount > 0 && (
-        <Badge color="gray" size="sm" type="pill-color">
-          +{hiddenCount}
-        </Badge>
+        <Button
+          aria-expanded={isExpanded}
+          color="link-color"
+          data-testid={testId}
+          size="sm"
+          onClick={handleToggle}>
+          {isExpanded
+            ? t('label.show-less')
+            : t('label.plus-count-more', { count: hiddenCount })}
+        </Button>
       )}
     </div>
   );
@@ -414,6 +424,7 @@ const RelatedTerms = () => {
                       ? [getRelatedTermElement(tr.term, tr.relationType)]
                       : []
                 )}
+                testId={`related-terms-toggle-${relationType}`}
               />
             </div>
           ))}


### PR DESCRIPTION
### Describe your changes:

Fixes #31009

I made the `+N` indicator in a glossary term's **Related Terms** panel an actual control, because it looked like an affordance but wasn't one.

`BadgeList` in `RelatedTerms.tsx` caps each relation-type group at five badges and summarises the rest as a `Badge` reading `+N`. `Badge` from `@openmetadata/ui-core-components` takes no `onPress`/`onClick`/`href` — it renders a bare `<span>` — so the overflow indicator was inert by construction: `tabIndex: -1`, no `role`, `cursor: auto`, click a no-op. Users without `EditGlossaryTerms` had no way to reach the hidden terms at all (with edit permission you could open the edit pencil, which expands every relation into editable rows — an accidental escape hatch read-only users don't get).

It is now a link-style `Button` that expands its group in place and collapses it again, with `aria-expanded` wired up. One toggle per relation type, matching how the data is already grouped.

Two notes on the approach:

- This mirrors `RelatedMetrics`, the closest sibling widget, which already has show-more/show-less — but built on `ui-core-components` rather than its legacy Ant Design `onClick`-on-a-`Typography.Text`.
- I deliberately did **not** use the `TagsViewer` `POPOVER` variant: `RelatedTermTagButton` already wraps every badge in a `Tooltip`/`TooltipTrigger`, so an overflow popover would nest an overlay inside an overlay.

**No new i18n keys** — `label.plus-count-more` and `label.show-less` already exist and are translated in all 20 locales.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change, 4 files.

#
### Tests:

#### Use cases covered
- A relation-type group with more than five terms renders five badges plus a working toggle.
- Clicking the toggle reveals every term in that group; clicking again collapses it.
- Each relation type gets its own independent toggle — expanding *Related To* leaves *Synonym* collapsed.
- A group with five or fewer terms renders no toggle at all.
- A term revealed by the toggle is fully functional and navigates to its own page.
- The toggle is keyboard reachable and operable (real `<button>`, `tabIndex 0`, Enter activates, `aria-expanded` reflects state).

#### Unit tests
- [x] Added unit tests for the new logic, written RED-first — all 4 behavioural tests fail on `main` before the fix.
- Files updated: `openmetadata-ui/.../GlossaryTerms/tabs/RelatedTerms.test.tsx` (5 new tests, 11 total in the file)
- `yarn test src/components/Glossary/GlossaryTerms/tabs/` → **62 passed, 6 suites**
- Coverage on `RelatedTerms.tsx`: **67.4% lines / 64.86% statements**. The new `BadgeList` logic is fully covered; the uncovered range (211–392) is the pre-existing edit-mode handlers and version-diff view, untouched by this PR.

#### Backend integration tests
- [x] Not applicable — no backend changes.

#### Ingestion integration tests
- [x] Not applicable — no ingestion changes.

#### Playwright (UI) tests
- [x] Added an E2E test to the existing related-terms spec.
- File updated: `openmetadata-ui/.../playwright/e2e/Features/Glossary/GlossaryTermRelatedTerms.spec.ts`
- Verified as a genuine regression test: it **fails on `main`** (`expect(toggle).toBeVisible()` → element not found) and passes with the fix.
- Full spec file against a live stack: **6 passed (50.8s)**.

#### Manual testing performed
1. Backend on `:8585` (stock `openmetadata/server:2.0.0-rc1` image, Postgres + Elasticsearch); UI served from this branch via `vite` on `:3000`.
2. Seeded a `Retail Taxonomy.Customer` glossary term with 19 related terms across three relation types: 9 × *Related To*, 7 × *Synonym*, 3 × *Broader*.
3. Confirmed *Broader* (3 terms) renders no toggle, while *Related To* and *Synonym* each show their own.
4. Expanded *Related To* → all 9 visible, label flips to "Show Less", *Synonym* stayed collapsed at "+ 2 More".
5. Clicked "Shopper", a previously hidden term → navigated to `/glossary/Retail%20Taxonomy.Shopper`.
6. Keyboard: focused the toggle, pressed Enter → collapsed, `aria-expanded` went `true` → `false`.
7. Negative/baseline check: reverted the component, reloaded, and confirmed the old `+4` pill is a `<span>` with `tabIndex: -1`, `cursor: auto`, and that clicking it leaves the DOM unchanged.

#
### UI screen recording / screenshots:

**Before** — `+2` and `+4` render as inert grey pills. Not clickable, not focusable, no cursor affordance.

![before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31009-before.png)

**After (collapsed)** — the same overflow now reads "+ 2 More" / "+ 4 More" as a real control. *Broader*, with only 3 terms, correctly has none.

![after collapsed](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31009-after-collapsed.png)

**After (expanded)** — both groups expanded independently, all 19 related terms reachable, each toggle now reading "Show Less".

![after expanded](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31009-after-expanded.png)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema changes.
- [x] For UI changes: I attached before/after screenshots above.
- [x] I have added tests (unit + Playwright) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing — both the Jest and Playwright tests fail on `main` and pass with this change.