### PR TITLE
Backport Kafka connector fixes to 2.0 (#30894, #30897, #31014)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/messaging/common_broker_source.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/common_broker_source.py
@@ -20,13 +20,9 @@ from abc import ABC
 from typing import Any, Iterable, Optional  # noqa: UP035
 
 import confluent_kafka
+from cachetools import LRUCache
 from confluent_kafka import KafkaError, KafkaException
 from confluent_kafka.admin import ConfigResource
-from confluent_kafka.error import (
-    ConsumeError,
-    KeyDeserializationError,
-    ValueDeserializationError,
-)
 from confluent_kafka.schema_registry.avro import AvroDeserializer
 from confluent_kafka.schema_registry.schema_registry_client import Schema
 
@@ -57,6 +53,19 @@ from metadata.utils.logger import ingestion_logger
 from metadata.utils.messaging_utils import merge_and_clean_protobuf_schema
 
 logger = ingestion_logger()
+
+# Confluent wire format: a zero magic byte followed by a 4-byte schema id.
+CONFLUENT_MAGIC_BYTE = 0
+CONFLUENT_HEADER_LENGTH = 5
+
+AVRO_DESERIALIZER_CACHE_SIZE = 100
+
+
+def strip_confluent_framing(record: bytes) -> bytes:
+    """Drop the Confluent wire-format header from a payload that carries one."""
+    if len(record) >= CONFLUENT_HEADER_LENGTH and record[0] == CONFLUENT_MAGIC_BYTE:
+        return record[CONFLUENT_HEADER_LENGTH:]
+    return record
 
 
 def on_partitions_assignment_to_consumer(consumer, partitions):
@@ -90,6 +99,7 @@ class CommonBrokerSource(MessagingServiceSource, ABC):
         self.admin_client = self.connection.admin_client
         self.schema_registry_client = self.connection.schema_registry_client
         self.context.processed_schemas = {}
+        self._avro_deserializers = LRUCache(maxsize=AVRO_DESERIALIZER_CACHE_SIZE)
         if self.generate_sample_data:
             self.consumer_client = self.connection.consumer_client
 
@@ -247,7 +257,6 @@ class CommonBrokerSource(MessagingServiceSource, ABC):
                 if self.consumer_client:
                     self.consumer_client.subscribe([topic_name], on_assign=on_partitions_assignment_to_consumer)
                     logger.info(f"Broker consumer polling for sample messages in topic {topic_name}")
-                    # DeserializingConsumer does not implement consume(), use poll() in a loop instead.
                     messages = []
                     n_poll = 10
                     total_timeout = 10
@@ -259,17 +268,16 @@ class CommonBrokerSource(MessagingServiceSource, ABC):
                             if remaining <= 0:
                                 break
                             msg = self.consumer_client.poll(timeout=remaining)
-                        except ConsumeError as exc:
+                        except KafkaException as exc:
                             logger.warning(f"Consumer error polling topic {topic_name}: {exc}")
-                            continue
-                        except (
-                            KeyDeserializationError,
-                            ValueDeserializationError,
-                        ) as exc:
-                            logger.warning(f"Failed to deserialize message from topic {topic_name}: {exc}")
                             continue
                         if msg is None:
                             break
+                        if msg.error():
+                            # End of a partition is not a failure; other partitions may still have data.
+                            if msg.error().code() != KafkaError._PARTITION_EOF:
+                                logger.warning(f"Consumer error polling topic {topic_name}: {msg.error()}")
+                            continue
                         messages.append(msg)
             except Exception as exc:
                 yield Either(
@@ -303,20 +311,22 @@ class CommonBrokerSource(MessagingServiceSource, ABC):
             )
 
     def decode_message(self, record: Any, schema: str, schema_type: SchemaType):
+        if not isinstance(record, (bytes, bytearray, memoryview)):
+            return str(record)
         if schema_type == SchemaType.Avro:
-            # DeserializingConsumer may already return decoded dict/object values.
-            if not isinstance(record, (bytes, bytearray, memoryview)):
-                return str(record)
-            deserializer = AvroDeserializer(schema_str=schema, schema_registry_client=self.schema_registry_client)
-            return str(deserializer(record, None))
+            # One deserializer per schema: this runs once per sampled message.
+            deserializer = self._avro_deserializers.get(schema)
+            if deserializer is None:
+                deserializer = AvroDeserializer(schema_str=schema, schema_registry_client=self.schema_registry_client)
+                self._avro_deserializers[schema] = deserializer
+            return str(deserializer(bytes(record), None))
         if schema_type == SchemaType.Protobuf:
             logger.debug("Protobuf deserializing sample data is not supported")
             return ""
-        if isinstance(record, (bytes, bytearray, memoryview)):
-            return bytes(record).decode("utf-8")
-        return str(record)
+        # Strict: a binary payload we cannot type (Avro with no registry configured)
+        # must be skipped by the caller, not stored as mojibake.
+        return strip_confluent_framing(bytes(record)).decode("utf-8")
 
     def close(self):
-        if getattr(self, "generate_sample_data", False) and getattr(self, "consumer_client", None):
-            self.consumer_client.close()
+        # The consumer belongs to the connection, which closes it on teardown.
         super().close()

--- a/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/kafka/connection.py
@@ -14,12 +14,10 @@ Source connection handler
 """
 
 from copy import deepcopy
-from dataclasses import dataclass
 from typing import Optional, Union
 
-from confluent_kafka import DeserializingConsumer
+from confluent_kafka import Consumer
 from confluent_kafka.admin import AdminClient, KafkaException
-from confluent_kafka.schema_registry.avro import AvroDeserializer
 from confluent_kafka.schema_registry.schema_registry_client import SchemaRegistryClient
 
 from metadata.generated.schema.entity.automations.workflow import (
@@ -58,12 +56,29 @@ class SchemaRegistryException(Exception):  # noqa: N818
 TIMEOUT_SECONDS = 10
 
 
-@dataclass
+# librdkafka rejects nothing, so consumer-only keys would silently ride along.
+CONSUMER_ONLY_CONFIG_KEYS = ("group.id", "enable.auto.commit", "auto.offset.reset")
+
+
 class KafkaClient:
-    def __init__(self, admin_client, schema_registry_client, consumer_client) -> None:
+    def __init__(self, admin_client, schema_registry_client, consumer_factory) -> None:
         self.admin_client = admin_client
         self.schema_registry_client = schema_registry_client  # Optional
-        self.consumer_client = consumer_client
+        self._consumer_factory = consumer_factory
+        self._consumer_client = None
+
+    @property
+    def consumer_client(self):
+        """Built on first use. Only sample-data runs need a consumer, and creating
+        one dials the broker — needless work on every other ingestion."""
+        if self._consumer_client is None:
+            self._consumer_client = self._consumer_factory()
+        return self._consumer_client
+
+    def close_consumer(self) -> None:
+        if self._consumer_client is not None:
+            self._consumer_client.close()
+            self._consumer_client = None
 
 
 def get_connection(connection: Union[KafkaConnectionConfig, RedpandaConnection]) -> KafkaClient:  # noqa: UP007
@@ -87,33 +102,26 @@ def get_connection(connection: Union[KafkaConnectionConfig, RedpandaConnection])
     if connection.basicAuthUserInfo:
         schema_registry_config["basic.auth.user.info"] = connection.basicAuthUserInfo.get_secret_value()
 
-    admin_client_config = consumer_config
+    admin_client_config = {k: v for k, v in consumer_config.items() if k not in CONSUMER_ONLY_CONFIG_KEYS}
     admin_client_config["bootstrap.servers"] = connection.bootstrapServers
     admin_client = AdminClient(admin_client_config)
 
     schema_registry_client = None
-    consumer_client = None
-
     if connection.schemaRegistryURL:
         schema_registry_config["url"] = str(connection.schemaRegistryURL)
         schema_registry_client = SchemaRegistryClient(schema_registry_config)
 
-        consumer_config["bootstrap.servers"] = connection.bootstrapServers
-        if "group.id" not in consumer_config:
-            consumer_config["group.id"] = "openmetadata-consumer"
-        if "auto.offset.reset" not in consumer_config:
-            consumer_config["auto.offset.reset"] = "largest"
-        consumer_config["enable.auto.commit"] = False
-
-        avro_deserializer = AvroDeserializer(schema_registry_client=schema_registry_client)
-        consumer_config["value.deserializer"] = avro_deserializer
-
-        consumer_client = DeserializingConsumer(consumer_config)
+    # Messages are handed back as raw bytes and decoded per topic, so sample data
+    # works for every schema type and does not require a Schema Registry.
+    consumer_config["bootstrap.servers"] = connection.bootstrapServers
+    consumer_config.setdefault("group.id", "openmetadata-consumer")
+    consumer_config.setdefault("auto.offset.reset", "largest")
+    consumer_config["enable.auto.commit"] = False
 
     return KafkaClient(
         admin_client=admin_client,
         schema_registry_client=schema_registry_client,
-        consumer_client=consumer_client,
+        consumer_factory=lambda: Consumer(consumer_config),
     )
 
 
@@ -163,7 +171,9 @@ def test_connection(
 
 class KafkaConnection(BaseConnection[KafkaConnectionConfig, KafkaClient]):
     def _get_client(self) -> KafkaClient:
-        return get_connection(self.service_connection)
+        client = get_connection(self.service_connection)
+        self._on_close(client.close_consumer)
+        return client
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/ingestion/source/messaging/redpanda/connection.py
+++ b/ingestion/src/metadata/ingestion/source/messaging/redpanda/connection.py
@@ -41,7 +41,9 @@ logger = ingestion_logger()
 
 class RedpandaConnection(BaseConnection[RedpandaConnectionConfig, KafkaClient]):
     def _get_client(self) -> KafkaClient:
-        return get_kafka_connection(self.service_connection)
+        client = get_kafka_connection(self.service_connection)
+        self._on_close(client.close_consumer)
+        return client
 
     def test_connection(
         self,

--- a/ingestion/src/metadata/profiler/api/models.py
+++ b/ingestion/src/metadata/profiler/api/models.py
@@ -33,6 +33,12 @@ from metadata.sampler.models import DatabaseAndSchemaConfig, TableConfig
 from metadata.utils.sqa_like_column import SQALikeColumn
 
 
+def processor_config_payload(processor) -> dict:
+    """Return a workflow processor's inner config, or an empty mapping when the
+    processor block or its config is absent."""
+    return (processor.model_dump().get("config") if processor else None) or {}
+
+
 class ProfilerProcessorConfig(ConfigModel):
     """
     Defines how we read the processor information

--- a/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
+++ b/ingestion/src/metadata/profiler/source/database/base/profiler_source.py
@@ -33,7 +33,11 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 )
 from metadata.generated.schema.type.samplingConfig import ProfileSampleConfig
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
-from metadata.profiler.api.models import ProfilerProcessorConfig, TableConfig
+from metadata.profiler.api.models import (
+    ProfilerProcessorConfig,
+    TableConfig,
+    processor_config_payload,
+)
 from metadata.profiler.interface.profiler_interface import ProfilerInterface
 from metadata.profiler.metrics.core import add_props
 from metadata.profiler.processor.core import Profiler
