### PR TITLE
perf(ui): hoist stateful nested components that lose state on remount (R2)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/AddDataQualityTest/components/ParameterForm.tsx
@@ -70,6 +70,185 @@ const CodeEditor = withSuspenseFallback(
   lazy(() => import('../../../Database/SchemaEditor/CodeEditor'))
 );
 
+interface TableDiffFormProps {
+  definition: ParameterFormProps['definition'];
+  table: ParameterFormProps['table'];
+  prepareForm: (
+    data: TestCaseParameterDefinition,
+    DynamicField?: ReactElement
+  ) => ReactElement;
+}
+
+const TableDiffForm = ({
+  definition,
+  table,
+  prepareForm,
+}: TableDiffFormProps) => {
+  const { t } = useTranslation();
+  const form = Form.useFormInstance();
+  const [isOptionsLoading, setIsOptionsLoading] = useState(false);
+  const [tableList, setTableList] = useState<
+    SearchHitBody<
+      SearchIndex.TABLE,
+      Pick<
+        TableSearchSource,
+        'name' | 'displayName' | 'fullyQualifiedName' | 'columns'
+      >
+    >[]
+  >([]);
+  const [table2Columns, setTable2Columns] = useState<Column[] | undefined>();
+
+  const tableOptions = useMemo(
+    () =>
+      tableList.map((hit) => ({
+        label: hit._source.fullyQualifiedName,
+        value: hit._source.fullyQualifiedName,
+      })),
+    [tableList]
+  );
+
+  const fetchTableData = useCallback(async (search = WILD_CARD_CHAR) => {
+    setIsOptionsLoading(true);
+    try {
+      const response = await searchQuery({
+        query: `*${search}*`,
+        pageNumber: 1,
+        pageSize: PAGE_SIZE_LARGE,
+        searchIndex: SearchIndex.TABLE,
+        fetchSource: true,
+        includeFields: ['name', 'fullyQualifiedName', 'displayName', 'columns'],
+      });
+      setTableList(response.hits.hits);
+    } catch {
+      setTableList([]);
+    } finally {
+      setIsOptionsLoading(false);
+    }
+  }, []);
+
+  const debounceFetchTableData = useMemo(
+    () => debounce(fetchTableData, 1000),
+    [fetchTableData]
+  );
+
+  useEffect(() => {
+    fetchTableData();
+  }, [fetchTableData]);
+
+  useEffect(() => {
+    const table2Value = form.getFieldValue(['params', 'table2']);
+    if (table2Value && !table2Columns && tableList.length > 0) {
+      const selectedTable = tableList.find(
+        (hit) => hit._source.fullyQualifiedName === table2Value
+      );
+      if (selectedTable) {
+        setTable2Columns(selectedTable._source.columns);
+      }
+    }
+  }, [tableList, table2Columns, form]);
+
+  const getFormData = (data: TestCaseParameterDefinition) => {
+    switch (data.name) {
+      case 'table2':
+        return (
+          <Form.Item noStyle shouldUpdate key={data.name}>
+            {({ setFieldsValue }) =>
+              prepareForm(
+                data,
+                <Select
+                  allowClear
+                  showSearch
+                  data-testid="table2"
+                  getPopupContainer={getPopupContainer}
+                  loading={isOptionsLoading}
+                  options={tableOptions}
+                  placeholder={t('label.table')}
+                  popupClassName="no-wrap-option"
+                  onChange={(value) => {
+                    // Clear key columns when table2 changes
+                    setFieldsValue({
+                      params: { 'table2.keyColumns': [{ value: undefined }] },
+                    });
+
+                    // Update columns or clear them
+                    if (value) {
+                      const selectedTable = tableList.find(
+                        (hit) => hit._source.fullyQualifiedName === value
+                      );
+                      setTable2Columns(selectedTable?._source.columns);
+                    } else {
+                      setTable2Columns(undefined);
+                    }
+                  }}
+                  onSearch={debounceFetchTableData}
+                />
+              )
+            }
+          </Form.Item>
+        );
+
+      case 'keyColumns':
+      case 'table2.keyColumns':
+      case 'useColumns':
+        return (
+          <Form.Item noStyle shouldUpdate key={data.name}>
+            {({ getFieldValue }) => {
+              const isTable2KeyColumns = data.name === 'table2.keyColumns';
+              const table2Value = getFieldValue(['params', 'table2']);
+
+              let sourceColumns = table?.columns;
+              if (isTable2KeyColumns) {
+                if (table2Value) {
+                  const selectedTable =
+                    tableList.find(
+                      (hit) => hit._source.fullyQualifiedName === table2Value
+                    ) ?? undefined;
+                  sourceColumns =
+                    selectedTable?._source.columns ?? table2Columns;
+                } else {
+                  sourceColumns = undefined;
+                }
+              }
+
+              // Disable when no table2 selected
+              const isDisabled = isTable2KeyColumns && !table2Value;
+
+              const selectedColumnsSet = getSelectedColumnsSet(
+                data,
+                getFieldValue
+              );
+
+              const columnOptions =
+                sourceColumns?.map((column) => ({
+                  label: getEntityName(column),
+                  value: column.name,
+                  disabled: selectedColumnsSet.has(column.name),
+                })) ?? [];
+
+              return prepareForm(
+                data,
+                <Select
+                  allowClear
+                  showSearch
+                  data-testid={`${data.name}-select`}
+                  disabled={isDisabled}
+                  getPopupContainer={getPopupContainer}
+                  options={columnOptions}
+                  placeholder={t('label.column')}
+                />
+              );
+            }}
+          </Form.Item>
+        );
+
+      default:
+        return prepareForm(data);
+    }
+  };
+
+  return <>{definition.parameterDefinition?.map(getFormData)}</>;
+};
+
 const ParameterForm: React.FC<ParameterFormProps> = ({ definition, table }) => {
   const { t } = useTranslation();
 
@@ -333,180 +512,16 @@ const ParameterForm: React.FC<ParameterFormProps> = ({ definition, table }) => {
     );
   };
 
