### PR TITLE
fix(ingestion): resolve topic sample values past nested record type names

### DIFF
--- a/ingestion/src/metadata/sampler/messaging/sampler.py
+++ b/ingestion/src/metadata/sampler/messaging/sampler.py
@@ -112,30 +112,41 @@ class MessagingSampler(SamplerInterface):
 
     @staticmethod
     def _walk(msg: dict, dotted: str) -> object:
-        """Walk a dotted path into nested dicts, returning MISSING when absent."""
+        """Walk a dotted path into nested dicts, returning MISSING when absent.
+
+        Schema paths interleave record *type* names with field names: the avro
+        parser emits ``Order.shipping.Address.city`` for a wire message shaped
+        ``{"shipping": {"city": ...}}``, naming the record type at every RECORD
+        level. Only the field names reach the wire, so a segment the current
+        object does not carry is a type name and is skipped.
+
+        The leaf is exempt from that skip. A missing leaf is a genuine miss, and
+        letting it through would resolve the column to its own container.
+        """
         cur: object = msg
-        for part in dotted.split("."):
-            if not isinstance(cur, dict) or part not in cur:
+        parts = dotted.split(".")
+        for index, part in enumerate(parts):
+            if not isinstance(cur, dict):
                 return MISSING
-            cur = cur[part]
+            if part in cur:
+                cur = cur[part]
+            elif index == len(parts) - 1:
+                return MISSING
         return cur
 
     @staticmethod
     def _resolve(msg: dict, dotted: str) -> object:
-        """Resolve a column path against a message, tolerating the schema root.
+        """Resolve a column path against a message, tolerating schema type names.
 