@@ -99,7 +103,7 @@ class ProfilerSource(ProfilerSourceInterface):
 
         self.config = config
         self.service_conn_config = self._copy_service_config(config, database)
-        self.profiler_config = profiler_config_class.model_validate(config.processor.model_dump().get("config"))
+        self.profiler_config = profiler_config_class.model_validate(processor_config_payload(config.processor))
         self.ometa_client = ometa_client
         self._interface_type: str = config.source.type.lower()
         self._interface = None

--- a/ingestion/src/metadata/sampler/messaging/sampler.py
+++ b/ingestion/src/metadata/sampler/messaging/sampler.py
@@ -27,6 +27,9 @@ from metadata.utils.sqa_like_column import SQALikeColumn
 
 logger = sampler_logger()
 
+# Distinguishes an absent path from a field explicitly set to null.
+MISSING = object()
+
 
 class MessagingSampler(SamplerInterface):
     """
@@ -108,15 +111,31 @@ class MessagingSampler(SamplerInterface):
         """
 
     @staticmethod
-    def _resolve(msg: dict, dotted: str) -> object:
-        """Walk a dotted path into nested dicts, returning None when absent."""
+    def _walk(msg: dict, dotted: str) -> object:
+        """Walk a dotted path into nested dicts, returning MISSING when absent."""
         cur: object = msg
         for part in dotted.split("."):
