### PR TITLE
Backport #29068 explore search and alerts lazy-loading to 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertDiagnosticInfo/AlertDiagnosticInfoTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertDiagnosticInfo/AlertDiagnosticInfoTab.tsx
@@ -19,7 +19,7 @@ import { GRAYED_OUT_COLOR } from '../../../../constants/constants';
 import { EventSubscriptionDiagnosticInfo } from '../../../../generated/events/api/eventSubscriptionDiagnosticInfo';
 import { useFqn } from '../../../../hooks/useFqn';
 import { getDiagnosticInfo } from '../../../../rest/observabilityAPI';
-import { getDiagnosticItems } from '../../../../utils/Alerts/AlertsUtil';
+import { getDiagnosticItems } from '../../../../utils/Alerts/AlertsUtilPure';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 
 function AlertDiagnosticInfoTab() {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertRecentEventsTab/AlertRecentEventsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/AlertDetails/AlertRecentEventsTab/AlertRecentEventsTab.tsx
@@ -37,12 +37,14 @@ import {
 import { usePaging } from '../../../../hooks/paging/usePaging';
 import { getAlertEventsFromId } from '../../../../rest/alertsAPI';
 import {
-  getAlertEventsFilterLabels,
   getAlertRecentEventsFilterOptions,
   getAlertStatusIcon,
+} from '../../../../utils/Alerts/AlertsUtil';
+import {
+  getAlertEventsFilterLabels,
   getChangeEventDataFromTypedEvent,
   getLabelsForEventDetails,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
 import { getEntityName } from '../../../../utils/EntityNameUtils';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.component.tsx
@@ -26,10 +26,12 @@ import { Destination } from '../../../generated/events/eventSubscription';
 import { testAlertDestination } from '../../../rest/alertsAPI';
 import {
   getConnectionTimeoutField,
-  getFormattedDestinations,
   getReadTimeoutField,
-  listLengthValidator,
 } from '../../../utils/Alerts/AlertsUtil';
+import {
+  getFormattedDestinations,
+  listLengthValidator,
+} from '../../../utils/Alerts/AlertsUtilPure';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import './destination-form-item.less';
 import { DestinationFormItemProps } from './DestinationFormItem.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationFormItem.test.tsx
@@ -39,19 +39,23 @@ jest.mock('../../../utils/Alerts/AlertsUtil', () => ({
   getDestinationConfigField: jest
     .fn()
     .mockReturnValue(<div data-testid="destination-field" />),
-  getSubscriptionTypeOptions: jest.fn().mockReturnValue([]),
-  listLengthValidator: jest.fn().mockImplementation(() => Promise.resolve()),
-  getFilteredDestinationOptions: jest
-    .fn()
-    .mockImplementation((key) => DESTINATION_SOURCE_ITEMS[key]),
   getConnectionTimeoutField: jest
     .fn()
     .mockReturnValue(<div data-testid="connection-timeout" />),
   getReadTimeoutField: jest
     .fn()
     .mockReturnValue(<div data-testid="read-timeout" />),
+}));
+
+jest.mock('../../../utils/Alerts/AlertsUtilPure', () => ({
+  listLengthValidator: jest.fn().mockImplementation(() => Promise.resolve()),
   getFormattedDestinations: (...args: unknown[]) =>
     mockGetFormattedDestinations(...args),
+  getSubscriptionTypeOptions: jest.fn().mockReturnValue([]),
+  getFilteredDestinationOptions: jest
+    .fn()
+    .mockImplementation((key) => DESTINATION_SOURCE_ITEMS[key]),
+  normalizeDestinationConfig: jest.fn().mockImplementation((config) => config),
 }));
 
 jest.mock('../../../utils/ObservabilityUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationSelectItem/DestinationSelectItem.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/DestinationFormItem/DestinationSelectItem/DestinationSelectItem.tsx
@@ -44,10 +44,12 @@ import { ModifiedDestination } from '../../../../pages/AddObservabilityPage/AddO
 import {
   getDestinationConfigField,
   getDestinationStatusAlertData,
+} from '../../../../utils/Alerts/AlertsUtil';
+import {
   getFilteredDestinationOptions,
   getSubscriptionTypeOptions,
   normalizeDestinationConfig,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import { Transi18next } from '../../../../utils/i18next/LocalUtil';
 import { checkIfDestinationIsInternal } from '../../../../utils/ObservabilityUtils';
 import { DestinationSelectItemProps } from './DestinationSelectItem.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Alerts/FQNListSelect/FQNListSelect.component.tsx
@@ -17,10 +17,9 @@ import type { CustomTagProps } from 'rc-select/lib/BaseSelect';
 import React, { useEffect, useState } from 'react';
 import { SearchIndex } from '../../../enums/search.enum';
 import { searchQuery } from '../../../rest/searchAPI';
-import { getTermQuery } from '../../../utils/SearchUtils';
+import { getTermQuery } from '../../../utils/SearchPureUtils';
 import { AsyncSelect } from '../../common/AsyncSelect/AsyncSelect';
 import { AsyncSelectListProps } from '../../common/AsyncSelect/AsyncSelectList.interface';
-
 interface FQNListSelectProps
   extends SelectProps,
     Pick<AsyncSelectListProps, 'api'> {

--- a/openmetadata-ui/src/main/resources/ui/src/components/AuditLog/AuditLogFilters.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/AuditLog/AuditLogFilters.component.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../utils/AuditLogUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { translateWithNestedKeys } from '../../utils/i18next/LocalUtil';
-import { getTermQuery } from '../../utils/SearchUtils';
+import { getTermQuery } from '../../utils/SearchPureUtils';
 import DatePickerMenu from '../common/DatePickerMenu/DatePickerMenu.component';
 import SearchDropdown from '../SearchDropdown/SearchDropdown';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
@@ -42,7 +42,6 @@ import {
   AuditLogFiltersProps,
   FilterOption,
 } from './AuditLogFilters.interface';
-
 const ENTITY_TYPE_OPTIONS: FilterOption[] = [
   // Data Assets
   { label: 'Table', value: 'table' },

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.test.tsx
@@ -104,6 +104,15 @@ jest.mock('../../Customization/GenericProvider/GenericContext', () => ({
   }),
 }));
 
+jest.mock('../../../utils/TablePureUtils', () => {
+  const actual = jest.requireActual('../../../utils/TablePureUtils');
+
+  return {
+    ...actual,
+    pruneEmptyChildren: jest.fn().mockImplementation((value) => value),
+  };
+});
+
 jest.mock('../../../utils/TableUtils', () => {
   const actual = jest.requireActual('../../../utils/TableUtils');
 
@@ -121,7 +130,6 @@ jest.mock('../../../utils/TableUtils', () => {
         'glossary',
       ]),
     handleUpdateTableColumnSelections: jest.fn(),
-    pruneEmptyChildren: jest.fn().mockImplementation((value) => value),
   };
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerDataModel/ContainerDataModel.tsx
@@ -46,7 +46,7 @@ import { useTreeTagFilter } from '../../../hooks/useTreeTagFilter';
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from '../../../utils/ContainerDetailUtils';
+} from '../../../utils/ContainerDetailPureUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import { columnFilterIcon } from '../../../utils/TableColumn.util';
 import {
@@ -65,7 +65,6 @@ import { ColumnFilter } from '../../Database/ColumnFilter/ColumnFilter.component
 import TableDescription from '../../Database/TableDescription/TableDescription.component';
 import TableTags from '../../Database/TableTags/TableTags.component';
 import { ContainerDataModelProps } from './ContainerDataModel.interface';
-
 const ModalWithMarkdownEditor = withSuspenseFallback(
   lazy(() =>
     import('../../Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor').then(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerVersion/ContainerVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Container/ContainerVersion/ContainerVersion.component.tsx
@@ -33,7 +33,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPartialNameFromTableFQN } from '../../../utils/FqnUtils';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVers
 import VersionTable from '../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { ContainerVersionProp } from './ContainerVersion.interface';
-
 const ContainerVersion: React.FC<ContainerVersionProp> = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.component.tsx
@@ -38,7 +38,7 @@ import { listTestCases } from '../../../rest/testAPI';
 import { calculateTestCaseStatusCounts } from '../../../utils/DataQuality/DataQualityPureUtils';
 import EntityLink from '../../../utils/EntityLink';
 import { getEntityName } from '../../../utils/EntityNameUtils';
-import { toEntityData } from '../../../utils/EntitySummaryPanelUtils';
+import { toEntityData } from '../../../utils/EntitySummaryPanelPureUtils';
 import { getErrorText, stringToHTML } from '../../../utils/StringUtils';
 import {
   buildColumnBreadcrumbPath,
@@ -76,7 +76,6 @@ import {
 import './ColumnDetailPanel.less';
 import { KeyProfileMetrics } from './KeyProfileMetrics';
 import { NestedColumnsSection } from './NestedColumnsSection';
-
 const isColumn = (item: ColumnOrTask | null): item is Column => {
   return item !== null && 'dataType' in item;
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/ColumnDetailPanel/ColumnDetailPanel.test.tsx
@@ -407,7 +407,7 @@ jest.mock('../../../utils/StringUtils', () => ({
   getDecodedFqn: jest.fn().mockImplementation((fqn: string) => fqn),
 }));
 
-jest.mock('../../../utils/TableUtils', () => ({
+jest.mock('../../../utils/TablePureUtils', () => ({
   flattenColumns: jest.fn().mockImplementation((columns) => columns || []),
   generateEntityLink: jest.fn().mockImplementation((fqn) => fqn),
   getDataTypeDisplay: jest.fn().mockReturnValue('VARCHAR'),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/DataQualityTab/DataQualityTab.tsx
@@ -77,7 +77,6 @@ import {
   TestCasePermission,
 } from '../ProfilerDashboard/profilerDashboard.interface';
 import './data-quality-tab.less';
-
 const DataQualityTab: React.FC<DataQualityTabProps> = ({
   isLoading = false,
   testCases,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/ColumnProfileTable/ColumnProfileTable.test.tsx
@@ -88,8 +88,7 @@ jest.mock('../../../../../utils/CommonUtils', () => ({
     ),
 }));
 
-jest.mock('../../../../../utils/TableUtils', () => ({
-  getTableExpandableConfig: jest.fn().mockReturnValue({}),
+jest.mock('../../../../../utils/TablePureUtils', () => ({
   pruneEmptyChildren: jest.fn().mockImplementation((data) => data),
 }));
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/Profiler/TableProfiler/TableProfilerProvider.tsx
@@ -48,10 +48,8 @@ import {
   getListTestCaseBySearch,
   ListTestCaseParamsBySearch,
 } from '../../../../rest/testAPI';
-import {
-  aggregateTestResultsByEntity,
-  TestCaseCountByStatus,
-} from '../../../../utils/DataQuality/DataQualityPureUtils';
+import type { TestCaseCountByStatus } from '../../../../utils/DataQuality/DataQualityPureUtils';
+import { aggregateTestResultsByEntity } from '../../../../utils/DataQuality/DataQualityPureUtils';
 import { formatNumberWithComma } from '../../../../utils/NumberUtils';
 import { bytesToSize } from '../../../../utils/StringUtils';
 import { generateEntityLink } from '../../../../utils/TablePureUtils';
@@ -65,7 +63,6 @@ import {
   TableProfilerContextInterface,
   TableProfilerProviderProps,
 } from './TableProfiler.interface';
-
 const TestCaseFormV1 = withSuspenseFallback(
   lazy(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SchemaTable/SchemaTable.component.tsx
@@ -117,7 +117,6 @@ import { ColumnFilter } from '../ColumnFilter/ColumnFilter.component';
 import TableDescription from '../TableDescription/TableDescription.component';
 import TableTags from '../TableTags/TableTags.component';
 import { TableCellRendered } from './SchemaTable.interface';
-
 const ModalWithMarkdownEditor = withSuspenseFallback(
   lazy(() =>
     import('../../Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor').then(

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/StoredProcedureVersion/StoredProcedureVersion.component.tsx
@@ -26,7 +26,7 @@ import {
   getCommonExtraInfoForVersionDetails,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
@@ -40,7 +40,6 @@ import DataProductsContainer from '../../DataProducts/DataProductsContainer/Data
 import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { StoredProcedureVersionProp } from './StoredProcedureVersion.interface';
-
 const StoredProcedureVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDataCardBody/TableDataCardBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableDataCardBody/TableDataCardBody.tsx
@@ -20,7 +20,6 @@ import { getTagValue } from '../../../utils/TagsPureUtils';
 import EntitySummaryDetails from '../../common/EntitySummaryDetails/EntitySummaryDetails';
 import RichTextEditorPreviewerV1 from '../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import TagsViewer from '../../Tag/TagsViewer/TagsViewer';
-
 type Props = {
   description: string;
   extraInfo: Array<ExtraInfo>;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/TableVersion/TableVersion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/TableVersion/TableVersion.component.tsx
@@ -34,7 +34,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../utils/EntityVersionUtils';
+} from '../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../utils/RouterUtils';
 import { pruneEmptyChildren } from '../../../utils/TablePureUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../Entity/EntityVersionTimeLine/EntityVers
 import VersionTable from '../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../Tag/TagsContainerV2/TagsContainerV2';
 import { TableVersionProp } from './TableVersion.interface';
-
 const TableVersion: React.FC<TableVersionProp> = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryDetails.tsx
@@ -72,7 +72,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { DirectoryDetailsProps } from './DirectoryDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Directory/DirectoryVersion/DirectoryVersion.tsx
@@ -37,7 +37,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
@@ -54,7 +54,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { DirectoryVersionProps } from './DirectoryVersion.interface';
-
 const DirectoryVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileDetails.tsx
@@ -70,7 +70,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { FileDetailsProps } from './FileDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileVersion/FileVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/File/FileVersion/FileVersion.tsx
@@ -28,7 +28,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { useRequiredParams } from '../../../../utils/useRequiredParams';
@@ -42,7 +42,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { FileVersionProps } from './FileVersion.interface';
-
 const FileVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.test.tsx
@@ -27,7 +27,6 @@ import { useRequiredParams } from '../../../utils/useRequiredParams';
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import SpreadsheetDetails from './SpreadsheetDetails';
 import { SpreadsheetDetailsProps } from './SpreadsheetDetails.interface';
-
 jest.mock('../../../hooks/useApplicationStore');
 jest.mock('../../../hooks/useCustomPages');
 jest.mock('../../../hooks/useFqn');

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetDetails.tsx
@@ -70,7 +70,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { SpreadsheetDetailsProps } from './SpreadsheetDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Spreadsheet/SpreadsheetVersion/SpreadsheetVersion.tsx
@@ -37,7 +37,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
 import { descriptionTableObject } from '../../../../utils/TableColumn.util';
@@ -54,7 +54,6 @@ import DataProductsContainer from '../../../DataProducts/DataProductsContainer/D
 import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityVersionTimeLine';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { SpreadsheetVersionProps } from './SpreadsheetVersion.interface';
-
 const SpreadsheetVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetColumnsTable/WorksheetColumnsTable.test.tsx
@@ -31,12 +31,16 @@ jest.mock('../../../../utils/TableTags/TableTags.utils', () => ({
   getAllTags: jest.fn(() => []),
   getFilteredTagsData: jest.fn((data) => data),
 }));
-jest.mock('../../../../utils/TableUtils', () => ({
-  ...jest.requireActual('../../../../utils/TableUtils'),
+jest.mock('../../../../utils/TablePureUtils', () => ({
+  ...jest.requireActual('../../../../utils/TablePureUtils'),
   pruneEmptyChildren: jest.fn().mockImplementation((columns) => columns),
-  prepareConstraintIcon: jest.fn(() => null),
   updateFieldDescription: jest.fn(),
   updateFieldTags: jest.fn(),
+}));
+
+jest.mock('../../../../utils/TableUtils', () => ({
+  ...jest.requireActual('../../../../utils/TableUtils'),
+  prepareConstraintIcon: jest.fn(() => null),
   getTableExpandableConfig: jest.fn(() => ({})),
 }));
 jest.mock(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetDetails.tsx
@@ -69,7 +69,6 @@ import { EntityName } from '../../Modals/EntityNameModal/EntityNameModal.interfa
 import PageLayoutV1 from '../../PageLayoutV1/PageLayoutV1';
 import { SourceType } from '../../SearchedData/SearchedData.interface';
 import { WorksheetDetailsProps } from './WorksheetDetails.interface';
-
 const EntityLineageTab = lazy(() =>
   import('../../Lineage/EntityLineageTab/EntityLineageTab').then((module) => ({
     default: module.EntityLineageTab,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.test.tsx
@@ -31,7 +31,7 @@ import { WorksheetVersionProps } from './WorksheetVersion.interface';
 
 jest.mock('../../../../utils/useRequiredParams');
 jest.mock('../../../../utils/RouterUtils');
-jest.mock('../../../../utils/EntityVersionUtils', () => ({
+jest.mock('../../../../utils/EntityVersionUtilsPure', () => ({
   getCommonExtraInfoForVersionDetails: jest.fn(() => ({
     ownerDisplayName: 'Test Owner',
     ownerRef: { id: 'owner-1', name: 'test-owner' },
@@ -53,8 +53,10 @@ jest.mock('../../../../utils/EntityVersionUtils', () => ({
 jest.mock('../../../../utils/FqnUtils', () => ({
   getPartialNameFromTableFQN: jest.fn(() => 'Column'),
 }));
-jest.mock('../../../../utils/TableUtils', () => ({
+jest.mock('../../../../utils/TablePureUtils', () => ({
   pruneEmptyChildren: jest.fn((columns) => columns),
+  getTagsWithoutTier: jest.fn((tags) => tags),
+  getTierTags: jest.fn(() => []),
 }));
 jest.mock('../../../common/CustomPropertyTable/CustomPropertyTable', () => ({
   CustomPropertyTable: jest.fn(() => (

--- a/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DriveService/Worksheet/WorksheetVersion/WorksheetVersion.tsx
@@ -33,7 +33,7 @@ import {
   getConstraintChanges,
   getEntityVersionByField,
   getEntityVersionTags,
-} from '../../../../utils/EntityVersionUtils';
+} from '../../../../utils/EntityVersionUtilsPure';
 import { getPartialNameFromTableFQN } from '../../../../utils/FqnUtils';
 import { getPrioritizedViewPermission } from '../../../../utils/PermissionsUtils';
 import { getVersionPath } from '../../../../utils/RouterUtils';
@@ -50,7 +50,6 @@ import EntityVersionTimeLine from '../../../Entity/EntityVersionTimeLine/EntityV
 import VersionTable from '../../../Entity/VersionTable/VersionTable.component';
 import TagsContainerV2 from '../../../Tag/TagsContainerV2/TagsContainerV2';
 import { WorksheetVersionProps } from './WorksheetVersion.interface';
-
 const WorksheetVersion = ({
   version,
   currentVersionData,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityLineage/CustomControls.component.tsx
@@ -58,7 +58,7 @@ import { useFqn } from '../../../hooks/useFqn';
 import { useLineageStore } from '../../../hooks/useLineageStore';
 import { QueryFieldInterface } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { exportLineageByEntityCountAsync } from '../../../rest/lineageAPI';
-import { getQuickFilterQuery } from '../../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../../utils/ExplorePureUtils';
 import { getSearchNameEsQuery } from '../../../utils/Lineage/LineageUtils';
 import { useRequiredParams } from '../../../utils/useRequiredParams';
 import Searchbar from '../../common/SearchBarComponent/SearchBar.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/AdvanceSearchProvider/AdvanceSearchProvider.component.tsx
@@ -33,8 +33,8 @@ import { SearchIndex } from '../../../enums/search.enum';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
 import { TabsInfoData } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { getAllCustomProperties } from '../../../rest/metadataTypeAPI';
+import { getEmptyJsonTree } from '../../../utils/AdvancedSearchPureUtils';
 import {
-  getEmptyJsonTree,
   getTreeConfig,
   processEntityTypeFields,
 } from '../../../utils/AdvancedSearchUtils';
@@ -49,7 +49,6 @@ import {
   AdvanceSearchProviderProps,
   SearchOutputType,
 } from './AdvanceSearchProvider.interface';
-
 const AdvancedSearchContext = createContext<AdvanceSearchContext>(
   {} as AdvanceSearchContext
 );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CustomPropertiesSection/CustomPropertiesSection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/CustomPropertiesSection/CustomPropertiesSection.test.tsx
@@ -75,7 +75,7 @@ jest.mock('../../../common/ErrorWithPlaceholder/ErrorPlaceHolderNew', () => ({
 }));
 
 // Mock utility functions
-jest.mock('../../../../utils/EntityBreadcrumbUtils', () => ({
+jest.mock('../../../../utils/EntityLinkUtils', () => ({
   getEntityLinkFromType: jest.fn().mockReturnValue('/test-entity-link'),
 }));
 jest.mock('../../../../utils/EntityNameUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DataProductSummary/DataProductSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DataProductSummary/DataProductSummary.component.tsx
@@ -16,7 +16,7 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { EntityType } from '../../../../enums/entity.enum';
 import { DataProduct } from '../../../../generated/entity/domains/dataProduct';
-import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelUtils';
+import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelPureUtils';
 import { DomainLabel } from '../../../common/DomainLabel/DomainLabel.component';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DomainSummary/DomainSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/DomainSummary/DomainSummary.component.tsx
@@ -15,7 +15,7 @@ import { get } from 'lodash';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Domain } from '../../../../generated/entity/domains/domain';
-import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelUtils';
+import { getSortedTagsWithHighlight } from '../../../../utils/EntitySummaryPanelPureUtils';
 import { OwnerLabel } from '../../../common/OwnerLabel/OwnerLabel.component';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import SummaryTagsDescription from '../../../common/SummaryTagsDescription/SummaryTagsDescription.component';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/SummaryList/SummaryListItems/SummaryListItems.component.tsx
@@ -20,7 +20,6 @@ import AppBadge from '../../../../common/Badge/Badge.component';
 import RichTextEditorPreviewerV1 from '../../../../common/RichTextEditor/RichTextEditorPreviewerV1';
 import TagsViewer from '../../../../Tag/TagsViewer/TagsViewer';
 import { SummaryListItemProps } from './SummaryListItems.interface';
-
 const { Text, Paragraph } = Typography;
 
 function SummaryListItem({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/EntitySummaryPanel/TagsSummary/TagsSummary.component.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SearchIndex } from '../../../../enums/search.enum';
 import { searchQuery } from '../../../../rest/searchAPI';
-import { getTermQuery } from '../../../../utils/SearchUtils';
+import { getTermQuery } from '../../../../utils/SearchPureUtils';
 import SummaryPanelSkeleton from '../../../common/Skeleton/SummaryPanelSkeleton/SummaryPanelSkeleton.component';
 import TableDataCardV2 from '../../../common/TableDataCardV2/TableDataCardV2';
 import { SourceType } from '../../../SearchedData/SearchedData.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreQuickFilters.tsx
@@ -21,7 +21,7 @@ import { SearchIndex } from '../../enums/search.enum';
 import useCustomLocation from '../../hooks/useCustomLocation/useCustomLocation';
 import { useSearchStore } from '../../hooks/useSearchStore';
 import { QueryFilterInterface } from '../../pages/ExplorePage/ExplorePage.interface';
-import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchUtils';
+import { getOptionsFromAggregationBucket } from '../../utils/AdvancedSearchPureUtils';
 import {
   getCombinedQueryFilterObject,
   getQuickFilterWithDeletedFlag,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreTree/ExploreTree.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/ExploreTree/ExploreTree.tsx
@@ -37,7 +37,7 @@ import {
   getSubLevelHierarchyKey,
   updateTreeData,
   updateTreeDataWithCounts,
-} from '../../../utils/ExploreUtils';
+} from '../../../utils/ExplorePureUtils';
 import { Transi18next } from '../../../utils/i18next/LocalUtil';
 import searchClassBase from '../../../utils/SearchClassBase';
 import serviceUtilClassBase from '../../../utils/ServiceUtilClassBase';
@@ -53,7 +53,6 @@ import {
   ExploreTreeProps,
   TreeNodeData,
 } from './ExploreTree.interface';
-
 const ExploreTreeTitle = ({ node }: { node: ExploreTreeNode }) => {
   const tooltipText = node.tooltip ?? node.title;
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Explore/QuickFilterDropdown.tsx
@@ -22,7 +22,7 @@ import { debounce, isUndefined } from 'lodash';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
-import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchUtils';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
 import Loader from '../common/Loader/Loader';
 import { SearchDropdownOption } from '../SearchDropdown/SearchDropdown.interface';
 import { QuickFilterDropdownProps } from './QuickFilterDropdown.interface';

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -58,7 +58,7 @@ import { getCombinedQueryFilterObject } from '../../utils/ExplorePage/ExplorePag
 import {
   getExploreQueryFilterMust,
   getSelectedValuesFromQuickFilter,
-} from '../../utils/ExploreUtils';
+} from '../../utils/ExplorePureUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import withSuspenseFallback from '../AppRouter/withSuspenseFallback';
 import FilterErrorPlaceHolder from '../common/ErrorWithPlaceholder/FilterErrorPlaceHolder';
@@ -76,7 +76,6 @@ import { ReactComponent as IconAscending } from './../../assets/svg/ic-ascending
 import { ReactComponent as IconDescending } from './../../assets/svg/ic-descending.svg';
 import './exploreV1.less';
 import { IndexNotFoundBanner } from './IndexNotFoundBanner';
-
 const EntitySummaryPanel = withSuspenseFallback(
   lazy(
     () =>

--- a/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/LineageTable/LineageTable.tsx
@@ -58,7 +58,7 @@ import {
 import { getEntityLinkFromType } from '../../utils/EntityLinkUtils';
 import { getEntityName } from '../../utils/EntityNameUtils';
 import { highlightSearchText } from '../../utils/EntitySearchUtils';
-import { getQuickFilterQuery } from '../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../utils/ExplorePureUtils';
 import Fqn from '../../utils/Fqn';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.component.tsx
@@ -30,7 +30,6 @@ import { ActivityFeedTabs } from '../ActivityFeed/ActivityFeedTab/ActivityFeedTa
 import ProfilePicture from '../common/ProfilePicture/ProfilePicture';
 import { SourceType } from '../SearchedData/SearchedData.interface';
 import { NotificationFeedProp } from './NotificationFeedCard.interface';
-
 const NotificationFeedCard: FC<NotificationFeedProp> = ({
   createdBy,
   entityFQN,

--- a/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/NotificationBox/NotificationFeedCard.test.tsx
@@ -19,6 +19,10 @@ import NotificationFeedCard from './NotificationFeedCard.component';
 jest.mock('../../utils/date-time/DateTimeUtils', () => ({
   formatDateTime: jest.fn().mockImplementation((date) => date),
   getRelativeTime: jest.fn().mockImplementation((date) => date),
+  getEpochMillisForPastDays: jest.fn().mockImplementation((days) => days),
+  getStartOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getEndOfDayInMillis: jest.fn().mockImplementation((val) => val),
+  getCurrentMillis: jest.fn().mockReturnValue(0),
 }));
 
 const mockPrepareFeedLink = jest.fn();

--- a/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/SearchDropdown/SearchDropdown.tsx
@@ -40,10 +40,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as DropDown } from '../../assets/svg/drop-down.svg';
 import { NULL_OPTION_KEY } from '../../constants/AdvancedSearch.constants';
+import { getSelectedOptionLabelString } from '../../utils/AdvancedSearchPureUtils';
 import {
   generateSearchDropdownLabel,
   getSearchDropdownLabels,
-  getSelectedOptionLabelString,
 } from '../../utils/AdvancedSearchUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import Loader from '../common/Loader/Loader';
@@ -52,7 +52,6 @@ import {
   SearchDropdownOption,
   SearchDropdownProps,
 } from './SearchDropdown.interface';
-
 const SearchDropdown: FC<SearchDropdownProps> = ({
   dropdownClassName,
   isSuggestionsLoading,

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.component.tsx
@@ -22,16 +22,15 @@ import {
   Effect,
   EventSubscription,
 } from '../../../../generated/events/eventSubscription';
+import { EDIT_LINK_PATH } from '../../../../utils/Alerts/AlertsUtil';
 import {
-  EDIT_LINK_PATH,
   getDisplayNameForEntities,
   getFunctionDisplayName,
-} from '../../../../utils/Alerts/AlertsUtil';
+} from '../../../../utils/Alerts/AlertsUtilPure';
 import TitleBreadcrumb from '../../../common/TitleBreadcrumb/TitleBreadcrumb.component';
 import { TitleBreadcrumbProps } from '../../../common/TitleBreadcrumb/TitleBreadcrumb.interface';
 import PageHeader from '../../../PageHeader/PageHeader.component';
 import { HeaderProps } from '../../../PageHeader/PageHeader.interface';
-
 interface AlertDetailsComponentProps {
   alerts: EventSubscription;
   onDelete: () => void;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Alerts/AlertsDetails/AlertDetails.test.tsx
@@ -23,6 +23,9 @@ import { AlertDetailsComponent } from './AlertDetails.component';
 
 jest.mock('../../../../utils/Alerts/AlertsUtil', () => ({
   EDIT_LINK_PATH: 'Edit Alert Link',
+}));
+
+jest.mock('../../../../utils/Alerts/AlertsUtilPure', () => ({
   getDisplayNameForEntities: jest.fn().mockImplementation((entity) => entity),
   getFunctionDisplayName: jest
     .fn()

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JSONSchemaTemplate/WorkflowArrayFieldTemplate.tsx
@@ -20,7 +20,6 @@ import { ReactComponent as CopyLeft } from '../../../../../assets/svg/copy-left.
 import { useClipboard } from '../../../../../hooks/useClipBoard';
 import { splitCSV } from '../../../../../utils/CSV/CSVPureUtils';
 import './workflow-array-field-template.less';
-
 const WorkflowArrayFieldTemplate = (props: FieldProps) => {
   const { t } = useTranslation();
   const isFilterPatternField = (id: string) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/QueryBuilderWidget/QueryBuilderWidget.tsx
@@ -42,7 +42,7 @@ import { searchQuery } from '../../../../../../rest/searchAPI';
 import {
   getEmptyJsonTree,
   getEmptyJsonTreeForQueryBuilder,
-} from '../../../../../../utils/AdvancedSearchUtils';
+} from '../../../../../../utils/AdvancedSearchPureUtils';
 import { elasticSearchFormat } from '../../../../../../utils/QueryBuilderElasticsearchFormatUtils';
 import {
   addEntityTypeFilter,
@@ -51,14 +51,13 @@ import {
   getJsonTreeFromQueryFilter,
   migrateJsonLogic,
   READONLY_SETTINGS,
-} from '../../../../../../utils/QueryBuilderUtils';
+} from '../../../../../../utils/QueryBuilderPureUtils';
 import { getExplorePath } from '../../../../../../utils/RouterUtils';
 import searchClassBase from '../../../../../../utils/SearchClassBase';
 import { withAdvanceSearch } from '../../../../../AppRouter/withAdvanceSearch';
 import { useAdvanceSearch } from '../../../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.component';
 import { SearchOutputType } from '../../../../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import './query-builder-widget.less';
-
 const QueryBuilderWidget: FC<
   WidgetProps & {
     fields?: Config['fields'];

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/SelectWidget.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Form/JSONSchema/JsonSchemaWidgets/SelectWidget.tsx
@@ -17,7 +17,6 @@ import { FC } from 'react';
 import { filterSelectOptions } from '../../../../../utils/FilterQueryUtils';
 import { getPopupContainer } from '../../../../../utils/formPureUtils';
 import TreeSelectWidget from './TreeSelectWidget';
-
 const getDisplayLabel = (
   label: string | number | boolean | null,
   shouldCapitalize: boolean

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.test.tsx
@@ -23,7 +23,7 @@ import { EntityType } from '../../../enums/entity.enum';
 import { searchQuery } from '../../../rest/searchAPI';
 import { getTreeConfig } from '../../../utils/AdvancedSearchUtils';
 import * as QueryBuilderElasticsearchFormatUtils from '../../../utils/QueryBuilderElasticsearchFormatUtils';
-import * as QueryBuilderUtils from '../../../utils/QueryBuilderUtils';
+import * as QueryBuilderUtils from '../../../utils/QueryBuilderPureUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
 import { SearchOutputType } from '../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import QueryBuilderWidgetV1 from './QueryBuilderWidgetV1';
@@ -48,6 +48,7 @@ jest.mock('../../../utils/AdvancedSearchUtils', () => ({
 }));
 
 jest.mock('../../../utils/QueryBuilderUtils');
+jest.mock('../../../utils/QueryBuilderPureUtils');
 jest.mock('../../../utils/QueryBuilderElasticsearchFormatUtils');
 jest.mock('../../../utils/RouterUtils', () => {
   return {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/QueryBuilderWidgetV1.tsx
@@ -50,22 +50,19 @@ import { EntityType } from '../../../enums/entity.enum';
 import { SearchIndex } from '../../../enums/search.enum';
 import { QueryFilterInterface } from '../../../pages/ExplorePage/ExplorePage.interface';
 import { searchQuery } from '../../../rest/searchAPI';
-import {
-  getEmptyJsonTreeForQueryBuilder,
-  getTreeConfig,
-} from '../../../utils/AdvancedSearchUtils';
+import { getEmptyJsonTreeForQueryBuilder } from '../../../utils/AdvancedSearchPureUtils';
+import { getTreeConfig } from '../../../utils/AdvancedSearchUtils';
 import { elasticSearchFormat } from '../../../utils/QueryBuilderElasticsearchFormatUtils';
 import {
   addEntityTypeFilter,
   getEntityTypeAggregationFilter,
   getJsonTreeFromQueryFilter,
   READONLY_SETTINGS,
-} from '../../../utils/QueryBuilderUtils';
+} from '../../../utils/QueryBuilderPureUtils';
 import { getExplorePath } from '../../../utils/RouterUtils';
 import searchClassBase from '../../../utils/SearchClassBase';
 import { SearchOutputType } from '../../Explore/AdvanceSearchProvider/AdvanceSearchProvider.interface';
 import './query-builder-widget-v1.less';
-
 const QueryBuilderWidgetV1: FC<{
   fields?: Config['fields'];
   onChange?: (value: string, tree?: JsonTree) => void;

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -134,7 +134,7 @@ import {
 import { getLoadingStatusValue } from '../../utils/EntityLineageUtils';
 import { updateNodeType } from '../../utils/EntityPureUtils';
 import { getEntityReferenceFromEntity } from '../../utils/EntityReferenceUtils';
-import { getQuickFilterQuery } from '../../utils/ExploreUtils';
+import { getQuickFilterQuery } from '../../utils/ExplorePureUtils';
 import { addBaseNodeDepthToNodes } from '../../utils/Lineage/LineageUtils';
 import tableClassBase from '../../utils/TableClassBase';
 import { showErrorToast } from '../../utils/ToastUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.test.tsx
@@ -124,6 +124,28 @@ jest.mock(
   () => jest.fn().mockReturnValue(<span>ContainerDataModel</span>)
 );
 
+jest.mock('../../components/Customization/GenericTab/GenericTab', () => ({
+  GenericTab: jest.fn().mockImplementation(() => {
+    const { getContainerByName } = jest.requireMock('../../rest/storageAPI');
+
+    getContainerByName('s3_storage_sample.transactions', {
+      fields: 'children',
+    });
+
+    return (
+      <>
+        <span>DescriptionV1</span>
+        <span>ContainerDataModel</span>
+        <span>CustomPropertyTable</span>
+        <span>label.glossary-term</span>
+        <span>label.tag-plural</span>
+        <span>label.data-product-plural</span>
+        <span>ContainerChildren</span>
+      </>
+    );
+  }),
+}));
+
 jest.mock(
   '../../components/DataAssets/DataAssetsHeader/DataAssetsHeader.component',
   () => ({
@@ -256,6 +278,26 @@ jest.mock('../../utils/ToastUtils', () => ({
   showSuccessToast: jest.fn(),
 }));
 
+jest.mock(
+  '../../components/Customization/GenericProvider/GenericProvider',
+  () => ({
+    GenericProvider: jest
+      .fn()
+      .mockImplementation(({ children }) => <>{children}</>),
+    useGenericContext: jest.fn().mockReturnValue({
+      data: {},
+      permissions: {
+        EditAll: true,
+        EditDescription: true,
+        EditGlossaryTerms: true,
+        EditTags: true,
+      },
+      isVersionView: false,
+      deleted: false,
+    }),
+  })
+);
+
 const mockUseParams = jest.fn().mockReturnValue({
   fqn: MOCK_CONTAINER_DATA.fullyQualifiedName,
   tab: 'schema',
@@ -302,6 +344,14 @@ jest.mock('../../hooks/useEntityRules', () => ({
 
 describe('Container Page Component', () => {
   beforeEach(() => {
+    mockGetEntityPermissionByFqn.mockResolvedValue({
+      ViewBasic: true,
+    });
+    mockUseParams.mockReturnValue({
+      fqn: MOCK_CONTAINER_DATA.fullyQualifiedName,
+      tab: 'schema',
+    });
+
     const { getPrioritizedEditPermission, getPrioritizedViewPermission } =
       jest.requireMock('../../utils/PermissionsUtils');
     getPrioritizedEditPermission.mockReturnValue(true);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContainerPage/ContainerPage.tsx
@@ -89,7 +89,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const ContainerPage = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.test.tsx
@@ -189,12 +189,15 @@ jest.mock('../../rest/feedsAPI', () => ({
   postThread: jest.fn().mockImplementation(() => Promise.resolve({})),
 }));
 
-jest.mock('../../utils/TableUtils', () => ({
+jest.mock('../../utils/TablePureUtils', () => ({
   getUsagePercentile: jest.fn().mockReturnValue('Medium - 45th pctile'),
   getTierTags: jest.fn().mockImplementation(() => ({})),
   getTagsWithoutTier: jest.fn().mockImplementation(() => []),
-  getTableExpandableConfig: jest.fn().mockReturnValue({}),
   extractColumnsFromData: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock('../../utils/TableUtils', () => ({
+  getTableExpandableConfig: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('../../components/common/NextPrevious/NextPrevious', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseDetailsPage/DatabaseDetailsPage.tsx
@@ -97,7 +97,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const DatabaseDetails: FunctionComponent = () => {
   const { t } = useTranslation();
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.component.tsx
@@ -95,7 +95,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const DatabaseSchemaPage: FunctionComponent = () => {
   const { t } = useTranslation();
   const { getEntityPermissionByFqn } = usePermissionProvider();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaPage/DatabaseSchemaPage.test.tsx
@@ -25,7 +25,6 @@ import {
   mockPatchDatabaseSchemaDetailsData,
   mockPostThreadData,
 } from './mocks/DatabaseSchemaPage.mock';
-
 const mockEntityPermissionByFqn = jest
   .fn()
   .mockImplementation(() => DEFAULT_ENTITY_PERMISSION);
@@ -122,9 +121,13 @@ jest.mock('../../utils/CommonUtils', () => ({
   getEntityMissingError: jest.fn().mockImplementation((error) => error),
   getFeedCounts: jest.fn().mockImplementation(() => FEED_COUNT_INITIAL_DATA),
 }));
+
 jest.mock('../../utils/FeedUtilsPure', () => ({
   fetchEntityActivityCountInto: jest.fn(),
   fetchEntityTaskCountsInto: jest.fn(),
+}));
+
+jest.mock('../../utils/TagsUtils', () => ({
   sortTagsCaseInsensitive: jest.fn(),
 }));
 
@@ -132,7 +135,7 @@ jest.mock('../../utils/RouterUtils', () => ({
   getDatabaseSchemaVersionPath: jest.fn().mockImplementation((path) => path),
 }));
 
-jest.mock('../../utils/TableUtils', () => ({
+jest.mock('../../utils/TablePureUtils', () => ({
   getTierTags: jest.fn(),
   getTagsWithoutTier: jest.fn(),
   extractColumnsFromData: jest.fn().mockReturnValue([]),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.test.tsx
@@ -106,6 +106,9 @@ jest.mock('../../pages/DatabaseSchemaPage/SchemaTablesTab', () =>
 jest.mock(
   '../../components/Customization/GenericProvider/GenericContext',
   () => ({
+    ...jest.requireActual(
+      '../../components/Customization/GenericProvider/GenericContext'
+    ),
     useGenericContext: jest.fn().mockImplementation(() => ({
       data: {
         tableDetails: {
@@ -144,7 +147,7 @@ jest.mock('../../utils/EntityNameUtils', () => ({
   getEntityName: jest.fn().mockReturnValue('entityName'),
 }));
 
-jest.mock('../../utils/EntityVersionUtils', () => ({
+jest.mock('../../utils/EntityVersionUtilsPure', () => ({
   getBasicEntityInfoFromVersionData: jest.fn().mockReturnValue({}),
   getCommonDiffsFromVersionData: jest.fn().mockReturnValue({}),
   getCommonExtraInfoForVersionDetails: jest.fn().mockReturnValue({}),

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseSchemaVersionPage/DatabaseSchemaVersionPage.tsx
@@ -56,7 +56,7 @@ import {
   getBasicEntityInfoFromVersionData,
   getCommonDiffsFromVersionData,
   getCommonExtraInfoForVersionDetails,
-} from '../../utils/EntityVersionUtils';
+} from '../../utils/EntityVersionUtilsPure';
 import {
   DEFAULT_ENTITY_PERMISSION,
   getPrioritizedViewPermission,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseVersionPage/DatabaseVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DatabaseVersionPage/DatabaseVersionPage.tsx
@@ -52,7 +52,7 @@ import {
   getBasicEntityInfoFromVersionData,
   getCommonDiffsFromVersionData,
   getCommonExtraInfoForVersionDetails,
-} from '../../utils/EntityVersionUtils';
+} from '../../utils/EntityVersionUtilsPure';
 import {
   DEFAULT_ENTITY_PERMISSION,
   getPrioritizedViewPermission,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -41,11 +41,10 @@ import { useSearchStore } from '../../hooks/useSearchStore';
 import { Aggregations, SearchResponse } from '../../interface/search.interface';
 import {
   extractTermKeys,
-  fetchEntityData,
   findActiveSearchIndex,
-  generateTabItems,
   parseSearchParams,
-} from '../../utils/ExploreUtils';
+} from '../../utils/ExplorePureUtils';
+import { fetchEntityData, generateTabItems } from '../../utils/ExploreUtils';
 import { getExplorePath } from '../../utils/RouterUtils';
 import searchClassBase from '../../utils/SearchClassBase';
 import { useRequiredParams } from '../../utils/useRequiredParams';

--- a/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/StoredProcedure/StoredProcedurePage.tsx
@@ -80,7 +80,6 @@ import {
 } from '../../utils/TagsPureUtils';
 import { showErrorToast, showSuccessToast } from '../../utils/ToastUtils';
 import { useRequiredParams } from '../../utils/useRequiredParams';
-
 const StoredProcedurePage = () => {
   const { t } = useTranslation();
   const { currentUser } = useApplicationStore();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.test.tsx
@@ -37,11 +37,13 @@ import {
   getEmptyJsonTreeForQueryBuilder,
   getOptionsFromAggregationBucket,
   getSchemaFieldOptions,
-  getSearchDropdownLabels,
   getSearchLabel,
   getSelectedOptionLabelString,
   getServiceOptions,
   getTasksOptions,
+} from './AdvancedSearchPureUtils';
+import {
+  getSearchDropdownLabels,
   processCustomPropertyField,
   processEntityTypeFields,
 } from './AdvancedSearchUtils';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AdvancedSearchUtils.tsx
@@ -39,23 +39,6 @@ import { t } from './i18next/LocalUtil';
 import jsonLogicSearchClassBase from './JSONLogicSearchClassBase';
 import searchClassBase from './SearchClassBase';
 
-export {
-  formatQueryValueBasedOnType,
-  getAssetsPageQuickFilters,
-  getChartsOptions,
-  getColumnsOptions,
-  getCustomPropertyAdvanceSearchEnumOptions,
-  getDataModelOptions,
-  getEmptyJsonTree,
-  getEmptyJsonTreeForQueryBuilder,
-  getOptionsFromAggregationBucket,
-  getSchemaFieldOptions,
-  getSearchLabel,
-  getSelectedOptionLabelString,
-  getServiceOptions,
-  getTasksOptions,
-} from './AdvancedSearchPureUtils';
-
 export const getDropDownItems = (index: string): ExploreQuickFilterField[] => {
   return searchClassBase.getDropDownItems(index);
 };

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.test.tsx
@@ -38,32 +38,34 @@ import {
 import { ModifiedDestination } from '../../pages/AddObservabilityPage/AddObservabilityPage.interface';
 import { searchContracts } from '../../rest/contractAPI';
 import { searchQuery } from '../../rest/searchAPI';
-import { getTermQuery } from '../SearchUtils';
+import { getTermQuery } from '../SearchPureUtils';
 import {
-  getAlertActionTypeDisplayName,
-  getAlertEventsFilterLabels,
   getAlertExtraInfo,
   getAlertRecentEventsFilterOptions,
   getAlertsActionTypeIcon,
   getAlertStatusIcon,
+  getConnectionTimeoutField,
+  getDestinationConfigField,
+  getFieldByArgumentType,
+  getFqnSearchIndexes,
+  searchEntity,
+} from './AlertsUtil';
+import {
+  getAlertActionTypeDisplayName,
+  getAlertEventsFilterLabels,
   getChangeEventDataFromTypedEvent,
   getConfigHeaderArrayFromObject,
   getConfigHeaderObjectFromArray,
   getConfigQueryParamsArrayFromObject,
   getConfigQueryParamsObjectFromArray,
-  getConnectionTimeoutField,
-  getDestinationConfigField,
   getDisplayNameForEntities,
-  getFieldByArgumentType,
   getFilteredDestinationOptions,
   getFormattedDestinations,
-  getFqnSearchIndexes,
   getFunctionDisplayName,
   getLabelsForEventDetails,
   listLengthValidator,
   normalizeDestinationConfig,
-  searchEntity,
-} from './AlertsUtil';
+} from './AlertsUtilPure';
 
 jest.mock('antd', () => ({
   ...jest.requireActual('antd'),

--- a/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/Alerts/AlertsUtil.tsx
@@ -11,28 +11,6 @@
  *  limitations under the License.
  */
 
-export {
-  getAlertActionTypeDisplayName,
-  getAlertEventsFilterLabels,
-  getChangeEventDataFromTypedEvent,
-  getConfigHeaderArrayFromObject,
-  getConfigHeaderObjectFromArray,
-  getConfigQueryParamsArrayFromObject,
-  getConfigQueryParamsObjectFromArray,
-  getDiagnosticItems,
-  getDisplayNameForEntities,
-  getFilteredDestinationOptions,
-  getFormattedDestinations,
-  getFunctionDisplayName,
-  getLabelsForEventDetails,
-  getMessageFromArgumentName,
-  getRandomizedAlertName,
-  getSelectOptionsFromEnum,
-  getSubscriptionTypeOptions,
-  listLengthValidator,
-  normalizeDestinationConfig,
-} from './AlertsUtilPure';
-
 import {
   CheckCircleOutlined,
   CloseOutlined,
@@ -104,7 +82,7 @@ import { getEntityName, getEntityNameLabel } from '../EntityNameUtils';
 import { t } from '../i18next/LocalUtil';
 import { getConfigFieldFromDestinationType } from '../ObservabilityUtils';
 import searchClassBase from '../SearchClassBase';
-import { getTermQuery } from '../SearchUtils';
+import { getTermQuery } from '../SearchPureUtils';
 import { showErrorToast } from '../ToastUtils';
 import './alerts-util.less';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.test.tsx
@@ -38,8 +38,8 @@ import {
 import type { EntityDataMapValue } from './ColumnUpdateUtils.interface';
 
 // Mock dependencies
-jest.mock('./TableUtils', () => {
-  const actual = jest.requireActual('./TableUtils');
+jest.mock('./TablePureUtils', () => {
+  const actual = jest.requireActual('./TablePureUtils');
 
   return {
     ...actual,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ColumnUpdateUtils.ts
@@ -37,7 +37,7 @@ import {
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from './ContainerDetailUtils';
+} from './ContainerDetailPureUtils';
 import {
   findFieldByFQN,
   normalizeTags,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.ts
@@ -16,9 +16,8 @@ import { Column, DataType } from '../generated/entity/data/container';
 import {
   updateContainerColumnDescription,
   updateContainerColumnTags,
-} from './ContainerDetailUtils';
+} from './ContainerDetailPureUtils';
 import { getEntityDetailsPath } from './RouterUtils';
-
 const mockTagOptions = [
   {
     tagFQN: 'PII.Sensitive',

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.test.tsx
@@ -18,7 +18,7 @@ import {
 } from '../generated/entity/data/container';
 import { EntityReference } from '../generated/type/entityReference';
 import { LabelType, State } from '../generated/type/tagLabel';
-import { extractContainerColumns } from './ContainerDetailUtils';
+import { extractContainerColumns } from './ContainerDetailPureUtils';
 
 type ContainerTestData = Partial<Container> &
   Pick<Omit<EntityReference, 'type'>, 'id'>;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ContainerDetailUtils.tsx
@@ -10,12 +10,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-export {
-  ContainerFields,
-  extractContainerColumns,
-  updateContainerColumnDescription,
-  updateContainerColumnTags,
-} from './ContainerDetailPureUtils';
 
 import { Col, Row } from 'antd';
 import { get } from 'lodash';

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DatabaseSchemaDetailsUtils.tsx
@@ -12,7 +12,7 @@
  */
 
 import { TabSpecificField } from '../enums/entity.enum';
-import { getTermQuery } from './SearchUtils';
+import { getTermQuery } from './SearchPureUtils';
 
 export const defaultFields = `${TabSpecificField.TAGS},${TabSpecificField.OWNERS},${TabSpecificField.USAGE_SUMMARY},${TabSpecificField.DOMAINS},${TabSpecificField.DATA_PRODUCTS}`;
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
@@ -22,7 +22,7 @@ import {
   getSelectedValuesFromQuickFilter,
   getSubLevelHierarchyKey,
   updateTreeData,
-} from './ExploreUtils';
+} from './ExplorePureUtils';
 
 describe('Explore Utils', () => {
   it('should return undefined if data is empty', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -41,24 +41,6 @@ import {
 import { escapeESReservedCharacters } from './StringUtils';
 import { showErrorToast } from './ToastUtils';
 
-export {
-  extractTermKeys,
-  findActiveSearchIndex,
-  getAggregations,
-  getExploreQueryFilterMust,
-  getParseValueFromLocation,
-  getQuickFilterObject,
-  getQuickFilterObjectForEntities,
-  getQuickFilterQuery,
-  getSelectedValuesFromQuickFilter,
-  getSubLevelHierarchyKey,
-  isElasticsearchError,
-  parseSearchParams,
-  updateCountsInTreeData,
-  updateTreeData,
-  updateTreeDataWithCounts,
-} from './ExplorePureUtils';
-
 export const getAggregationOptions = async (
   index: SearchIndex | SearchIndex[],
   key: string,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.test.ts
@@ -23,8 +23,7 @@ import {
   getJsonTreeFromQueryFilter,
   jsonLogicToElasticsearch,
   resolveFieldType,
-} from './QueryBuilderUtils';
-
+} from './QueryBuilderPureUtils';
 jest.mock('./StringUtils', () => ({
   generateUUID: jest.fn(),
 }));

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderUtils.tsx
@@ -15,30 +15,6 @@ import type { RenderSettings } from '@react-awesome-query-builder/antd';
 import { Button } from 'antd';
 import { t } from './i18next/LocalUtil';
 
-export {
-  addEntityTypeFilter,
-  buildExploreUrlParams,
-  elasticsearchToJsonLogic,
-  getCommonFieldProperties,
-  getEntityTypeAggregationFilter,
-  getEqualFieldProperties,
-  getFieldsByKeys,
-  getJsonTreeFromQueryFilter,
-  getJsonTreePropertyFromQueryFilter,
-  getOperator,
-  getSelectAnyInProperties,
-  getSelectEqualsNotEqualsProperties,
-  getSelectNotAnyInProperties,
-  jsonLogicToElasticsearch,
-  JSONLOGIC_FIELDS_TO_IGNORE_SPLIT,
-  JSONLOGIC_OPERATORS,
-  migrateJsonLogic,
-  READONLY_SETTINGS,
-  resolveFieldType,
-  type ElasticsearchQuery,
-  type JsonLogic,
-} from './QueryBuilderPureUtils';
-
 export const renderQueryBuilderFilterButtons: RenderSettings['renderButton'] = (
   props
 ) => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.test.ts
@@ -14,11 +14,10 @@ import { EntityType } from '../enums/entity.enum';
 import { SearchIndex } from '../enums/search.enum';
 import {
   getEntityTypeFromSearchIndex,
-  getGroupLabel,
   getTermQuery,
   parseBucketsData,
-} from './SearchUtils';
-
+} from './SearchPureUtils';
+import { getGroupLabel } from './SearchUtils';
 // Add type definition for ESQueryClause to fix type errors
 type ESQueryClause = {
   term?: Record<string, string | number | boolean>;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchUtils.tsx
@@ -42,12 +42,6 @@ import i18n from './i18next/LocalUtil';
 import searchClassBase from './SearchClassBase';
 import serviceUtilClassBase from './ServiceUtilClassBase';
 
-export {
-  getEntityTypeFromSearchIndex,
-  getTermQuery,
-  parseBucketsData,
-} from './SearchPureUtils';
-
 export const getGroupLabel = (index: string) => {
   let label = '';
   let GroupIcon;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TablePureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TablePureUtils.ts
@@ -43,8 +43,8 @@ import {
   TagSource,
   type TagLabel,
 } from '../generated/type/tagLabel';
-import { extractApiEndpointFields } from './APIEndpoints/APIEndpointUtils';
-import { extractContainerColumns } from './ContainerDetailUtils';
+import { extractApiEndpointFields } from './APIEndpoints/APIEndpointFieldUtils';
+import { extractContainerColumns } from './ContainerDetailPureUtils';
 import { extractDataModelColumns } from './DashboardDataModelUtils';
 import EntityLink from './EntityLink';
 import {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TopicDetailsUtils.tsx
@@ -28,7 +28,6 @@ import { Field } from '../generated/type/schema';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import i18n from './i18next/LocalUtil';
 import { TopicDetailPageTabProps } from './TopicClassBase';
-
 const ContractTab = withSuspenseFallback(
   lazy(() =>
     import('../components/DataContract/ContractTab/ContractTab').then(

--- a/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetDetailsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/WorksheetDetailsUtils.tsx
@@ -22,7 +22,6 @@ import { EntityTabs, EntityType, TabSpecificField } from '../enums/entity.enum';
 import { PageType } from '../generated/system/ui/page';
 import { WidgetConfig } from '../pages/CustomizablePage/CustomizablePage.interface';
 import i18n from './i18next/LocalUtil';
-
 const ContractTab = withSuspenseFallback(
   lazy(() =>
     import('../components/DataContract/ContractTab/ContractTab').then(


### PR DESCRIPTION
## Summary
- Direct stacked backport for OSS sequence seq29: #29068.
- Uses the already reviewed 1.13 backport resolution from open-metadata/OpenMetadata#30135.
- This PR is stacked on the previous sequence branch so it can be reviewed and merged in ticket order.

## Tracking
- Source PR(s): #29068
- Source commit(s): d436e535
- Common branch backport PR: open-metadata/OpenMetadata#30135
- Cherry-picked commit: f20e68399c
- Depends on: ui/direct-1.13-seq27-29067-db-schema-container-lazy

## Testing
- git diff --check HEAD~1..HEAD
