### PR TITLE
test(e2e): make expandLineageSection wait on state instead of proxies

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -1441,6 +1441,41 @@ test.describe('Input Output Ports', () => {
   });
 
   test.describe('Section 7: Fullscreen Mode', () => {
+    test('Lineage stays expanded when expandLineageSection runs twice', async ({
+      page,
+    }) => {
+      const dataProduct = new DataProduct([domain]);
+
+      await test.step('Create data product with ports', async () => {
+        const { apiContext } = await getApiContext(page);
+        await dataProduct.create(apiContext);
+
+        await dataProduct.addAssets(apiContext, [
+          createAssetRef(tables[0], 'table'),
+        ]);
+
+        await dataProduct.addInputPorts(apiContext, [
+          createAssetRef(tables[0], 'table'),
+        ]);
+      });
+
+      await test.step('Navigate and expand lineage twice', async () => {
+        await sidebarClick(page, SidebarItem.DATA_PRODUCT);
+        await selectDataProduct(page, dataProduct.data);
+        await navigateToPortsTab(page);
+
+        await expandLineageSection(page);
+        // The helper is documented as "only expands if currently collapsed",
+        // so a second call must be a no-op rather than a collapse.
+        await expandLineageSection(page);
+      });
+
+      await test.step('Lineage section is still expanded', async () => {
+        await expect(page.getByTestId('ports-lineage-view')).toBeVisible();
+        await expect(page.getByTestId('toggle-fullscreen-btn')).toBeVisible();
+      });
+    });
+
     test('Toggle fullscreen mode', async ({ page }) => {
       const dataProduct = new DataProduct([domain]);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1687,15 +1687,43 @@ export const navigateToPortsTab = async (page: Page) => {
 
 /**
  * Expands the lineage section in the InputOutputPortsTab.
- * Only expands if currently collapsed.
+ * No-op when the section is already expanded.
  */
 export const expandLineageSection = async (page: Page) => {
-  const portsViewRes = page.waitForResponse((response) =>
-    response.url().includes('/portsView')
-  );
-  await page.getByTestId('toggle-lineage-collapse').click();
-  await portsViewRes;
+  const header = page.getByTestId('toggle-lineage-collapse');
+  await header.waitFor({ state: 'visible' });
+
+  // The header is a toggle, so clicking it while the section is already
+  // expanded collapses it — and no /portsView request follows, which left the
+  // response wait below hanging until the test timeout.
+  const alreadyExpanded =
+    (await header.getAttribute('aria-expanded')) === 'true';
+
+  if (!alreadyExpanded) {
+    // Match only the lineage fetch. The port-count probe hits the same
+    // /portsView endpoint but always carries pagination params, so matching on
+    // '/portsView' alone can resolve against the counts response while the
+    // lineage request is still in flight.
+    const lineageResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/portsView') &&
+        !response.url().includes('inputLimit=')
+    );
+
+    await header.click();
+    await lineageResponse;
+  }
+
   await waitForAllLoadersToDisappear(page);
+
+  // Settle on the rendered end state. A loader count alone can pass vacuously
+  // when React has not yet mounted the loader, letting callers act on a panel
+  // that is still loading.
+  await page
+    .getByTestId('ports-lineage-view')
+    .or(page.locator('.ports-lineage-view-empty'))
+    .first()
+    .waitFor({ state: 'visible' });
 };
 
 /**


### PR DESCRIPTION
## Problem

Two tests in `InputOutputPorts.spec.ts` have been **flaky in 16 of the last 16 AUT 2.0 nightly runs**:

- `Section 7: Fullscreen Mode › Toggle fullscreen mode`
- `Section 4: Removing Ports › Remove last port shows empty state`

Both fail the first attempt on a 60s timeout and pass on retry, so they are permanently in the flaky column and never block a run.

## Root cause

`expandLineageSection` had three defects, all variants of waiting on a proxy rather than the actual state:

1. **Unconditional toggle.** The accordion header is a toggle, but the helper clicked it on every call — despite its own doc comment saying *"Only expands if currently collapsed"*. Calling it on an already-expanded section **collapses** it, and because no `/portsView` request follows a collapse, the subsequent `waitForResponse` hangs until the test timeout.

2. **Ambiguous response matcher.** `url.includes('/portsView')` cannot distinguish the lineage fetch from the port-count probe — both hit the same endpoint. The wait could therefore resolve on the *counts* response while the *lineage* request was still in flight. The count probe always carries pagination params, so excluding `inputLimit=` targets the lineage call specifically.

3. **Vacuous loader wait.** `toHaveCount(0)` on `[data-testid="loader"]` passes when React has not yet mounted the loader, letting callers act on a panel that is still loading. The helper now also waits for a terminal state — `ports-lineage-view` or `.ports-lineage-view-empty`.

## Regression test

Added `Lineage stays expanded when expandLineageSection runs twice`. Against the old helper it fails with **the same signature as the flaky tests**:

```
Test timeout of 60000ms exceeded.
Error: page.waitForResponse: Target page, context or browser has been closed
   at ../utils/domain.ts:1693
```

With the fix it passes.

## Verification

| Check | Result |
|---|---|
| New regression test, before fix | failed — 60s timeout, same signature |
| New regression test, after fix | passed |
| Full `InputOutputPorts.spec.ts` | 44/44 passed |
| `--repeat-each=20` on both flaky tests + new test | 60/60 passed |

All callers of `expandLineageSection` live in `InputOutputPorts.spec.ts`, so the blast radius is one file.

> **Note on what this proves.** Both flaky tests already passed 10/10 locally *before* this change — the trigger only appears under CI load. Local green therefore demonstrates **no regression**, not that the CI flake is gone. The idempotency defect (1) is conclusively fixed and covered by a test; confirmation for the flake itself should come from the next few 2.0 nightlies.

## Not included

Investigation also surfaced a separate backend issue: `/portsView` sources `data` from `findToWithOffset` + `Entity.getEntities(..., NON_DELETED)` but `total` from a separate `countFindTo`, and silently drops unresolvable records without adjusting `total`. Soft-deleting an asset that is a port reproduces it deterministically — the UI then shows "Input Ports (1)" beside "assign assets to this Data Product". That is a real user-facing bug but it would not have stabilised these tests, so it belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)