-            if isinstance(cur, dict):
-                cur = cur.get(part)
-            else:
-                return None
+            if not isinstance(cur, dict) or part not in cur:
+                return MISSING
+            cur = cur[part]
         return cur
+
+    @staticmethod
+    def _resolve(msg: dict, dotted: str) -> object:
+        """Resolve a column path against a message, tolerating the schema root.
+
+        Column paths carry the schema's root RECORD (``Order.email``) because that
+        is what the auto-classification processor matches on, but the message on
+        the wire is unwrapped (``{"email": ...}``). Try the full path first so a
+        genuinely wrapped message keeps winning.
+        """
+        for candidate in (dotted, dotted.split(".", 1)[-1]):
+            value = MessagingSampler._walk(msg, candidate)
+            # Only an absent path falls through: a field explicitly set to null is
+            # the schema-correct answer and must not inherit a same-named sibling.
+            if value is not MISSING:
+                return value
+        return None
 
     def fetch_sample_data(self, columns: Optional[List[SQALikeColumn]]) -> TableData:  # noqa: UP006, UP045
         column_objs = columns or self.get_columns()

--- a/ingestion/src/metadata/sampler/processor.py
+++ b/ingestion/src/metadata/sampler/processor.py
@@ -32,7 +32,10 @@ from metadata.ingestion.api.step import Step  # noqa: TC001
 from metadata.ingestion.api.steps import Processor
 from metadata.ingestion.ometa.ometa_api import OpenMetadata  # noqa: TC001
 from metadata.pii.types import ClassifiableEntityType  # noqa: TC001
-from metadata.profiler.api.models import ProfilerProcessorConfig  # noqa: TC001
+from metadata.profiler.api.models import (
+    ProfilerProcessorConfig,
+    processor_config_payload,
+)
 from metadata.profiler.source.metadata import ProfilerSourceAndEntity  # noqa: TC001
 from metadata.sampler.entity_adapters import (
     EntityAdapter,
@@ -76,12 +79,7 @@ class SamplerProcessor(Processor):
 
         self.source_config = self.config.source.sourceConfig.config
 
-        # Messaging and storage auto-classification have no processor to configure,
-        # so the block, or its inner config, is routinely omitted.
-        processor = self.config.processor
-        self.profiler_config = profiler_config_class.model_validate(
-            (processor.model_dump().get("config") if processor else None) or {}
-        )
+        self.profiler_config = profiler_config_class.model_validate(processor_config_payload(self.config.processor))
 
         self._interface_type: str = config.source.type.lower()
 

--- a/ingestion/src/metadata/sampler/processor.py
+++ b/ingestion/src/metadata/sampler/processor.py
@@ -76,7 +76,12 @@ class SamplerProcessor(Processor):
 
         self.source_config = self.config.source.sourceConfig.config
 
-        self.profiler_config = profiler_config_class.model_validate(self.config.processor.model_dump().get("config"))
+        # Messaging and storage auto-classification have no processor to configure,
+        # so the block, or its inner config, is routinely omitted.
+        processor = self.config.processor
+        self.profiler_config = profiler_config_class.model_validate(
+            (processor.model_dump().get("config") if processor else None) or {}
+        )
 
         self._interface_type: str = config.source.type.lower()
 

--- a/ingestion/tests/integration/auto_classification/messaging/conftest.py
+++ b/ingestion/tests/integration/auto_classification/messaging/conftest.py
@@ -58,8 +58,9 @@ from metadata.generated.schema.entity.teams.user import AuthenticationMechanism,
 from metadata.generated.schema.type import schema
 from metadata.generated.schema.type.predefinedRecognizer import Name
 from metadata.generated.schema.type.recognizer import Recognizer
-from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel, SchemaType
+from metadata.generated.schema.type.schema import SchemaType
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
+from metadata.parsers.json_schema_parser import parse_json_schema
 from metadata.workflow.classification import AutoClassificationWorkflow
 
 from ...kafka.conftest import CustomKafkaContainer  # noqa: TID252
@@ -118,21 +119,40 @@ NON_PII_MESSAGES = [
     {"order_id": "1005", "product_id": "PROD-D", "quantity": "1", "price": "99.99"},
 ]
 
-PII_SCHEMA_FIELDS = [
-    FieldModel(name="customer_id", dataType=DataTypeTopic.STRING),
-    FieldModel(name="name", dataType=DataTypeTopic.STRING),
-    FieldModel(name="email", dataType=DataTypeTopic.STRING),
-    FieldModel(name="phone", dataType=DataTypeTopic.STRING),
-    FieldModel(name="ssn", dataType=DataTypeTopic.STRING),
-    FieldModel(name="credit_card", dataType=DataTypeTopic.STRING),
-]
 
-NON_PII_SCHEMA_FIELDS = [
-    FieldModel(name="order_id", dataType=DataTypeTopic.STRING),
-    FieldModel(name="product_id", dataType=DataTypeTopic.STRING),
-    FieldModel(name="quantity", dataType=DataTypeTopic.STRING),
-    FieldModel(name="price", dataType=DataTypeTopic.STRING),
-]
+def iter_leaf_fields(fields):
+    """Yield every non-RECORD field in a parsed schema tree."""
+    for field in fields or []:
+        if field.children:
+            yield from iter_leaf_fields(field.children)
+        else:
+            yield field
+
+
+def find_schema_field(fields, name: str):
+    """Return the leaf field with this name, or None."""
+    return next((field for field in iter_leaf_fields(fields) if field.name.root == name), None)
+
+
+def _json_schema(title: str, properties: list[str]) -> str:
+    return json.dumps(
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": title,
+            "type": "object",
+            "properties": {name: {"type": "string"} for name in properties},
+        }
+    )
+
+
+# Run the real parser rather than hand-listing fields: it wraps everything in a
+# root RECORD named after the schema, and a flat hand-built list models a shape
+# the connector cannot produce.
+PII_SCHEMA_TEXT = _json_schema("Customer", list(PII_MESSAGES[0]))
+NON_PII_SCHEMA_TEXT = _json_schema("Order", list(NON_PII_MESSAGES[0]))
+
+PII_SCHEMA_FIELDS = parse_json_schema(PII_SCHEMA_TEXT)
+NON_PII_SCHEMA_FIELDS = parse_json_schema(NON_PII_SCHEMA_TEXT)
 
 
 def _produce_messages(bootstrap_server: str, topic_name: str, messages: list[dict]) -> None:
