### PR TITLE
Fixes #30678: propagate inherited domains to descendants in search on domain move

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductDomainMigrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductDomainMigrationIT.java
@@ -738,7 +738,90 @@ public class DataProductDomainMigrationIT {
         domainC.getFullyQualifiedName(), finalDp.getDomains().get(0).getFullyQualifiedName());
   }
 
+  /**
+   * Reproduces #30678: when a data product's asset is a container (a schema), descendants that
+   * inherit the schema's domain must follow it to the new domain in the search index, not just on
+   * the entity page. Descendants that carry an explicit domain must be left untouched.
+   */
+  @Test
+  void testDataProductDomainMigrationPropagatesToInheritedDescendants(TestNamespace ns)
+      throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String shortId = ns.shortPrefix();
+
+    Domain sourceDomain = createDomain(client, "inh_src_" + shortId);
+    Domain targetDomain = createDomain(client, "inh_tgt_" + shortId);
+    Domain otherDomain = createDomain(client, "inh_other_" + shortId);
+
+    // The schema carries an explicit domain and is the data product's only asset.
+    DatabaseSchema schema = createSchemaInDomain(ns, "inh_schema_" + shortId, sourceDomain);
+
+    // t1 inherits the schema's domain (no explicit domain of its own); t2 has an explicit domain
+    // equal to the source; t3 has an explicit unrelated domain.
+    Table t1 = createTableUnderSchema(ns, "inh_t1_" + shortId, schema, null);
+    Table t2 = createTableUnderSchema(ns, "inh_t2_" + shortId, schema, sourceDomain);
+    Table t3 = createTableUnderSchema(ns, "inh_t3_" + shortId, schema, otherDomain);
+
+    CreateDataProduct createDp = new CreateDataProduct();
+    createDp.setName("inh_dp_" + shortId);
+    createDp.setDescription("Data product asserting inherited-descendant search propagation");
+    createDp.setDomains(List.of(sourceDomain.getFullyQualifiedName()));
+    DataProduct dataProduct = client.dataProducts().create(createDp);
+
+    BulkAssets bulkRequest =
+        new BulkAssets()
+            .withAssets(
+                List.of(
+                    new EntityReference()
+                        .withId(schema.getId())
+                        .withType("databaseSchema")
+                        .withFullyQualifiedName(schema.getFullyQualifiedName())));
+    client.dataProducts().bulkAddAssets(dataProduct.getFullyQualifiedName(), bulkRequest);
+    waitForSearchIndexUpdate();
+
+    // Baseline: the inherited descendant is under the source domain in search.
+    verifyAssetsInDomainSearch(client, sourceDomain.getFullyQualifiedName(), List.of(t1), true);
+
+    // Move the data product (and its schema asset) to the target domain.
+    moveDataProductToDomain(client, dataProduct, targetDomain);
+    waitForSearchIndexUpdate();
+
+    // The inherited descendant follows the schema in search — the fix for #30678.
+    verifyAssetsInDomainSearch(client, targetDomain.getFullyQualifiedName(), List.of(t1), true);
+    verifyAssetsInDomainSearch(client, sourceDomain.getFullyQualifiedName(), List.of(t1), false);
+    verifyAssetsHaveDomainViaAPI(client, List.of(t1), targetDomain, true);
+    verifyAssetsHaveDomainViaAPI(client, List.of(t1), sourceDomain, false);
+
+    // Descendants with an explicit domain are left untouched by the migration.
+    verifyAssetsInDomainSearch(client, sourceDomain.getFullyQualifiedName(), List.of(t2), true);
+    verifyAssetsInDomainSearch(client, otherDomain.getFullyQualifiedName(), List.of(t3), true);
+    verifyAssetsHaveDomainViaAPI(client, List.of(t2), sourceDomain, true);
+    verifyAssetsHaveDomainViaAPI(client, List.of(t3), otherDomain, true);
+  }
+
   // ==================== Helper Methods ====================
