### PR TITLE
test(e2e): Playwright flaky fixes — batch 3

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -372,7 +372,14 @@ test.describe('Context Center - Documents Page', () => {
       expect(bulkMoveBody.numberOfRowsFailed ?? 0).toBe(0);
       expectBulkIdsRequest(bulkMoveRes.request().postData(), [document.id]);
 
+      // The root document list is ordered updatedAt DESC and paginated at
+      // PAGE_SIZE_BASE rows, and this reload refetches page 1. Workers share
+      // this backend, so uploads landing between the move and the reload can
+      // push the moved row off page 1 — and the test never scrolls, so it is
+      // then on no page the test loads. Scope the list to the target folder,
+      // where the row is the only hit and pagination cannot displace it.
       await navigateToDocuments(page);
+      await selectFolderInSidebar(page, lastPageFolder.name);
       await expect(
         getDocumentRowByName(page, fileName).getByTestId('document-folder-name')
       ).toHaveText(lastPageFolder.name);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts
@@ -209,13 +209,22 @@ test.describe('Large Glossary Performance Tests', () => {
     // Clear search
     await searchInput.clear();
     await page.waitForResponse('api/v1/glossaryTerms?*');
+    await waitForAllLoadersToDisappear(page);
 
-    // Verify all terms are shown again
-
-    const allTerms = await page.locator('tbody tr[data-row-key]').count();
-
-    // 51 because there is one additional row which is not rendered
-    expect(allTerms).toBeGreaterThanOrEqual(50);
+    // Verify all terms are shown again.
+    //
+    // waitForResponse only proves the listing bytes arrived — the component
+    // still has to apply the store update and re-render the rows, which
+    // happens in a later microtask (GlossaryTermTab sets the terms after its
+    // own await). A single count() here has no retry budget and samples the
+    // stale search results instead, so poll the rendered row count.
+    //
+    // Polling rather than toHaveCount: the tab auto-fetches another page when
+    // the rows do not fill the viewport, so an exact count would swap this
+    // flake for a different one.
+    await expect
+      .poll(() => page.locator('tbody tr[data-row-key]').count())
+      .toBeGreaterThanOrEqual(50);
   });
 
   test('should expand and collapse all terms', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -627,10 +627,26 @@ test.describe.serial('Team persona setting flow', () => {
       await adminPage.getByTestId(teamUser.responseData.name).click();
       await userProfileResponse;
 
-      // The inherited team persona must NOT be shown as the user's default persona
       await adminPage.getByTestId('persona-details-card').waitFor();
-      await expect(adminPage.getByTestId('default-persona-chip')).toContainText(
-        'No default persona'
+
+      const defaultPersonaChip = adminPage.getByTestId('default-persona-chip');
+      // Asserted so the negative check below cannot pass against a chip that
+      // never rendered.
+      await expect(defaultPersonaChip).toBeVisible();
+
+      // The inherited team persona must NOT be shown as the user's default
+      // persona.
+      //
+      // Deliberately not asserting the literal "No default persona"
+      // placeholder: when a user has no default persona the backend resolves
+      // the field to the *system* default persona, which is global state this
+      // test does not own. The sibling describe in this file sets and clears a
+      // system default, and the environment ships with one pre-seeded, so the
+      // placeholder only appears when unrelated work happens to have cleared
+      // it. The invariant under test is just that the team's persona is not
+      // auto-applied.
+      await expect(defaultPersonaChip).not.toContainText(
+        teamPersona.responseData.displayName
       );
 
       // The misleading inherited icon must not be rendered on the default persona

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/alert.ts
@@ -180,16 +180,38 @@ export const findPageWithAlert = async (
 ) => {
   const { id } = alertDetails;
   await waitForAllLoadersToDisappear(page);
+
+  // The alerts page renders no [data-testid="loader"], so the wait above is
+  // vacuous here, and the table body renders zero rows while a fetch is in
+  // flight. isHidden() does NOT wait, so sampling it against an unpainted table
+  // reports a false "not on this page"; isEnabled() DOES wait, so it resolves
+  // after the paint and reports Next as enabled. That mismatch walked the
+  // pagination past the alert, and because the walk is forward-only and returns
+  // silently, the caller's click then waited out the whole test budget on a row
+  // sitting on an earlier page. Wait for the body to paint before sampling.
+  await expect(page.locator('[data-row-key]').first()).toBeVisible();
+
   // Support both core-ui Table (id attr) and legacy Ant Design Table (data-row-key)
   const alertRow = page.locator(`[id="${id}"], [data-row-key="${id}"]`);
   const nextButton = page.locator('[data-testid="next"]');
-  if ((await alertRow.isHidden()) && (await nextButton.isEnabled())) {
-    const getAlerts = page.waitForResponse('/api/v1/events/subscriptions?*');
-    await nextButton.click();
-    await getAlerts;
-    await waitForAllLoadersToDisappear(page);
-    await findPageWithAlert(page, alertDetails);
+
+  if (await alertRow.isVisible()) {
+    return;
   }
+
+  // isVisible() before isEnabled(): isEnabled() waits for attachment with no
+  // timeout, so on a single-page list — where pagination is not rendered at all
+  // — it would block indefinitely.
+  if (!(await nextButton.isVisible()) || !(await nextButton.isEnabled())) {
+    throw new Error(
+      `Alert "${alertDetails.name}" (${id}) was not found on any page of the alerts list.`
+    );
+  }
+
+  const getAlerts = page.waitForResponse('/api/v1/events/subscriptions?*');
+  await nextButton.click();
+  await getAlerts;
+  await findPageWithAlert(page, alertDetails);
 };
 
 export const deleteAlertSteps = async (

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entityPanel.ts
@@ -26,30 +26,57 @@ export const getEntityFqn = (
 };
 
 const findOptionByScrolling = async (page: Page, endpoint: string) => {
-  let tries = 0;
-  const maxTries = 5; // Limit the number of scroll attempts to prevent infinite loops
+  const maxTries = 12; // Bound the scan; the list is ~25 options over ~3 viewports.
   const filterName = ENDPOINT_TO_FILTER_MAP[endpoint];
   const dropdown = page
     .getByTestId('global-search-select-dropdown')
     .locator('.rc-virtual-list-holder');
   const option = page.getByTestId(`global-search-select-option-${filterName}`);
-  while (tries < maxTries) {
-    if (await option.isVisible()) {
+
+  // The filter list is virtualised, so only the ~11 rows around the current
+  // offset exist in the DOM: every option below "Container" — Stored Procedure,
+  // Data Product, API Endpoint, API Collection, Metric and the rest — is absent
+  // until scrolled into range.
+  //
+  // waitFor() rather than isVisible(): isVisible() resolves immediately and
+  // never retries, so probing it straight after scrollBy() races the re-render
+  // of the virtual window. That is why every entity type past the initial
+  // window was flaky under CI load while those inside it never were. When the
+  // option is already rendered this resolves instantly, so the timeout is only
+  // ever paid once per scroll step.
+  for (let tries = 0; tries < maxTries; tries++) {
+    const appeared = await option
+      .waitFor({ state: 'visible', timeout: 1_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (appeared) {
       await option.click();
-      return;
+
+      return true;
     }
-    // Scroll the dropdown to load more options
-    await dropdown.evaluate((element) => {
-      element.scrollBy(0, 100); // Adjust scroll amount as needed
+
+    // Advance a whole viewport so the scan covers the list in a few steps, and
+    // detect the end from the clamped scrollTop rather than a fixed try count.
+    const movedBy = await dropdown.evaluate((element) => {
+      const before = element.scrollTop;
+      element.scrollBy(0, element.clientHeight);
+
+      return element.scrollTop - before;
     });
-    tries++;
+
+    if (movedBy === 0) {
+      break; // Already at the bottom: the option is not in this list.
+    }
   }
+
   await dropdown.evaluate((element) => {
     element.scrollTop = 0;
   });
-  throw new Error(
-    `Unable to find global search filter option "${filterName}" for endpoint "${endpoint}" after ${maxTries} scroll attempts.`
-  );
+
+  // Returned rather than thrown: the caller runs this inside an expect.poll,
+  // and a thrown error aborts that poll outright instead of letting it retry.
+  return false;
 };
 
 export const openEntitySummaryPanel = async ({
@@ -76,7 +103,9 @@ export const openEntitySummaryPanel = async ({
       await page.getByTestId('global-search-select-dropdown').waitFor({
         state: 'visible',
       });
-      await findOptionByScrolling(page, endpoint);
+      if (!(await findOptionByScrolling(page, endpoint))) {
+        return false;
+      }
     }
     const searchResponsePromise = page.waitForResponse((response) =>
       response.url().includes('/api/v1/search/query')
@@ -98,6 +127,8 @@ export const openEntitySummaryPanel = async ({
       await tab.click();
       await waitForAllLoadersToDisappear(page);
     }
+
+    return true;
   };
 
   const entityResultCard = fullyQualifiedName
@@ -111,8 +142,12 @@ export const openEntitySummaryPanel = async ({
 
   if (dataAssetTypeLeftPanelTestId) {
     // The knowledge-center card is only revealed after selecting the KC item
-    // below, so it cannot gate the retry — issue a single search here.
-    await runSearch();
+    // below, so it cannot gate the retry — issue a single search here. No poll
+    // wraps this branch, so a filter option that never rendered is fatal.
+    expect(
+      await runSearch(),
+      `Unable to select global search filter for endpoint "${endpoint}"`
+    ).toBe(true);
   } else {
     // Search indexing is eventually consistent and lags further under CI load, so
     // a freshly created entity may not surface on the first query. Retry the
@@ -127,7 +162,12 @@ export const openEntitySummaryPanel = async ({
             await waitForAllLoadersToDisappear(page);
           }
           hasSearched = true;
-          await runSearch();
+
+          // A filter option that has not rendered yet is transient: let the
+          // poll reload and retry rather than failing the test outright.
+          if (!(await runSearch())) {
+            return false;
+          }
 
           return entityResultCard.isVisible();
         },


### PR DESCRIPTION
Rolling batch of flaky-test fixes for `2.0`, continuing #31076. Each commit is independently root-caused, with evidence from the failing attempt's artifacts.

---

## 1. Poll the glossary row count instead of sampling it once

**Fixes:** `Large Glossary Performance Tests › should search and filter glossary terms` — flaky **6/16** AUT 2.0 nightlies.

```
expect(received).toBeGreaterThanOrEqual(expected)
Expected: >= 50
Received: 17
```

### Root cause

After clearing the search box the test awaits the listing response, then reads `locator.count()` **exactly once**, with no retry budget. `waitForResponse` only proves the bytes arrived — `GlossaryTermTab` still has to apply the store update and re-render the rows, which happens in a later microtask. The single sample returns the stale search results.

### Evidence

- **17 is not a partial render.** It is precisely what `Term_5` matches: `Term_5` + `Term_50..59` + six child terms. The same 17 appears in two independent failing runs.
- The failure-time page snapshot shows **all 50 rows present and the search box already cleared** — the state the assertion wanted had arrived, just after it looked.
- **Working-vs-broken pair in the same test:** the search branch waits for loaders (line 198) and does not flake; the clear branch omitted it. In one failing run that loader wait took **906 ms**; the clear branch granted the same work **2 ms**.

### Fix

Poll the rendered row count. Deliberately *not* `toHaveCount(50)` — the tab auto-fetches another page when rows do not fill the viewport, so an exact count would swap this flake for a different one.

**Verified:** 3/3 locally.

---

*Further fixes will be appended to this PR as they are verified.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Test fixes:**
    - Updated virtualised filter option lookup in `entityPanel.ts` to use `waitFor()` with retries and viewport scrolling
    - Scoped the moved-document assertion to its target folder in `ContextCenterDocument.spec.ts` to prevent pagination displacement
    - Settled alerts table rows before pagination checks in `alert.ts` to avoid false negatives
    - Asserted team-persona invariant against global defaults in `PersonaFlow.spec.ts`

<sub>This will update automatically on new commits.</sub>