@@ -193,6 +213,7 @@ def kafka_pii_topic(metadata: OpenMetadata, kafka_container, messaging_service: 
             partitions=1,
             messageSchema=schema.Topic(
                 schemaType=SchemaType.JSON,
+                schemaText=PII_SCHEMA_TEXT,
                 schemaFields=PII_SCHEMA_FIELDS,
             ),
         )
@@ -209,6 +230,7 @@ def kafka_non_pii_topic(metadata: OpenMetadata, kafka_container, messaging_servi
             partitions=1,
             messageSchema=schema.Topic(
                 schemaType=SchemaType.JSON,
+                schemaText=NON_PII_SCHEMA_TEXT,
                 schemaFields=NON_PII_SCHEMA_FIELDS,
             ),
         )

--- a/ingestion/tests/integration/auto_classification/messaging/test_kafka_classification.py
+++ b/ingestion/tests/integration/auto_classification/messaging/test_kafka_classification.py
@@ -25,6 +25,8 @@ pytest.importorskip("confluent_kafka", reason="confluent_kafka not installed; sk
 from ingestion.tests.integration.auto_classification.messaging.conftest import (
     NON_PII_TOPIC_NAME,
     PII_TOPIC_NAME,
+    find_schema_field,
+    iter_leaf_fields,
 )
 from metadata.generated.schema.entity.data.topic import Topic
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
@@ -53,7 +55,7 @@ class TestKafkaAutoClassification:
         )
         assert topic.messageSchema is not None
         fields = topic.messageSchema.schemaFields
-        email_field = next((f for f in fields if f.name.root == "email"), None)
+        email_field = find_schema_field(fields, "email")
         assert email_field is not None
         assert email_field.tags is not None
         assert any(tag.tagFQN.root == "PII.Sensitive" for tag in email_field.tags), (
@@ -72,7 +74,7 @@ class TestKafkaAutoClassification:
             fields=["messageSchema", "tags"],
         )
         fields = topic.messageSchema.schemaFields
-        ssn_field = next((f for f in fields if f.name.root == "ssn"), None)
+        ssn_field = find_schema_field(fields, "ssn")
         assert ssn_field is not None
         assert ssn_field.tags is not None
         assert any(tag.tagFQN.root == "PII.Sensitive" for tag in ssn_field.tags)
@@ -89,7 +91,7 @@ class TestKafkaAutoClassification:
             fields=["messageSchema", "tags"],
         )
         fields = topic.messageSchema.schemaFields
-        cc_field = next((f for f in fields if f.name.root == "credit_card"), None)
+        cc_field = find_schema_field(fields, "credit_card")
         assert cc_field is not None
         assert cc_field.tags is not None
         assert any(tag.tagFQN.root == "PII.Sensitive" for tag in cc_field.tags)
@@ -106,7 +108,7 @@ class TestKafkaAutoClassification:
             fields=["messageSchema", "tags"],
         )
         fields = topic.messageSchema.schemaFields
-        id_field = next((f for f in fields if f.name.root == "customer_id"), None)
+        id_field = find_schema_field(fields, "customer_id")
         assert id_field is not None
         assert id_field.tags is None or len(id_field.tags) == 0, "customer_id should not have PII tags"
 
