### PR TITLE
fix(data-quality): pass Azure SQL connection parameters to data diff

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/azuresql/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/connection.py
@@ -23,7 +23,12 @@ from metadata.generated.schema.entity.automations.workflow import (
 from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
     Authentication,
     AuthenticationMode,
-    AzureSQLConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
+    AzureSQLConnection as AzureSQLConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
+    AzureSQLScheme,
 )
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection,
@@ -36,18 +41,23 @@ from metadata.ingestion.connections.builders import (
     get_connection_args_common,
     get_connection_options_dict,
 )
+from metadata.ingestion.connections.connection import BaseConnection
 from metadata.ingestion.connections.test_connections import test_connection_db_common
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.utils.constants import THREE_MIN
 
+DEFAULT_SQL_SERVER_PORT = 1433
 
-def get_connection_url(connection: Union[AzureSQLConnection, MssqlConnection]) -> str:
+
+def get_connection_url(
+    connection: Union[AzureSQLConnectionConfig, MssqlConnection]
+) -> str:
     """
     Build the connection URL
     """
 
     if (
-        isinstance(connection, AzureSQLConnection)
+        isinstance(connection, AzureSQLConnectionConfig)
         and isinstance(connection.authenticationMode, AuthenticationMode)
         and connection.authenticationMode.authentication is not None
     ):
@@ -93,7 +103,7 @@ def get_connection_url(connection: Union[AzureSQLConnection, MssqlConnection]) -
     return url
 
 
-def get_connection(connection: AzureSQLConnection) -> Engine:
+def get_connection(connection: AzureSQLConnectionConfig) -> Engine:
     """
     Create connection
     """
@@ -107,7 +117,7 @@ def get_connection(connection: AzureSQLConnection) -> Engine:
 def test_connection(
     metadata: OpenMetadata,
     engine: Engine,
-    service_connection: AzureSQLConnection,
+    service_connection: AzureSQLConnectionConfig,
     automation_workflow: Optional[AutomationWorkflow] = None,
     timeout_seconds: Optional[int] = THREE_MIN,
 ) -> TestConnectionResult:
@@ -122,3 +132,58 @@ def test_connection(
         automation_workflow=automation_workflow,
         timeout_seconds=timeout_seconds,
     )
