### PR TITLE
perf(ui): single-commit GenericProvider column registration (R1)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -158,6 +158,13 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     if (columnFqn && extractedColumns.length > 0) {
       const col = findFieldByFQN(extractedColumns as Column[], columnFqn);
       if (col) {
+        // Seed the panel navigation list on the deep-link path too — the child's
+        // ref write is dropped here because the panel-open gate is still null.
+        setPanelColumns(
+          displayedColumnsRef.current.length > 0
+            ? displayedColumnsRef.current
+            : extractedColumns
+        );
         setSelectedColumn(cleanColumn(col));
       }
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Customization/GenericProvider/GenericProvider.tsx
@@ -96,14 +96,30 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     null
   );
 
-  // State to store the displayed columns (sorted/filtered) from SchemaTable
-  const [displayedColumns, setDisplayedColumns] = useState<ColumnOrTask[]>([]);
+  // Children (SchemaTable, ModelTab, etc.) register their sorted/filtered/paginated
+  // column list here. Kept in a ref so the write does not re-render the provider on
+  // load; only mirrored into `panelColumns` state while the column detail panel is open.
+  const displayedColumnsRef = useRef<ColumnOrTask[]>([]);
+  const selectedColumnRef = useRef<ColumnOrTask | null>(null);
+  const [panelColumns, setPanelColumns] = useState<ColumnOrTask[]>([]);
+
+  const setDisplayedColumns = useCallback((cols: ColumnOrTask[]) => {
+    displayedColumnsRef.current = cols;
+    // Keep the open panel's navigation list live; when closed, skip the re-render.
+    if (selectedColumnRef.current) {
+      setPanelColumns(cols);
+    }
+  }, []);
 
   // Derive isColumnDetailOpen from selectedColumn - if a column is selected, panel is open
   const isColumnDetailOpen = useMemo(
     () => selectedColumn !== null,
     [selectedColumn]
   );
+
+  useEffect(() => {
+    selectedColumnRef.current = selectedColumn;
+  }, [selectedColumn]);
 
   const { entityRules } = useEntityRules(type);
 
@@ -121,10 +137,11 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
     return extractColumnsFromData(data, type) as ColumnOrTask[];
   }, [data, type]);
 
-  // Use displayed columns if available (sorted), otherwise fall back to extracted columns
+  // Use the panel's snapshot of displayed columns (sorted) if available, otherwise
+  // fall back to the extracted columns.
   const columnsForPanel = useMemo(() => {
-    return displayedColumns.length > 0 ? displayedColumns : extractedColumns;
-  }, [displayedColumns, extractedColumns]);
+    return panelColumns.length > 0 ? panelColumns : extractedColumns;
+  }, [panelColumns, extractedColumns]);
 
   // Helper to clean column by removing empty children array
   const cleanColumn = useCallback((column: ColumnOrTask): ColumnOrTask => {
@@ -234,6 +251,13 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
         return;
       }
 
+      // Snapshot the child's current displayed list for panel prev/next navigation.
+      setPanelColumns(
+        displayedColumnsRef.current.length > 0
+          ? displayedColumnsRef.current
+          : extractedColumns
+      );
+
       // Set selected column immediately to avoid flicker
       setSelectedColumn(column);
 
@@ -254,11 +278,13 @@ export const GenericProvider = <T extends Omit<EntityReference, 'type'>>({
       navigate,
       location.pathname,
       selectedColumn?.fullyQualifiedName,
+      extractedColumns,
     ]
   );
 
   const closeColumnDetailPanel = useCallback(() => {
     setSelectedColumn(null);
+    setPanelColumns([]);
 
     // Update URL to remove column FQN
     if (data?.fullyQualifiedName) {


### PR DESCRIPTION
## Problem
Nine entity-detail tabs (`SchemaTable`, `ModelTab`, `SearchIndexFieldsTable`, `TopicSchema`, `ContainerDataModel`, `PipelineTaskTab`, `MlModelFeaturesList`, `WorksheetColumnsTable`, `APIEndpointSchema`) push their sorted/filtered/**paginated**/searched column list into `GenericProvider` via a `useEffect` + `useState` setter. A setter fired from a child effect re-renders the provider **after** the child commits, so every entity detail page double-renders (2 commits) on load.

## Fix
`displayedColumns`' only consumer is `columnsForPanel` → `ColumnDetailPanel`'s `allColumns`, which is mounted only when a column is selected (a user action). So the value is never needed on the initial, panel-closed render.

- Store the child registration in a `useRef` (`displayedColumnsRef`) — the write no longer re-renders the provider.
- `setDisplayedColumns` is now a stable `useCallback`; it mirrors into new `panelColumns` state **only while the panel is open** (`selectedColumnRef` gate).
- `openColumnDetailPanel` snapshots the ref at click-time; `columnsForPanel` reads `panelColumns`.

Result: **load path is one commit**; prev/next navigation over the displayed list is byte-for-byte unchanged. **No child changes, no context-interface change.**


https://github.com/user-attachments/assets/756418a1-3f6f-409b-8f9d-523a42047aa8


https://github.com/user-attachments/assets/45afad6b-896b-4c5d-ab28-dbdb3565cecd



## Testing
- Jest: `GenericProvider` + all 6 child specs + `ColumnDetailPanel` — **10 suites / 127 tests pass, unmodified**.
- `tsc --noEmit`: no new errors (2 pre-existing `WidgetConfig[]` layout errors on `main` are untouched).
- `lint:base` clean.
- React DevTools Profiler on a Table detail tab load: 2 commits → 1 (provider absent from the 2nd commit).

Part of the UI Quality Audit epic — open-metadata/openmetadata-collate#5442, ticket open-metadata/openmetadata-collate#5446 (R1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)