### PR TITLE
test(e2e): match docStore update in navigation blocker save test

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/NavigationBlocker.spec.ts
@@ -213,12 +213,23 @@ test.describe('Navigation Blocker Tests', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       adminPage.locator('[data-testid="save-button"]')
     ).toBeEnabled();
 
-    // Save changes
-    const saveResponse = adminPage.waitForResponse('/api/v1/docStore');
+    // Save changes.
+    // The persona is shared across the tests in this file and an earlier test
+    // already saves a layout for it, so this save is an UPDATE
+    // (PUT /api/v1/docStore/{id}) rather than a create. A bare
+    // '/api/v1/docStore' string is an exact URL match, and '*' does not cross
+    // a '/', so both would miss the update and hang until the test timeout.
+    const saveResponse = adminPage.waitForResponse('**/api/v1/docStore**');
     await adminPage.locator('[data-testid="save-button"]').click();
     await saveResponse;
 
-    await toastNotification(adminPage, /Page layout created successfully/i);
+    // This test asserts navigation-blocker behaviour, not create-vs-update
+    // semantics, so accept either outcome rather than depending on whether a
+    // preceding test already created the layout.
+    await toastNotification(
+      adminPage,
+      /Page layout (created|updated) successfully/i
+    );
     await expect(
       adminPage.locator('[data-testid="save-button"]')
     ).toBeDisabled();


### PR DESCRIPTION
## Problem

`Navigation Blocker Tests › should not show navigation blocker after saving changes` is flaky in:

| Branch | Flaky runs |
|---|---|
| `2.0` | **16 / 16** |
| `main` | **9 / 9** |
| `1.13` | 20 / 34 |

It fails the first attempt on a 60s timeout and passes on retry, so it sits permanently in the flaky column and never blocks a run.

```
Test timeout of 60000ms exceeded.
Error: page.waitForResponse: Target page, context or browser has been closed
waiting for response "/api/v1/docStore"
```

## Root cause

The tests in this file **share one persona** and run **sequentially** (`describe.configure({ mode: 'default' })`). An earlier test — *"should confirm navigation when Save changes is clicked"* — already saves a layout for that persona. So by the time this test saves, the request is an **UPDATE** (`PUT /api/v1/docStore/{id}`), not a create.

The wait was:

```ts
const saveResponse = adminPage.waitForResponse('/api/v1/docStore');
```

A bare string is an **exact URL match**, so it never matches the update and the await hangs until the test timeout. This was the **only exact `docStore` matcher left in the suite** — every other one uses a wildcard.

Worth noting: `*` does not cross a `/` in Playwright globs, so the sibling's `'api/v1/docStore*'` works only because *its own* save is a create. Matching the update requires `**`.

On retry, Playwright starts a fresh worker, `beforeAll` creates a **new** persona, and the save becomes a create again — which is exactly why this test always passes on the second attempt and never on the first.

Evidence from the failed attempt: the Save button is already `[disabled]` in the error-context snapshot, i.e. the save had completed — only the matcher missed it.

## Fix

- Match `**/api/v1/docStore**`, covering both create and update.
- Relax the toast assertion to accept `created` **or** `updated`. This test covers navigation-blocker behaviour, not create-vs-update semantics, and should not depend on whether a preceding test already created the layout.

## Verification

Unlike most flaky tests, this one **reproduces deterministically** by running the file in order.

| Check | Result |
|---|---|
| Full file in order, **before** fix | test 4 **fails** at 1.0m — `waiting for response "/api/v1/docStore"` (same as CI) |
| Full file in order, **after** fix | **5/5 passed**, test 4 completes in 4.3s |
| `--repeat-each=20` on the target test | **20/20 passed** |

The repeat run is meaningful here: iterations 2+ exercise the update path that was previously unmatched.

## Related

- `main` PR held as draft pending this one's nightly result.
- `1.13` carries an identical file and is also affected — not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)