### PR TITLE
Fix 1.13 UI build duplicate schema editor declarations

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
@@ -70,10 +70,6 @@ const CodeEditor = withSuspenseFallback(
   lazy(() => import('../../../Database/SchemaEditor/CodeEditor'))
 );
 
-const CodeEditor = withSuspenseFallback(
-  lazy(() => import('../../../Database/SchemaEditor/CodeEditor'))
-);
-
 const ParameterForm: React.FC<ParameterFormProps> = ({ definition, table }) => {
   const { t } = useTranslation();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/IncidentManager/TestCaseResultTab/TestCaseResultTab.component.tsx
@@ -74,10 +74,6 @@ const SchemaEditor = withSuspenseFallback(
   lazy(() => import('../../../Database/SchemaEditor/SchemaEditor'))
 );
 
-const SchemaEditor = withSuspenseFallback(
-  lazy(() => import('../../../Database/SchemaEditor/SchemaEditor'))
-);
-
 function ParameterTooltipText({
   className,
   title,


### PR DESCRIPTION
## Summary
- Remove duplicated lazy declarations for CodeEditor and SchemaEditor introduced on 1.13.
- Keep the existing lazy-loaded editor behavior unchanged.

## Testing
- yarn build