### PR TITLE
backport(2.0): domain/data-product UI polish + Add Assets scroll anchoring (#30450, #30510, #30622, #30641)

### DIFF
--- a/.github/playwright/impact-map.json
+++ b/.github/playwright/impact-map.json
@@ -120,7 +120,8 @@
         "ImportExport",
         "search-nightly",
         "Reindex",
-        "GlobalSettings"
+        "GlobalSettings",
+        "SearchRBAC"
       ],
       "specs": [
         "playwright/e2e/Pages/Explore*.spec.ts",

--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -611,6 +611,47 @@ def test_targeted_selection_combines_changed_specs_impacts_and_unmapped_canaries
     assert selection["directChangedSpecs"] == ["playwright/e2e/Pages/Entity.spec.ts"]
 
 
+def test_explore_changes_schedule_search_rbac_in_its_own_lane(tmp_path, monkeypatch):
+    """The Explore mapping's ``Flow/*Search*.spec.ts`` glob also matches
+    SearchRBAC.spec.ts, which ``chromium`` testIgnores and only the dedicated
+    ``SearchRBAC`` project runs. Without that project in the mapping the selector
+    resolves to zero units and build_playwright_shards.py aborts the whole plan.
+    """
+    selector = load_script("select_playwright_tests")
+    changed = tmp_path / "changed.txt"
+    output = tmp_path / "selection.json"
+    changed.write_text(
+        "openmetadata-ui/src/main/resources/ui/src/components/Explore/"
+        "QuickFilterDropdown.tsx\n"
+    )
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "select_playwright_tests.py",
+            "--event-name",
+            "pull_request_target",
+            "--changed-files",
+            str(changed),
+            "--impact-map",
+            str(Path(".github/playwright/impact-map.json")),
+            "--output",
+            str(output),
+        ],
+    )
+
+    selector.main()
+
+    selection = json.loads(output.read_text())
+    search_rbac = next(
+        entry
+        for entry in selection["selectors"]
+        if entry["spec"] == "playwright/e2e/Flow/SearchRBAC.spec.ts"
+    )
+    assert "SearchRBAC" in search_rbac["projects"]
+
+
 def test_targeted_selection_does_not_schedule_deleted_specs(tmp_path, monkeypatch):
     selector = load_script("select_playwright_tests")
     existing_spec = tmp_path / selector.UI_ROOT / "playwright/e2e/Smoke.spec.ts"

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
@@ -30,11 +30,16 @@ const ReactGridLayout = WidthProvider(RGL) as React.ComponentType<
   ReactGridLayoutProps & { children?: React.ReactNode }
 >;
 
+export type GenericTabVariant = 'default' | 'flat';
+
 interface GenericTabProps {
   type: PageType;
+  // 'flat' drops the left-panel frame card so the sole widget (e.g. the
+  // Description on Domain/Data Product) stands on its own. Defaults to 'default'.
+  variant?: GenericTabVariant;
 }
 