@@ -122,7 +124,7 @@ class TestKafkaAutoClassification:
             fields=["messageSchema", "tags"],
         )
         fields = topic.messageSchema.schemaFields
-        for field in fields:
+        for field in iter_leaf_fields(fields):
             assert field.tags is None or len(field.tags) == 0, (
                 f"Non-PII field {field.name.root} should not have PII tags"
             )

--- a/ingestion/tests/integration/auto_classification/messaging/test_redpanda_classification.py
+++ b/ingestion/tests/integration/auto_classification/messaging/test_redpanda_classification.py
@@ -21,7 +21,9 @@ pytest.importorskip("confluent_kafka", reason="confluent_kafka not installed; sk
 
 from ingestion.tests.integration.auto_classification.messaging.conftest import (
     PII_SCHEMA_FIELDS,
+    PII_SCHEMA_TEXT,
     PII_TOPIC_NAME,
+    find_schema_field,
 )
 from metadata.generated.schema.entity.data.topic import Topic
 from metadata.generated.schema.entity.services.messagingService import MessagingServiceType
@@ -117,6 +119,7 @@ def redpanda_pii_topic(metadata, kafka_pii_topic, redpanda_messaging_service):
             partitions=1,
             messageSchema=schema_module.Topic(
                 schemaType=SchemaType.JSON,
+                schemaText=PII_SCHEMA_TEXT,
                 schemaFields=PII_SCHEMA_FIELDS,
             ),
         )
@@ -174,7 +177,7 @@ class TestRedpandaAutoClassification:
             fields=["messageSchema", "tags"],
         )
         fields = topic.messageSchema.schemaFields
-        email_field = next((f for f in fields if f.name.root == "email"), None)
+        email_field = find_schema_field(fields, "email")
         assert email_field is not None
         assert email_field.tags is not None
         assert any(tag.tagFQN.root == "PII.Sensitive" for tag in email_field.tags)