+
+
+class AzureSQLConnection(BaseConnection[AzureSQLConnectionConfig, Engine]):
+    def __init__(self, connection: AzureSQLConnectionConfig):
+        super().__init__(connection)
+
+    def _get_client(self) -> Engine:
+        return get_connection(self.service_connection)
+
+    def get_connection_dict(self) -> dict:
+        """Return the connection parameters for data-diff."""
+        # data-diff reads credentials from the URL authority only, and the Active Directory URL
+        # keeps them inside an opaque `odbc_connect` query parameter - hence the explicit dict.
+        connection = self.service_connection
+        host, _, port = connection.hostPort.partition(":")
+        scheme = connection.scheme or AzureSQLScheme.mssql_pyodbc
+
+        connection_dict = {
+            "driver": scheme.value,
+            "host": host,
+            "port": int(port) if port else DEFAULT_SQL_SERVER_PORT,
+            "user": connection.username,
+            "password": connection.password.get_secret_value()
+            if connection.password
+            else None,
+            "database": connection.database,
+        }
+
+        authentication_mode = connection.authenticationMode
+        if (
+            isinstance(authentication_mode, AuthenticationMode)
+            and authentication_mode.authentication is not None
+        ):
+            connection_dict["Authentication"] = authentication_mode.authentication.value
+            connection_dict["Encrypt"] = "yes" if authentication_mode.encrypt else "no"
+
+        return connection_dict
+
+    def test_connection(
+        self,
+        metadata: OpenMetadata,
+        automation_workflow: Optional[AutomationWorkflow] = None,
+        timeout_seconds: Optional[int] = THREE_MIN,
+    ) -> TestConnectionResult:
+        """
+        Test connection. This can be executed either as part
+        of a metadata workflow or during an Automation Workflow
+        """
+        return test_connection(
+            metadata=metadata,
+            engine=self.client,
+            service_connection=self.service_connection,
+            automation_workflow=automation_workflow,
+            timeout_seconds=timeout_seconds,
+        )

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/data_diff/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/data_diff/__init__.py
@@ -1,0 +1,10 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/data_diff/data_diff.py
@@ -1,0 +1,44 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""AzureSQL spec for data diff"""
+
+from typing import Optional, Union
+
+from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
+    BaseTableParameter,
+)
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.utils import fqn
+
+
+class AzureSQLTableParameter(BaseTableParameter):
+    """AzureSQL data_diff parameter setter.
+
+    The base get_data_diff_url obtains a connection dict from
+    AzureSQLConnection.get_connection_dict, which carries the *service-level*
+    database and no schema. data_diff needs the *table-specific* database and
+    schema to resolve the table path of each side of the diff.
+    """
+
+    def get_data_diff_url(
+        self,
+        db_service: DatabaseService,
+        table_fqn: str,
+        override_url: Optional[Union[str, dict]] = None,  # noqa: UP007, UP045
+    ) -> Union[str, dict]:  # noqa: UP007
+        source_url = super().get_data_diff_url(db_service, table_fqn, override_url)
+        if isinstance(source_url, dict):
+            # Work on a copy to avoid mutating a dict that might be reused
+            source_url = dict(source_url)
+            _, database, schema, _ = fqn.split(table_fqn)
+            source_url["database"] = database
+            source_url["schema"] = schema
+        return source_url

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/service_spec.py
@@ -13,6 +13,6 @@ ServiceSpec = DefaultDatabaseSpec(
     lineage_source_class=AzuresqlLineageSource,
     usage_source_class=AzuresqlUsageSource,
     sampler_class=AzureSQLSampler,
-    data_diff=AzureSQLTableParameter,
-    connection_class=AzureSQLConnection,
+    data_diff=AzureSQLTableParameter,  # pyright: ignore[reportArgumentType]
+    connection_class=AzureSQLConnection,  # pyright: ignore[reportArgumentType]
 )

--- a/ingestion/src/metadata/ingestion/source/database/azuresql/service_spec.py
+++ b/ingestion/src/metadata/ingestion/source/database/azuresql/service_spec.py
@@ -1,3 +1,7 @@
+from metadata.ingestion.source.database.azuresql.connection import AzureSQLConnection
+from metadata.ingestion.source.database.azuresql.data_diff.data_diff import (
+    AzureSQLTableParameter,
+)
 from metadata.ingestion.source.database.azuresql.lineage import AzuresqlLineageSource
 from metadata.ingestion.source.database.azuresql.metadata import AzuresqlSource
 from metadata.ingestion.source.database.azuresql.usage import AzuresqlUsageSource
@@ -9,4 +13,6 @@ ServiceSpec = DefaultDatabaseSpec(
     lineage_source_class=AzuresqlLineageSource,
     usage_source_class=AzuresqlUsageSource,
     sampler_class=AzureSQLSampler,
+    data_diff=AzureSQLTableParameter,
+    connection_class=AzureSQLConnection,
 )

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py
@@ -2,7 +2,7 @@
 
 from typing import Optional, cast
 
-from sqlalchemy.engine import make_url
+from sqlalchemy.engine import URL, make_url
 
 from metadata.data_quality.validations.models import TableParameter
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
@@ -26,7 +26,7 @@ class SnowflakeTableParameter(BaseTableParameter):
         key_columns,
         extra_columns,
         case_sensitive_columns,
-        service_url: Optional[str],
+        service_url: Optional[str],  # noqa: UP045
     ) -> TableParameter:
         table_param: TableParameter = super().get(
             service,
@@ -36,7 +36,9 @@ class SnowflakeTableParameter(BaseTableParameter):
             case_sensitive_columns,
             service_url,
         )
-        connection_config = cast(SnowflakeConnection, service.connection.config)
+        connection_config = cast(
+            SnowflakeConnection, service.connection.config
+        )  # noqa: TC006
         table_param.privateKey = connection_config.privateKey
         table_param.passPhrase = connection_config.snowflakePrivatekeyPassphrase
         if table_param.privateKey and isinstance(table_param.serviceUrl, str):
@@ -49,7 +51,13 @@ class SnowflakeTableParameter(BaseTableParameter):
                     "Using the private key.",
                     service.name.root,
                 )
-                table_param.serviceUrl = url.set(password="").render_as_string(
-                    hide_password=False
-                )
+                # URL.set(password=None) leaves the password untouched, so rebuild the url without it
+                table_param.serviceUrl = URL.create(
+                    drivername=url.drivername,
+                    username=url.username,
+                    host=url.host,
+                    port=url.port,
+                    database=url.database,
+                    query=url.query,
+                ).render_as_string(hide_password=False)
         return table_param

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py
@@ -2,6 +2,8 @@
 
 from typing import Optional, cast
 
+from sqlalchemy.engine import make_url
+
 from metadata.data_quality.validations.models import TableParameter
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
     BaseTableParameter,
@@ -9,6 +11,9 @@ from metadata.data_quality.validations.runtime_param_setter.base_diff_params_set
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.ingestion.source.database.snowflake.metadata import SnowflakeConnection
+from metadata.utils.logger import test_suite_logger
+
+logger = test_suite_logger()
 
 
 class SnowflakeTableParameter(BaseTableParameter):
@@ -34,4 +39,17 @@ class SnowflakeTableParameter(BaseTableParameter):
         connection_config = cast(SnowflakeConnection, service.connection.config)
         table_param.privateKey = connection_config.privateKey
         table_param.passPhrase = connection_config.snowflakePrivatekeyPassphrase
+        if table_param.privateKey and isinstance(table_param.serviceUrl, str):
+            url = make_url(table_param.serviceUrl)
+            # data-diff refuses a password and a private key at once. The private key wins, as it
+            # does for ingestion, where the connector passes it as a connection argument.
+            if url.password:
+                logger.warning(
+                    "[Data Diff]: Service %s is configured with both a password and a private key. "
+                    "Using the private key.",
+                    service.name.root,
+                )
+                table_param.serviceUrl = url.set(password="").render_as_string(
+                    hide_password=False
+                )
         return table_param

--- a/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_base_diff_params_setter.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_base_diff_params_setter.py
@@ -14,11 +14,30 @@
 import uuid
 from unittest.mock import patch
 
+import data_diff
+from sqlalchemy.engine import make_url
+
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
     BaseTableParameter,
 )
+from metadata.generated.schema.entity.data.table import (
+    Column,
+    ColumnName,
+    DataType,
+    Table,
+)
+from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
+    Authentication,
+    AuthenticationMode,
+)
+from metadata.generated.schema.entity.services.connections.database.azureSQLConnection import (
+    AzureSQLConnection as AzureSQLConnectionConfig,
+)
 from metadata.generated.schema.entity.services.connections.database.mysqlConnection import (
     MysqlConnection,
+)
+from metadata.generated.schema.entity.services.connections.database.snowflakeConnection import (
+    SnowflakeConnection,
 )
 from metadata.generated.schema.entity.services.connections.database.trinoConnection import (
     TrinoConnection,
@@ -27,6 +46,12 @@ from metadata.generated.schema.entity.services.databaseService import (
     DatabaseConnection,
     DatabaseService,
     DatabaseServiceType,
+)
+from metadata.ingestion.source.database.azuresql.data_diff.data_diff import (
+    AzureSQLTableParameter,
+)
+from metadata.ingestion.source.database.snowflake.data_diff.data_diff import (
+    SnowflakeTableParameter,
 )
 
 
@@ -173,3 +198,134 @@ def test_trino_get_data_diff_url_sets_catalog_and_schema_from_fqn():
     # And the original service-level dict must remain unchanged
     assert service_level_dict["catalog"] == "default_catalog"
     assert service_level_dict["schema"] is None
+
+
+def azuresql_service(
+    authentication_mode: AuthenticationMode | None = None,
+) -> DatabaseService:
+    return DatabaseService(
+        id=uuid.uuid4(),
+        name="azuresql_service",
+        serviceType=DatabaseServiceType.AzureSQL,
+        connection=DatabaseConnection(
+            config=AzureSQLConnectionConfig(
+                hostPort="my-server.database.windows.net:1433",
+                username="user@example.com",
+                password="my_password",
+                database="my_default_db",
+                authenticationMode=authentication_mode,
+            )
+        ),
+    )
+
+
+def test_azuresql_get_data_diff_url_carries_credentials_and_fqn_database():
+    """AzureSQL must hand data_diff a connection dict, not a URL.
+
+    With Active Directory authentication the connection URL keeps the credentials inside an
+    opaque `odbc_connect` query parameter, which data_diff cannot read.
+    """
+    db_service = azuresql_service(
+        AuthenticationMode(
+            authentication=Authentication.ActiveDirectoryPassword,
+            encrypt=True,
+            trustServerCertificate=False,
+        )
+    )
+
+    result = AzureSQLTableParameter().get_data_diff_url(
+        db_service, "azuresql_service.my_db.my_schema.my_table"
+    )
+
+    assert result == {
+        "driver": "mssql",
+        "host": "my-server.database.windows.net",
+        "port": 1433,
+        "user": "user@example.com",
+        "password": "my_password",
+        "database": "my_db",
+        "schema": "my_schema",
+        "Authentication": "ActiveDirectoryPassword",
+        "Encrypt": "yes",
+    }
+
+
+def test_azuresql_data_diff_url_defaults_the_port_and_skips_unset_authentication():
+    db_service = azuresql_service()
+    db_service.connection.config.hostPort = "my-server.database.windows.net"
+
+    result = AzureSQLTableParameter().get_data_diff_url(
+        db_service, "azuresql_service.my_db.my_schema.my_table"
+    )
+
+    assert result["port"] == 1433
+    assert "Authentication" not in result
+    assert "Encrypt" not in result
+
+
+def test_azuresql_data_diff_url_connects_to_the_mssql_client():
+    """The connection dict must be enough for data_diff to build its MsSQL client.
+
+    Guards the TypeError raised when data_diff has to fall back to parsing credentials
+    out of the URL authority, which the Active Directory URL does not have.
+    """
+    db_service = azuresql_service(
+        AuthenticationMode(
+            authentication=Authentication.ActiveDirectoryPassword,
+            encrypt=True,
+            trustServerCertificate=False,
+        )
+    )
+
+    source_url = AzureSQLTableParameter().get_data_diff_url(
+        db_service, "azuresql_service.my_db.my_schema.my_table"
+    )
+    client = data_diff.connect(source_url, 1)
+
+    assert client.default_database == "my_db"
+    assert client.default_schema == "my_schema"
+    assert client._args["server"] == "my-server.database.windows.net"
+    assert client._args["user"] == "user@example.com"
+    assert client._args["Authentication"] == "ActiveDirectoryPassword"
+
+
+def test_snowflake_private_key_drops_the_password_from_the_service_url():
+    """data_diff rejects a password and a private key at once, so the key must win."""
+    db_service = DatabaseService(
+        id=uuid.uuid4(),
+        name="snowflake_service",
+        serviceType=DatabaseServiceType.Snowflake,
+        connection=DatabaseConnection(
+            config=SnowflakeConnection(
+                username="my_user",
+                password="my_password",
+                account="my_account",
+                warehouse="my_warehouse",
+                privateKey="-----BEGIN PRIVATE KEY-----\nmy_key\n-----END PRIVATE KEY-----",
+                snowflakePrivatekeyPassphrase="my_passphrase",
+            )
+        ),
+    )
+    entity = Table(
+        id=uuid.uuid4(),
+        name="my_table",
+        fullyQualifiedName="snowflake_service.my_db.my_schema.my_table",
+        columns=[Column(name=ColumnName("id"), dataType=DataType.INT)],
+    )
+
+    table_param = SnowflakeTableParameter().get(
+        db_service,
+        entity,
+        {"id"},
+        set(),
+        False,
+        "snowflake://my_user:my_password@my_account/my_default_db",
+    )
+
+    url = make_url(table_param.serviceUrl)
+    assert not url.password
+    assert url.username == "my_user"
+    assert url.host == "my_account"
+    assert url.database == "my_db/my_schema"
+    assert table_param.privateKey is not None
+    assert table_param.passPhrase is not None

--- a/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_base_diff_params_setter.py
+++ b/ingestion/tests/unit/observability/data_quality/validations/runtime_param_setter/test_base_diff_params_setter.py
@@ -15,6 +15,8 @@ import uuid
 from unittest.mock import patch
 
 import data_diff
+import dsnparse
+from data_diff.databases._connect import CustomParseResult
 from sqlalchemy.engine import make_url
 
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
@@ -323,9 +325,15 @@ def test_snowflake_private_key_drops_the_password_from_the_service_url():
     )
 
     url = make_url(table_param.serviceUrl)
-    assert not url.password
+    assert url.password is None
     assert url.username == "my_user"
     assert url.host == "my_account"
     assert url.database == "my_db/my_schema"
     assert table_param.privateKey is not None
     assert table_param.passPhrase is not None
+
+    # data_diff reads the password off its own parse of the url, and passes on anything not None
+    dsn = dsnparse.parse(table_param.serviceUrl, parse_class=CustomParseResult)
+    assert dsn.password is None
+    assert dsn.user == "my_user"
+    assert dsn.host == "my_account"


### PR DESCRIPTION
Backport of #31057 to 1.13.

Azure SQL builds its connection URL with an ODBC connection string, so
data-diff cannot read host, port, user and password from it and fails to
construct the MsSQL client.

The connection is now handed to data-diff as an explicit connection dict —
the same path Trino and Oracle already use — with the per-table database and
schema applied.

Also drops the Snowflake password from the data-diff URL when a private key is
configured, since data-diff rejects receiving both.

1.13 predates the Azure SQL BaseConnection migration, so the backport adds the
connection class wrapping the existing module-level functions. The connection
dict and the parameter setter are unchanged from #31057.