### PR TITLE
perf(ui): hoist stateless nested components out of render (R2)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/ModalWithMarkdownEditor/ModalWithMarkdownEditor.tsx
@@ -13,7 +13,7 @@
 
 import { Button, Modal, Typography } from 'antd';
 import { AxiosError } from 'axios';
-import { FunctionComponent, useRef, useState } from 'react';
+import { FunctionComponent, ReactNode, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { removeAttachmentsWithoutUrl } from '../../../utils/StringUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
@@ -22,6 +22,10 @@ import RichTextEditor from '../../common/RichTextEditor/RichTextEditor';
 import { EditorContentRef } from '../../common/RichTextEditor/RichTextEditor.interface';
 import './modal-with-markdown-editor.less';
 import { ModalWithMarkdownEditorProps } from './ModalWithMarkdownEditor.interface';
+
+const modalRender = (node: ReactNode) => (
+  <div data-react-aria-top-layer>{node}</div>
+);
 
 export const ModalWithMarkdownEditor: FunctionComponent<
   ModalWithMarkdownEditorProps
@@ -80,7 +84,7 @@ export const ModalWithMarkdownEditor: FunctionComponent<
         </KeyDownStopPropagationWrapper>
       }
       maskClosable={false}
-      modalRender={(node) => <div data-react-aria-top-layer>{node}</div>}
+      modalRender={modalRender}
       open={visible}
       title={<Typography.Text data-testid="header">{header}</Typography.Text>}
       width="90%"

--- a/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/MyData/Widgets/KPIWidget/KPILegend/KPILegend.tsx
@@ -28,30 +28,34 @@ interface KPILegendProps {
   isFullSize: boolean;
 }
 