-        Column paths carry the schema's root RECORD (``Order.email``) because that
-        is what the auto-classification processor matches on, but the message on
-        the wire is unwrapped (``{"email": ...}``). Try the full path first so a
-        genuinely wrapped message keeps winning.
+        Column paths carry the schema's record type names because that is what
+        the auto-classification processor matches on, while the message on the
+        wire carries only field names. Consuming a segment whenever the message
+        does have it keeps a genuinely wrapped message winning over a same-named
+        sibling, and keeps a field explicitly set to null on its own value
+        instead of inheriting one.
         """
-        for candidate in (dotted, dotted.split(".", 1)[-1]):
-            value = MessagingSampler._walk(msg, candidate)
-            # Only an absent path falls through: a field explicitly set to null is
-            # the schema-correct answer and must not inherit a same-named sibling.
-            if value is not MISSING:
-                return value
-        return None
+        value = MessagingSampler._walk(msg, dotted)
+        return None if value is MISSING else value
 
     def fetch_sample_data(self, columns: Optional[List[SQALikeColumn]]) -> TableData:  # noqa: UP006, UP045
         column_objs = columns or self.get_columns()

--- a/ingestion/tests/unit/sampler/test_messaging_sampler.py
+++ b/ingestion/tests/unit/sampler/test_messaging_sampler.py
@@ -25,6 +25,11 @@ from metadata.generated.schema.type.schema import DataTypeTopic, FieldModel
 from metadata.generated.schema.type.schema import Topic as MessageSchema
 from metadata.sampler.messaging.sampler import MessagingSampler
 
+# Mirrors what metadata.parsers.avro_parser actually emits: every RECORD level
+# contributes the record *type* name as its own path segment -- ``Order`` at the
+# root, ``Address`` under the ``shipping`` field -- and none of those segments
+# exist in the message on the wire. An earlier version of this fixture omitted
+# the nested type name, so no test ever walked a path deeper than the root.
 NESTED_FIELDS = [
     FieldModel(
         name="Order",
@@ -36,8 +41,14 @@ NESTED_FIELDS = [
                 name="shipping",
                 dataType=DataTypeTopic.RECORD,
                 children=[
-                    FieldModel(name="city", dataType=DataTypeTopic.STRING),
-                    FieldModel(name="country", dataType=DataTypeTopic.STRING),
+                    FieldModel(
+                        name="Address",
+                        dataType=DataTypeTopic.RECORD,
+                        children=[
+                            FieldModel(name="city", dataType=DataTypeTopic.STRING),
+                            FieldModel(name="country", dataType=DataTypeTopic.STRING),
+                        ],
+                    )
                 ],
             ),
         ],
@@ -82,8 +93,8 @@ def test_column_names_keep_the_schema_root_prefix() -> None:
     assert [col.name for col in sampler.get_columns()] == [
         "Order.order_id",
         "Order.email",
-        "Order.shipping.city",
-        "Order.shipping.country",
+        "Order.shipping.Address.city",
+        "Order.shipping.Address.country",
     ]
 
 
@@ -99,8 +110,30 @@ def test_unwrapped_message_resolves_against_a_nested_schema() -> None:
 
     assert row["Order.order_id"] == "o-1"
     assert row["Order.email"] == "user@example.com"
-    assert row["Order.shipping.city"] == "Springfield"
-    assert row["Order.shipping.country"] == "US"
+    assert row["Order.shipping.Address.city"] == "Springfield"
+    assert row["Order.shipping.Address.country"] == "US"
+
+
+def test_wrapped_message_resolves_past_a_nested_record_type_name() -> None:
+    message = {"Order": {"shipping": {"city": "Springfield"}}}
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    assert _row(sampler)["Order.shipping.Address.city"] == "Springfield"
+
+
+def test_nested_record_carrying_its_type_name_still_resolves() -> None:
+    """A producer that does emit the type name must keep working."""
+    message = {"shipping": {"Address": {"city": "Shelbyville"}}}
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [message])
+
+    assert _row(sampler)["Order.shipping.Address.city"] == "Shelbyville"
+
+
+def test_absent_nested_leaf_is_none_not_its_container() -> None:
+    """Skipping absent segments must never let a leaf resolve to the dict above it."""
+    sampler = _StubSampler(_topic(NESTED_FIELDS), [{"shipping": {"country": "US"}}])
+
+    assert _row(sampler)["Order.shipping.Address.city"] is None
 
 
 def test_wrapped_message_still_resolves_on_the_full_path() -> None:


### PR DESCRIPTION
### Describe your changes:

Follow-up to #30894. No separate issue — this is the same defect that PR fixed, still reachable one level down. Happy to open one if you'd rather have it tracked.

#30894 fixed the schema root, but **only** the root. The avro parser names the record *type* at every RECORD level, not just the top one — `parse_record_fields` emits the field name and the record type name as two separate segments:

```python
# ingestion/src/metadata/parsers/avro_parser.py
children = cls(
    name=field.name,                    # "shipping" — the field name, on the wire
    dataType=RECORD_DATATYPE_NAME,
    children=[cls(name=field.type.name, # "Address"  — the record type, NOT on the wire
                  dataType=RECORD_DATATYPE_NAME, ...)],
)
```

So a wire message shaped `{"shipping": {"city": ...}}` gets the column path `Order.shipping.Address.city`. Stripping one leading segment leaves `shipping.Address.city`, which still misses on `Address`, and every field below a nested record sampled as `null` — exactly the symptom #30894 set out to fix, for anything deeper than a flat schema.

`_walk` now consumes a segment when the current object has it and skips it when it does not, which handles a type name at any depth. The leaf is exempt from that skip: an absent leaf stays `MISSING` rather than resolving to its own container. `_resolve` loses the two-candidate retry, which skipping subsumes.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Two files, but the invariant is subtle enough to state:

- **Consume-or-skip, leaf exempt.** Consuming a segment whenever the message carries it preserves both guarantees #30894 landed — a genuinely wrapped message still wins over a same-named sibling, and a field the producer explicitly set to `null` keeps its own value instead of inheriting one. Exempting the leaf is what stops `Order.shipping.Address.city` from resolving to the `shipping` dict when `city` is absent.
- **Alternative rejected:** teaching `_flatten_field` to drop record type names from the column path. The column names cannot change — `AutoClassificationProcessor._find_column_by_dotted_path` matches on exactly that dotted scheme and is shared with database and storage entities, so renaming would break tagging for every entity type. Same constraint that scoped #30894 to value resolution.
- **Blast radius:** `_walk`/`_resolve` are reached only from `MessagingSampler.fetch_sample_data` (Kafka, Redpanda, and the Kinesis/PubSub stubs). Database and storage samplers are separate classes and untouched. No schema change, so no migration.

#
### Tests:

#### Use cases covered
- Auto Classification on an Avro topic with a nested RECORD samples real values instead of `null`, so PII tags apply below the top level
- A producer that *does* emit the record type name on the wire keeps resolving (no regression)
- A nested leaf absent from the message reports `null`, not the dict above it
- Flat schemas, wrapped messages, and explicitly-null fields keep the #30894 behaviour

#### Unit tests
- [x] Added, in `ingestion/tests/unit/sampler/test_messaging_sampler.py`
- `test_wrapped_message_resolves_past_a_nested_record_type_name` (new) and `test_unwrapped_message_resolves_against_a_nested_schema` (existing, fixture corrected) **fail on `main`** with `assert None == 'Springfield'` and pass here
- `test_nested_record_carrying_its_type_name_still_resolves` and `test_absent_nested_leaf_is_none_not_its_container` are green on `main` too — they are guards, not the fix

The fixture is why this was missed: its nested branch omitted the record type name under `shipping`, a shape `parse_record_fields` cannot produce, so no test ever walked a path deeper than the root and the one-segment strip looked sufficient. It now mirrors the parser.

```
ingestion/tests/unit/sampler        -> 87 passed
ingestion/tests/unit/source/messaging -> 73 passed
```

Coverage on `metadata/sampler/messaging/sampler.py`: **89%**. The misses are the abstract/`NotImplementedError` stubs, the `max_depth` warning, and the mid-path non-dict guard in `_walk` — that guard is pre-existing behaviour that the old code folded into a single `or` expression, so splitting it out exposed an already-untested branch rather than adding one.

#### Backend integration tests
- [x] Not applicable (no backend API changes)

#### Ingestion integration tests
- `ingestion/tests/integration/auto_classification/messaging/` (Kafka + Redpanda) already derives its fields from the real schema parser as of #30894 and covers this path; not re-run here (needs Docker).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes)

#### Manual testing performed
None on a live stack — the defect and the fix are both pinned by unit tests that flip RED→GREEN across the one-line behaviour change, and the parser claim is read straight out of `parse_record_fields`. Worth a live Kafka run with a nested Avro topic before release if you want belt and braces.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue; follows the `fix(ingestion):` convention used by #30894 and #31014 in this series
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — see note at the top
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A, no schema change.
- [x] For UI changes: N/A.
- [x] I have added tests (unit) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)