### PR TITLE
perf(ui): derive mirror state during render instead of via effect (R1)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/ActivityFeedCard.tsx
@@ -14,9 +14,8 @@
 import { Popover, Space } from 'antd';
 import classNames from 'classnames';
 import { compare, Operation } from 'fast-json-patch';
-import { FC, useEffect, useRef, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 import { ReactionOperation } from '../../../enums/reactions.enum';
-import { Post } from '../../../generated/entity/feed/thread';
 import { Reaction, ReactionType } from '../../../generated/type/reaction';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import {
@@ -54,7 +53,7 @@ const ActivityFeedCard: FC<ActivityFeedCardProp> = ({
   const entityField = getEntityField(entityLink ?? '');
   const { currentUser } = useApplicationStore();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [feedDetail, setFeedDetail] = useState<Post>(feed);
+  const feedDetail = feed;
 
   const [visible, setVisible] = useState<boolean>(false);
   const [isEditPost, setEditPost] = useState<boolean>(false);
@@ -119,10 +118,6 @@ const ActivityFeedCard: FC<ActivityFeedCardProp> = ({
   const handleVisibleChange = (newVisible: boolean) => setVisible(newVisible);
 
   const onHide = () => setVisible(false);
-
-  useEffect(() => {
-    setFeedDetail(feed);
-  }, [feed]);
 
   return (
     <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Tag/TagsContainerV2/TagsContainerV2.tsx
@@ -14,7 +14,7 @@
 import { Col, Form, Row, Space } from 'antd';
 import { DefaultOptionType } from 'antd/lib/select';
 import { isArray, isEmpty, isEqual } from 'lodash';
-import { lazy, useCallback, useEffect, useMemo, useState } from 'react';
+import { lazy, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -52,7 +52,6 @@ import { SelectOption } from '../../common/AsyncSelectList/AsyncSelectList.inter
 import { EditIconButton } from '../../common/IconButtons/EditIconButton';
 import WidgetCard from '../../common/WidgetCard/WidgetCard';
 import { useGenericContext } from '../../Customization/GenericProvider/GenericContext';
-import { TableTagsProps } from '../../Database/TableTags/TableTags.interface';
 import SuggestionsAlert from '../../Suggestions/SuggestionsAlert/SuggestionsAlert';
 import { useSuggestionsContext } from '../../Suggestions/SuggestionsProvider/SuggestionsProvider';
 import TagsV1 from '../TagsV1/TagsV1.component';
@@ -95,7 +94,7 @@ const TagsContainerV2 = ({
     updateActiveTagDropdownKey,
   } = useGenericContext();
   const { selectedUserSuggestions } = useSuggestionsContext();
-  const [tags, setTags] = useState<TableTagsProps>();
+  const tags = useMemo(() => getFilterTags(selectedTags), [selectedTags]);
   const [internalIsEditTags, setInternalIsEditTags] = useState(false);
 
   const { isEditTags, dropdownKey } = useMemo(() => {
@@ -489,10 +488,6 @@ const TagsContainerV2 = ({
 
     return null;
   }, [permission, entityType, isGlossaryType, selectedUserSuggestions]);
-
-  useEffect(() => {
-    setTags(getFilterTags(selectedTags));
-  }, [selectedTags]);
 
   if (newLook) {
     return (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RichTextEditor/RichTextEditorPreviewerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RichTextEditor/RichTextEditorPreviewerV1.tsx
@@ -40,7 +40,7 @@ const RichTextEditorPreviewerV1: FC<PreviewerProp> = ({
   extensionOptions,
 }) => {
   const { t, i18n } = useTranslation();
-  const [content, setContent] = useState<string>('');
+  const content = useMemo(() => formatClientContent(markdown), [markdown]);
 
   const [readMore, setReadMore] = useState<boolean>(false);
 
@@ -63,10 +63,6 @@ const RichTextEditorPreviewerV1: FC<PreviewerProp> = ({
 
     return content;
   }, [hasReadMore, readMore, maxLength, content]);
-
-  useEffect(() => {
-    setContent(formatClientContent(markdown));
-  }, [markdown]);
 
   useEffect(() => {
     setReadMore(Boolean(isDescriptionExpanded));


### PR DESCRIPTION
## Problem
Three high-frequency components mirror a prop into `useState` via a `useEffect` setter. Prop-into-state-via-effect forces an extra render/commit on every prop change. Each of these has a **single setter** (the mirror itself), so the value is pure derived state.

## Fix
| Component | Before | After |
|---|---|---|
| `RichTextEditorPreviewerV1` (behind **every** description) | `useState('') ` + effect `setContent(formatClientContent(markdown))` | `const content = useMemo(() => formatClientContent(markdown), [markdown])` |
| `TagsContainerV2` (**every** tag chip in every table) | `useState()` + effect `setTags(getFilterTags(selectedTags))` | `const tags = useMemo(() => getFilterTags(selectedTags), [selectedTags])` |
| `ActivityFeedCard` | `useState(feed)` + effect `setFeedDetail(feed)` | `const feedDetail = feed` (straight prop alias) |

User-mutable state is deliberately left alone (e.g. the read-more toggle in `RichTextEditorPreviewerV1`, which is toggled by the user, not derived).

## Testing
- Jest: RichTextEditor + TagsContainerV2 + ActivityFeedCard suites — **19 suites / 216 tests pass, unmodified**.
- `lint:base` clean (0 errors); `tsc --noEmit` no new errors.


https://github.com/user-attachments/assets/5b8ad2c9-0501-4a0e-8077-b417323ca8ea


Part of the UI Quality Audit epic — open-metadata/openmetadata-collate#5442, ticket open-metadata/openmetadata-collate#5446 (R1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)