-  const TableDiffForm = () => {
-    const form = Form.useFormInstance();
-    const [isOptionsLoading, setIsOptionsLoading] = useState(false);
-    const [tableList, setTableList] = useState<
-      SearchHitBody<
-        SearchIndex.TABLE,
-        Pick<
-          TableSearchSource,
-          'name' | 'displayName' | 'fullyQualifiedName' | 'columns'
-        >
-      >[]
-    >([]);
-    const [table2Columns, setTable2Columns] = useState<Column[] | undefined>();
-
-    const tableOptions = useMemo(
-      () =>
-        tableList.map((hit) => ({
-          label: hit._source.fullyQualifiedName,
-          value: hit._source.fullyQualifiedName,
-        })),
-      [tableList]
-    );
-
-    const fetchTableData = useCallback(async (search = WILD_CARD_CHAR) => {
-      setIsOptionsLoading(true);
-      try {
-        const response = await searchQuery({
-          query: `*${search}*`,
-          pageNumber: 1,
-          pageSize: PAGE_SIZE_LARGE,
-          searchIndex: SearchIndex.TABLE,
-          fetchSource: true,
-          includeFields: [
-            'name',
-            'fullyQualifiedName',
-            'displayName',
-            'columns',
-          ],
-        });
-        setTableList(response.hits.hits);
-      } catch {
-        setTableList([]);
-      } finally {
-        setIsOptionsLoading(false);
-      }
-    }, []);
-
-    const debounceFetchTableData = useMemo(
-      () => debounce(fetchTableData, 1000),
-      [fetchTableData]
-    );
-
-    useEffect(() => {
-      fetchTableData();
-    }, [fetchTableData]);
-
-    useEffect(() => {
-      const table2Value = form.getFieldValue(['params', 'table2']);
-      if (table2Value && !table2Columns && tableList.length > 0) {
-        const selectedTable = tableList.find(
-          (hit) => hit._source.fullyQualifiedName === table2Value
-        );
-        if (selectedTable) {
-          setTable2Columns(selectedTable._source.columns);
-        }
-      }
-    }, [tableList, table2Columns, form]);
-
-    const getFormData = (data: TestCaseParameterDefinition) => {
-      switch (data.name) {
-        case 'table2':
-          return (
-            <Form.Item noStyle shouldUpdate key={data.name}>
-              {({ setFieldsValue }) =>
-                prepareForm(
-                  data,
-                  <Select
-                    allowClear
-                    showSearch
-                    data-testid="table2"
-                    getPopupContainer={getPopupContainer}
-                    loading={isOptionsLoading}
-                    options={tableOptions}
-                    placeholder={t('label.table')}
-                    popupClassName="no-wrap-option"
-                    onChange={(value) => {
-                      // Clear key columns when table2 changes
-                      setFieldsValue({
-                        params: { 'table2.keyColumns': [{ value: undefined }] },
-                      });
-
-                      // Update columns or clear them
-                      if (value) {
-                        const selectedTable = tableList.find(
-                          (hit) => hit._source.fullyQualifiedName === value
-                        );
-                        setTable2Columns(selectedTable?._source.columns);
-                      } else {
-                        setTable2Columns(undefined);
-                      }
-                    }}
-                    onSearch={debounceFetchTableData}
-                  />
-                )
-              }
-            </Form.Item>
-          );
-
-        case 'keyColumns':
-        case 'table2.keyColumns':
-        case 'useColumns':
-          return (
-            <Form.Item noStyle shouldUpdate key={data.name}>
-              {({ getFieldValue }) => {
-                const isTable2KeyColumns = data.name === 'table2.keyColumns';
-                const table2Value = getFieldValue(['params', 'table2']);
-
-                let sourceColumns = table?.columns;
-                if (isTable2KeyColumns) {
-                  if (table2Value) {
-                    const selectedTable =
-                      tableList.find(
-                        (hit) => hit._source.fullyQualifiedName === table2Value
-                      ) ?? undefined;
-                    sourceColumns =
-                      selectedTable?._source.columns ?? table2Columns;
-                  } else {
-                    sourceColumns = undefined;
-                  }
-                }
-
-                // Disable when no table2 selected
-                const isDisabled = isTable2KeyColumns && !table2Value;
-
-                const selectedColumnsSet = getSelectedColumnsSet(
-                  data,
-                  getFieldValue
-                );
-
-                const columnOptions =
-                  sourceColumns?.map((column) => ({
-                    label: getEntityName(column),
-                    value: column.name,
-                    disabled: selectedColumnsSet.has(column.name),
-                  })) ?? [];
-
-                return prepareForm(
-                  data,
-                  <Select
-                    allowClear
-                    showSearch
-                    data-testid={`${data.name}-select`}
-                    disabled={isDisabled}
-                    getPopupContainer={getPopupContainer}
-                    options={columnOptions}
-                    placeholder={t('label.column')}
-                  />
-                );
-              }}
-            </Form.Item>
-          );
-
-        default:
-          return prepareForm(data);
-      }
-    };
-
-    return <>{definition.parameterDefinition?.map(getFormData)}</>;
-  };
-
   const paramsForm: FormListProps['children'] = () => {
     switch (definition.fullyQualifiedName) {
       case TABLE_DIFF:
-        return <TableDiffForm />;
+        return (
+          <TableDiffForm
+            definition={definition}
+            prepareForm={prepareForm}
+            table={table}
+          />
+        );
 
       default:
         return definition.parameterDefinition?.map((data) => prepareForm(data));

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilder/FormBuilder.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/FormBuilder/FormBuilder.tsx
@@ -47,6 +47,14 @@ export interface Props extends FormProps {
   capitalizeOptionLabel?: boolean;
 }
 
+const createSelectWidget = (capitalizeOptionLabel?: boolean) => {
+  const CapitalizedSelectWidget = (props: WidgetProps) => (
+    <SelectWidget {...props} capitalizeOptionLabel={capitalizeOptionLabel} />
+  );
+
+  return CapitalizedSelectWidget;
+};
+
 const FormBuilder = forwardRef<Form, Props>(
   (
     {
@@ -85,18 +93,18 @@ const FormBuilder = forwardRef<Form, Props>(
       setLocalFormData(formatFormDataForRender(formData ?? {}));
     }, [formData]);
 
+    const selectWidget = useMemo(
+      () => createSelectWidget(capitalizeOptionLabel),
+      [capitalizeOptionLabel]
+    );
+
     const widgets = {
       PasswordWidget: PasswordWidget,
       autoComplete: AsyncSelectWidget,
       queryBuilder: QueryBuilderWidget,
       code: CodeWidget,
       ...(useSelectWidget && {
-        SelectWidget: (props: WidgetProps) => (
-          <SelectWidget
-            {...props}
-            capitalizeOptionLabel={capitalizeOptionLabel}
-          />
-        ),
+        SelectWidget: selectWidget,
       }),
       ...widgetsOverride,
     };


### PR DESCRIPTION
## Problem
Two components were defined **inside** their parent's render, so every parent render gave them a new identity → React remounted them → their internal state reset. This is the same failure class as the ColumnGrid focus-loss bug (#30927), but here it silently resets fetched data.

## Fix
### `ParameterForm` → `TableDiffForm`
Held its own `useState` (fetched table list, selected table2 columns, loading) and re-ran its table-fetch `useEffect` on **every** parent render. Now module-scope; `definition`, `table`, `prepareForm` passed as props (it calls `useTranslation` / `useFormInstance` itself). `prepareForm`'s identity still changes per render, but that only re-renders the now-stable component — it no longer **remounts**, so the fetched list and selections survive.

### `FormBuilder` → `SelectWidget`
An RJSF `widgets` map entry rebuilt inline every render; RJSF can treat a new widget function as a new widget and remount it. Replaced with a module-scope `createSelectWidget(capitalizeOptionLabel)` factory, memoised via `useMemo` on `capitalizeOptionLabel`, giving the widget a stable identity across renders.

## Scope
Only the two **stateful** remounts (real user-visible impact). The stateless genuine remounts (recharts ticks, KPILegend badges, …) are in #31084; antd render-callback false positives are intentionally left.

## Testing
- Jest: ParameterForm + FormBuilder suites — **10 suites / 73 tests pass**.
- `lint:base` clean (rule cleared on both); `tsc --noEmit` no new errors.
- ⚠️ Recommend manual QA of the **Table Diff** test-parameter form (select table2, key columns) and any RJSF form using `SelectWidget`, since these drive interactive form state.

Part of the UI Quality Audit — open-metadata/openmetadata-collate#5442, R2 under open-metadata/openmetadata-collate#5447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)