+const GoalCompleted = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="goal-completed-container">
+      <CheckIcon />
+      <Typography.Text>{t('label.goal-completed')}</Typography.Text>
+    </div>
+  );
+};
+
+const GoalMissed = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="goal-missed-container">
+      <WarningOutlined />
+      <Typography.Text>{t('label.goal-missed')}</Typography.Text>
+    </div>
+  );
+};
+
 const KPILegend: React.FC<KPILegendProps> = ({
   kpiLatestResultsRecord,
   isFullSize,
 }) => {
   const { t } = useTranslation();
   const entries = Object.entries(kpiLatestResultsRecord);
-
-  const GoalCompleted = () => {
-    return (
-      <div className="goal-completed-container">
-        <CheckIcon />
-        <Typography.Text>{t('label.goal-completed')}</Typography.Text>
-      </div>
-    );
-  };
-
-  const GoalMissed = () => {
-    return (
-      <div className="goal-missed-container">
-        <WarningOutlined />
-        <Typography.Text>{t('label.goal-missed')}</Typography.Text>
-      </div>
-    );
-  };
 
   return (
     <div className="w-full h-full kpi-legend d-flex flex-column p-sm">

--- a/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CardinalityDistributionChart.component.tsx
@@ -53,6 +53,57 @@ export interface CardinalityDistributionChartProps {
   noDataPlaceholderText?: string | React.ReactNode;
 }
 
+const renderPlaceholder = (placeholderText?: string | React.ReactNode) => (
+  <div className="tw:flex tw:items-center tw:justify-center tw:h-full tw:w-full tw:min-h-87.5">
+    <ErrorPlaceHolder placeholderText={placeholderText} />
+  </div>
+);
+
+interface CustomYAxisTickProps {
+  x?: number;
+  y?: number;
+  payload?: { value: string };
+  selectedCategory: string | null;
+  onCategoryClick: (categoryName: string) => void;
+}
+
+const CustomYAxisTick = ({
+  x,
+  y,
+  payload,
+  selectedCategory,
+  onCategoryClick,
+}: CustomYAxisTickProps) => {
+  if (!payload) {
+    return null;
+  }
+
+  const categoryName = payload.value;
+  const isSelected = selectedCategory === categoryName;
+  const isHighlighted = selectedCategory && selectedCategory !== categoryName;
+
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        cursor="pointer"
+        dy={4}
+        fill={
+          isSelected ? CHART_BLUE_1 : isHighlighted ? COLOR_GREY_400 : GRAY_600
+        }
+        fontSize={12}
+        fontWeight={isSelected ? 600 : 400}
+        opacity={isHighlighted ? 0.5 : 1}
+        textAnchor="end"
+        x={-8}
+        onClick={() => onCategoryClick(categoryName)}>
+        {categoryName.length > 15
+          ? `${categoryName.slice(0, 15)}...`
+          : categoryName}
+      </text>
+    </g>
+  );
+};
+
 const CardinalityDistributionChart = ({
   data,
   noDataPlaceholderText,
@@ -71,16 +122,6 @@ const CardinalityDistributionChart = ({
 
   const renderHorizontalGridLine = useMemo(
     () => createHorizontalGridLineRenderer(),
-    []
-  );
-
-  const renderPlaceholder = useMemo(
-    () => (placeholderText: string | React.ReactNode) =>
-      (
-        <div className="tw:flex tw:items-center tw:justify-center tw:h-full tw:w-full tw:min-h-87.5">
-          <ErrorPlaceHolder placeholderText={placeholderText} />
-        </div>
-      ),
     []
   );
 
@@ -139,46 +180,6 @@ const CardinalityDistributionChart = ({
   const handleCategoryClick = (categoryName: string) => {
     setSelectedCategory((prev) =>
       prev === categoryName ? null : categoryName
-    );
-  };
-
-  const CustomYAxisTick = (props: {
-    x?: number;
-    y?: number;
-    payload?: { value: string };
-  }) => {
-    const { x, y, payload } = props;
-    if (!payload) {
-      return null;
-    }
-
-    const categoryName = payload.value;
-    const isSelected = selectedCategory === categoryName;
-    const isHighlighted = selectedCategory && selectedCategory !== categoryName;
-
-    return (
-      <g transform={`translate(${x},${y})`}>
-        <text
-          cursor="pointer"
-          dy={4}
-          fill={
-            isSelected
-              ? CHART_BLUE_1
-              : isHighlighted
-              ? COLOR_GREY_400
-              : GRAY_600
-          }
-          fontSize={12}
-          fontWeight={isSelected ? 600 : 400}
-          opacity={isHighlighted ? 0.5 : 1}
-          textAnchor="end"
-          x={-8}
-          onClick={() => handleCategoryClick(categoryName)}>
-          {categoryName.length > 15
-            ? `${categoryName.slice(0, 15)}...`
-            : categoryName}
-        </text>
-      </g>
     );
   };
 
@@ -279,7 +280,12 @@ const CardinalityDistributionChart = ({
                             axisLine={false}
                             dataKey="name"
                             padding={{ top: 16, bottom: 16 }}
-                            tick={<CustomYAxisTick />}
+                            tick={
+                              <CustomYAxisTick
+                                selectedCategory={selectedCategory}
+                                onCategoryClick={handleCategoryClick}
+                              />
+                            }
                             tickLine={false}
                             type="category"
                             width={120}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CustomAreaChart.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Visualisations/Chart/CustomAreaChart.component.tsx
@@ -24,6 +24,38 @@ import { formatDate } from '../../../utils/date-time/DateTimeUtils';
 import { CustomAreaChartProps } from './Chart.interface';
 import './chart.less';
 
+interface CustomTooltipProps extends TooltipProps<string, number | string> {
+  valueFormatter?: CustomAreaChartProps['valueFormatter'];
+}
+
+const CustomTooltip = ({
+  active,
+  payload = [],
+  valueFormatter,
+}: CustomTooltipProps) => {
+  if (active && payload && payload.length) {
+    const payloadData = payload[0].payload;
+
+    return (
+      <Card className="custom-tooltip-area-chart">
+        <div className="flex-center gap-2">
+          <Typography.Text className="font-medium text-md">
+            {valueFormatter
+              ? valueFormatter(payloadData['count'])
+              : payloadData['count']}
+          </Typography.Text>
+          <Divider type="vertical" />
+          <Typography.Text className="text-xs">
+            {formatDate(payloadData.timestamp)}
+          </Typography.Text>
+        </div>
+      </Card>
+    );
+  }
+
+  return null;
+};
+
 const CustomAreaChart = ({
   data,
   name,
@@ -31,31 +63,6 @@ const CustomAreaChart = ({
   colorScheme,
   valueFormatter,
 }: CustomAreaChartProps) => {
-  const CustomTooltip = (props: TooltipProps<string, number | string>) => {
-    const { active, payload = [] } = props;
-
-    if (active && payload && payload.length) {
-      const payloadData = payload[0].payload;
-
-      return (
-        <Card className="custom-tooltip-area-chart">
-          <div className="flex-center gap-2">
-            <Typography.Text className="font-medium text-md">
-              {valueFormatter
-                ? valueFormatter(payloadData['count'])
-                : payloadData['count']}
-            </Typography.Text>
-            <Divider type="vertical" />
-            <Typography.Text className="text-xs">
-              {formatDate(payloadData.timestamp)}
-            </Typography.Text>
-          </div>
-        </Card>
-      );
-    }
-
-    return null;
-  };
   const gradientId = `${name}-splitColor`;
 
   const gradientArea = useMemo(() => {
@@ -88,7 +95,7 @@ const CustomAreaChart = ({
           left: 0,
           bottom: 5,
         }}>
-        <Tooltip content={<CustomTooltip />} />
+        <Tooltip content={<CustomTooltip valueFormatter={valueFormatter} />} />
 
         {gradientArea}
         <Area


### PR DESCRIPTION
## Problem
A React component defined **inside** another component gets a new identity every render → React unmounts/remounts its subtree (`react/no-unstable-nested-components`).

## Fix — hoist the genuine remounts to module scope
| File | Component | Usage | Fix |
|---|---|---|---|
| KPILegend | `GoalCompleted`, `GoalMissed` | `<GoalCompleted/>` | hoist; each calls `useTranslation` itself |
| CardinalityDistributionChart | `CustomYAxisTick` | recharts `tick={<.../>}` | hoist + `selectedCategory`/`onCategoryClick` props |
| CardinalityDistributionChart | `renderPlaceholder` | invoked helper | hoist (pure) |
| CustomAreaChart | `CustomTooltip` | recharts `content={<.../>}` | hoist + `valueFormatter` prop |
| ModalWithMarkdownEditor | `modalRender` | antd `modalRender` | hoist (pure) |

## Scope (deliberate)
This PR fixes only **genuine component-type remounts**. The rule also flags **antd render callbacks** (`dropdownRender`, `maxTagPlaceholder`, `expandIcon`, `expandedRowRender`, `titleRender`, `iconLeading`, …) — antd re-invokes these as functions and the returned element types are stable, so they do **not** remount. Hoisting them would be churn with no benefit, so they're left. The two **stateful** cases (`ParameterForm` TableDiffForm, `FormBuilder` SelectWidget), where a remount actually loses state, are handled in a separate PR.

## Testing
- Jest: KPILegend, CardinalityDistributionChart, CustomAreaChart, ModalWithMarkdownEditor — **4 suites / 38 tests pass**.
- `lint:base` clean (rule cleared on all four); `tsc --noEmit` no new errors.
- Recharts tick/tooltip render is visually unchanged (same JSX, props threaded).

Part of the UI Quality Audit — open-metadata/openmetadata-collate#5442, R2 under open-metadata/openmetadata-collate#5447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)