--- a/ingestion/tests/unit/sampler/test_messaging_sampler.py
+++ b/ingestion/tests/unit/sampler/test_messaging_sampler.py
@@ -1,0 +1,151 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Column naming and value resolution in the messaging sampler.
+
+Column names are the contract with
+``AutoClassificationProcessor._find_column_by_dotted_path`` and must not change.
+"""
+
+import uuid
+
+import pytest
+
+from metadata.generated.schema.entity.data.topic import Topic
+from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel
+from metadata.generated.schema.type.schema import Topic as MessageSchema
+from metadata.sampler.messaging.sampler import MessagingSampler
+
+NESTED_FIELDS = [
+    FieldModel(
+        name="Order",
+        dataType=DataTypeTopic.RECORD,
+        children=[
+            FieldModel(name="order_id", dataType=DataTypeTopic.STRING),
+            FieldModel(name="email", dataType=DataTypeTopic.STRING),
+            FieldModel(
+                name="shipping",
+                dataType=DataTypeTopic.RECORD,
+                children=[
+                    FieldModel(name="city", dataType=DataTypeTopic.STRING),
+                    FieldModel(name="country", dataType=DataTypeTopic.STRING),
+                ],
+            ),
+        ],
+    )
+]
+
+FLAT_FIELDS = [
+    FieldModel(name="email", dataType=DataTypeTopic.STRING),
+    FieldModel(name="ssn", dataType=DataTypeTopic.STRING),
+]
+
+
+class _StubSampler(MessagingSampler):
+    """Messaging sampler with the broker replaced by a fixed message list."""
+
+    def __init__(self, entity: Topic, messages: list[dict]):
+        super().__init__(service_connection_config=None, ometa_client=None, entity=entity)
+        self._messages = messages
+
+    def _fetch_messages(self, count: int) -> list[dict]:
+        return self._messages[:count]
+
+
+def _topic(fields: list[FieldModel]) -> Topic:
+    return Topic(
+        id=uuid.uuid4(),
+        name="om_orders_avro",
+        partitions=1,
+        service=EntityReference(id=uuid.uuid4(), type="messagingService"),
+        messageSchema=MessageSchema(schemaFields=fields),
+    )
+
+
+def _row(sampler: _StubSampler) -> dict:
+    table_data = sampler.fetch_sample_data(columns=None)
+    return dict(zip([c.root for c in table_data.columns], table_data.rows[0], strict=True))
+
+
+def test_column_names_keep_the_schema_root_prefix() -> None:
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [{}])
+
+    assert [col.name for col in sampler.get_columns()] == [
+        "Order.order_id",
+        "Order.email",
+        "Order.shipping.city",
+        "Order.shipping.country",
+    ]
+
+
+def test_unwrapped_message_resolves_against_a_nested_schema() -> None:
+    message = {
+        "order_id": "o-1",
+        "email": "user@example.com",
+        "shipping": {"city": "Springfield", "country": "US"},
+    }
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    row = _row(sampler)
+
+    assert row["Order.order_id"] == "o-1"
+    assert row["Order.email"] == "user@example.com"
+    assert row["Order.shipping.city"] == "Springfield"
+    assert row["Order.shipping.country"] == "US"
+
+
+def test_wrapped_message_still_resolves_on_the_full_path() -> None:
+    message = {"Order": {"order_id": "o-2", "email": "other@example.com"}}
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    row = _row(sampler)
+
+    assert row["Order.order_id"] == "o-2"
+    assert row["Order.email"] == "other@example.com"
+
+
+def test_full_path_wins_when_both_shapes_are_present() -> None:
+    message = {"email": "unwrapped@example.com", "Order": {"email": "wrapped@example.com"}}
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    assert _row(sampler)["Order.email"] == "wrapped@example.com"
+
+
+def test_flat_schema_is_unaffected() -> None:
+    message = {"email": "user@example.com", "ssn": "123-45-6789"}
+    sampler = _StubSampler(_topic(FLAT_FIELDS), [message])
+
+    row = _row(sampler)
+
+    assert row["email"] == "user@example.com"
+    assert row["ssn"] == "123-45-6789"
+
+
+def test_explicit_null_does_not_inherit_a_same_named_sibling() -> None:
+    message = {"email": "sibling@example.com", "Order": {"email": None}}
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    assert _row(sampler)["Order.email"] is None
+
+
+def test_absent_field_stays_none() -> None:
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [{"order_id": "o-3"}])
+
+    assert _row(sampler)["Order.email"] is None
+
+
+@pytest.mark.parametrize("fields", [[], None])
+def test_topic_without_schema_fields_yields_no_columns(fields) -> None:
+    sampler = _StubSampler(_topic(fields), [{"email": "user@example.com"}])
+
+    assert sampler.get_columns() == []
+    assert sampler.fetch_sample_data(columns=None).rows == []

--- a/ingestion/tests/unit/sampler/test_sampler_processor_config.py
+++ b/ingestion/tests/unit/sampler/test_sampler_processor_config.py
@@ -1,0 +1,69 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""SamplerProcessor construction when the workflow declares no processor.
+
+Messaging and storage auto-classification have nothing to configure there, so
+the block is routinely omitted.
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock
+
+import pytest
+
+from metadata.sampler.processor import SamplerProcessor
+
+BASE_CONFIG = {
+    "source": {
+        "type": "kafka",
+        "serviceName": "kafka_test",
+        "serviceConnection": {
+            "config": {
+                "type": "Kafka",
+                "bootstrapServers": "localhost:9092",
+            }
+        },
+        "sourceConfig": {
+            "config": {
+                "type": "AutoClassification",
+                "storeSampleData": True,
+                "enableAutoClassification": True,
+            }
+        },
+    },
+    "sink": {"type": "metadata-rest", "config": {}},
+    "workflowConfig": {
+        "openMetadataServerConfig": {
+            "hostPort": "http://localhost:8585/api",
+            "authProvider": "openmetadata",
+            "securityConfig": {"jwtToken": "token"},
+        }
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "processor",
+    [
+        pytest.param(None, id="no-processor-block"),
+        pytest.param({"type": "orm-profiler"}, id="processor-without-config"),
+        pytest.param({"type": "orm-profiler", "config": {}}, id="processor-with-empty-config"),
+    ],
+)
+def test_processor_block_is_optional(processor) -> None:
+    config = deepcopy(BASE_CONFIG)
+    if processor is not None:
+        config["processor"] = processor
+
+    sampler_processor = SamplerProcessor.create(config, MagicMock())
+
+    assert sampler_processor.profiler_config is not None

--- a/ingestion/tests/unit/sampler/test_sampler_processor_config.py
+++ b/ingestion/tests/unit/sampler/test_sampler_processor_config.py
@@ -67,3 +67,29 @@ def test_processor_block_is_optional(processor) -> None:
     sampler_processor = SamplerProcessor.create(config, MagicMock())
 
     assert sampler_processor.profiler_config is not None
+
+
+@pytest.mark.parametrize(
+    "processor",
+    [
+        pytest.param(None, id="no-processor-block"),
+        pytest.param({"type": "orm-profiler"}, id="processor-without-config"),
+    ],
+)
+def test_profiler_source_accepts_an_absent_processor(processor) -> None:
+    """The auto-classification fetcher builds a ProfilerSource, so it sees the same config."""
+    from metadata.ingestion.api.parser import parse_workflow_config_gracefully
+    from metadata.profiler.source.database.base.profiler_source import ProfilerSource
+
+    config = deepcopy(BASE_CONFIG)
+    if processor is not None:
+        config["processor"] = processor
+
+    source = ProfilerSource(
+        config=parse_workflow_config_gracefully(config),
+        database=MagicMock(),
+        ometa_client=MagicMock(),
+        global_profiler_configuration=MagicMock(),
+    )
+
+    assert source.profiler_config is not None

--- a/ingestion/tests/unit/source/messaging/kafka/test_connection.py
+++ b/ingestion/tests/unit/source/messaging/kafka/test_connection.py
@@ -38,3 +38,73 @@ def test_test_connection_runs_steps():
         result = conn.test_connection(metadata=MagicMock())
 
     assert result is mock_step.return_value
+
+
+def _kafka_config(**overrides):
+    from metadata.generated.schema.entity.services.connections.messaging.kafkaConnection import (
+        KafkaConnection as KafkaConnectionConfig,
+    )
+
+    return KafkaConnectionConfig(bootstrapServers="localhost:9092", **overrides)
+
+
+def test_consumer_is_built_without_a_schema_registry():
+    from metadata.ingestion.source.messaging.kafka.connection import get_connection
+
+    # The consumer is built lazily, so it must be touched inside the patch or the
+    # factory resolves the real Consumer and dials a broker.
+    with patch(f"{CONNECTION_MODULE}.AdminClient"), patch(f"{CONNECTION_MODULE}.Consumer") as mock_consumer:
+        client = get_connection(_kafka_config())
+
+        assert client.schema_registry_client is None
+        assert client.consumer_client is mock_consumer.return_value
+        consumer_config = mock_consumer.call_args.args[0]
+        assert consumer_config["bootstrap.servers"] == "localhost:9092"
+        assert "value.deserializer" not in consumer_config
+
+
+def test_admin_client_does_not_inherit_consumer_only_settings():
+    from metadata.ingestion.source.messaging.kafka.connection import get_connection
+
+    with (
+        patch(f"{CONNECTION_MODULE}.AdminClient") as mock_admin,
+        patch(f"{CONNECTION_MODULE}.Consumer"),
+    ):
+        get_connection(_kafka_config())
+
+    admin_config = mock_admin.call_args.args[0]
+    assert "group.id" not in admin_config
+    assert "enable.auto.commit" not in admin_config
+
+
+def test_consumer_is_not_built_until_it_is_used():
+    from metadata.ingestion.source.messaging.kafka.connection import get_connection
+
+    with patch(f"{CONNECTION_MODULE}.AdminClient"), patch(f"{CONNECTION_MODULE}.Consumer") as mock_consumer:
+        client = get_connection(_kafka_config())
+        mock_consumer.assert_not_called()
+
+        assert client.consumer_client is mock_consumer.return_value
+        assert client.consumer_client is mock_consumer.return_value
+        mock_consumer.assert_called_once()
+
+
+def test_close_consumer_is_a_no_op_when_none_was_built():
+    from metadata.ingestion.source.messaging.kafka.connection import get_connection
+
+    with patch(f"{CONNECTION_MODULE}.AdminClient"), patch(f"{CONNECTION_MODULE}.Consumer") as mock_consumer:
+        client = get_connection(_kafka_config())
+        client.close_consumer()
+
+    mock_consumer.return_value.close.assert_not_called()
+
+
+def test_close_consumer_releases_a_built_consumer():
+    from metadata.ingestion.source.messaging.kafka.connection import get_connection
+
+    with patch(f"{CONNECTION_MODULE}.AdminClient"), patch(f"{CONNECTION_MODULE}.Consumer") as mock_consumer:
+        client = get_connection(_kafka_config())
+        client.consumer_client  # noqa: B018
+        client.close_consumer()
+
+    mock_consumer.return_value.close.assert_called_once()

--- a/ingestion/tests/unit/source/messaging/test_common_broker_source.py
+++ b/ingestion/tests/unit/source/messaging/test_common_broker_source.py
@@ -10,15 +10,32 @@
 #  limitations under the License.
 """Unit tests for common broker message decoding."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+from cachetools import LRUCache