+
+  private DatabaseSchema createSchemaInDomain(TestNamespace ns, String baseName, Domain domain) {
+    initializeSharedDbEntities(ns);
+    CreateDatabaseSchema schemaReq = new CreateDatabaseSchema();
+    schemaReq.setName(ns.prefix(baseName));
+    schemaReq.setDatabase(sharedDatabase.getFullyQualifiedName());
+    schemaReq.setDomains(List.of(domain.getFullyQualifiedName()));
+    return SdkClients.adminClient().databaseSchemas().create(schemaReq);
+  }
+
+  private Table createTableUnderSchema(
+      TestNamespace ns, String baseName, DatabaseSchema schema, Domain explicitDomain) {
+    CreateTable tableRequest = new CreateTable();
+    tableRequest.setName(ns.prefix(baseName));
+    tableRequest.setDatabaseSchema(schema.getFullyQualifiedName());
+    if (explicitDomain != null) {
+      tableRequest.setDomains(List.of(explicitDomain.getFullyQualifiedName()));
+    }
+    tableRequest.setColumns(
+        List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)));
+    return SdkClients.adminClient().tables().create(tableRequest);
+  }
 
   private Domain createDomain(OpenMetadataClient client, String name) {
     CreateDomain request = new CreateDomain();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
@@ -35,6 +35,7 @@ import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.VoteRequest;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
 import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.domains.CreateDomain;
 import org.openmetadata.schema.api.domains.CreateDomain.DomainType;
@@ -51,6 +52,8 @@ import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Votes;
+import org.openmetadata.schema.type.api.BulkAssets;
+import org.openmetadata.schema.type.api.BulkOperationResult;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.fluent.Databases;
 import org.openmetadata.sdk.models.ListParams;
@@ -1499,6 +1502,70 @@ public class DomainResourceIT extends BaseEntityIT<Domain, CreateDomain> {
 
     // ...and the prefix-sharing sibling must stay exactly as it was (no double / no spillover).
     verifyDomainInSearch(siblingFqn, sibling.getId().toString());
+  }
+
+  // ===================================================================
+  // Issue #30678: moving an asset between domains from the Domain page must
+  // propagate the new domain to descendants that INHERIT their domain in the
+  // search index, not just on the entity page — otherwise Explore and domain
+  // filters keep the descendant under the old domain until a full reindex.
+  // ===================================================================
+  @Test
+  void test_moveSchemaBetweenDomains_propagatesToInheritedDescendantsInSearch(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    ObjectMapper mapper = new ObjectMapper();
+
+    Domain source = createEntity(createRequest(ns.prefix("dom_inh_src"), ns));
+    Domain target = createEntity(createRequest(ns.prefix("dom_inh_tgt"), ns));
+
+    // Schema carries an explicit domain; the child table inherits it (no explicit domain).
+    DatabaseSchema schema = createSchemaInDomain(ns, "inh", source.getFullyQualifiedName());
+    Table child = createInheritingTable(ns, "inh", schema);
+
+    awaitAssetDomainFqn(client, mapper, child.getId().toString(), source.getFullyQualifiedName());
+
+    // Move the schema into the target domain from the Domain page (bulk assets/add).
+    EntityReference schemaRef =
+        new EntityReference()
+            .withId(schema.getId())
+            .withType("databaseSchema")
+            .withFullyQualifiedName(schema.getFullyQualifiedName());
+    client
+        .getHttpClient()
+        .execute(
+            HttpMethod.PUT,
+            "/v1/domains/" + target.getFullyQualifiedName() + "/assets/add",
+            new BulkAssets().withAssets(List.of(schemaRef)),
+            BulkOperationResult.class);
+
+    // The inherited descendant follows the schema into the target domain in search (#30678).
+    awaitAssetDomainFqn(client, mapper, child.getId().toString(), target.getFullyQualifiedName());
+  }
+
+  private DatabaseSchema createSchemaInDomain(TestNamespace ns, String suffix, String domainFqn) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    Database database =
+        Databases.create()
+            .name(ns.shortPrefix("dom_db_" + suffix))
+            .in(service.getFullyQualifiedName())
+            .execute();
+    CreateDatabaseSchema createSchema =
+        new CreateDatabaseSchema()
+            .withName(ns.shortPrefix("dom_sch_" + suffix))
+            .withDatabase(database.getFullyQualifiedName())
+            .withDomains(List.of(domainFqn));
+    return SdkClients.adminClient().databaseSchemas().create(createSchema);
+  }
+
+  private Table createInheritingTable(TestNamespace ns, String suffix, DatabaseSchema schema) {
+    return SdkClients.adminClient()
+        .tables()
+        .create(
+            new CreateTable()
+                .withName(ns.shortPrefix("dom_tbl_" + suffix))
+                .withDatabaseSchema(schema.getFullyQualifiedName())
+                .withColumns(
+                    List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
   }
 
   private Table createTableInDomain(TestNamespace ns, String suffix, String domainFqn) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -1026,6 +1026,13 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
           List<UUID> assetIds =
               allRecords.stream().map(CollectionDAO.EntityRelationshipRecord::getId).toList();
           searchRepository.updateAssetDomainsByIds(assetIds, oldDomainFqns, updatedDomains);
+          // updateAssetDomainsByIds only rewrites the direct assets' own search docs. Descendants
+          // that inherit their domain (e.g. tables under a migrated schema) must follow in search
+          // too, otherwise Explore keeps them under the old domain until a reindex (#30678).
+          for (CollectionDAO.EntityRelationshipRecord record : allRecords) {
+            searchRepository.propagateAssetDomainChangeToChildren(
+                record.getType(), record.getId(), updatedDomains);
+          }
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
@@ -414,6 +414,7 @@ public class DomainRepository extends EntityRepository<Domain> {
       result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
 
       searchRepository.updateEntity(ref);
+      propagateInheritedDomainToAssetChildren(entityId, ref, isAdd);
     }
 
     result.withSuccessRequest(success);
@@ -431,6 +432,16 @@ public class DomainRepository extends EntityRepository<Domain> {
     }
 
     return result;
+  }
+
+  private void propagateInheritedDomainToAssetChildren(
+      UUID domainId, EntityReference asset, boolean isAdd) {
+    // updateEntity only rebuilds the moved asset's own search doc. Descendants that inherit their
+    // domain must follow in search too, else Explore keeps them under the old domain (#30678).
+    List<EntityReference> newDomains =
+        isAdd ? List.of(getEntityReferenceById(DOMAIN, domainId, ALL)) : List.of();
+    searchRepository.propagateAssetDomainChangeToChildren(
+        asset.getType(), asset.getId(), newDomains);
   }
 
   private BulkResponse buildDryRunImpactResponse(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -2351,6 +2351,80 @@ public class SearchRepository {
     }
   }
 
+  /**
+   * Cascades an asset's domain change to its inherited descendants in the search index. When a Data
+   * Product's domain changes or an asset is moved between domains, the direct asset's own document is
+   * updated by the caller, but descendants that <em>inherit</em> the asset's domain (no explicit
+   * domain of their own) keep the old domain in search until a full reindex. This rewrites those
+   * descendant documents with {@code newDomains}; descendants that carry an explicit domain are left
+   * untouched by the underlying script. Fixes the divergence where Explore and the entity page
+   * disagreed after a domain move (#30678).
+   */
+  public void propagateAssetDomainChangeToChildren(
+      String entityType, UUID entityId, List<EntityReference> newDomains) {
+    if (entityId == null || !checkIfIndexingIsSupported(entityType)) {
+      return;
+    }
+    if (deferSearchWrite(
+        new DeferredSearchWrite(
+            () -> propagateAssetDomainChangeToChildren(entityType, entityId, newDomains),
+            "propagateAssetDomainChangeToChildren",
+            entityId.toString(),
+            null,
+            entityType))) {
+      return;
+    }
+    if (!getSearchClient().isClientAvailable()) {
+      SearchIndexRetryQueue.enqueue(
+          entityId.toString(),
+          null,
+          "propagateAssetDomainChangeToChildren: Search client unavailable");
+      return;
+    }
+    Timer.Sample s = RequestLatencyContext.startSearchOperation();
+    try {
+      propagateInheritedDomainsToChildren(entityType, entityId, newDomains);
+    } catch (IOException e) {
+      SearchIndexRetryQueue.enqueue(
+          entityId.toString(),
+          null,
+          SearchIndexRetryQueue.failureReason("propagateAssetDomainChangeToChildren", e));
+    } finally {
+      RequestLatencyContext.endSearchOperation(s);
+    }
+  }
+
+  private void propagateInheritedDomainsToChildren(
+      String entityType, UUID entityId, List<EntityReference> newDomains) throws IOException {
+    IndexMapping indexMapping = entityIndexMap.get(entityType);
+    if (indexMapping == null
+        || nullOrEmpty(indexMapping.getChildAliases())
+        || Entity.DOMAIN.equalsIgnoreCase(entityType)) {
+      return;
+    }
+    Pair<String, Map<String, Object>> updates = buildInheritedDomainChildUpdate(newDomains);
+    applyChildFieldUpdates(entityType, entityId.toString(), indexMapping, updates);
+  }
+
+  private Pair<String, Map<String, Object>> buildInheritedDomainChildUpdate(
+      List<EntityReference> newDomains) {
+    List<EntityReference> inheritedDomains =
+        nullOrEmpty(newDomains)
+            ? new ArrayList<>()
+            : JsonUtils.deepCopyList(newDomains, EntityReference.class);
+    inheritedDomains.forEach(domain -> domain.setInherited(true));
+    Map<String, Object> params = new HashMap<>();
+    String script;
+    if (inheritedDomains.isEmpty()) {
+      params.put("removedDomains", inheritedDomains);
+      script = generateRemoveListScript(FIELD_DOMAINS);
+    } else {
+      params.put("updatedDomains", inheritedDomains);
+      script = generateAddListScript(FIELD_DOMAINS);
+    }
+    return new ImmutablePair<>(script, params);
+  }
+
   public void updateDomainFqnByPrefix(String oldFqn, String newFqn) {
     if (deferSearchWrite(
         new DeferredSearchWrite(
@@ -2469,18 +2543,27 @@ public class SearchRepository {
     if (changeDescription != null && !nullOrEmpty(indexMapping.getChildAliases())) {
       Pair<String, Map<String, Object>> updates =
           getInheritedFieldChanges(changeDescription, entity, entityType);
-      if (updates.getKey() != null && !updates.getKey().isEmpty()) {
-        if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
-          propagateToDomainChildren(entityId, indexMapping, updates);
-        } else {
-          String parentFieldName = resolveParentFieldName(entityType, updates);
-          Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
-          List<String> entityChildren =
-              filterChildAliasesByCapability(
-                  indexMapping, capability -> capability == null || !capability.isTimeSeries());
-          if (!nullOrEmpty(entityChildren)) {
-            searchClient.updateChildren(entityChildren, parentMatch, updates);
-          }
+      applyChildFieldUpdates(entityType, entityId, indexMapping, updates);
+    }
+  }
+
+  private void applyChildFieldUpdates(
+      String entityType,
+      String entityId,
+      IndexMapping indexMapping,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    if (updates.getKey() != null && !updates.getKey().isEmpty()) {
+      if (entityType.equalsIgnoreCase(Entity.DOMAIN)) {
+        propagateToDomainChildren(entityId, indexMapping, updates);
+      } else {
+        String parentFieldName = resolveParentFieldName(entityType, updates);
+        Pair<String, String> parentMatch = new ImmutablePair<>(parentFieldName, entityId);
+        List<String> entityChildren =
+            filterChildAliasesByCapability(
+                indexMapping, capability -> capability == null || !capability.isTimeSeries());
+        if (!nullOrEmpty(entityChildren)) {
+          searchClient.updateChildren(entityChildren, parentMatch, updates);
         }
       }
     }


### PR DESCRIPTION
### Describe your changes:

Fixes #30678

I made these changes because changing an asset's domain left its **inherited** descendants stale in the search index. When a Data Product's domain changes (or an asset is moved between domains from the Domain page), the moved asset's own search document is updated, but descendants that *inherit* their domain (children with no explicit domain of their own) keep the **old** domain in search — so Explore, domain filters and asset counts disagree with the entity page until a full reindex.

Both write paths bypassed the change-driven child cascade that a normal entity `domains` PATCH already runs:

- **Data Product route** — `DataProductRepository.updateDataProductDomains()` → `SearchRepository.updateAssetDomainsByIds(assetIds, …)`, an `ids` query over the **direct assets only**. No `ChangeDescription`, so the child cascade never fires.
- **Domain-page asset-move route** — `DomainRepository.bulkAssetsOperation()` → `SearchRepository.updateEntity(EntityReference)`, which sets `changeDescription = null`, so `requiresPropagation` is `false` and `propagateInheritedFieldsToChildren` is skipped.

The fix adds `SearchRepository.propagateAssetDomainChangeToChildren(entityType, id, newDomains)` and calls it from **both** routes after the direct asset's own document is updated. It reuses the existing inherited-field cascade (a parent-match `updateByQuery` whose painless script `generateAddListScript("domains")` rewrites a child document's `domains` **only when it is empty or currently inherited**), so:

- descendants that **inherit** the domain follow the asset to the new domain in search (the bug), and
- descendants with an **explicit** domain are left untouched (intended behaviour — they stay consistent with their own data product and remain editable).

Since search documents denormalize the full ancestry (`databaseSchema.id`, `database.id`, …), a single parent-match update reaches every level, and the method is a no-op for leaf assets with no separate-document descendants.

**Scope:** this PR is the `#30678` half of #30676 (targeted for an early release). The remaining sub-issue #30679 — a dry-run conflict check that detaches data-product assignments no longer matching the new domain, plus the "warn when the moved asset's own explicit domain is overwritten" parity item — is a separate, larger change and will be a follow-up PR.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small, focused change. The new `SearchRepository` method extracts the existing child-update tail (`applyChildFieldUpdates`, refactored from `propagateInheritedFieldsToChildren` with no behaviour change) and drives it from a domain-only `ChangeDescription` built in-process, so both move routes share exactly the same cascade the entity PATCH path uses.

#
### Tests:

#### Use cases covered
- Data Product domain change where the asset is a **schema**: a child table that **inherits** the schema domain follows to the new domain in search *and* on the entity page; child tables with an **explicit** domain (equal to the old domain, or an unrelated domain) are left untouched.
- Moving a **schema** between domains from the **Domain page** (`/assets/add`): an inherited child table follows to the new domain in the search index.

#### Unit tests
Not applicable — the behaviour is search-index cascade over real Elasticsearch/OpenSearch, covered by integration tests below rather than mocks.

#### Backend integration tests
- [x] Added integration tests for the changed behaviour.
- Files added/updated:
  - `openmetadata-integration-tests/.../DataProductDomainMigrationIT.java` — `testDataProductDomainMigrationPropagatesToInheritedDescendants`
  - `openmetadata-integration-tests/.../DomainResourceIT.java` — `test_moveSchemaBetweenDomains_propagatesToInheritedDescendantsInSearch`

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Reproduction from the issue (`Finance`/`HR` domains, schema asset, inherited/explicit child tables) verified against the described behaviour; `mvn -pl openmetadata-service,openmetadata-integration-tests -am install -DskipTests` → BUILD SUCCESS, spotless clean.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] My PR is linked to a GitHub issue via `Fixes #30678` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added a test that covers the exact scenario we are fixing (#30678 referenced in the tests).
