### PR TITLE
Fixes 31012: stop Playwright importing app code from src/

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -405,6 +405,54 @@ export default [
       '@typescript-eslint/no-unused-expressions': 'warn',
       'prefer-const': 'off',
 
+      // Playwright must not import application code from `src/`.
+      //
+      // Playwright runs in plain Node with no bundler, no CSS pipeline and no
+      // i18n bootstrap. A single import of an app util drags the whole app
+      // dependency graph into the test process, e.g.:
+      //
+      //   IncidentManager.spec.ts
+      //     -> playwright/utils/incidentManager        (playwright util)
+      //       -> src/utils/StringUtils                 (app util)
+      //         -> src/utils/i18next/LocalUtil         (app i18n bootstrap)
+      //           -> @openmetadata/ui-core-components  (the whole component library)
+      //
+      // Two exceptions, both dependency-free by construction:
+      //   • src/generated/**  — code-generated schema types/enums; they are the
+      //     API contract the tests build request payloads from, and generated
+      //     files only ever reference other generated files.
+      //   • src/enums/**      — leaf enum modules with no imports of their own.
+      //
+      // Anything else (utils, context, components, rest, hooks, pages) must be
+      // duplicated under playwright/ instead — see playwright/utils/dateTime.ts
+      // and playwright/support/entity/Entity.interface.ts for the pattern.
+      // Type-only imports are restricted too: an `import type` that later loses
+      // its `type` keyword silently reintroduces the runtime dependency.
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              // A `group` of ['**/src/**', '!**/src/generated/**'] does NOT
+              // work here: `group` uses gitignore semantics, which cannot
+              // re-include a path whose parent directory is already excluded.
+              // The negative lookahead is what actually carves out the two
+              // allowed subtrees.
+              regex: '(^|/)src/(?!generated/|enums/)',
+              message:
+                'Playwright tests must not import app code from src/ — it pulls the app dependency graph (i18n, @openmetadata/ui-core-components) into the test process. Only src/generated/** and src/enums/** are allowed; duplicate anything else under playwright/.',
+            },
+          ],
+          paths: [
+            {
+              name: '@openmetadata/ui-core-components',
+              message:
+                'The component library must never be imported by Playwright tests — it is browser-only React code with no place in a Node test process.',
+            },
+          ],
+        },
+      ],
+
       // Playwright rules — blocking (error): zero existing violations, prevent regressions
       'playwright/no-networkidle': 'error',
       'playwright/no-page-pause': 'error',

--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/dataQualityPermissions.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/dataQualityPermissions.ts
@@ -10,12 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ResourceEntity } from '../../src/context/PermissionProvider/PermissionProvider.interface';
 import {
   Effect,
   Operation,
 } from '../../src/generated/entity/policies/accessControl/rule';
 import { uuid } from '../utils/common';
