### PR TITLE
feat(appConfig): add tenant-level defaultAppMode override via yaml

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -854,6 +854,13 @@ rdf:
   dataset: ${RDF_DATASET:-"openmetadata"}
   inferenceEnabled: ${RDF_INFERENCE_ENABLED:-false}
 
+# App Configuration
+# Tenant-wide, yaml/env-only UI configuration. Not backed by the database.
+appConfiguration:
+  # Non-null pins every user to this mode at boot regardless of their per-user
+  # preference (e.g. "ai" or "classic"); null means the user's own preference wins.
+  defaultAppMode: ${APP_DEFAULT_MODE:-null}
+
 # Cache Configuration
 # Caching layer for entity metadata, relationships, and tag usage to reduce database load
 # Default: none (no external dependency). Set CACHE_PROVIDER=redis to enable the

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.openmetadata.DefaultOperationalConfigProvider;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
 import org.openmetadata.schema.api.configuration.dataQuality.DataQualityConfiguration;
 import org.openmetadata.schema.api.configuration.events.EventHandlerConfiguration;
 import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
@@ -191,6 +192,10 @@ public class OpenMetadataApplicationConfig extends Configuration {
 
   @JsonProperty("rdf")
   private RdfConfiguration rdfConfiguration = new RdfConfiguration();
+
+  @JsonProperty("appConfiguration")
+  @Valid
+  private AppConfiguration appConfiguration = new AppConfiguration();
 
   @JsonProperty("cache")
   private org.openmetadata.service.cache.CacheConfig cacheConfig;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.catalog.security.client.SamlSSOClientConfig;
 import org.openmetadata.catalog.type.IdentityProviderConfig;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.api.security.AuthorizerConfiguration;
@@ -158,6 +159,26 @@ public class ConfigResource {
       responseAuthorizerConfig.setPrincipalDomain(yamlConfig.getPrincipalDomain());
     }
     return responseAuthorizerConfig;
+  }
+
+  @GET
+  @Path(("/appConfig"))
+  @Operation(
+      operationId = "getAppConfiguration",
+      summary = "Get app-wide UI configuration (yaml-backed)",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "App configuration",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = AppConfiguration.class)))
+      })
+  public AppConfiguration getAppConfig() {
+    return openMetadataApplicationConfig.getAppConfiguration() != null
+        ? openMetadataApplicationConfig.getAppConfiguration()
+        : new AppConfiguration();
   }
 
   @GET

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/ConfigResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/ConfigResourceTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.resources.system;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+
+/**
+ * Unit tests for {@link ConfigResource}. These exercise the yaml-backed config getters directly
+ * (no HTTP layer, no DB/ES) by mocking {@link OpenMetadataApplicationConfig}, mirroring the
+ * pattern used by {@link IndexResourceTest}.
+ */
+class ConfigResourceTest {
+  private ConfigResource resource;
+
+  @BeforeEach
+  void setUp() {
+    resource = new ConfigResource();
+  }
+
+  @Test
+  void getAppConfig_default_returnsNullDefaultAppMode() {
+    OpenMetadataApplicationConfig config = mock(OpenMetadataApplicationConfig.class);
+    when(config.getAppConfiguration()).thenReturn(new AppConfiguration());
+    resource.initialize(config);
+
+    AppConfiguration result = resource.getAppConfig();
+
+    assertNull(result.getDefaultAppMode());
+  }
+
+  @Test
+  void getAppConfig_whenConfigurationAbsent_returnsFreshDefault() {
+    OpenMetadataApplicationConfig config = mock(OpenMetadataApplicationConfig.class);
+    when(config.getAppConfiguration()).thenReturn(null);
+    resource.initialize(config);
+
+    AppConfiguration result = resource.getAppConfig();
+
+    assertNotNull(result);
+    assertNull(result.getDefaultAppMode());
+  }
+
+  @Test
+  void getAppConfig_withForcedMode_returnsConfiguredValue() {
+    AppConfiguration forced = new AppConfiguration();
+    forced.setDefaultAppMode(AppConfiguration.DefaultAppMode.AI);
+    OpenMetadataApplicationConfig config = mock(OpenMetadataApplicationConfig.class);
+    when(config.getAppConfiguration()).thenReturn(forced);
+    resource.initialize(config);
+
+    AppConfiguration result = resource.getAppConfig();
+
+    assertNotNull(result.getDefaultAppMode());
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/api/configuration/appConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/configuration/appConfiguration.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://open-metadata.org/schema/api/configuration/appConfiguration.json",
+  "title": "AppConfiguration",
+  "description": "App-wide UI configuration set by the deployment operator via yaml/env. Not backed by the database; not mutable at runtime.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.api.configuration.AppConfiguration",
+  "properties": {
+    "defaultAppMode": {
+      "description": "Tenant-wide app-mode force. Non-null pins every user to this mode at boot regardless of their per-user preference; null means user preference wins.",
+      "type": ["string", "null"],
+      "enum": ["ai", "classic", null],
+      "default": null
+    }
+  },
+  "additionalProperties": false
+}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -54,6 +54,7 @@ import { AuthProvider as AuthProviderEnum } from '../../../generated/settings/se
 import { withActivePersonaHeader } from '../../../hoc/withActivePersonaHeader';
 import { withDomainFilter } from '../../../hoc/withDomainFilter';
 import { withLanguageHeader } from '../../../hoc/withLanguageHeader';
+import { hydrateAppModeConfig } from '../../../hooks/currentUserStore/useAppModeConfig';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import { clearAppMode, resolveInitialAppMode } from '../../../hooks/useAppMode';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
@@ -64,6 +65,7 @@ import { clearEtagCache } from '../../../rest/etagInterceptor';
 import {
   fetchAuthenticationConfig,
   fetchAuthorizerConfig,
+  getAppConfig,
 } from '../../../rest/miscAPI';
 import { getLoggedInUser } from '../../../rest/userAPI';
 import applicationRoutesClass from '../../../utils/ApplicationRoutesClassBase';
@@ -127,6 +129,13 @@ let pendingRequests: {
   reject: (reason?: unknown) => void;
   config: InternalAxiosRequestConfig<unknown>;
 }[] = [];
+
+// The tenant app-mode force is a nice-to-have overlay on top of login —
+// an older server without the endpoint (404) or any other fetch failure
+// should not block or fail authentication. Callers treat a caught
+// failure the same as an explicit "no force configured" response.
+const fetchAppConfigSafe = () =>
+  getAppConfig().catch(() => ({ defaultAppMode: null }));
 
 type AuthContextType = {
   onLoginHandler: () => void;
@@ -329,10 +338,14 @@ export const AuthProvider = ({
   const getLoggedInUserDetails = async () => {
     setApplicationLoading(true);
     try {
-      const res = await getLoggedInUser({ fields: userAPIQueryFields });
+      const [res, appConfig] = await Promise.all([
+        getLoggedInUser({ fields: userAPIQueryFields }),
+        fetchAppConfigSafe(),
+      ]);
       if (res) {
         setCurrentUser(res);
         setIsAuthenticated(true);
+        hydrateAppModeConfig(appConfig);
       } else {
         resetUserDetails();
       }
@@ -469,10 +482,14 @@ export const AuthProvider = ({
           clientType,
         });
 
-        const res = await getLoggedInUser({ fields });
+        const [res, appConfig] = await Promise.all([
+          getLoggedInUser({ fields }),
+          fetchAppConfigSafe(),
+        ]);
         if (res) {
           const userDetails = await checkIfUpdateRequired(res, newUser);
           setCurrentUser(userDetails);
+          hydrateAppModeConfig(appConfig);
 
           handledVerifiedUser();
           // Start expiry timer on successful login

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
@@ -22,11 +22,7 @@ export interface AppConfiguration {
     defaultAppMode?: DefaultAppMode | null;
 }
 
-/**
- * Tenant-wide app-mode force. Non-null pins every user to this mode at boot regardless of
- * their per-user preference; null means user preference wins.
- */
 export enum DefaultAppMode {
-    Ai = "ai",
+    AI = "ai",
     Classic = "classic",
 }

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * App-wide UI configuration set by the deployment operator via yaml/env. Not backed by the
+ * database; not mutable at runtime.
+ */
+export interface AppConfiguration {
+    /**
+     * Tenant-wide app-mode force. Non-null pins every user to this mode at boot regardless of
+     * their per-user preference; null means user preference wins.
+     */
+    defaultAppMode?: DefaultAppMode | null;
+}
+
+/**
+ * Tenant-wide app-mode force. Non-null pins every user to this mode at boot regardless of
+ * their per-user preference; null means user preference wins.
+ */
+export enum DefaultAppMode {
+    Ai = "ai",
+    Classic = "classic",
+}

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.test.ts
@@ -66,4 +66,19 @@ describe('hydrateAppModeConfig', () => {
     expect(useAppModeConfig.getState().isForced).toBe(true);
     expect(writeAppMode).toHaveBeenCalledWith('default');
   });
+
+  it('re-pins the runtime mode on a same-tab re-hydration when isForced is stale', () => {
+    // Regression: the store is module-level and survives an SPA logout→login
+    // without a page reload. If a prior session left `isForced=true`,
+    // writeAppMode's own guard would no-op the re-hydration's initial pin
+    // and the new session would be stuck on the previous runtime mode.
+    // hydrateAppModeConfig must reset the force BEFORE the pin so the write
+    // always lands.
+    useAppModeConfig.getState().setForced('ai'); // stale from prior session
+
+    hydrateAppModeConfig({ defaultAppMode: 'ai' });
+
+    expect(writeAppMode).toHaveBeenCalledWith('ai');
+    expect(useAppModeConfig.getState().isForced).toBe(true);
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.test.ts
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { writeAppMode } from '../useAppMode';
+import { hydrateAppModeConfig, useAppModeConfig } from './useAppModeConfig';
+
+jest.mock('../useAppMode', () => ({
+  writeAppMode: jest.fn(),
+  useAppMode: () => 'classic',
+}));
+
+beforeEach(() => {
+  useAppModeConfig.getState().setForced(null);
+  (writeAppMode as jest.Mock).mockClear();
+});
+
+describe('useAppModeConfig', () => {
+  it('setForced with a value sets isForced true and forcedMode', () => {
+    useAppModeConfig.getState().setForced('ai');
+
+    expect(useAppModeConfig.getState().isForced).toBe(true);
+    expect(useAppModeConfig.getState().forcedMode).toBe('ai');
+  });
+
+  it('setForced(null) clears the force', () => {
+    useAppModeConfig.getState().setForced('ai');
+    useAppModeConfig.getState().setForced(null);
+
+    expect(useAppModeConfig.getState().isForced).toBe(false);
+    expect(useAppModeConfig.getState().forcedMode).toBeNull();
+  });
+});
+
+describe('hydrateAppModeConfig', () => {
+  it('with a value forces and pins runtime mode', () => {
+    hydrateAppModeConfig({ defaultAppMode: 'ai' });
+
+    expect(useAppModeConfig.getState().isForced).toBe(true);
+    expect(writeAppMode).toHaveBeenCalledWith('ai');
+  });
+
+  it('null clears force and does not pin runtime', () => {
+    hydrateAppModeConfig({ defaultAppMode: null });
+
+    expect(useAppModeConfig.getState().isForced).toBe(false);
+    expect(writeAppMode).not.toHaveBeenCalled();
+  });
+
+  it('maps the "classic" wire value to the DEFAULT_APP_MODE runtime string', () => {
+    // Core's runtime mode string for Classic is "default", not "classic" —
+    // see APP_MODE_ENUM_TO_RUNTIME in useResolvedAppMode.ts. The tenant
+    // force must go through the same translation or writeAppMode('classic')
+    // would set a runtime mode nothing else recognizes.
+    hydrateAppModeConfig({ defaultAppMode: 'classic' });
+
+    expect(useAppModeConfig.getState().isForced).toBe(true);
+    expect(writeAppMode).toHaveBeenCalledWith('default');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
@@ -52,16 +52,19 @@ const CONFIG_MODE_TO_RUNTIME: Record<string, string> = {
  * Hydrate the tenant-level app-mode force from the boot-time
  * `GET /system/config/appConfig` response.
  *
- * Order matters: the runtime pin (`writeAppMode`) is written BEFORE
- * `setForced` flips `isForced` to true. `writeAppMode` has its own guard
- * that no-ops once a force is active (see `useAppMode.ts`) — writing
- * first means this initial pin lands while the store still looks
- * unforced, and every write after this one is correctly blocked.
+ * Order matters. `writeAppMode` no-ops once `isForced` is true, so:
+ *   1. Reset the force first — the store is module-level and survives an
+ *      SPA logout→login on the same tab, so a stale `isForced=true` from a
+ *      prior session would block the re-pin below.
+ *   2. Write the runtime pin while the store still looks unforced.
+ *   3. Flip `isForced` to true (if this tenant has a force) so every
+ *      subsequent user-initiated write is blocked.
  */
 export const hydrateAppModeConfig = (config: AppConfiguration): void => {
   const wireMode = config?.defaultAppMode ?? null;
   const runtimeMode = wireMode ? CONFIG_MODE_TO_RUNTIME[wireMode] : null;
 
+  useAppModeConfig.getState().setForced(null);
   if (runtimeMode) {
     writeAppMode(runtimeMode);
   }

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
@@ -45,7 +45,7 @@ export const useAppModeConfig = create<AppModeConfigStore>((set) => ({
  */
 const CONFIG_MODE_TO_RUNTIME: Record<string, string> = {
   [DefaultAppMode.Classic]: DEFAULT_APP_MODE,
-  [DefaultAppMode.Ai]: AI_APP_MODE,
+  [DefaultAppMode.AI]: AI_APP_MODE,
 };
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useAppModeConfig.ts
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { create } from 'zustand';
+import {
+  AI_APP_MODE,
+  DEFAULT_APP_MODE,
+} from '../../constants/appMode.constants';
+import {
+  AppConfiguration,
+  DefaultAppMode,
+} from '../../generated/api/configuration/appConfiguration';
+import { writeAppMode } from '../useAppMode';
+
+interface AppModeConfigStore {
+  isForced: boolean;
+  forcedMode: string | null;
+  setForced: (mode: string | null) => void;
+}
+
+export const useAppModeConfig = create<AppModeConfigStore>((set) => ({
+  isForced: false,
+  forcedMode: null,
+  setForced: (mode) => set({ isForced: mode != null, forcedMode: mode }),
+}));
+
+/**
+ * Translate the yaml/env-facing `defaultAppMode` wire value into the
+ * runtime mode string consumed by `useAppMode`. Mirrors
+ * `APP_MODE_ENUM_TO_RUNTIME` in `useResolvedAppMode.ts`: core has always
+ * used the string `DEFAULT_APP_MODE` ("default") for Classic, while the
+ * Collate plugin registers its routes under `AI_APP_MODE` ("ai"). The
+ * yaml value stays the readable "ai" / "classic" pair for operators; this
+ * map is the only place that needs to know the runtime strings differ.
+ */
+const CONFIG_MODE_TO_RUNTIME: Record<string, string> = {
+  [DefaultAppMode.Classic]: DEFAULT_APP_MODE,
+  [DefaultAppMode.Ai]: AI_APP_MODE,
+};
+
+/**
+ * Hydrate the tenant-level app-mode force from the boot-time
+ * `GET /system/config/appConfig` response.
+ *
+ * Order matters: the runtime pin (`writeAppMode`) is written BEFORE
+ * `setForced` flips `isForced` to true. `writeAppMode` has its own guard
+ * that no-ops once a force is active (see `useAppMode.ts`) — writing
+ * first means this initial pin lands while the store still looks
+ * unforced, and every write after this one is correctly blocked.
+ */
+export const hydrateAppModeConfig = (config: AppConfiguration): void => {
+  const wireMode = config?.defaultAppMode ?? null;
+  const runtimeMode = wireMode ? CONFIG_MODE_TO_RUNTIME[wireMode] : null;
+
+  if (runtimeMode) {
+    writeAppMode(runtimeMode);
+  }
+  useAppModeConfig.getState().setForced(wireMode);
+};

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
@@ -12,6 +12,7 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { useApplicationStore } from '../useApplicationStore';
+import { useAppModeConfig } from './useAppModeConfig';
 import {
   useCurrentUserPreferences,
   usePersistentStorage,
@@ -207,6 +208,56 @@ describe('useCurrentUserStore', () => {
       rerender();
 
       expect(result.current.setPreference).toBe(firstSetPreference);
+    });
+
+    // Regression guard: a tenant-level appMode force (useAppModeConfig)
+    // must lock out only the `appMode` key of setPreference, not the
+    // whole hook — see useAppModeConfig.ts / hydrateAppModeConfig.
+    describe('with a tenant appMode force active', () => {
+      afterEach(() => {
+        useAppModeConfig.getState().setForced(null);
+      });
+
+      it('setPreference({ appMode }) is a no-op', () => {
+        mockUseApplicationStore.mockImplementation((selector) => {
+          const mockState = {
+            currentUser: { name: 'alice' },
+          } as any;
+
+          return selector(mockState);
+        });
+        usePersistentStorage.setState({
+          preferences: {
+            alice: { ...defaultPreferences, appMode: 'classic' },
+          },
+        });
+        useAppModeConfig.getState().setForced('ai');
+
+        const { result } = renderHook(() => useCurrentUserPreferences());
+        result.current.setPreference({ appMode: 'ai' });
+
+        expect(
+          usePersistentStorage.getState().preferences.alice.appMode
+        ).toBe('classic');
+      });
+
+      it('setPreference({ isSidebarCollapsed }) still writes (per-key guard)', () => {
+        mockUseApplicationStore.mockImplementation((selector) => {
+          const mockState = {
+            currentUser: { name: 'alice' },
+          } as any;
+
+          return selector(mockState);
+        });
+        useAppModeConfig.getState().setForced('ai');
+
+        const { result } = renderHook(() => useCurrentUserPreferences());
+        result.current.setPreference({ isSidebarCollapsed: true });
+
+        expect(
+          usePersistentStorage.getState().preferences.alice.isSidebarCollapsed
+        ).toBe(true);
+      });
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
@@ -236,9 +236,9 @@ describe('useCurrentUserStore', () => {
         const { result } = renderHook(() => useCurrentUserPreferences());
         result.current.setPreference({ appMode: 'ai' });
 
-        expect(
-          usePersistentStorage.getState().preferences.alice.appMode
-        ).toBe('classic');
+        expect(usePersistentStorage.getState().preferences.alice.appMode).toBe(
+          'classic'
+        );
       });
 
       it('setPreference({ isSidebarCollapsed }) still writes (per-key guard)', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
@@ -17,6 +17,7 @@ import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { PAGE_SIZE_BASE } from '../../constants/constants';
 import { useApplicationStore } from '../useApplicationStore';
+import { useAppModeConfig } from './useAppModeConfig';
 
 export interface MarketplaceRecentSearchEntry {
   term: string;
@@ -116,9 +117,20 @@ export const useCurrentUserPreferences = () => {
   // identity would recreate those callbacks and cancel debounced work.
   const setPreference = useCallback(
     (newPreferences: Partial<UserPreferences>) => {
-      if (userName) {
-        setUserPreference(userName, newPreferences);
+      if (!userName) {
+        return;
       }
+      const guarded = { ...newPreferences };
+      // Per-key guard: a tenant-level appMode force (see useAppModeConfig)
+      // makes the appMode key read-only from the user's side. Every other
+      // key still writes through — this is not a whole-hook lockout.
+      if (useAppModeConfig.getState().isForced && 'appMode' in guarded) {
+        delete guarded.appMode;
+      }
+      if (Object.keys(guarded).length === 0) {
+        return;
+      }
+      setUserPreference(userName, guarded);
     },
     [userName, setUserPreference]
   );

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
@@ -19,6 +19,7 @@ import {
   APP_MODE_SESSION_KEY,
   DEFAULT_APP_MODE,
 } from '../constants/appMode.constants';
+import { useAppModeConfig } from './currentUserStore/useAppModeConfig';
 import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 import {
   clearAppMode,
@@ -171,6 +172,37 @@ describe('writeAppMode', () => {
     const parsed = JSON.parse(raw ?? '') as { mode: string; ts: number };
 
     expect(parsed.mode).toBe(DEFAULT_APP_MODE);
+  });
+});
+
+describe('writeAppMode guard (tenant appMode force)', () => {
+  beforeEach(resetStore);
+
+  afterEach(() => {
+    useAppModeConfig.getState().setForced(null);
+  });
+
+  it('is a no-op when appModeConfig.isForced is true', () => {
+    useAppModeConfig.getState().setForced('ai');
+
+    writeAppMode('classic');
+
+    // The force flag alone (set directly, bypassing hydrateAppModeConfig)
+    // does not pin the runtime store — only writeAppMode does that, and
+    // it is exactly what this call is asserting stays blocked. So the
+    // store must still read its resetStore baseline, not the rejected
+    // 'classic' write.
+    expect(useAppModeStore.getState().currentMode).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('does not block writes once the force is cleared', () => {
+    useAppModeConfig.getState().setForced('ai');
+    writeAppMode('classic');
+    useAppModeConfig.getState().setForced(null);
+
+    writeAppMode('classic');
+
+    expect(useAppModeStore.getState().currentMode).toBe('classic');
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
@@ -19,6 +19,7 @@ import {
   APP_MODE_SESSION_KEY,
   DEFAULT_APP_MODE,
 } from '../constants/appMode.constants';
+import { useAppModeConfig } from './currentUserStore/useAppModeConfig';
 import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 
 /**
@@ -262,6 +263,16 @@ export const writeAppMode = (
   mode: string,
   personaAppMode?: string | null
 ): void => {
+  // Tenant-level force (see useAppModeConfig / hydrateAppModeConfig) hard-
+  // locks the runtime mode: once active, neither the switcher nor the
+  // resolver may move it. `hydrateAppModeConfig` itself calls this
+  // function to perform the INITIAL pin before flipping `isForced`, so
+  // this guard never blocks that first write — only writes that happen
+  // after the force is already active.
+  if (useAppModeConfig.getState().isForced) {
+    return;
+  }
+
   const nextPersonaAppMode =
     personaAppMode === undefined
       ? readSession()?.personaAppMode ?? null

--- a/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/miscAPI.ts
@@ -19,6 +19,7 @@ import { WILD_CARD_CHAR } from '../constants/char.constants';
 import { PAGE_SIZE } from '../constants/constants';
 import { AsyncDeleteJob } from '../context/AsyncDeleteProvider/AsyncDeleteProvider.interface';
 import { SearchIndex } from '../enums/search.enum';
+import { AppConfiguration } from '../generated/api/configuration/appConfiguration';
 import { AuthenticationConfiguration } from '../generated/configuration/authenticationConfiguration';
 import { AuthorizerConfiguration } from '../generated/configuration/authorizerConfiguration';
 import { AggregationRequest } from '../generated/search/aggregationRequest';
@@ -118,6 +119,14 @@ export const fetchAuthenticationConfig = async () => {
 export const fetchAuthorizerConfig = async () => {
   const response = await APIClient.get<AuthorizerConfiguration>(
     '/system/config/authorizer'
+  );
+
+  return response.data;
+};
+
+export const getAppConfig = async (): Promise<AppConfiguration> => {
+  const response = await APIClient.get<AppConfiguration>(
+    '/system/config/appConfig'
   );
 
   return response.data;


### PR DESCRIPTION
## Summary

Add a **yaml-configured tenant-level force** for the app mode. Operators can pin every user in a deployment to a specific mode (`ai` or `classic`) via `openmetadata.yaml` — overriding the per-user preference. When unset, the current per-user behavior wins.

Complements #31030 (per-user preference persistence). Independent of it — this PR branches off `main` and can land in either order.

## Fallback chain at boot

1. `appConfiguration.defaultAppMode` (tenant force from yaml)
2. `user.preferences.appMode` (per-user preference, from #31030)
3. `DEFAULT_APP_MODE` constant

## What changed

**Backend (yaml → Java → REST):**
- New JSON schema `openmetadata-spec/.../api/configuration/appConfiguration.json` with a nullable `defaultAppMode` field (enum: `"ai" | "classic" | null`).
- `OpenMetadataApplicationConfig.appConfiguration` field, defaulted to `new AppConfiguration()` so `getDefaultAppMode()` is null-safe when yaml is absent.
- New endpoint `GET /v1/system/config/appConfig` in `ConfigResource` — mirrors the `/authorizer` pattern (reads from `openMetadataApplicationConfig`, not `SettingsCache`). Standard `JwtFilter` auth.
- `conf/openmetadata.yaml` gains:
  ```yaml
  appConfiguration:
    defaultAppMode: ${APP_DEFAULT_MODE:-null}
  ```

**UI:**
- `getAppConfig()` in `rest/miscAPI.ts`.
- New `useAppModeConfig` Zustand store with `{ isForced, forcedMode, setForced }`.
- `hydrateAppModeConfig(config)` — called from both bootstrap paths in `AuthProvider.tsx` (returning-session AND fresh-login), via `Promise.all([getLoggedInUser(), getAppConfig()])` to avoid a waterfall. When `defaultAppMode` is non-null, pins runtime via `writeAppMode` and sets `isForced=true`.
- **Hard force**: both `writeAppMode(...)` (in `useAppMode.ts`) and `setPreference({ appMode })` (in `useCurrentUserStore.ts`) short-circuit when `isForced` is true. The `setPreference` guard is per-key — other preference keys still write through normally.
- **Correctness fix discovered during implementation**: added a `CONFIG_MODE_TO_RUNTIME` translation (`'classic'` → `DEFAULT_APP_MODE` which is `'default'`). Without this, forcing "classic" would have set an unrecognized runtime string, and `useIsAiMode()` would incorrectly return `true` for a classic-forced tenant. Mirrors the existing `APP_MODE_ENUM_TO_RUNTIME` pattern in `useResolvedAppMode.ts`.

## Testing

- **Java**: `ConfigResourceTest` (new, 3/3 pass) — Mockito unit test in the same style as `IndexResourceTest.java`. No infra needed; runs via plain `mvn test`. Covers: default returns null; configured value is echoed; null-safe when `getAppConfiguration()` returns `null`.
- **Jest**: 54/54 pass across `useAppModeConfig` (new suite), `useCurrentUserStore` (+2 guard tests), `useAppMode` (+2 guard tests). Pre-existing `AuthProvider.test.tsx` still 12/12 (no regression).
- **Lint + tsc**: clean on touched files.
- `mvn spotless:apply` clean on `openmetadata-service` / `openmetadata-spec`.

## Design decisions locked

- **Yaml-only** — no DB storage, no `SettingsCache`, no admin UI page, no runtime mutation. Ops change the value by editing yaml + restart, same as `authorizerConfiguration`.
- **Boot-only enforcement** — no mid-session flip when yaml changes.
- **Hard force** — user can't fight the admin's choice. `AppModeSwitcher` (Collate-side follow-up) will hide when forced.
- **Per-key guard** — only the `appMode` key is guarded on `setPreference`; other user prefs pass through.

## Not in scope

- Admin UI settings page — future PR if ever needed. For now ops set via env var / yaml.
- Live enforcement / SSE push of yaml changes — would need a new subsystem.
- `AppModeSwitcher` visibility guard — lives in Collate, tracked separately.

## Test plan for reviewers

- [ ] CI passes (Java unit tests + Jest suite).
- [ ] Deploy with `APP_DEFAULT_MODE=ai` → every user lands in AI mode at login; user toggle attempts are no-ops.
- [ ] Deploy with `APP_DEFAULT_MODE=classic` → same in reverse (verifies the runtime translation).
- [ ] Deploy without setting the env → behavior is identical to today (user preference wins, or `DEFAULT_APP_MODE` if no preference).
- [ ] `GET /api/v1/system/config/appConfig` returns `{ defaultAppMode: null }` on a default deployment; returns the configured value when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
