### PR TITLE
fix(search): apply minimum_should_match floor to column index search

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
@@ -381,6 +381,8 @@ public class ElasticSearchSourceBuilderFactory
       queryBuilder = Query.of(q -> q.matchAll(m -> m));
     } else {
       Map<String, Float> fields = ColumnSearchIndex.getFields();
+      // Require a minimum token overlap so a single shared parent token (e.g. in
+      // fullyQualifiedName or table.name) does not match every column in the index.
       queryBuilder =
           ElasticQueryBuilder.multiMatchQuery(
               query,
@@ -388,7 +390,10 @@ public class ElasticSearchSourceBuilderFactory
               TextQueryType.BestFields,
               Operator.Or,
               String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
+              "0",
+              MINIMUM_SHOULD_MATCH,
+              null,
+              null);
     }
     Highlight hb = buildHighlightsV2(List.of("name", "displayName", "description"));
     return searchBuilderV2(queryBuilder, hb, from, size);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
@@ -382,6 +382,8 @@ public class OpenSearchSourceBuilderFactory
       queryBuilder = Query.of(q -> q.matchAll(m -> m));
     } else {
       Map<String, Float> fields = ColumnSearchIndex.getFields();
+      // Require a minimum token overlap so a single shared parent token (e.g. in
+      // fullyQualifiedName or table.name) does not match every column in the index.
       queryBuilder =
           OpenSearchQueryBuilder.multiMatchQuery(
               query,
@@ -389,7 +391,10 @@ public class OpenSearchSourceBuilderFactory
               TextQueryType.BestFields,
               Operator.Or,
               String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
+              "0",
+              MINIMUM_SHOULD_MATCH,
+              null,
+              null);
     }
     Highlight highlighter = buildHighlightsV2(List.of("name", "displayName", "description"));
     return searchBuilderV2(queryBuilder, highlighter, from, size);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
@@ -347,6 +347,28 @@ public class SearchSourceBuilderFactoryTest {
     assertTrue(esQuery.contains("\"operator\":\"and\""), esQuery);
   }
 
+  @Test
+  public void testColumnIndexSearchAppliesMinimumShouldMatchFloor() {
+    // Regression: column search must not degrade into matching every column that shares a single
+    // token (e.g. a common parent-name token in fullyQualifiedName/table.name). Without a
+    // minimum_should_match floor an FQN-style query returned the whole column index while the
+    // dataAsset aggregation counted only the true matches, so the tab count and results diverged.
+    OpenSearchSourceBuilderFactory osFactory = new OpenSearchSourceBuilderFactory(searchSettings);
+    ElasticSearchSourceBuilderFactory esFactory =
+        new ElasticSearchSourceBuilderFactory(searchSettings);
+
+    String query = "pw-database-service pw-table first_name";
+
+    String osQuery =
+        serializeOpenSearchRequest(
+            osFactory.getSearchSourceBuilderV2(Entity.TABLE_COLUMN, query, 0, 15));
+    String esQuery =
+        esFactory.getSearchSourceBuilderV2(Entity.TABLE_COLUMN, query, 0, 15).query().toString();
+
+    assertTrue(osQuery.contains("\"minimum_should_match\":\"2<70%\""), osQuery);
+    assertTrue(esQuery.contains("\"minimum_should_match\":\"2<70%\""), esQuery);
+  }
+
   private static String serializeOpenSearchRequest(OpenSearchRequestBuilder requestBuilder) {
     JacksonJsonpMapper mapper = new JacksonJsonpMapper();
     StringWriter writer = new StringWriter();


### PR DESCRIPTION
### Describe your changes:

Fixes open-metadata/openmetadata-collate#3851

Column search (`index=tableColumn`) routes through `buildColumnSearchBuilderV2`, which passed `"0"` as the `multi_match` **fuzziness** argument. `minimum_should_match` was only ever applied inside the `!fuzziness.equals("0")` branch, so the `"0"` sentinel silently dropped the floor — leaving a bare `best_fields`/OR `multi_match` that matches any column sharing a **single** token (e.g. a common parent-name token in `fullyQualifiedName` / `table.name`).

As a result, a specific-FQN column search returned the **entire** column index, while the `dataAsset` aggregation (strict builder, `minimum_should_match(1)`) counted only the true matches — so the Explore **Columns** tab count and the results list diverged (observed: tab count **1**, results **7,381**).

**Fix:** pass the existing `MINIMUM_SHOULD_MATCH` (`"2<70%"`) constant to the `multi_match` in both the OpenSearch and Elasticsearch source-builder factories. The 9-arg overload applies `minimum_should_match` unconditionally (independent of fuzziness). Exact-name searches (1–2 tokens) still match; long FQN-style queries now require ~70% token overlap instead of a single shared token.

Changed:
- `openmetadata-service/.../search/opensearch/OpenSearchSourceBuilderFactory.java` — `buildColumnSearchBuilderV2`
- `openmetadata-service/.../search/elasticsearch/ElasticSearchSourceBuilderFactory.java` — `buildColumnSearchBuilderV2`

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Unit tests
- [x] Added `SearchSourceBuilderFactoryTest.testColumnIndexSearchAppliesMinimumShouldMatchFloor` — builds the column query for both OpenSearch and Elasticsearch and asserts the serialized query carries `"minimum_should_match":"2<70%"`. Fails on the previous code (floor absent), passes with the fix.
- `SearchSourceBuilderFactoryTest`: 18/18 pass locally.

#### Backend integration tests
- [x] Not applicable (no API changes). Existing `ColumnSearchIndexIT` asserts a column is findable by name, which this change preserves — and makes more robust, since the target column is no longer buried beyond `size(10)` among thousands of permissive matches.

#
### UI screen recording / screenshots:
Not applicable (backend search-query change).

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
