### PR TITLE
fix(ui): show active Explore tab count from its own index, not the aggregate

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ExplorePage/ExplorePageV1.component.tsx
@@ -299,11 +299,22 @@ const ExplorePageV1: FC<unknown> = () => {
 
   // Use the utility function to generate tab items
   const tabItems = useMemo(() => {
-    const items = generateTabItems(tabsInfo, searchHitCounts, searchIndex);
+    const items = generateTabItems(
+      tabsInfo,
+      searchHitCounts,
+      searchIndex,
+      searchResults?.hits?.total?.value
+    );
 
     return searchQueryParam
       ? items.filter((tabItem) => {
-          return tabItem.count > 0 || tabItem.key === searchCriteria;
+          // Keep the active tab even when its own results total is 0, so the
+          // tab you are viewing never disappears out from under you.
+          return (
+            tabItem.count > 0 ||
+            tabItem.key === searchCriteria ||
+            tabItem.key === searchIndex
+          );
         })
       : items;
   }, [
@@ -312,6 +323,7 @@ const ExplorePageV1: FC<unknown> = () => {
     searchIndex,
     searchQueryParam,
     searchCriteria,
+    searchResults,
   ]);
 
   const getAdvancedSearchQuickFilters = useCallback(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.test.ts
@@ -27,7 +27,11 @@ import {
   getSubLevelHierarchyKey,
   updateTreeData,
 } from './ExplorePureUtils';
-import { fetchEntityData, getAggregationOptions } from './ExploreUtils';
+import {
+  fetchEntityData,
+  generateTabItems,
+  getAggregationOptions,
+} from './ExploreUtils';
 
 jest.mock('../rest/searchAPI');
 jest.mock('./ToastUtils');
@@ -940,5 +944,45 @@ describe('fetchEntityData', () => {
     expect(params.setSearchHitCounts).toHaveBeenCalledWith({
       [SearchIndex.TABLE]: 42,
     });
+  });
+});
+
+describe('generateTabItems', () => {
+  const mockTab = (label: string) => ({ label, icon: () => null });
+  const tabsInfo = {
+    [SearchIndex.TABLE]: mockTab('Tables'),
+    [SearchIndex.DASHBOARD]: mockTab('Dashboards'),
+  } as unknown as Parameters<typeof generateTabItems>[0];
+  const aggregateHitCounts = {
+    [SearchIndex.TABLE]: 1,
+    [SearchIndex.DASHBOARD]: 5,
+  } as unknown as Parameters<typeof generateTabItems>[1];
+
+  it('uses the active tab own results total, not the cross-index aggregate', () => {
+    const items = generateTabItems(
+      tabsInfo,
+      aggregateHitCounts,
+      SearchIndex.TABLE,
+      7381
+    );
+
+    // Active tab (TABLE) shows its own index total, not the aggregate 1
+    expect(items.find((item) => item.key === SearchIndex.TABLE)?.count).toBe(
+      7381
+    );
+    // Inactive tab keeps the aggregate bucket count
+    expect(
+      items.find((item) => item.key === SearchIndex.DASHBOARD)?.count
+    ).toBe(5);
+  });
+
+  it('falls back to the aggregate count when no active total is provided', () => {
+    const items = generateTabItems(
+      tabsInfo,
+      aggregateHitCounts,
+      SearchIndex.TABLE
+    );
+
+    expect(items.find((item) => item.key === SearchIndex.TABLE)?.count).toBe(1);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ExploreUtils.tsx
@@ -103,10 +103,20 @@ export const getAggregationOptions = async (
 export const generateTabItems = (
   tabsInfo: Record<string, TabsInfoData>,
   searchHitCounts: SearchHitCounts | undefined,
-  searchIndex: ExploreSearchIndex
+  searchIndex: ExploreSearchIndex,
+  activeIndexTotalHits?: number
 ) => {
   return Object.entries(tabsInfo).map(([tabSearchIndex, tabDetail]) => {
     const Icon = tabDetail.icon as React.FC<{ className?: string }>;
+    const isActiveTab = tabSearchIndex === searchIndex;
+    // Badge counts come from a cross-index dataAsset aggregation, which can
+    // diverge from the active tab's own index total (ancestral matches inflate
+    // the aggregate). For the tab in view, use its results total so the badge
+    // matches the list the user is actually looking at.
+    const tabCount =
+      isActiveTab && !isNil(activeIndexTotalHits)
+        ? activeIndexTotalHits
+        : searchHitCounts?.[tabSearchIndex as ExploreSearchIndex];
 
     return {
       key: tabSearchIndex,
@@ -134,18 +144,12 @@ export const generateTabItems = (
           </div>
           <span>
             {!isNil(searchHitCounts)
-              ? getCountBadge(
-                  searchHitCounts[tabSearchIndex as ExploreSearchIndex],
-                  '',
-                  tabSearchIndex === searchIndex
-                )
+              ? getCountBadge(tabCount, '', isActiveTab)
               : getCountBadge()}
           </span>
         </div>
       ),
-      count: searchHitCounts
-        ? searchHitCounts[tabSearchIndex as ExploreSearchIndex]
-        : 0,
+      count: tabCount ?? 0,
     };
   });
 };


### PR DESCRIPTION
### Describe your changes:

Fixes open-metadata/openmetadata-collate#3851

The Explore tab badges are populated from a single `index=dataAsset` aggregation (its `entityType` buckets), while each tab's result list is fetched from that tab's **own** index (e.g. `tableColumn`, `databaseSchema`). The two paths run through different query builders, so the number on the tab you're viewing can diverge from the list it shows:

- a column search where the `dataAsset` aggregate counted **1** but the `tableColumn` index returned **7,381**
- a schema search where the aggregate counted **87** but only **~15** were actually listed

**Fix:** for the **active** tab, use its own results total (`searchResults.hits.total.value`) as the badge count, so the number always matches the list in view. Inactive tabs keep the aggregate estimate (their lists aren't visible to verify anyway), and the active tab stays visible even when its own total is 0.

Supersedes #31019 — tightening the column search builder there regressed exact-FQN column lookups to 0 hits (Playwright `SearchRBAC › Table Column`); the divergence is a UI counting concern, not a matching one.

#
### Type of change:

- [x] Bug fix

#
### Tests:

#### Unit tests
- `generateTabItems`: the active tab reports its own results total (not the aggregate), and falls back to the aggregate when no active total is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)