### PR TITLE
fix(ui): derive teams page default tab from the rendered tab list

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.test.tsx
@@ -14,6 +14,7 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { OperationPermission } from '../../../../context/PermissionProvider/PermissionProvider.interface';
 import { Team, TeamType } from '../../../../generated/entity/teams/team';
+import { TeamsPageTab } from './team.interface';
 import TeamDetailsV1 from './TeamDetailsV1';
 import { TeamDetailsProp } from './TeamDetailsV1.interface';
 
@@ -34,9 +35,10 @@ jest.mock('../../../../hooks/useApplicationStore', () => ({
   useApplicationStore: () => ({ currentUser: { id: 'admin-id' } }),
 }));
 
+let mockLocationSearch = '';
 jest.mock('../../../../hooks/useCustomLocation/useCustomLocation', () => ({
   __esModule: true,
-  default: () => ({ search: '' }),
+  default: () => ({ search: mockLocationSearch }),
 }));
 
 jest.mock(
@@ -56,8 +58,9 @@ jest.mock(
   })
 );
 
+const mockGetTabs = jest.fn().mockReturnValue([]);
 jest.mock('./TeamDetailsV1.utils', () => ({
-  getTabs: () => [],
+  getTabs: (...args: unknown[]) => mockGetTabs(...args),
 }));
 
 jest.mock('../../../common/EntityPageInfos/ManageButton/ManageButton', () =>
@@ -185,5 +188,62 @@ describe('TeamDetailsV1 Import/Export permission gating', () => {
 
     expect(await screen.findByTestId('export-button')).toBeInTheDocument();
     expect(screen.queryByTestId('import-button')).not.toBeInTheDocument();
+  });
+});
+
+describe('TeamDetailsV1 default tab selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetTabs.mockReturnValue([]);
+    mockLocationSearch = '';
+  });
+
+  it('should default to the first tab in the list when teamType is inconsistent with the tab list', async () => {
+    mockGetTabs.mockReturnValue([
+      { name: 'label.team-plural', key: TeamsPageTab.TEAMS },
+    ]);
+
+    // Corrupted data shape: root team named Organization but typed Group.
+    // The old teamType-based default picked the Users tab, which is not in
+    // the tab list, rendering no tab pane at all.
+    renderComponent({
+      currentTeam: {
+        ...ORGANIZATION_TEAM,
+        teamType: TeamType.Group,
+      } as Team,
+      childTeams: [ORGANIZATION_TEAM],
+    });
+
+    expect(await screen.findByText('TeamHierarchy')).toBeInTheDocument();
+  });
+
+  it('should default to the Users tab for a Group team', async () => {
+    mockGetTabs.mockReturnValue([
+      { name: 'label.user-plural', key: TeamsPageTab.USERS },
+      { name: 'label.asset-plural', key: TeamsPageTab.ASSETS },
+    ]);
+
+    renderComponent({
+      currentTeam: {
+        ...ORGANIZATION_TEAM,
+        name: 'group-team',
+        teamType: TeamType.Group,
+      } as Team,
+    });
+
+    expect(await screen.findByText('UserTab')).toBeInTheDocument();
+  });
+
+  it('should never fall back when an explicit activeTab is in the URL, even if it is not in the tab list yet', async () => {
+    // Plugin-contributed tabs register asynchronously; an explicit URL tab
+    // must be honored as-is rather than redirected while tabs populate.
+    mockLocationSearch = '?activeTab=policies';
+    mockGetTabs.mockReturnValue([
+      { name: 'label.team-plural', key: TeamsPageTab.TEAMS },
+    ]);
+
+    renderComponent({ childTeams: [ORGANIZATION_TEAM] });
+
+    expect(screen.queryByText('TeamHierarchy')).not.toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Team/TeamDetails/TeamDetailsV1.tsx
@@ -168,8 +168,20 @@ const TeamDetailsV1 = ({
       return activeTab;
     }
 
-    return isGroupType ? TeamsPageTab.USERS : TeamsPageTab.TEAMS;
-  }, [activeTab, isGroupType]);
+    // Derive the default from the actual tab list so a team with inconsistent
+    // name/teamType data (e.g. root team mistyped as Group) can't default to a
+    // tab that isn't rendered, which would leave the page blank.
+    const [defaultTab] = getTabs(
+      currentTeam,
+      isGroupType,
+      isOrganization,
+      0,
+      0,
+      false
+    );
+
+    return defaultTab?.key ?? TeamsPageTab.TEAMS;
+  }, [activeTab, currentTeam, isGroupType, isOrganization]);
   const [deletingUser, setDeletingUser] = useState<{
     user: UserTeams | undefined;
     state: boolean;


### PR DESCRIPTION
### Describe your changes:

The teams page picked its default tab from `teamType` alone (`Group` → Users, otherwise Teams), while the tab *list* keys on the team **name** for the root Organization team. A team with inconsistent name/teamType data (e.g. a root team mistyped as `Group` — observed on a live tenant) therefore defaulted to the Users tab, which is not rendered for Organization, leaving the page blank until a tab was clicked manually.

This PR derives the default tab from the first entry of the actual tab list (`getTabs(...)`), so the default can never point at a tab that does not exist and bad data degrades gracefully.

Guardrails (per review discussion):
- An explicit `?activeTab=` in the URL is always honored as-is — asynchronously registered plugin tabs are never redirected away from while tabs populate.
- The fallback only reads `currentTeam.name`/`teamType`, which are loaded before `TeamDetailsV1` mounts (page-level loader gates rendering), so the tab list cannot flip mid-load.


https://github.com/user-attachments/assets/e2c3f8d2-126a-45cf-804c-543f7a10b225


#
### Type of change:
- [x] Bug fix

#
### Checklist:
- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/developers/contribute) document.
- [x] My change requires a change to the documentation. → No
- [x] I have added unit tests covering the change:
  - blank-page regression (name=Organization + teamType=Group defaults to first existing tab)
  - Group team still defaults to Users tab
  - explicit `?activeTab=` never overridden even when absent from the tab list
- [x] E2E considered and intentionally skipped: the corrupted-data state cannot be created safely via API (Group type change is irreversible server-side and would permanently mutate the shared Organization team in the e2e environment); the healthy default-tab path is already covered by `Teams.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)