+
 from metadata.generated.schema.type.schema import SchemaType
-from metadata.ingestion.source.messaging.common_broker_source import CommonBrokerSource
+from metadata.ingestion.source.messaging.common_broker_source import (
+    AVRO_DESERIALIZER_CACHE_SIZE,
+    CommonBrokerSource,
+    strip_confluent_framing,
+)
+
+CONFLUENT_HEADER = b"\x00\x00\x00\x00\x01"
+
+
+def _source():
+    return SimpleNamespace(
+        schema_registry_client=object(),
+        _avro_deserializers=LRUCache(maxsize=AVRO_DESERIALIZER_CACHE_SIZE),
+    )
 
 
 def test_decode_message_avro_skips_re_deserialization_for_decoded_values():
-    source = SimpleNamespace(schema_registry_client=object())
+    source = _source()
     decoded_payload = {"event_id": "1", "status": "ok"}
 
     with patch("metadata.ingestion.source.messaging.common_broker_source.AvroDeserializer") as mock_deserializer:
@@ -29,7 +46,7 @@ def test_decode_message_avro_skips_re_deserialization_for_decoded_values():
 
 
 def test_decode_message_avro_deserializes_bytes_payload():
-    source = SimpleNamespace(schema_registry_client=object())
+    source = _source()
 
     with patch("metadata.ingestion.source.messaging.common_broker_source.AvroDeserializer") as mock_deserializer:
         mock_deserializer.return_value.return_value = {"event_id": "2"}
@@ -43,8 +60,40 @@ def test_decode_message_avro_deserializes_bytes_payload():
     assert result == str({"event_id": "2"})
 
 
+def test_avro_deserializer_is_built_once_per_schema():
+    source = _source()
+
+    with patch("metadata.ingestion.source.messaging.common_broker_source.AvroDeserializer") as mock_deserializer:
+        mock_deserializer.return_value.return_value = {"event_id": "3"}
+        for _ in range(5):
+            CommonBrokerSource.decode_message(source, b"binary-payload", "avro-schema", SchemaType.Avro)
+        CommonBrokerSource.decode_message(source, b"binary-payload", "other-avro-schema", SchemaType.Avro)
+
+    assert mock_deserializer.call_count == 2
+
+
+def test_decode_message_json_payload_is_readable():
+    source = _source()
+    payload = json.dumps({"email": "user@example.com"}).encode("utf-8")
+
+    assert CommonBrokerSource.decode_message(source, payload, "", SchemaType.JSON) == payload.decode("utf-8")
+
+
+def test_decode_message_strips_confluent_framing_from_json():
+    source = _source()
+    body = json.dumps({"email": "user@example.com"}).encode("utf-8")
+
+    result = CommonBrokerSource.decode_message(source, CONFLUENT_HEADER + body, "", SchemaType.JSON)
+
+    assert result == body.decode("utf-8")
+
+
+def test_decode_message_protobuf_is_not_supported():
+    assert CommonBrokerSource.decode_message(_source(), b"anything", "", SchemaType.Protobuf) == ""
+
+
 def test_decode_message_non_avro_handles_bytes_and_decoded_values():
-    source = SimpleNamespace(schema_registry_client=object())
+    source = _source()
     decoded_payload = {"foo": "bar"}
 
     bytes_result = CommonBrokerSource.decode_message(source, b"plain-text", "ignored-schema", SchemaType.Other)
