### PR TITLE
docs: add 'Use It From Code' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,71 @@ Developers can use the AI SDK to build custom AI applications that use OpenMetad
 
 ---
 
+## Use It From Code
+
+Two packages, depending on what you're building.
+
+| Goal | Package | Install |
+|------|---------|---------|
+| Read/write metadata, lineage, glossary, quality | [`openmetadata-ingestion`](https://pypi.org/project/openmetadata-ingestion/) | `pip install "openmetadata-ingestion~=1.13.1.0"` |
+| Give an LLM or agent governed access (MCP, LangChain) | [`data-ai-sdk`](https://pypi.org/project/data-ai-sdk/) | `pip install data-ai-sdk` |
+
+Also available: [`@openmetadata/ai-sdk`](https://www.npmjs.com/package/@openmetadata/ai-sdk) (TypeScript), [`org.open-metadata:ai-sdk`](https://central.sonatype.com/artifact/org.open-metadata/ai-sdk) (Java).
+
+### Python SDK — connect and read metadata
+
+Match the SDK version to your server version.
+
+```python
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.services.connections.metadata.openMetadataConnection import (
+    OpenMetadataConnection, AuthProvider,
+)
+from metadata.generated.schema.security.client.openMetadataJWTClientConfig import (
+    OpenMetadataJWTClientConfig,
+)
+from metadata.ingestion.ometa.ometa_api import OpenMetadata
+
+metadata = OpenMetadata(OpenMetadataConnection(
+    hostPort="http://localhost:8585/api",
+    authProvider=AuthProvider.openmetadata,
+    securityConfig=OpenMetadataJWTClientConfig(jwtToken="<your-token>"),
+))
+assert metadata.health_check()
+
+table = metadata.get_by_name(entity=Table, fqn="sample_data.ecommerce_db.shopify.raw_product_catalog")
+print(table.description, [c.name.root for c in table.columns])
+```
+
+Entities are hierarchical — a Table belongs to a Schema, which belongs to a Database, which belongs to a DatabaseService. Every entity references its parent by `fullyQualifiedName`.
+
+### AI SDK — give an agent governed context via MCP
+
+OpenMetadata exposes an [MCP server](https://modelcontextprotocol.io/) at `/mcp`. Unlike generic connectors that only read raw database schemas, it exposes semantic search, lineage traversal, glossary/classification, and metadata mutations as tools any LLM can call.
+
+```python
+from ai_sdk import AISdk, AISdkConfig
+
+client = AISdk.from_config(AISdkConfig.from_env())
+
+# Convert MCP tools to LangChain format — one line
+tools = client.mcp.as_langchain_tools()
+
+# Or call a tool directly
+result = client.mcp.call_tool("search_metadata", {"query": "customers"})
+```
+
+Works with LangChain and OpenAI function calling out of the box.
+
+### Docs & examples
+
+- **Python SDK reference:** https://docs.open-metadata.org/latest/sdk/python
+- **MCP server guide:** https://docs.open-metadata.org/latest/how-to-guides/mcp
+- **AI SDK (MCP tools + agents):** https://github.com/open-metadata/ai-sdk
+- **REST API:** https://docs.open-metadata.org/latest/main-concepts/metadata-standard/apis
+
+---
+
 ## What You Can Build
 
 ### AI Data Discovery

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Two packages, depending on what you're building.
 
 | Goal | Package | Install |
 |------|---------|---------|
-| Read/write metadata, lineage, glossary, quality | [`openmetadata-ingestion`](https://pypi.org/project/openmetadata-ingestion/) | `pip install "openmetadata-ingestion~=1.13.1.0"` |
+| Read/write metadata, lineage, glossary, quality | [`openmetadata-ingestion`](https://pypi.org/project/openmetadata-ingestion/) | `pip install "openmetadata-ingestion"` |
 | Give an LLM or agent governed access (MCP, LangChain) | [`data-ai-sdk`](https://pypi.org/project/data-ai-sdk/) | `pip install data-ai-sdk` |
 
 Also available: [`@openmetadata/ai-sdk`](https://www.npmjs.com/package/@openmetadata/ai-sdk) (TypeScript), [`org.open-metadata:ai-sdk`](https://central.sonatype.com/artifact/org.open-metadata/ai-sdk) (Java).


### PR DESCRIPTION
## What this changes

Adds a **Use It From Code** section to the README, placed immediately after the "MCP, Semantic Search, APIs, AI SDK, and Memory" section and before "What You Can Build".

Additive only — no existing content was modified or removed.

## Why

The README describes the SDKs well but contains no code and no installable package names. Across all 310 lines:

| Term | Occurrences (before this PR) |
|---|---|
| `MCP` | 22 |
| `SDK` | 15 |
| `pip install` | **0** |
| `python` | **0** |
| `langchain` | **0** |
| `openmetadata-ingestion` | **0** |

The existing `### APIs, SDKs, Events, and Webhooks` subsection is two sentences with no example, and the Quickstart is a conceptual nine-step list rather than executable steps.

This matters beyond human readers. AI coding assistants answer "how do I use X from Python?" by lifting complete, runnable snippets — retrieval is extractive. This README is the single highest-authority OpenMetadata artifact on the web, and it currently offers nothing quotable for a coding question, so assistants fall back to third-party sources or outdated examples.

The package name is also genuinely non-obvious: the Python SDK ships in `openmetadata-ingestion`, so a reasonable guess of `pip install openmetadata` fails.

## What the section contains

- A table of the two Python packages — `openmetadata-ingestion` (metadata operations) and `data-ai-sdk` (AI / MCP / agents) — plus the TypeScript and Java packages
- A complete connect-and-read example with imports and `health_check()`
- The entity hierarchy explained (Service → Database → Schema → Table, referenced by `fullyQualifiedName`)
- An MCP example showing `as_langchain_tools()` and a direct `call_tool` invocation
- Links to the SDK reference, MCP guide, `ai-sdk` repo, and REST API docs

## Placement

Positioned at roughly 60% of the document rather than near the end. Retrieval systems weight content by position, and material in the last third of a long README is substantially less likely to be extracted. It also sits directly adjacent to the existing SDK prose, which is where a reader looking for code would already be.

## Notes for reviewers

- The version pin `~=1.13.1.0` should be bumped as releases move — worth deciding whether to pin at all here, or point to the docs for current versions.
- Code examples follow the documented 1.13 SDK surface. A maintainer running them once against a live instance before merge would be worthwhile.
- Happy to adjust placement, trim the section, or fold it into the existing `### APIs, SDKs, Events, and Webhooks` subsection instead if you prefer a smaller footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
