### PR TITLE
Chore(UI): Fix the Kafka service ingestion test failure. (2.0)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/KafkaIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/KafkaIngestionClass.ts
@@ -68,7 +68,15 @@ class KafkaIngestionClass extends ServiceBaseClass {
   async fillIngestionDetails(page: Page) {
     await this.openIngestionFilterSection(page);
     await page.getByTestId('filter-section-topicFilterPattern').click();
+
+    // Since we need to ingest `__transaction_state` topic, the exclude rule startsWith:^__.* needs to be removed.
+    await page
+      .getByTestId('exclude-chip-startsWith:^__.*')
+      .getByTestId('remove-button')
+      .click();
+
     await page.getByTestId('topicFilterPattern-only-specific-button').click();
+
     await page
       .getByTestId('filter-section-topicFilterPattern')
       .getByTestId('include-filter-input')


### PR DESCRIPTION
Cherry-pick of #31083 onto `2.0`.

This pull request updates the Kafka ingestion UI automation to ensure the `__transaction_state` topic is included during ingestion. The main change is the removal of a filter rule that previously excluded topics starting with double underscores.

Kafka ingestion filter improvements:

* In `KafkaIngestionClass.ts`, the automation now removes the `startsWith:^__.*` exclude rule by clicking its remove button, allowing ingestion of the `__transaction_state` topic.