@@ -52,3 +101,18 @@ def test_decode_message_non_avro_handles_bytes_and_decoded_values():
 
     assert bytes_result == "plain-text"
     assert decoded_result == str(decoded_payload)
+
+
+def test_strip_confluent_framing_leaves_unframed_payloads_alone():
+    assert strip_confluent_framing(b"plain-text") == b"plain-text"
+    assert strip_confluent_framing(b"\x00\x00") == b"\x00\x00"
+
+
+def test_decode_message_rejects_undecodable_binary():
+    """A payload that is not valid UTF-8 must raise so the caller skips it."""
+    with pytest.raises(UnicodeDecodeError):
+        CommonBrokerSource.decode_message(_source(), b"\xff\xfe\x00binary", "", SchemaType.Other)
+
+
+def test_strip_confluent_framing_handles_a_header_only_payload():
+    assert strip_confluent_framing(CONFLUENT_HEADER) == b""

--- a/ingestion/tests/unit/test_ssl_manager.py
+++ b/ingestion/tests/unit/test_ssl_manager.py
@@ -61,9 +61,13 @@ class SSLManagerTest(TestCase):
 
 
 class KafkaSourceSSLTest(TestCase):
+    # Building a KafkaSource runs get_connection for real; without these the test
+    # spins up librdkafka clients that background-dial localhost:9092.
+    @patch("metadata.ingestion.source.messaging.kafka.connection.Consumer")
+    @patch("metadata.ingestion.source.messaging.kafka.connection.AdminClient")
     @patch("metadata.ingestion.source.messaging.messaging_service.MessagingServiceSource.test_connection")
     @patch("metadata.ingestion.source.messaging.kafka.metadata.SSLManager")
-    def test_init(self, mock_ssl_manager, test_connection):
+    def test_init(self, mock_ssl_manager, test_connection, _admin_client, _consumer):
         test_connection.return_value = True
         config = WorkflowSource(
             **{  # noqa: PIE804

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/kafkaConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/kafkaConnection.json
@@ -101,7 +101,11 @@
     "topicFilterPattern": {
       "description": "Regex to only fetch topics that matches the pattern.",
       "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern",
-      "title": "Default Topic Filter Pattern"
+      "title": "Default Topic Filter Pattern",
+      "default": {
+        "includes": [],
+        "excludes": ["^__.*", "^_schemas$", "^_confluent.*"]
+      }
     },
     "supportsMetadataExtraction": {
       "title": "Supports Metadata Extraction",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/redpandaConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/messaging/redpandaConnection.json
@@ -84,7 +84,11 @@
     "topicFilterPattern": {
       "description": "Regex to only fetch topics that matches the pattern.",
       "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern",
-      "title": "Default Topic Filter Pattern"
+      "title": "Default Topic Filter Pattern",
+      "default": {
+        "includes": [],
+        "excludes": ["^__.*", "^_schemas$", "^_confluent.*"]
+      }
     },
     "supportsMetadataExtraction": {
       "title": "Supports Metadata Extraction",


### PR DESCRIPTION
Cherry-picks three merged Kafka connector fixes onto `2.0`, found during the release connector-testing pass. All three applied cleanly with no conflicts.

| Cherry-pick | Original |
|---|---|
| `9c0de8f18f` | #30894 — resolve topic sample values against unwrapped messages |
| `2b81e68a38` | #30897 — decode Kafka sample data per topic, exclude internal topics |
| `fcd5eda83e` | #31014 — accept an absent processor block on the classification path |

## Why these matter for 2.0

**#30894 is the significant one.** Auto Classification on any messaging service stores an all-`null` sample and never applies a PII tag. The sampler names its columns from the schema tree, which always carries a root RECORD, so paths come out `Customer.email`; the message on the wire is unwrapped, so every lookup misses. Confirmed on a live 2.0 instance — the stored sample was literally `{"Customer": {"email": null, "ssn": null, ...}}` with no tag anywhere. The feature has never produced a non-null sample. It affects every Avro and JSON Schema topic, and Redpanda equally.

**#30897** — sample data only ever decoded Avro, because the consumer hard-wired `AvroDeserializer` for every topic regardless of schema type. It also silently did nothing at all when no Schema Registry was configured, since the consumer was only built inside that branch. Measured before and after on the same seeded topics, with a registry: `om_customers_json` 0 → 8 messages, `om_logs_noschema` 0 → 6, Avro topics unchanged at 10. Also gives `topicFilterPattern` a default so Kafka's own `_schemas` and `__consumer_offsets` stop arriving as Topic entities.

**#31014** — a messaging AutoClassification workflow without a `processor:` block died at startup with `AttributeError: 'NoneType' object has no attribute 'model_dump'`. Every field on `ProfilerProcessorConfig` is optional with a default, so the block was never mandatory by the model's own definition; the code simply assumed it. Verified live: the same config went from `1 Errors` / `Success 87.5%` / exit 1 to `0 Errors` / `100%` / exit 0.

## Verification on this branch

All three cherry-picked without conflict, and the suites covering every changed path are green:

```
ingestion/tests/unit/sampler
ingestion/tests/unit/source/messaging
ingestion/tests/unit/profiler
ingestion/tests/unit/test_ssl_manager.py
-> 190 passed
```

## Not included

#30952 (`fix(tests): stop the Glue pipeline unit test calling the real AWS API`) is not in this backport. It is a test-only fix for the Python unit-test job timing out — a real AWS call inside a unit test that blocks where egress is dropped, hanging an xdist worker until the 60-minute job limit. It changes no product behaviour, but if `2.0` runs the same unit-test job it will have the same hang, so it may be worth picking separately.