### PR TITLE
test(e2e): tag async governance workflow specs with @workflow

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/GlossaryWorkflow.spec.ts
@@ -78,7 +78,7 @@ test.beforeEach(async ({ page }) => {
   await redirectToHomePage(page);
 });
 
-test.describe('Term Status Transitions', () => {
+test.describe('Term Status Transitions', { tag: ['@workflow'] }, () => {
   const glossaryNoReviewers = new Glossary();
   const glossaryWithReviewer = new Glossary();
 
@@ -228,269 +228,282 @@ test.describe('Term Status Transitions', () => {
   });
 });
 
-test('non-reviewer should not see approve/reject buttons', async ({
-  page,
-  reviewer2Page,
-}) => {
-  const { apiContext, afterAction } = await getApiContext(page);
-  const glossary = new Glossary();
-  const termName = `TermForReview${Date.now()}`;
+test(
+  'non-reviewer should not see approve/reject buttons',
+  { tag: ['@workflow'] },
+  async ({ page, reviewer2Page }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    const termName = `TermForReview${Date.now()}`;
 
-  try {
-    await glossary.create(apiContext);
+    try {
+      await glossary.create(apiContext);
 
-    await glossary.patch(apiContext, [
-      {
-        op: 'add',
-        path: '/reviewers/0',
-        value: {
-          id: reviewer1.responseData.id,
-          type: 'user',
-          displayName: reviewer1.responseData.displayName,
-          fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
-          name: reviewer1.responseData.name,
-        },
-      },
-    ]);
-
-    await sidebarClick(page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(page, glossary.data.displayName);
-
-    await openAddGlossaryTermModal(page);
-
-    await page.fill('[data-testid="name"]', termName);
-    await page.locator(descriptionBox).fill('Term for review testing');
-
-    const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
-    await page.click('[data-testid="save-glossary-term"]');
-    await createResponse;
-
-    await expect(
-      page.locator('[role="dialog"].edit-glossary-modal')
-    ).not.toBeVisible();
-
-    await redirectToHomePage(reviewer2Page);
-    await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
-
-    const termRow = reviewer2Page.locator(`[data-row-key*="${termName}"]`);
-
-    await expect(termRow).toBeVisible();
-
-    const approveBtn = reviewer2Page.getByTestId(`${termName}-approve-btn`);
-    const rejectBtn = reviewer2Page.getByTestId(`${termName}-reject-btn`);
-
-    await expect(approveBtn).not.toBeVisible();
-    await expect(rejectBtn).not.toBeVisible();
-  } finally {
-    await glossary.delete(apiContext);
-    await afterAction();
-  }
-});
-
-test('should display correct status badge color and icon', async ({ page }) => {
-  const { apiContext, afterAction } = await getApiContext(page);
-  const glossary = new Glossary();
-
-  try {
-    await glossary.create(apiContext);
-
-    await glossary.patch(apiContext, [
-      {
-        op: 'add',
-        path: '/reviewers/0',
-        value: {
-          id: reviewer1.responseData.id,
-          type: 'user',
-          displayName: reviewer1.responseData.displayName,
-          fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
-          name: reviewer1.responseData.name,
-        },
-      },
-    ]);
-
-    await sidebarClick(page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(page, glossary.data.displayName);
-
-    const termName = `StatusBadgeTerm${Date.now()}`;
-    await openAddGlossaryTermModal(page);
-
-    await page.fill('[data-testid="name"]', termName);
-    await page.locator(descriptionBox).fill('Test term for status badge');
-
-    const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
-    await page.click('[data-testid="save-glossary-term"]');
-    await createResponse;
-
-    await expect(
-      page.locator('[role="dialog"].edit-glossary-modal')
-    ).not.toBeVisible();
-
-    const termRow = page.locator(`[data-row-key*="${termName}"]`);
-
-    await expect(termRow).toBeVisible();
-
-    const statusBadge = termRow.locator('.status-badge');
-
-    await expect(statusBadge).toHaveText('Draft');
-
-    await expect(statusBadge).toBeVisible();
-  } finally {
-    await glossary.delete(apiContext);
-    await afterAction();
-  }
-});
-
-test('owner should not see approve/reject buttons if not a reviewer', async ({
-  page,
-  reviewer2Page,
-}) => {
-  const { apiContext, afterAction } = await getApiContext(page);
-  const glossary = new Glossary();
-  const termName = `OwnerTermTest${Date.now()}`;
-
-  try {
-    await glossary.create(apiContext);
-
-    await glossary.patch(apiContext, [
-      {
-        op: 'add',
-        path: '/owners/0',
-        value: {
-          id: reviewer2.responseData.id,
-          type: 'user',
-          displayName: reviewer2.responseData.displayName,
-          fullyQualifiedName: reviewer2.responseData.fullyQualifiedName,
-          name: reviewer2.responseData.name,
-        },
-      },
-      {
-        op: 'add',
-        path: '/reviewers/0',
-        value: {
-          id: reviewer1.responseData.id,
-          type: 'user',
-          displayName: reviewer1.responseData.displayName,
-          fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
-          name: reviewer1.responseData.name,
-        },
-      },
-    ]);
-
-    await sidebarClick(page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(page, glossary.data.displayName);
-
-    await openAddGlossaryTermModal(page);
-
-    await page.fill('[data-testid="name"]', termName);
-    await page.locator(descriptionBox).fill('Term for owner approval test');
-
-    const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
-    await page.click('[data-testid="save-glossary-term"]');
-    await createResponse;
-
-    await expect(
-      page.locator('[role="dialog"].edit-glossary-modal')
-    ).not.toBeVisible();
-
-    await redirectToHomePage(reviewer2Page);
-    await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
-
-    const termRow = reviewer2Page.locator(`[data-row-key*="${termName}"]`);
-
-    await expect(termRow).toBeVisible();
-
-    const approveBtn = reviewer2Page.getByTestId(`${termName}-approve-btn`);
-    const rejectBtn = reviewer2Page.getByTestId(`${termName}-reject-btn`);
-
-    await expect(approveBtn).not.toBeVisible();
-    await expect(rejectBtn).not.toBeVisible();
-  } finally {
-    await glossary.delete(apiContext);
-    await afterAction();
-  }
-});
-
-test('should change status when non-reviewer edits approved term', async ({
-  page,
-  reviewer2Page,
-}) => {
-  test.slow(true);
-
-  const { apiContext, afterAction } = await getApiContext(page);
-  const glossary = new Glossary();
-  let glossaryTerm: GlossaryTerm;
-
-  try {
-    await glossary.create(apiContext);
-
-    await glossary.patch(apiContext, [
-      {
-        op: 'add',
-        path: '/reviewers/0',
-        value: {
-          id: reviewer1.responseData.id,
-          type: 'user',
-          displayName: reviewer1.responseData.displayName,
-          fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
-          name: reviewer1.responseData.name,
-        },
-      },
-    ]);
-
-    glossaryTerm = new GlossaryTerm(glossary, undefined, 'ApprovedTermForEdit');
-    await glossaryTerm.create(apiContext);
-
-    await apiContext.patch(
-      `/api/v1/glossaryTerms/${glossaryTerm.responseData.id}`,
-      {
-        data: [
-          {
-            op: 'replace',
-            path: '/status',
-            value: 'Approved',
+      await glossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/reviewers/0',
+          value: {
+            id: reviewer1.responseData.id,
+            type: 'user',
+            displayName: reviewer1.responseData.displayName,
+            fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
+            name: reviewer1.responseData.name,
           },
-        ],
-        headers: {
-          'Content-Type': 'application/json-patch+json',
         },
-      }
-    );
+      ]);
 
-    await redirectToHomePage(reviewer2Page);
-    await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
 
-    const termRow = reviewer2Page.locator(
-      `[data-row-key*="${glossaryTerm.responseData.name}"]`
-    );
+      await openAddGlossaryTermModal(page);
 
-    await expect(termRow).toBeVisible();
+      await page.fill('[data-testid="name"]', termName);
+      await page.locator(descriptionBox).fill('Term for review testing');
 
-    await reviewer2Page.click(
-      `[data-testid="${glossaryTerm.responseData.name}"]`
-    );
+      const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
+      await page.click('[data-testid="save-glossary-term"]');
+      await createResponse;
 
-    const editDescBtn = reviewer2Page.getByTestId('edit-description');
+      await expect(
+        page.locator('[role="dialog"].edit-glossary-modal')
+      ).not.toBeVisible();
 
-    if (await editDescBtn.isVisible()) {
-      await editDescBtn.click();
-      await reviewer2Page
-        .locator(descriptionBox)
-        .fill('Non-reviewer update to trigger review');
+      await redirectToHomePage(reviewer2Page);
+      await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
 
-      const saveRes = reviewer2Page.waitForResponse('/api/v1/glossaryTerms/*');
-      await reviewer2Page.getByTestId('save').click();
-      await saveRes;
+      const termRow = reviewer2Page.locator(`[data-row-key*="${termName}"]`);
+
+      await expect(termRow).toBeVisible();
+
+      const approveBtn = reviewer2Page.getByTestId(`${termName}-approve-btn`);
+      const rejectBtn = reviewer2Page.getByTestId(`${termName}-reject-btn`);
+
+      await expect(approveBtn).not.toBeVisible();
+      await expect(rejectBtn).not.toBeVisible();
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
     }
-  } finally {
-    await glossary.delete(apiContext);
-    await afterAction();
   }
-});
+);
 
-test.describe('Workflow History', () => {
+test(
+  'should display correct status badge color and icon',
+  { tag: ['@workflow'] },
+  async ({ page }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+
+    try {
+      await glossary.create(apiContext);
+
+      await glossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/reviewers/0',
+          value: {
+            id: reviewer1.responseData.id,
+            type: 'user',
+            displayName: reviewer1.responseData.displayName,
+            fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
+            name: reviewer1.responseData.name,
+          },
+        },
+      ]);
+
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
+
+      const termName = `StatusBadgeTerm${Date.now()}`;
+      await openAddGlossaryTermModal(page);
+
+      await page.fill('[data-testid="name"]', termName);
+      await page.locator(descriptionBox).fill('Test term for status badge');
+
+      const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
+      await page.click('[data-testid="save-glossary-term"]');
+      await createResponse;
+
+      await expect(
+        page.locator('[role="dialog"].edit-glossary-modal')
+      ).not.toBeVisible();
+
+      const termRow = page.locator(`[data-row-key*="${termName}"]`);
+
+      await expect(termRow).toBeVisible();
+
+      const statusBadge = termRow.locator('.status-badge');
+
+      await expect(statusBadge).toHaveText('Draft');
+
+      await expect(statusBadge).toBeVisible();
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
+  }
+);
+
+test(
+  'owner should not see approve/reject buttons if not a reviewer',
+  { tag: ['@workflow'] },
+  async ({ page, reviewer2Page }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    const termName = `OwnerTermTest${Date.now()}`;
+
+    try {
+      await glossary.create(apiContext);
+
+      await glossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/owners/0',
+          value: {
+            id: reviewer2.responseData.id,
+            type: 'user',
+            displayName: reviewer2.responseData.displayName,
+            fullyQualifiedName: reviewer2.responseData.fullyQualifiedName,
+            name: reviewer2.responseData.name,
+          },
+        },
+        {
+          op: 'add',
+          path: '/reviewers/0',
+          value: {
+            id: reviewer1.responseData.id,
+            type: 'user',
+            displayName: reviewer1.responseData.displayName,
+            fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
+            name: reviewer1.responseData.name,
+          },
+        },
+      ]);
+
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
+
+      await openAddGlossaryTermModal(page);
+
+      await page.fill('[data-testid="name"]', termName);
+      await page.locator(descriptionBox).fill('Term for owner approval test');
+
+      const createResponse = page.waitForResponse('/api/v1/glossaryTerms');
+      await page.click('[data-testid="save-glossary-term"]');
+      await createResponse;
+
+      await expect(
+        page.locator('[role="dialog"].edit-glossary-modal')
+      ).not.toBeVisible();
+
+      await redirectToHomePage(reviewer2Page);
+      await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
+
+      const termRow = reviewer2Page.locator(`[data-row-key*="${termName}"]`);
+
+      await expect(termRow).toBeVisible();
+
+      const approveBtn = reviewer2Page.getByTestId(`${termName}-approve-btn`);
+      const rejectBtn = reviewer2Page.getByTestId(`${termName}-reject-btn`);
+
+      await expect(approveBtn).not.toBeVisible();
+      await expect(rejectBtn).not.toBeVisible();
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
+  }
+);
+
+test(
+  'should change status when non-reviewer edits approved term',
+  { tag: ['@workflow'] },
+  async ({ page, reviewer2Page }) => {
+    test.slow(true);
+
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    let glossaryTerm: GlossaryTerm;
+
+    try {
+      await glossary.create(apiContext);
+
+      await glossary.patch(apiContext, [
+        {
+          op: 'add',
+          path: '/reviewers/0',
+          value: {
+            id: reviewer1.responseData.id,
+            type: 'user',
+            displayName: reviewer1.responseData.displayName,
+            fullyQualifiedName: reviewer1.responseData.fullyQualifiedName,
+            name: reviewer1.responseData.name,
+          },
+        },
+      ]);
+
+      glossaryTerm = new GlossaryTerm(
+        glossary,
+        undefined,
+        'ApprovedTermForEdit'
+      );
+      await glossaryTerm.create(apiContext);
+
+      await apiContext.patch(
+        `/api/v1/glossaryTerms/${glossaryTerm.responseData.id}`,
+        {
+          data: [
+            {
+              op: 'replace',
+              path: '/status',
+              value: 'Approved',
+            },
+          ],
+          headers: {
+            'Content-Type': 'application/json-patch+json',
+          },
+        }
+      );
+
+      await redirectToHomePage(reviewer2Page);
+      await sidebarClick(reviewer2Page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(reviewer2Page, glossary.data.displayName);
+
+      const termRow = reviewer2Page.locator(
+        `[data-row-key*="${glossaryTerm.responseData.name}"]`
+      );
+
+      await expect(termRow).toBeVisible();
+
+      await reviewer2Page.click(
+        `[data-testid="${glossaryTerm.responseData.name}"]`
+      );
+
+      const editDescBtn = reviewer2Page.getByTestId('edit-description');
+
+      if (await editDescBtn.isVisible()) {
+        await editDescBtn.click();
+        await reviewer2Page
+          .locator(descriptionBox)
+          .fill('Non-reviewer update to trigger review');
+
+        const saveRes = reviewer2Page.waitForResponse(
+          '/api/v1/glossaryTerms/*'
+        );
+        await reviewer2Page.getByTestId('save').click();
+        await saveRes;
+      }
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
+  }
+);
+
+test.describe('Workflow History', { tag: ['@workflow'] }, () => {
   const glossary = new Glossary();
   let glossaryTerm: GlossaryTerm;
 
@@ -604,69 +617,71 @@ test.describe('Workflow History', () => {
   });
 });
 
-test('should delete parent term and cascade delete children', async ({
-  page,
-}) => {
-  const { apiContext, afterAction } = await getApiContext(page);
-  const glossary = new Glossary();
-  let parentTerm: GlossaryTerm;
-  let childTerm: GlossaryTerm;
+test(
+  'should delete parent term and cascade delete children',
+  { tag: ['@workflow'] },
+  async ({ page }) => {
+    const { apiContext, afterAction } = await getApiContext(page);
+    const glossary = new Glossary();
+    let parentTerm: GlossaryTerm;
+    let childTerm: GlossaryTerm;
 
-  try {
-    await glossary.create(apiContext);
+    try {
+      await glossary.create(apiContext);
 
-    parentTerm = new GlossaryTerm(glossary, undefined, 'ParentToDelete');
-    await parentTerm.create(apiContext);
+      parentTerm = new GlossaryTerm(glossary, undefined, 'ParentToDelete');
+      await parentTerm.create(apiContext);
 
-    childTerm = new GlossaryTerm(
-      glossary,
-      parentTerm.responseData.fullyQualifiedName,
-      'ChildToDelete'
-    );
-    await childTerm.create(apiContext);
+      childTerm = new GlossaryTerm(
+        glossary,
+        parentTerm.responseData.fullyQualifiedName,
+        'ChildToDelete'
+      );
+      await childTerm.create(apiContext);
 
-    await sidebarClick(page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(page, glossary.data.displayName);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
 
-    await performExpandAll(page);
+      await performExpandAll(page);
 
-    const parentRow = page
-      .locator(`[data-row-key*="${parentTerm.responseData.name}"]`)
-      .first();
+      const parentRow = page
+        .locator(`[data-row-key*="${parentTerm.responseData.name}"]`)
+        .first();
 
-    await expect(parentRow).toBeVisible();
+      await expect(parentRow).toBeVisible();
 
-    const childRow = page.locator(
-      `[data-row-key*="${childTerm.responseData.name}"]`
-    );
+      const childRow = page.locator(
+        `[data-row-key*="${childTerm.responseData.name}"]`
+      );
 
-    await expect(childRow).toBeVisible();
+      await expect(childRow).toBeVisible();
 
-    await page.click(`[data-testid="${parentTerm.responseData.name}"]`);
+      await page.click(`[data-testid="${parentTerm.responseData.name}"]`);
 
-    await page.getByTestId('manage-button').click();
-    await page.getByTestId('delete-button').click();
+      await page.getByTestId('manage-button').click();
+      await page.getByTestId('delete-button').click();
 
-    await expect(page.locator('[role="dialog"]')).toBeVisible();
+      await expect(page.locator('[role="dialog"]')).toBeVisible();
 
-    await page.getByTestId('confirmation-text-input').fill('DELETE');
+      await page.getByTestId('confirmation-text-input').fill('DELETE');
 
-    const deleteRes = page.waitForResponse('/api/v1/glossaryTerms/async/*');
-    await page.getByTestId('confirm-button').click();
-    await deleteRes;
+      const deleteRes = page.waitForResponse('/api/v1/glossaryTerms/async/*');
+      await page.getByTestId('confirm-button').click();
+      await deleteRes;
 
-    await sidebarClick(page, SidebarItem.GLOSSARY);
-    await selectActiveGlossary(page, glossary.data.displayName);
+      await sidebarClick(page, SidebarItem.GLOSSARY);
+      await selectActiveGlossary(page, glossary.data.displayName);
 
-    await expect(
-      page.locator(`[data-row-key*="${parentTerm.responseData.name}"]`)
-    ).not.toBeVisible();
+      await expect(
+        page.locator(`[data-row-key*="${parentTerm.responseData.name}"]`)
+      ).not.toBeVisible();
 
-    await expect(
-      page.locator(`[data-row-key*="${childTerm.responseData.name}"]`)
-    ).not.toBeVisible();
-  } finally {
-    await glossary.delete(apiContext);
-    await afterAction();
+      await expect(
+        page.locator(`[data-row-key*="${childTerm.responseData.name}"]`)
+      ).not.toBeVisible();
+    } finally {
+      await glossary.delete(apiContext);
+      await afterAction();
+    }
   }
-});
+);


### PR DESCRIPTION
Backport of #31015 to `1.13`. Companion: **open-metadata/openmetadata-collate#5518** (the collate side on 1.13).

## Only one file applies here

1.13 has neither `ArticleReviewerWorkflow` nor `Tasks/TaskCustomFormWorkflow`, and no `Workflows/*` specs at all — `GlossaryWorkflow` is the only async governance workflow spec on this branch. So this is a **one-file** change rather than three.

## Why 1.13 needs it

Collate's nightly AUT builds its Playwright image from `OPENMETADATA_DESTINATION_VERSION`, so a 1.13-destination validation runs *this* copy of the spec. That's live — [run 30964402587](https://github.com/open-metadata/openmetadata-nightly/actions/runs/30964402587) ("AUT PostgreSQL 1.11.13 ➡ 1.13") ran today. Tagging it here is what lets that run route the spec into a dedicated worker instead of leaving it in the eight-way shard pool, where its async engine churn overlaps every other shard.

## No behaviour change

Nothing in OpenMetadata CI filters on `@workflow`. This only makes the spec addressable by the downstream AUT.

## All seven top-level sites are tagged, not just the workflow-named ones

The file has file-level `beforeAll` / `afterAll` / `beforeEach` hooks (L60/69/77), and those run once **per project** — so tagging a subset would split the file across the shard pool and the dedicated worker and run that setup **twice**. Tagging every top-level owner moves the file as a unit.

**Audited: 10 test declarations, 0 uncovered.**

## Formatting

Formatted with this branch's pinned **prettier 2.8.8**, and I confirmed the file was already 2.8.8-clean beforehand, so every reformatted line is attributable to the tags rather than pre-existing drift. The 278/263 line count is prettier reindenting callback bodies after the third argument; `git diff -w` collapses it to **40/25**.
