### PR TITLE
ci(playwright): exclude setup-project tests from coverage reconciliation

### DIFF
--- a/.github/scripts/tests/test_playwright_ci_planning.py
+++ b/.github/scripts/tests/test_playwright_ci_planning.py
@@ -1489,6 +1489,126 @@ def test_coverage_verifier_reconciles_zero_attempt_skips_in_output(
     assert coverage["zeroAttemptSkippedTests"][0]["reason"] == "unknown"
 
 
+def test_is_lifecycle_test_matches_setup_projects():
+    # Every project in playwright.config.ts that appears as a `dependencies:`
+    # value on another project — those tests run once per shard-invocation
+    # instead of once per plan.
+    verifier = load_script("verify_playwright_coverage")
+
+    for project in [
+        "setup",
+        "entity-data-setup",
+        "entity-data-teardown",
+        "data-insight-application",
+        "search-rbac-setup",
+        "search-rbac-teardown",
+    ]:
+        assert verifier.is_lifecycle_test({"id": "x", "project": project}), project
+
+    for project in ["chromium", "Basic", "ImportExport", "SearchRBAC"]:
+        assert not verifier.is_lifecycle_test({"id": "x", "project": project}), project
+
+
+def test_coverage_verifier_ignores_lifecycle_executions(tmp_path, monkeypatch):
+    # Reproduces merge_group run 31083026904's failure: two @data-insight spec
+    # files were assigned to different chromium shards, so Playwright ran the
+    # `data-insight-application` setup project on both. The setup test is not
+    # planned (it isn't in FULL_PROJECTS), but its per-invocation duplication
+    # in the timings used to trip `unexpected + duplicate execution`.
+    verifier = load_script("verify_playwright_coverage")
+    plan_a = {
+        "shardId": "chromium-04",
+        "testIds": ["real-test-a"],
+    }
+    plan_b = {
+        "shardId": "chromium-17",
+        "testIds": ["real-test-b"],
+    }
+    # Both shards' timing artifacts include the data-insight setup test
+    # (same test ID) — that's the pattern the checker used to false-positive.
+    timing_a = {
+        "tests": [
+            {"id": "real-test-a", "project": "chromium"},
+            {"id": "data-insight-setup", "project": "data-insight-application"},
+        ],
+    }
+    timing_b = {
+        "tests": [
+            {"id": "real-test-b", "project": "chromium"},
+            {"id": "data-insight-setup", "project": "data-insight-application"},
+        ],
+    }
+    (tmp_path / "plan-a.json").write_text(json.dumps(plan_a))
+    (tmp_path / "plan-b.json").write_text(json.dumps(plan_b))
+    (tmp_path / "timing-a.json").write_text(json.dumps(timing_a))
+    (tmp_path / "timing-b.json").write_text(json.dumps(timing_b))
+    output = tmp_path / "coverage.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_playwright_coverage.py",
+            "--plan-glob",
+            str(tmp_path / "plan-*.json"),
+            "--timing-glob",
+            str(tmp_path / "timing-*.json"),
+            "--output",
+            str(output),
+        ],
+    )
+
+    verifier.main()
+
+    coverage = json.loads(output.read_text())
+    # The data-insight setup test is filtered from `executed` — no unexpected,
+    # no duplicate, no missing.
+    assert coverage["duplicateExecutionTestIds"] == []
+    assert coverage["unexpectedTestIds"] == []
+    assert coverage["missingTestIds"] == []
+    assert coverage["plannedTests"] == 2
+    assert coverage["executedTests"] == 2
+
+
+def test_coverage_verifier_still_flags_real_test_duplicates_and_unexpected(
+    tmp_path, monkeypatch
+):
+    # Guard against the fix being too permissive — a real test executed on a
+    # shard that didn't plan it, or executed twice on one shard, must still
+    # fire the mismatch.
+    verifier = load_script("verify_playwright_coverage")
+    plan = {"shardId": "chromium-01", "testIds": ["planned-only"]}
+    timing = {
+        "tests": [
+            {"id": "planned-only", "project": "chromium"},
+            {"id": "planned-only", "project": "chromium"},  # duplicate execution
+            {"id": "stowaway", "project": "chromium"},       # unexpected
+        ]
+    }
+    (tmp_path / "plan.json").write_text(json.dumps(plan))
+    (tmp_path / "timing.json").write_text(json.dumps(timing))
+    output = tmp_path / "coverage.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_playwright_coverage.py",
+            "--plan-glob",
+            str(tmp_path / "plan.json"),
+            "--timing-glob",
+            str(tmp_path / "timing.json"),
+            "--output",
+            str(output),
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="Playwright coverage mismatch"):
+        verifier.main()
+
+    coverage = json.loads(output.read_text())
+    assert coverage["duplicateExecutionTestIds"] == ["planned-only"]
+    assert coverage["unexpectedTestIds"] == ["stowaway"]
+
+
 def test_request_metrics_count_app_boots_bytes_and_hot_api_endpoints():
     requests = load_script("summarize_playwright_requests")
     accumulator = requests.RequestAccumulator()

--- a/.github/scripts/verify_playwright_coverage.py
+++ b/.github/scripts/verify_playwright_coverage.py
@@ -10,6 +10,42 @@ from collections import Counter
 from pathlib import Path
 
 
