### PR TITLE
fix(ingestion): accept an absent processor block on the whole classification path

### DIFF
--- a/ingestion/src/metadata/profiler/api/models.py
+++ b/ingestion/src/metadata/profiler/api/models.py
@@ -33,6 +33,12 @@ from metadata.sampler.models import DatabaseAndSchemaConfig, TableConfig
 from metadata.utils.sqa_like_column import SQALikeColumn
 
 
+def processor_config_payload(processor) -> dict:
+    """Return a workflow processor's inner config, or an empty mapping when the
+    processor block or its config is absent."""
+    return (processor.model_dump().get("config") if processor else None) or {}
+
+
 class ProfilerProcessorConfig(ConfigModel):
     """
     Defines how we read the processor information

--- a/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
+++ b/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
@@ -33,7 +33,11 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.samplingConfig import ProfileSampleConfig
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.profiler.api.models import ProfilerProcessorConfig, TableConfig
+from metadata.profiler.api.models import (
+    ProfilerProcessorConfig,
+    TableConfig,
+    processor_config_payload,
+)
 from metadata.profiler.interface.profiler_interface import ProfilerInterface
 from metadata.profiler.metrics.core import add_props
 from metadata.profiler.processor.core import Profiler
@@ -99,7 +103,7 @@ class ProfilerSource(ProfilerSourceInterface):
 
         self.config = config
         self.service_conn_config = self._copy_service_config(config, database)
-        self.profiler_config = profiler_config_class.model_validate(config.processor.model_dump().get("config"))
+        self.profiler_config = profiler_config_class.model_validate(processor_config_payload(config.processor))
         self.ometa_client = ometa_client
         self._interface_type: str = config.source.type.lower()
         self._interface = None

--- a/ingestion/src/metadata/sampler/processor.py
+++ b/ingestion/src/metadata/sampler/processor.py
@@ -32,7 +32,10 @@ from metadata.ingestion.api.step import Step  # noqa: TC001
 from metadata.ingestion.api.steps import Processor
 from metadata.ingestion.ometa.ometa_api import OpenMetadata  # noqa: TC001
 from metadata.pii.types import ClassifiableEntityType  # noqa: TC001
-from metadata.profiler.api.models import ProfilerProcessorConfig  # noqa: TC001
+from metadata.profiler.api.models import (
+    ProfilerProcessorConfig,
+    processor_config_payload,
+)
 from metadata.profiler.source.metadata import ProfilerSourceAndEntity  # noqa: TC001
 from metadata.sampler.entity_adapters import (
     EntityAdapter,
@@ -76,12 +79,7 @@ class SamplerProcessor(Processor):
 
         self.source_config = self.config.source.sourceConfig.config
 
-        # Messaging and storage auto-classification have no processor to configure,
-        # so the block, or its inner config, is routinely omitted.
-        processor = self.config.processor
-        self.profiler_config = profiler_config_class.model_validate(
-            (processor.model_dump().get("config") if processor else None) or {}
-        )
+        self.profiler_config = profiler_config_class.model_validate(processor_config_payload(self.config.processor))
 
         self._interface_type: str = config.source.type.lower()
 

--- a/ingestion/src/metadata/workflow/ingestion.py
+++ b/ingestion/src/metadata/workflow/ingestion.py
@@ -41,7 +41,7 @@ from metadata.ingestion.api.step import Step
 from metadata.ingestion.api.steps import BulkSink, Processor, Sink, Source, Stage
 from metadata.ingestion.models.custom_types import ServiceWithConnectionType
 from metadata.ingestion.ometa.utils import sanitize_user_agent
-from metadata.profiler.api.models import ProfilerProcessorConfig, processor_config_payload
+from metadata.profiler.api.models import ProfilerProcessorConfig
 from metadata.utils.class_helper import (
     get_pipeline_type_from_source_config,
     get_service_class_from_service_type,
@@ -231,7 +231,7 @@ class IngestionWorkflow(BaseWorkflow, ABC):
             if not self.config.source.serviceConnection.root.config.supportsProfiler:  # pyright: ignore[reportAttributeAccessIssue]
                 raise AttributeError()  # noqa: TRY301
         except AttributeError:
-            if profiler_config_class.model_validate(processor_config_payload(self.config.processor)).ignoreValidation:
+            if profiler_config_class.model_validate(self.config.processor.model_dump().get("config")).ignoreValidation:
                 logger.debug(
                     f"Profiler is not supported for the service connection: {self.config.source.serviceConnection}"
                 )

--- a/ingestion/src/metadata/workflow/ingestion.py
+++ b/ingestion/src/metadata/workflow/ingestion.py
@@ -41,7 +41,7 @@ from metadata.ingestion.api.step import Step
 from metadata.ingestion.api.steps import BulkSink, Processor, Sink, Source, Stage
 from metadata.ingestion.models.custom_types import ServiceWithConnectionType
 from metadata.ingestion.ometa.utils import sanitize_user_agent
-from metadata.profiler.api.models import ProfilerProcessorConfig
+from metadata.profiler.api.models import ProfilerProcessorConfig, processor_config_payload
 from metadata.utils.class_helper import (
     get_pipeline_type_from_source_config,
     get_service_class_from_service_type,
@@ -231,7 +231,7 @@ class IngestionWorkflow(BaseWorkflow, ABC):
             if not self.config.source.serviceConnection.root.config.supportsProfiler:  # pyright: ignore[reportAttributeAccessIssue]
                 raise AttributeError()  # noqa: TRY301
         except AttributeError:
-            if profiler_config_class.model_validate(self.config.processor.model_dump().get("config")).ignoreValidation:
+            if profiler_config_class.model_validate(processor_config_payload(self.config.processor)).ignoreValidation:
                 logger.debug(
                     f"Profiler is not supported for the service connection: {self.config.source.serviceConnection}"
                 )

--- a/ingestion/tests/unit/sampler/test_sampler_processor_config.py
+++ b/ingestion/tests/unit/sampler/test_sampler_processor_config.py
@@ -67,3 +67,29 @@ def test_processor_block_is_optional(processor) -> None:
     sampler_processor = SamplerProcessor.create(config, MagicMock())
 
     assert sampler_processor.profiler_config is not None
+
+
+@pytest.mark.parametrize(
+    "processor",
+    [
+        pytest.param(None, id="no-processor-block"),
+        pytest.param({"type": "orm-profiler"}, id="processor-without-config"),
+    ],
+)
+def test_profiler_source_accepts_an_absent_processor(processor) -> None:
+    """The auto-classification fetcher builds a ProfilerSource, so it sees the same config."""
+    from metadata.ingestion.api.parser import parse_workflow_config_gracefully
+    from metadata.profiler.source.database.base.profiler_source import ProfilerSource
+
+    config = deepcopy(BASE_CONFIG)
+    if processor is not None:
+        config["processor"] = processor
+
+    source = ProfilerSource(
+        config=parse_workflow_config_gracefully(config),
+        database=MagicMock(),
+        ometa_client=MagicMock(),
+        global_profiler_configuration=MagicMock(),
+    )
+
+    assert source.profiler_config is not None


### PR DESCRIPTION
Follow-up to #30894, found during release validation of the Kafka connector.

## The gap

#30894 guarded `SamplerProcessor` against a missing `processor:` block. But the auto-classification fetcher also builds a `ProfilerSource`, which dereferenced `config.processor` the same way — so removing the block from a messaging AutoClassification workflow still failed, one layer deeper:

```
File "metadata/profiler/source/fetcher/fetcher_strategy.py", line 513, in fetch
  profiler_source = profiler_source_factory.create(...)
File "metadata/profiler/source/database/base/profiler_source.py", line 102, in __init__
  self.profiler_config = profiler_config_class.model_validate(
      config.processor.model_dump().get("config"))
AttributeError: 'NoneType' object has no attribute 'model_dump'
```

The workflow reported `Workflow Success %: 87.5` and exited 1.

## Why the block is optional in the first place

Every field on `ProfilerProcessorConfig` is optional with a default, so an empty mapping is a fully valid config — `ProfilerProcessorConfig() == ProfilerProcessorConfig.model_validate({})`. The block was never mandatory by the model's own definition; the code simply assumed it was present and dereferenced it. The same crash was reachable on the database profiler path too, it just never surfaced, because every profiler example ships a `processor:` block out of habit.

## The fix

The guard is a single `processor_config_payload` helper beside `ProfilerProcessorConfig`, used by the two sites on the failing path: `ProfilerSource` and `SamplerProcessor`. It also covers a `processor:` block whose inner `config:` is omitted, which otherwise raised a `ValidationError` one line further on, since `model_validate(None)` is not valid.

Deliberately **not** touched:

- `workflow/ingestion.py` — the `supportsProfiler` check. It has the same expression, but it is not on the path that fails here. Rewriting it shifted `.ignoreValidation` by one column, and the basedpyright baseline matches by column, so a pre-existing suppressed error resurfaced. That error is real — `ignoreValidation` is not a field on `ProfilerProcessorConfig` — but it predates this branch and is not this PR's to fix.
- `workflow/usage.py` and `data_quality/processor/test_case_runner.py` — outside this failure.

## No regression

The helper is the identity function on every input the old expression did not crash on:

| processor | old | new | |
|---|---|---|---|
| absent (`None`) | `AttributeError` | `{}` | was broken |
| block, no `config` key | `None` → `ValidationError` | `{}` | was broken |
| block, `config: None` | `None` → `ValidationError` | `{}` | was broken |
| block, `config: {}` | `{}` | `{}` | **identical** |
| block, populated config | the dict | the dict | **identical** |

Only rows that previously raised behave differently. No previously-working configuration changes.

## Verification

Against a live Kafka service on a 2.0 instance, running `metadata classify` with the `processor:` block removed:

| | Result |
|---|---|
| before | `1 Errors`, `Workflow Success %: 87.5`, exit 1 |
| after | `0 Errors`, `Workflow Success %: 100.0`, exit 0 |

`test_profiler_source_accepts_an_absent_processor` fails on `main` with exactly the `AttributeError` above and passes here. Suites covering the changed paths — `profiler`, `sampler`, `source/messaging`, `workflow` — are green: 209 passed.