+import { ResourceEntity } from './permission';
 
 type PolicyRule = {
   name: string;

--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/permission.ts
@@ -25,6 +25,18 @@ export const SYSTEM_POLICY_NAMES = {
   taskAuthorPolicy: 'TaskAuthorPolicy',
 };
 
+/**
+ * Policy resource names, mirrored for Playwright so tests never import app code
+ * from `src/`. The backend is the source of truth (`GET /v1/policies/resources`);
+ * add members here as tests need them.
+ */
+export enum ResourceEntity {
+  ALL = 'all',
+  TABLE = 'table',
+  TEST_CASE = 'testCase',
+  TEST_SUITE = 'testSuite',
+}
+
 export const RULE_DETAILS = {
   resources: 'All',
   operations: 'All',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataObservabilityGovernanceTab.spec.ts
@@ -12,7 +12,6 @@
  */
 
 import { expect, Page, test } from '@playwright/test';
-import { getCurrentMillis } from '../../../../src/utils/date-time/DateTimeUtils';
 import { Domain } from '../../../support/domain/Domain';
 import { TableClass } from '../../../support/entity/TableClass';
 import { Glossary } from '../../../support/glossary/Glossary';
@@ -27,6 +26,7 @@ import {
   isDashboardReportBatchResponse,
   TEST_CASE_STATUS_PIE_CHART_TEST_ID,
 } from '../../../utils/dataQuality';
+import { getCurrentMillis } from '../../../utils/dateTime';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQualityDashboard.spec.ts
@@ -14,7 +14,6 @@
 import test, { expect, Page } from '@playwright/test';
 import { TestCaseResolutionStatusTypes } from '../../../../src/generated/tests/testCaseResolutionStatus';
 import { DataQualityDimensions } from '../../../../src/generated/tests/testDefinition';
-import { getCurrentMillis } from '../../../../src/utils/date-time/DateTimeUtils';
 import { DOMAIN_TAGS } from '../../../constant/config';
 import { DataProduct } from '../../../support/domain/DataProduct';
 import { Domain } from '../../../support/domain/Domain';
@@ -41,6 +40,7 @@ import {
   TEST_CASE_STATUS_PIE_CHART_TEST_ID,
   waitForIncidentToBeIndexed,
 } from '../../../utils/dataQuality';
+import { getCurrentMillis } from '../../../utils/dateTime';
 import { waitForAllLoadersToDisappear } from '../../../utils/entity';
 import { visitDataQualityTab } from '../../../utils/testCases';
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -15,12 +15,11 @@ import {
   PipelineState,
   PipelineStatus,
 } from '../../src/generated/entity/services/ingestionPipelines/ingestionPipeline';
-import { getEncodedFqn } from '../../src/utils/StringUtils';
 import { SidebarItem } from '../constant/sidebar';
 import { ResponseDataType } from '../support/entity/Entity.interface';
 import { TableClass } from '../support/entity/TableClass';
 import { getCurrentMillis } from './dateTime';
-import { waitForAllLoadersToDisappear } from './entity';
+import { getEncodedFqn, waitForAllLoadersToDisappear } from './entity';
 import { sidebarClick } from './sidebar';
 import { waitForTaskResolveResponse } from './task';
 


### PR DESCRIPTION
### Describe your changes:

Fixes #31012

Playwright runs in plain Node — no bundler, no CSS pipeline, no i18n bootstrap — so a single import of an app util drags the whole app dependency graph into the test process:

```
IncidentManager.spec.ts
  ↳ import '../../utils/incidentManager'                  ← playwright util
     ↳ import '../../../src/utils/StringUtils'            ← app util
        ↳ import '../../../src/utils/i18next/LocalUtil'   ← app i18n bootstrap
           ↳ import '@openmetadata/ui-core-components'    ← the whole component library
```

I repointed the four offending imports and added a lint rule so the dependency cannot creep back in.

**The fix.** Three of the four already had a byte-identical equivalent living under `playwright/` — this is mostly re-pointing, not new code:

| File | Was | Now |
|---|---|---|
| `playwright/utils/incidentManager.ts` | `getEncodedFqn` from `src/utils/StringUtils` | `playwright/utils/entity.ts` (already exports it) |
| `.../DataQuality/DataQualityDashboard.spec.ts` | `getCurrentMillis` from `src/utils/date-time/DateTimeUtils` | `playwright/utils/dateTime.ts` (already exports it) |
| `.../DataQuality/DataObservabilityGovernanceTab.spec.ts` | same | same |
| `playwright/constant/dataQualityPermissions.ts` | `ResourceEntity` from `src/context/PermissionProvider` (pulls React in) | new 4-member enum in `playwright/constant/permission.ts` |

**The guard.** `no-restricted-imports`, scoped to the existing Playwright block in `eslint.config.mjs`. Any `src/**` import errors, except two subtrees that are dependency-free by construction:

- `src/generated/**` — code-generated schema types the tests build request payloads from; generated files only ever reference other generated files (~33 call sites).
- `src/enums/**` — leaf enum modules; `entity.enum.ts` and `search.enum.ts` import nothing at all.

Plus an explicit ban on `@openmetadata/ui-core-components`. Type-only imports are restricted too, since an `import type` that later loses its `type` keyword silently reintroduces the runtime dependency.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (6 files). One implementation note worth flagging for review, since it is a silent trap:

The obvious spelling of the rule does **not** work.

```js
group: ['**/src/**', '!**/src/generated/**', '!**/src/enums/**']
```

`no-restricted-imports`' `group` option uses gitignore semantics, which cannot re-include a path whose parent directory is already excluded. That config still flags the generated types — with no error, no warning, just a rule that rejects more than it claims to. The rule therefore uses `regex: '(^|/)src/(?!generated/|enums/)'` instead, and the reason is commented inline so nobody "simplifies" it back.

#
### Tests:

#### Use cases covered

- Playwright can still import generated schema types and leaf enums (`src/generated/**`, `src/enums/**`).
- Playwright importing any other app module — `src/utils`, `src/context`, `src/components`, … — fails lint.
- The same applies to a type-only import and to `@openmetadata/ui-core-components` directly.
- The four repointed call sites resolve to the Playwright-local equivalents.

#### Unit tests

Not applicable — no product logic changed. The behavioural change is a lint rule; I verified it against a throwaway probe file covering the allow/deny matrix above (errors on exactly the 4 banned lines, silent on the 2 allowed ones), then deleted the probe.

#### Backend integration tests

Not applicable (no backend changes).

#### Ingestion integration tests

Not applicable (no ingestion changes).

#### Playwright (UI) tests

No new tests. This PR changes only import paths within existing Playwright tests; the imported symbols are byte-identical implementations, so test behaviour is unchanged.

#### Manual testing performed

From `openmetadata-ui/src/main/resources/ui`:

1. `eslint playwright` → **0 errors** (275 warnings, all pre-existing aspirational rules, unchanged by this PR).
2. Rule-fires check: temporary probe file with 6 imports covering the allow/deny matrix → errored on exactly the 4 intended lines, clean on `src/generated/**` and `src/enums/**`. This is what caught the `group`-vs-`regex` trap above.
3. `tsc --noEmit -p playwright/tsconfig.json` → 336 error lines, vs **339 on a stashed clean tree**. None in any file this PR touches. That tree is already broken and is not in CI (root tsconfig is `include: ["src"]`); left untouched.
4. `prettier --check` and `organize-imports-cli` on all 6 changed files → clean, no reformatting.

I did **not** run the E2E specs themselves — they need a live stack. `IncidentManager.spec.ts` and the two DataQuality specs are the ones to smoke-test if a reviewer wants certainty beyond the identical-implementation argument.

#
### UI screen recording / screenshots:

Not applicable — no product UI changes; this only touches test-side imports and lint config.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable (no product UI change).
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing — the ESLint rule *is* the regression test here: it fails the build on any reintroduction of the dependency, which a unit test could not do.

#
### Note for reviewers

`src/enums/**` stays on the allowlist. `entity.enum.ts` and `search.enum.ts` are zero-import leaves *today*, so they cannot drag in the component library — but nothing stops someone adding an import to them later and quietly reopening this hole. The stricter alternative is duplicating an 87-member and a 57-member enum into `playwright/`, which drifts. Happy to tighten if you would rather take the duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