+# Playwright "setup" projects declared in playwright.config.ts as
+# `dependencies: [...]` values on other projects. Their tests run once per
+# shard-invocation that includes a dependent project (Playwright behaviour —
+# a setup project runs before each dependent), not once per plan. The planner
+# already excludes them from `FULL_PROJECTS`, so they never appear in a
+# shard's `testIds`. But they DO appear in the shard's timing artifact, so
+# the coverage checker used to flag them as "unexpected + duplicate" whenever
+# LPT split two dependent files across shards.
+#
+# Example failure — merge_group run 31083026904:
+#   [data-insight-application] > dataInsightApp.ts > Run Data Insight
+#   application and wait until success
+# ran on chromium-04 AND chromium-17 because two @data-insight spec files
+# landed on separate shards, but appeared in neither plan's `testIds`.
+#
+# Keep this list aligned with playwright.config.ts's setup-project section.
+LIFECYCLE_PROJECTS: frozenset[str] = frozenset({
+    "setup",
+    "entity-data-setup",
+    "entity-data-teardown",
+    "data-insight-application",
+    "search-rbac-setup",
+    "search-rbac-teardown",
+})
+
+
+def is_lifecycle_test(test: dict) -> bool:
+    """A `test` from the timing artifact is a lifecycle test if its Playwright
+    project name matches one of the setup projects declared in the config.
+    Lifecycle tests are expected to run once per shard-invocation, not once
+    per plan, so the coverage checker must exclude them from the plan-vs-exec
+    reconciliation.
+    """
+    return test.get("project") in LIFECYCLE_PROJECTS
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--plan-glob", required=True)
@@ -68,7 +104,11 @@ def main() -> None:
 
     for filename in timing_files:
         payload = json.loads(Path(filename).read_text(encoding="utf-8"))
-        executed.update(test["id"] for test in payload.get("tests", []))
+        executed.update(
+            test["id"]
+            for test in payload.get("tests", [])
+            if not is_lifecycle_test(test)
+        )
 
     zero_attempt_skipped: dict[str, dict] = {}
     for filename in result_files:


### PR DESCRIPTION
## Summary

Merge_group run [31083026904](https://github.com/open-metadata/OpenMetadata/actions/runs/31083026904/job/92568547950) failed with:

```
Playwright coverage mismatch: 0 missing, 1 unexpected, 0 duplicate plans, and 1 duplicate executions
```

Every timing gate passed (execution 1360 s / 1500 s, elapsed-before-upload 1575 s / 1800 s, env 189 s / 300 s). The failure was from `verify_playwright_coverage.py` incorrectly flagging a Playwright setup-project's cascade execution.

## Root cause

`data-insight-application` is a **setup project** (declared as `dependencies: ['data-insight-application']` on the `Data Insight` project in `playwright.config.ts:264`). Setup projects run once per shard-invocation of any dependent — Playwright semantics, not a bug.

Two `@data-insight` spec files (`Pages/DataInsight.spec.ts`, `Pages/DataInsightSettings.spec.ts`) got assigned to different chromium shards by LPT. Both shards' plans include `"Data Insight"` in their `projects` array. Playwright ran `dataInsightApp.ts` — the setup test — on both shards. The planner correctly excludes setup projects from `FULL_PROJECTS`, so the setup test's ID appears in NEITHER shard's `testIds`. But it DOES appear in both shards' timing artifacts.

The verifier's arithmetic then reads:

- `planned` — 4422 real test ids, setup test absent (as it should be)
- `executed` — 4423 unique ids: 4422 real + 1 setup id with count == 2
- `executed - planned` = {setup id} → 1 unexpected
- `count > 1` on executed = 1 duplicate execution

Latent since forever. Only fired now because LPT split the two files across shards this time; prior runs (31082358372, 31078498819) had them on the same shard and setup ran once.

## Fix

`verify_playwright_coverage.py` gets a `LIFECYCLE_PROJECTS` frozenset — every project declared as a `dependencies:` value in `playwright.config.ts`:

```python
LIFECYCLE_PROJECTS = frozenset({
    "setup",
    "entity-data-setup",
    "entity-data-teardown",
    "data-insight-application",
    "search-rbac-setup",
    "search-rbac-teardown",
})
```

Tests from those projects are filtered out of the `executed` counter before mismatch calculation. `planned` stays untouched — the planner already excludes them from `FULL_PROJECTS`. The verifier's real signal (missed / unexpected / duplicated **real** tests) is preserved.

## Tests

3 new pytest cases in `test_playwright_ci_planning.py`:

- `test_is_lifecycle_test_matches_setup_projects` — enumerates each lifecycle project + each planned project, asserts the filter direction.
- `test_coverage_verifier_ignores_lifecycle_executions` — end-to-end reproduction of run 31083026904's exact shape (two shards each executing `data-insight-application` under distinct plans), asserts clean coverage.
- `test_coverage_verifier_still_flags_real_test_duplicates_and_unexpected` — guard against the fix being too permissive: a real test executed twice, or on an unplanned shard, must still fire the mismatch.

**114 tests pass** locally (111 existing + 3 new).

## Maintenance note

Comment in the code:

> Keep this list aligned with playwright.config.ts's setup-project section.

If a new setup project gets added to playwright.config.ts (or an old one renamed), the list needs a matching entry. A future harness-integrity check could enforce this alignment automatically — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)