### PR TITLE
chore(migrations): move the services-overview indexes into 2.0.0

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
@@ -537,3 +537,30 @@ SET json = JSON_INSERT(
 WHERE serviceType = 'DatabricksPipeline'
   AND JSON_EXTRACT(json, '$.connection.config.token') IS NOT NULL
   AND NOT JSON_CONTAINS_PATH(json, 'one', '$.connection.config.authType');
+
+-- Services overview endpoint (/v1/services/overview) - OpenMetadata 2.0.0
+
+-- The (deleted, name) composite that lets `WHERE deleted = FALSE ORDER BY name, id` be served
+-- index-only. Nine service tables got it in 1.8.2; these four were added later and were missed,
+-- so the overview endpoint's per-type key scan would full-scan them.
+CREATE INDEX idx_security_service_entity_deleted_name ON security_service_entity(deleted, name);
+CREATE INDEX idx_drive_service_entity_deleted_name ON drive_service_entity(deleted, name);
+CREATE INDEX idx_llm_service_entity_deleted_name ON llm_service_entity(deleted, name);
+CREATE INDEX idx_mcp_service_entity_deleted_name ON mcp_service_entity(deleted, name);
+
+-- The overview endpoint derives both the per-entity-type total and the per-connector breakdown
+-- from one `GROUP BY serviceType` per service table. Without a (deleted, serviceType) composite
+-- that grouping reads the table; with it the aggregate is index-only.
+CREATE INDEX idx_dbservice_entity_deleted_service_type ON dbservice_entity(deleted, serviceType);
+CREATE INDEX idx_dashboard_service_entity_deleted_service_type ON dashboard_service_entity(deleted, serviceType);
+CREATE INDEX idx_messaging_service_entity_deleted_service_type ON messaging_service_entity(deleted, serviceType);
+CREATE INDEX idx_metadata_service_entity_deleted_service_type ON metadata_service_entity(deleted, serviceType);
+CREATE INDEX idx_mlmodel_service_entity_deleted_service_type ON mlmodel_service_entity(deleted, serviceType);
+CREATE INDEX idx_pipeline_service_entity_deleted_service_type ON pipeline_service_entity(deleted, serviceType);
+CREATE INDEX idx_search_service_entity_deleted_service_type ON search_service_entity(deleted, serviceType);
+CREATE INDEX idx_storage_service_entity_deleted_service_type ON storage_service_entity(deleted, serviceType);
+CREATE INDEX idx_api_service_entity_deleted_service_type ON api_service_entity(deleted, serviceType);
+CREATE INDEX idx_security_service_entity_deleted_service_type ON security_service_entity(deleted, serviceType);
+CREATE INDEX idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
+CREATE INDEX idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
+CREATE INDEX idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);

