### PR TITLE
fix(ingestion): bump datamodel-code-generator to 0.72.1 for CVE fixes

### DIFF
--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -123,7 +123,7 @@ WORKDIR /home/airflow/ingestion
 # Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
 # but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
 RUN pip install --no-deps "sqlalchemy-redshift==0.8.14" "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
-RUN pip install "datamodel-code-generator==0.25.6"
+RUN pip install "datamodel-code-generator==0.72.1"
 RUN mkdir -p /home/airflow/ingestion/src/metadata/generated
 RUN python /home/airflow/scripts/datamodel_generation.py
 RUN wget -q https://repo1.maven.org/maven2/org/antlr/antlr4/4.9.2/antlr4-4.9.2-complete.jar -O /tmp/antlr.jar \

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -131,7 +131,7 @@ ARG INGESTION_DEPENDENCY="all"
 # Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
 # but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
 RUN pip install --no-deps "sqlalchemy-redshift==0.8.14" "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
-RUN pip install "datamodel-code-generator==0.25.6"
+RUN pip install "datamodel-code-generator==0.72.1"
 RUN mkdir -p /ingestion/src/metadata/generated
 RUN python /scripts/datamodel_generation.py
 RUN pip install ".[airflow]"

--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -435,7 +435,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
 dev = {
     "ruff~=0.15.12",
     "uvloop==0.21.0",
-    "datamodel-code-generator==0.25.6",
+    "datamodel-code-generator==0.72.1",
     "boto3-stubs",
     "mypy-boto3-glue",
     "google-api-python-client-stubs",

--- a/scripts/datamodel_generation.py
+++ b/scripts/datamodel_generation.py
@@ -17,10 +17,13 @@ import glob
 import os
 
 from datamodel_code_generator.imports import Import
-from datamodel_code_generator.model import pydantic as pydantic_model
+from datamodel_code_generator.model.pydantic_v2 import types as pydantic_v2_types
 from datamodel_code_generator.__main__ import main
 
-pydantic_model.types.IMPORT_SECRET_STR = Import.from_full_path(
+# datamodel-code-generator dropped the pydantic v1 model package in 0.30; the SecretStr
+# import constant now lives in the pydantic_v2 types module. It is read as a module global
+# when the type map is built, so rebinding it here still redirects password fields.
+pydantic_v2_types.IMPORT_SECRET_STR = Import.from_full_path(
     "metadata.ingestion.models.custom_pydantic.CustomSecretStr"
 )
 


### PR DESCRIPTION
## What

Bumps the pinned `datamodel-code-generator` from `0.25.6` to `0.72.1` and adapts `scripts/datamodel_generation.py` to the API move that came with it.

## Why

`0.25.6` is affected by eight advisories surfaced by an AWS Inspector scan of the ingestion image:

| CVE | Fixed in |
|---|---|
| CVE-2026-54621 | 0.60.1 |
| CVE-2026-54653 | 0.60.2 |
| CVE-2026-54654 | 0.60.2 |
| CVE-2026-54690 | 0.61.0 |
| CVE-2026-54691 | 0.61.0 |
| CVE-2026-55389 | 0.62.0 |
| CVE-2026-55391 | 0.63.0 |
| CVE-2026-55415 | 0.64.0 |

`0.64.0` is the earliest release that clears all eight; this pins the current `0.72.1`.

## The script change

`0.30` removed the pydantic v1 model package entirely, so this no longer resolves:

```python
from datamodel_code_generator.model import pydantic as pydantic_model
pydantic_model.types.IMPORT_SECRET_STR = ...
```

`IMPORT_SECRET_STR` now lives in `datamodel_code_generator.model.pydantic_v2.imports` and is re-exported into `pydantic_v2.types`. The type map reads it as a module global when it is built, not at import time, so rebinding it on `pydantic_v2.types` keeps the redirect working. Without this the script fails outright with `ImportError`.

## Verification

Generated the full model tree under both `0.25.6` and `0.72.1` from the same schemas and diffed:

- **`CustomSecretStr` still applied to the same 125 files** — the secrets-manager redirect is intact.
- **Zero occurrences of bare `pydantic.SecretStr`** in the output (a leak here would silently break secret resolution).
- The whole tree byte-compiles (`compileall`, exit 0).
- **885 of 1048 files change beyond the timestamp header.** All of it is `0.72`'s typing modernisation, three mechanical shapes:
  - `Optional[X]` → `X | None`
  - defaults moved out of `Field(default, ...)` into assignment (`= 3`)
  - `typing_extensions.Annotated` → `typing.Annotated`
- One file added: `schema/__init__.py`.

Sample:

```diff
-from typing import Optional
-from typing_extensions import Annotated
+from typing import Annotated
     jwtTokenExpiryTime: Annotated[
-        Optional[int],
-        Field(3600, description='Jwt Token Expiry time for login in seconds'),
-    ]
+        int | None, Field(description='Jwt Token Expiry time for login in seconds')
+    ] = 3600
```

`generated/` is gitignored, so none of that churn lands in the diff — but it is real, and reviewers should expect the ingestion test suite to exercise it. CI running the full suite against the regenerated models is the gate here.

## Note

`0.72.1` emits a `FutureWarning` that the default `black`/`isort` formatters will become opt-in. Not addressed here; worth a follow-up to pin `formatters=` explicitly before that flips.