-export const GenericTab = ({ type }: GenericTabProps) => {
+export const GenericTab = ({ type, variant = 'default' }: GenericTabProps) => {
   const { layout, updateWidgetHeight } = useGenericContext();
 
   const handleHeightChange = useCallback(
@@ -86,6 +91,7 @@ export const GenericTab = ({ type }: GenericTabProps) => {
       className={classNames('grid-container bg-grey', {
         'custom-tab': !leftSideWidgetPresent,
         'height-auto': type === PageType.Glossary,
+        'flat-left-panel': variant === 'flat',
       })}
       cols={8}
       containerPadding={[0, 0]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/GenericTab.tsx
@@ -94,7 +94,13 @@ export const GenericTab = ({ type, variant = 'default' }: GenericTabProps) => {
         'flat-left-panel': variant === 'flat',
       })}
       cols={8}
-      containerPadding={[0, 0]}
+      // react-grid-layout rounds each item's `left` and `width` independently, so
+      // although the two exact values sum to the container width, each rounding
+      // can add just under half a pixel and the last column can land 1px past the
+      // container -- taking the widget card's right border with it. A 1px
+      // horizontal containerPadding pulls the exact right edge in to
+      // `width - 1`, which the rounding can never exceed.
+      containerPadding={[1, 0]}
       isDraggable={false}
       isResizable={false}
       margin={[GRID_VERTICAL_MARGIN, GRID_VERTICAL_MARGIN]}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/generic-tab.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericTab/generic-tab.less
@@ -48,6 +48,20 @@
       padding: @padding-md;
     }
   }
+
+  // `flat` variant: drop the left-panel frame card so the sole widget stands on
+  // its own (used by Domain & Data Product docs, which only hold the Description).
+  // Also drop the frame's inner padding so the widget lines up flush with the
+  // tabs (left) and the right panel (top) instead of being inset by the frame gap.
+  &.flat-left-panel > #KnowledgePanel\.LeftPanel {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+
+    > .dynamic-height-widget > .left-panel-content {
+      padding: 0;
+    }
+  }
 }
 
 .ant-tabs.ant-tabs-top.tabs-new {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -197,7 +197,7 @@ const DataProductListPage = ({
 
           return (
             <Box
-              align="start"
+              align="center"
               className={NAME_CELL_WRAP_CLASS}
               direction="row"
               gap={3}>
@@ -233,7 +233,7 @@ const DataProductListPage = ({
 
           return (
             <Box
-              align="start"
+              align="center"
               className={COMPACT_CELL_WRAP_CLASS}
               direction="row"
               gap={1}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -821,7 +821,6 @@ const DataProductsDetailsPage = ({
           <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-start tw:justify-between">
             <div className="tw:max-w-full tw:lg:max-w-[60%]">
               <EntityHeader
-                badge={statusBadge}
                 breadcrumb={[]}
                 displayNameClassName="entity-header-title-wrap"
                 entityData={{ ...dataProduct, displayName, name }}
@@ -833,7 +832,10 @@ const DataProductsDetailsPage = ({
                 nameClassName="entity-header-title-wrap"
                 serviceName=""
                 suffix={
-                  <LearningIcon pageId={LEARNING_PAGE_IDS.DATA_PRODUCT} />
+                  <>
+                    {statusBadge}
+                    <LearningIcon pageId={LEARNING_PAGE_IDS.DATA_PRODUCT} />
+                  </>
                 }
                 titleColor={dataProduct.style?.color}
               />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.test.tsx
@@ -214,6 +214,19 @@ describe('QuickFilterDropdown', () => {
     jest.useRealTimers();
   });
 
+  // Without a containing block on the list, the Checkbox's absolutely
+  // positioned hidden input resolves against the popover root, escapes the
+  // list's clip, and lets a click on an off-screen option scroll the page.
+  it('should own the containing block for its option list', () => {
+    renderDropdown();
+
+    fireEvent.click(screen.getByTestId('search-dropdown-entityType'));
+
+    expect(screen.getByTestId('quick-filter-option-list')).toHaveClass(
+      'tw:relative'
+    );
+  });
+
   it('should close when the route pathname changes', () => {
     const { rerender } = renderDropdown();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -203,7 +203,17 @@ const QuickFilterDropdown: FC<QuickFilterDropdownProps> = ({
             </div>
           )}
 
-          <div className="tw:max-h-64 tw:overflow-auto tw:px-1.5 tw:py-1">
+          {/*
+           * `relative` makes this list the containing block for the Checkbox's
+           * visually-hidden input. Those inputs are `position: absolute`, so
+           * without it they resolve against the popover root — escaping this
+           * list's clip, extending <html>'s scroll area by the full option
+           * count, and letting a click on an off-screen option scroll the
+           * whole page to bring the focused input into view.
+           */}
+          <div
+            className="tw:relative tw:max-h-64 tw:overflow-auto tw:px-1.5 tw:py-1"
+            data-testid="quick-filter-option-list">
             {isSuggestionsLoading ? (
               <div className="tw:flex tw:justify-center tw:py-3">
                 <Loader size="small" />

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityDescription/Description.tsx
@@ -276,7 +276,7 @@ const Description = ({
       <Box
         className={classNames(
           wrapInCard
-            ? 'tw:rounded-[10px] tw:border tw:border-secondary tw:bg-bg-primary tw:p-[18px] tw:shadow-xs'
+            ? 'tw:rounded-xl tw:border tw:border-secondary tw:bg-bg-primary tw:p-[18px] tw:shadow-xs'
             : undefined,
           className
         )}

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -50,7 +50,7 @@ export const CARD_NAME_WRAP_CLASS = 'tw:min-w-0 tw:[overflow-wrap:anywhere]';
 export const renderDomainNameCell = (
   entity: Domain | DataProduct
 ): ReactNode => (
-  <Box align="start" className={NAME_CELL_WRAP_CLASS} direction="row" gap={3}>
+  <Box align="center" className={NAME_CELL_WRAP_CLASS} direction="row" gap={3}>
     <Avatar size="md" {...getEntityAvatarProps(entity)} />
     <Typography size="text-sm" weight="medium">
       {getEntityName(entity)}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataProductUtils.tsx
@@ -201,7 +201,7 @@ export const getDataProductDetailTabs = ({
         />
       ),
       key: EntityTabs.DOCUMENTATION,
-      children: <GenericTab type={PageType.DataProduct} />,
+      children: <GenericTab type={PageType.DataProduct} variant="flat" />,
     },
     ...(isVersionsView
       ? []

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DomainUtils.tsx
@@ -269,7 +269,7 @@ export const getDomainDetailTabs = ({
         />
       ),
       key: EntityTabs.DOCUMENTATION,
-      children: <GenericTab type={PageType.Domain} />,
+      children: <GenericTab type={PageType.Domain} variant="flat" />,
     },
     ...(isVersionsView
       ? []


### PR DESCRIPTION
### Describe your changes:

Backports four already-merged, already-reviewed `main` PRs onto `2.0` so the release branch picks up
the Domain / Data Product marketplace polish and the Add-Assets scroll-anchoring fix.

| main PR | cherry-pick | What it does |
|---|---|---|
| #30450 | `9ce8a5c2ff` | Drops the redundant outer frame card on Domain & Data Product docs (`GenericTab` `variant="flat"`) |
| #30510 | `cd6b0d5afe` | Centers domain/data-product list row items; fixes the DP detail header title width (status badge moves into `suffix`) |
| #30622 | `7ab65b7bcc` | Keeps `GenericTab`'s react-grid-layout widget grid inside its container (sub-pixel rounding pushed the last column 1px past the edge) |
| #30641 | `5a678bcb11` | Keeps the page anchored when picking an off-screen Add Assets filter option, plus the `SearchRBAC` impact-map lane fix |

Each commit carries its `(cherry picked from commit …)` trailer.

**Deliberately not backported:** #30613 (`brace-expansion`/`postcss` resolution bumps). `2.0` already
pins **higher** versions than that PR introduced — `brace-expansion 5.0.9` (vs 5.0.8) and
`postcss 8.5.23` (vs 8.5.18) — so the advisory is already cleared there and cherry-picking would be a
downgrade.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — backport only, no new design.

#
### Tests:

#### Use cases covered
- Domain and Data Product **Documentation** tabs render the description widget without the extra frame card.
- Domain / Data Product **list** rows vertically center the icon against the name; DP detail header title uses the full available width with the status badge inline.
- A customized entity tab's widget grid stays inside its container at widths where rounding previously overflowed by 1px.
- Selecting an **off-screen** option in an Add Assets quick-filter dropdown no longer scrolls the page out from under the drawer.
- The CI planner routes `Explore/*` changes that match `Flow/*Search*.spec.ts` into the dedicated `SearchRBAC` project instead of resolving to zero units.

#### Unit tests
- `QuickFilterDropdown.test.tsx` — regression test for the containing-block fix (backported verbatim from #30641).
- `.github/scripts/tests/test_playwright_ci_planning.py::test_explore_changes_schedule_search_rbac_in_its_own_lane` — new here.
  Suite on this branch: **57 passed, 1 failed**; the single failure
  (`test_main_skips_tag_filtered_spec_but_fails_on_a_nonexistent_one`, a `NameError: name 'sys' is not defined`
  in `build_playwright_shards.py`) reproduces on pristine `origin/2.0` (**56 passed, 1 failed**) and is unrelated to this PR.

#### Backend integration tests
- [x] Not applicable (no backend changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — no new specs; `.github/playwright/impact-map.json` gains `SearchRBAC` on the `Explore` mapping so existing specs get scheduled into a lane that actually runs them.

#### Manual testing performed

Verified structurally rather than by re-running the UI, since every change was already reviewed, merged, and CI-green on `main`:

1. **Post-image byte-identity** — every `.tsx`/`.less` file produced by these cherry-picks is byte-identical to `main`'s post-image (`git rev-parse <sha>:<path>`), and every **pre**-image matched `main`'s parent, so no surrounding code diverges on `2.0`.
2. **The two `.github/` files legitimately diverge** (`2.0`'s impact map and planner test file already differed). Verified the applied hunks landed correctly: `SearchRBAC` added to the `Explore` mapping's `projects`, and exactly the one new test function from #30641 added — the conflict pulled in a second, unrelated test from a PR that was never backported, and that one was dropped.
3. **`SearchRBAC` prerequisites exist on `2.0`** — `playwright/e2e/Flow/SearchRBAC.spec.ts` is present, and `playwright.config.ts` both `testIgnore`s it from `chromium` (line 197) and defines the dedicated `SearchRBAC` project (line 317).
4. Confirmed the branch is a clean fast-forward of `origin/2.0`.

#
### UI screen recording / screenshots:

Before/after from the original PRs — the backported diffs are byte-identical, so these hold.

**#30450 — flat docs card (Domain, then Data Product)**

<img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/flat-domain-before.png" width="460"> <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/flat-domain-after.png" width="460">

<img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/flat-dataproduct-before.png" width="460"> <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/flat-dataproduct-after.png" width="460">

**#30510 — list row centering (before / after)**

![before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pr-assets-mktplace-2026-07/list-before-wide.png)
![after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/pr-assets-mktplace-2026-07/list-after-wide.png)

**#30622 — widget grid overflow (before / after crop)**

![before and after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-generic-tab-grid/.pr-assets/generic-tab-grid/pr-zoom-v2.png)

**#30641 — Add Assets off-screen filter option (before / after)**

![before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/issue-30640-pr-before.png)
![after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/issue-30640-pr-after.png)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: I attached screenshots above.
- [x] I have added tests (carried over from the source PRs) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