--- a/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
@@ -460,3 +460,30 @@ SET json = jsonb_set(
 WHERE serviceType = 'DatabricksPipeline'
   AND json #> '{connection,config,token}' IS NOT NULL
   AND NOT jsonb_exists(json #> '{connection,config}', 'authType');
+
+-- Services overview endpoint (/v1/services/overview) - OpenMetadata 2.0.0
+
+-- The (deleted, name) composite that lets `WHERE deleted = FALSE ORDER BY name, id` be served
+-- index-only. Nine service tables got it in 1.8.2; these four were added later and were missed,
+-- so the overview endpoint's per-type key scan would full-scan them.
+CREATE INDEX IF NOT EXISTS idx_security_service_entity_deleted_name ON security_service_entity(deleted, name);
+CREATE INDEX IF NOT EXISTS idx_drive_service_entity_deleted_name ON drive_service_entity(deleted, name);
+CREATE INDEX IF NOT EXISTS idx_llm_service_entity_deleted_name ON llm_service_entity(deleted, name);
+CREATE INDEX IF NOT EXISTS idx_mcp_service_entity_deleted_name ON mcp_service_entity(deleted, name);
+
+-- The overview endpoint derives both the per-entity-type total and the per-connector breakdown
+-- from one `GROUP BY serviceType` per service table. Without a (deleted, serviceType) composite
+-- that grouping reads the table; with it the aggregate is index-only.
+CREATE INDEX IF NOT EXISTS idx_dbservice_entity_deleted_service_type ON dbservice_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_dashboard_service_entity_deleted_service_type ON dashboard_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_messaging_service_entity_deleted_service_type ON messaging_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_metadata_service_entity_deleted_service_type ON metadata_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_mlmodel_service_entity_deleted_service_type ON mlmodel_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_pipeline_service_entity_deleted_service_type ON pipeline_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_search_service_entity_deleted_service_type ON search_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_storage_service_entity_deleted_service_type ON storage_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_api_service_entity_deleted_service_type ON api_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_security_service_entity_deleted_service_type ON security_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
+CREATE INDEX IF NOT EXISTS idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);

--- a/bootstrap/sql/migrations/native/2.1.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/mysql/schemaChanges.sql
@@ -35,30 +35,3 @@ CREATE TABLE IF NOT EXISTS test_case_incident (
     INDEX idx_tci_assignee (assignee, testCaseResolutionStatusType),
     INDEX idx_tci_updated (updatedAt)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
-
--- Services overview endpoint (/v1/services/overview) - OpenMetadata 2.1.0
-
--- The (deleted, name) composite that lets `WHERE deleted = FALSE ORDER BY name, id` be served
--- index-only. Nine service tables got it in 1.8.2; these four were added later and were missed,
--- so the overview endpoint's per-type key scan would full-scan them.
-CREATE INDEX idx_security_service_entity_deleted_name ON security_service_entity(deleted, name);
-CREATE INDEX idx_drive_service_entity_deleted_name ON drive_service_entity(deleted, name);
-CREATE INDEX idx_llm_service_entity_deleted_name ON llm_service_entity(deleted, name);
-CREATE INDEX idx_mcp_service_entity_deleted_name ON mcp_service_entity(deleted, name);
-
--- The overview endpoint derives both the per-entity-type total and the per-connector breakdown
--- from one `GROUP BY serviceType` per service table. Without a (deleted, serviceType) composite
--- that grouping reads the table; with it the aggregate is index-only.
-CREATE INDEX idx_dbservice_entity_deleted_service_type ON dbservice_entity(deleted, serviceType);
-CREATE INDEX idx_dashboard_service_entity_deleted_service_type ON dashboard_service_entity(deleted, serviceType);
-CREATE INDEX idx_messaging_service_entity_deleted_service_type ON messaging_service_entity(deleted, serviceType);
-CREATE INDEX idx_metadata_service_entity_deleted_service_type ON metadata_service_entity(deleted, serviceType);
-CREATE INDEX idx_mlmodel_service_entity_deleted_service_type ON mlmodel_service_entity(deleted, serviceType);
-CREATE INDEX idx_pipeline_service_entity_deleted_service_type ON pipeline_service_entity(deleted, serviceType);
-CREATE INDEX idx_search_service_entity_deleted_service_type ON search_service_entity(deleted, serviceType);
-CREATE INDEX idx_storage_service_entity_deleted_service_type ON storage_service_entity(deleted, serviceType);
-CREATE INDEX idx_api_service_entity_deleted_service_type ON api_service_entity(deleted, serviceType);
-CREATE INDEX idx_security_service_entity_deleted_service_type ON security_service_entity(deleted, serviceType);
-CREATE INDEX idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
-CREATE INDEX idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
-CREATE INDEX idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);

--- a/bootstrap/sql/migrations/native/2.1.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.1.0/postgres/schemaChanges.sql
@@ -35,30 +35,3 @@ CREATE INDEX IF NOT EXISTS idx_tci_status_fqn ON test_case_incident (testCaseRes
 CREATE INDEX IF NOT EXISTS idx_tci_fqn ON test_case_incident (entityFQNHash);
 CREATE INDEX IF NOT EXISTS idx_tci_assignee ON test_case_incident (assignee, testCaseResolutionStatusType);
 CREATE INDEX IF NOT EXISTS idx_tci_updated ON test_case_incident (updatedAt);
-
--- Services overview endpoint (/v1/services/overview) - OpenMetadata 2.1.0
-
--- The (deleted, name) composite that lets `WHERE deleted = FALSE ORDER BY name, id` be served
--- index-only. Nine service tables got it in 1.8.2; these four were added later and were missed,
--- so the overview endpoint's per-type key scan would full-scan them.
-CREATE INDEX IF NOT EXISTS idx_security_service_entity_deleted_name ON security_service_entity(deleted, name);
-CREATE INDEX IF NOT EXISTS idx_drive_service_entity_deleted_name ON drive_service_entity(deleted, name);
-CREATE INDEX IF NOT EXISTS idx_llm_service_entity_deleted_name ON llm_service_entity(deleted, name);
-CREATE INDEX IF NOT EXISTS idx_mcp_service_entity_deleted_name ON mcp_service_entity(deleted, name);
-
--- The overview endpoint derives both the per-entity-type total and the per-connector breakdown
--- from one `GROUP BY serviceType` per service table. Without a (deleted, serviceType) composite
--- that grouping reads the table; with it the aggregate is index-only.
-CREATE INDEX IF NOT EXISTS idx_dbservice_entity_deleted_service_type ON dbservice_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_dashboard_service_entity_deleted_service_type ON dashboard_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_messaging_service_entity_deleted_service_type ON messaging_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_metadata_service_entity_deleted_service_type ON metadata_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_mlmodel_service_entity_deleted_service_type ON mlmodel_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_pipeline_service_entity_deleted_service_type ON pipeline_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_search_service_entity_deleted_service_type ON search_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_storage_service_entity_deleted_service_type ON storage_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_api_service_entity_deleted_service_type ON api_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_security_service_entity_deleted_service_type ON security_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
-CREATE INDEX IF NOT EXISTS idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);


### PR DESCRIPTION
Fixes #30717

## What

Moves the 17 `/v1/services/overview` index statements (added in #30718) from
`bootstrap/sql/migrations/native/2.1.0/{mysql,postgres}/schemaChanges.sql` to the matching `2.0.0`
files.

Pure move — 17 statements per engine, `+54/-54`, nothing rewritten but the header comment's version
number. The Incident Manager block that shares `2.1.0` is untouched; it genuinely targets 2.1.0.

## Why

The overview endpoint ships on the **2.0 release line**, so `2.0.0` is where its DDL belongs. The
`2.1.0` directory is main-only and does not exist on the `2.0` branch, so the backport had to
relocate the block regardless — this moves it on `main` so both branches agree rather than diverging.

Same convention as #29391 (*"chore(migrations): move 2.0.1 migrations into 2.0.0"*).

## Why editing an already-released version is safe

The usual objection is that a cluster past `2.0.0` would never re-read the file and would silently
miss the indexes. The runner is built for this case:

- **Applied versions are reprocessed.** `MigrationWorkflow.getReprocessingVersions` re-parses the
  highest executed version in the current release train *and* the previous one. `ReleaseTrain` is a
  `(major, minor)` record, so `2.0.x` and `2.1.x` are distinct trains and a `2.1.0` cluster
  reprocesses `2.0.0`. Covered by
  `getMigrationsToApplyReprocessesPreviousReleaseTrainAcrossMajorBoundary`.
- **Dedup is global, by checksum.** `MigrationFile.parseSQLFiles` skips any statement already logged;
  `MigrationDAO`'s lookup is `... where checksum = :checksum` with **no `version` predicate**, so a
  statement executes at most once across the whole history regardless of which file holds it.

Net: fresh install runs them from `2.0.0`; a `2.0.0` or `2.1.0` cluster picks them up on reprocessing;
anyone who already ran them from `2.1.0` skips them. No missed index, no double-apply.

That last point is load-bearing — the MySQL statements are plain `CREATE INDEX` (MySQL has no
`CREATE INDEX IF NOT EXISTS`), so a genuine second execution would raise `Duplicate key name`.
Consolidating into one version means only checksum dedup has to hold, not statement idempotency.

## Verification

- `2.1.0` now has 0 services-overview statements; `2.0.0` has 17, both engines.
- Incident Manager block in `2.1.0` byte-identical to `origin/main`.
- `2.0.0` files byte-identical to what the 2.0 branch carries, so the branches converge exactly.
- No index name defined more than once per engine across the migration tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
