### PR TITLE
perf(ui): bounded-concurrency batch upload in UploadDocumentModal (W3)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
@@ -135,8 +135,8 @@ const UploadDocumentModal: FC<UploadDocumentModalProps> = ({
       (entry) => uploadSingleFile(entry),
       () => cancelledRef.current
     );
-    const batchFiles = results.filter(
-      (file): file is ContextFile => Boolean(file)
+    const batchFiles = results.filter((file): file is ContextFile =>
+      Boolean(file)
     );
 
     if (!cancelledRef.current) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
@@ -25,6 +25,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { DOCUMENT_MAX_FILE_SIZE } from '../../../constants/ContextCenter.constants';
 import { ContextFile } from '../../../generated/entity/data/contextFile';
 import { uploadDriveFile } from '../../../rest/assetAPI';
+import { runWithConcurrencyLimit } from '../../../utils/AsyncUtils';
 import { showSuccessToast } from '../../../utils/ToastUtils';
 import {
   QueuedFile,
@@ -33,6 +34,9 @@ import {
 
 const getFileExt = (name: string) =>
   name.split('.').pop()?.toLowerCase() ?? 'empty';
+
+// Cap simultaneous uploads so a large batch does not fire one request per file at once.
+const UPLOAD_CONCURRENCY = 3;
 
 const UploadDocumentModal: FC<UploadDocumentModalProps> = ({
   isOpen,
@@ -125,17 +129,15 @@ const UploadDocumentModal: FC<UploadDocumentModalProps> = ({
     cancelledRef.current = false;
     setIsUploading(true);
 
-    const batchFiles: ContextFile[] = [];
-    for (const entry of pending) {
-      if (cancelledRef.current) {
-        break;
-      }
-
-      const contextFile = await uploadSingleFile(entry);
-      if (contextFile) {
-        batchFiles.push(contextFile);
-      }
-    }
+    const results = await runWithConcurrencyLimit(
+      pending,
+      UPLOAD_CONCURRENCY,
+      (entry) => uploadSingleFile(entry),
+      () => cancelledRef.current
+    );
+    const batchFiles = results.filter(
+      (file): file is ContextFile => Boolean(file)
+    );
 
     if (!cancelledRef.current) {
       setIsUploading(false);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.test.ts
@@ -1,0 +1,134 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { runWithConcurrencyLimit } from './AsyncUtils';
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+// Manually-resolved promise so ordering is controlled without timers
+// (the repo's Jest config uses fake timers, so setTimeout would never fire).
+const createDeferred = (): Deferred => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+
+  return { promise, resolve };
+};
+
+describe('runWithConcurrencyLimit', () => {
+  it('returns results in original order regardless of settle order', async () => {
+    const items = [0, 1, 2, 3];
+    const gates = items.map(() => createDeferred());
+    const pending = runWithConcurrencyLimit(items, 4, async (_, index) => {
+      await gates[index].promise;
+
+      return index;
+    });
+
+    // Settle in reverse order — the result array must still be index-ordered.
+    gates[3].resolve();
+    gates[2].resolve();
+    gates[1].resolve();
+    gates[0].resolve();
+
+    await expect(pending).resolves.toEqual([0, 1, 2, 3]);
+  });
+
+  it('never exceeds the concurrency limit', async () => {
+    const items = Array.from({ length: 6 }, (_, i) => i);
+    const gates = items.map(() => createDeferred());
+    let inFlight = 0;
+    let peak = 0;
+
+    const pending = runWithConcurrencyLimit(items, 3, async (index) => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await gates[index].promise;
+      inFlight -= 1;
+
+      return index;
+    });
+
+    // Only the initial pool of 3 may be in flight before anything settles.
+    expect(peak).toBe(3);
+
+    gates.forEach((gate) => gate.resolve());
+    await pending;
+
+    expect(peak).toBe(3);
+  });
+
+  it('stops starting new work once shouldStop returns true', async () => {
+    const items = Array.from({ length: 8 }, (_, i) => i);
+    const gates = items.map(() => createDeferred());
+    const started: number[] = [];
+    let stop = false;
+
+    const pending = runWithConcurrencyLimit(
+      items,
+      2,
+      async (index) => {
+        started.push(index);
+        await gates[index].promise;
+
+        return index;
+      },
+      () => stop
+    );
+
+    expect(started).toEqual([0, 1]);
+
+    stop = true;
+    gates[0].resolve();
+    gates[1].resolve();
+    await pending;
+
+    // No further items are started after the stop signal trips.
+    expect(started).toEqual([0, 1]);
+  });
+
+  it('processes every item when limit exceeds item count', async () => {
+    const worker = jest.fn(async (n: number) => n * 2);
+    const results = await runWithConcurrencyLimit([1, 2, 3], 10, worker);
+
+    expect(worker).toHaveBeenCalledTimes(3);
+    expect(results).toEqual([2, 4, 6]);
+  });
+
+  it('isolates per-item failures when the worker catches its own errors', async () => {
+    const results = await runWithConcurrencyLimit([1, 2, 3, 4], 2, async (n) => {
+      try {
+        if (n % 2 === 0) {
+          throw new Error(`fail ${n}`);
+        }
+
+        return n;
+      } catch {
+        return null;
+      }
+    });
+
+    expect(results).toEqual([1, null, 3, null]);
+  });
+
+  it('returns an empty array for empty input', async () => {
+    const worker = jest.fn();
+    const results = await runWithConcurrencyLimit([], 4, worker);
+
+    expect(results).toEqual([]);
+    expect(worker).not.toHaveBeenCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.test.ts
@@ -109,17 +109,21 @@ describe('runWithConcurrencyLimit', () => {
   });
 
   it('isolates per-item failures when the worker catches its own errors', async () => {
-    const results = await runWithConcurrencyLimit([1, 2, 3, 4], 2, async (n) => {
-      try {
-        if (n % 2 === 0) {
-          throw new Error(`fail ${n}`);
-        }
+    const results = await runWithConcurrencyLimit(
+      [1, 2, 3, 4],
+      2,
+      async (n) => {
+        try {
+          if (n % 2 === 0) {
+            throw new Error(`fail ${n}`);
+          }
 
-        return n;
-      } catch {
-        return null;
+          return n;
+        } catch {
+          return null;
+        }
       }
-    });
+    );
 
     expect(results).toEqual([1, null, 3, null]);
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AsyncUtils.ts
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Run an async worker over `items` with at most `limit` executions in flight at
+ * once, instead of one-at-a-time (`for … await`) or all-at-once (`Promise.all`).
+ *
+ * Results are written back by original index, so the returned array is in the
+ * same order as `items`. A worker that rejects propagates its rejection (wrap
+ * per-item error handling inside `worker` if you need isolation).
+ *
+ * If `shouldStop` is provided and returns `true`, no further items are started;
+ * already in-flight tasks still settle. Indices that were never started are left
+ * as holes (`undefined`) — filter the result if the caller needs only completed
+ * values.
+ */
+export const runWithConcurrencyLimit = async <T, R>(
+  items: T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>,
+  shouldStop?: () => boolean
+): Promise<R[]> => {
+  const results = new Array<R>(items.length);
+  let next = 0;
+
+  const runNext = async (): Promise<void> => {
+    while (next < items.length && !shouldStop?.()) {
+      const index = next;
+      next += 1;
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  const poolSize = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: poolSize }, () => runNext()));
+
+  return results;
+};


### PR DESCRIPTION
> **Stacked on #31079** (base branch is `perf/w2-parallelize-independent-awaits`, not `main`). Review/merge #31079 first; GitHub will retarget this to `main` automatically on merge. The diff below is only this PR's changes.

## Problem
`handleAttach` uploaded pending files **one at a time** (`for … await uploadSingleFile`), so a batch of N files cost N sequential round-trips.

## Fix
Replace the serial loop with a reusable **bounded-concurrency pool** (`runWithConcurrencyLimit`, limit 3):
- at most 3 uploads in flight instead of 1 (or an unbounded `Promise.all` that would open one request per file at once);
- **per-file error isolation** preserved — `uploadSingleFile` still catches, marks the row errored, returns `null`;
- **cancellation** honoured — `cancelledRef` stops new uploads from starting; in-flight ones settle;
- **result order** preserved, so `onUploaded` gets files in queue order.

New util `src/utils/AsyncUtils.ts` + unit tests (order, concurrency cap, stop signal, error isolation, empty input). Tests use manually-resolved deferred promises because the repo's Jest config uses fake timers.

## Testing
- Jest: `AsyncUtils` + `UploadDocumentModal` — **2 suites / 21 tests pass**.
- `lint:base` clean; `tsc --noEmit` no new errors.

Part of the UI Quality Audit — open-metadata/openmetadata-collate#5442, W3 residual under open-metadata/openmetadata-collate#5445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)