### PR TITLE
test(e2e): Playwright flaky fixes — batch 4

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeCenterTextEditor.common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/KnowledgeCenterTextEditor.common.ts
@@ -37,6 +37,7 @@ import {
   selectAll,
   selectAllText,
   selectLastWord,
+  selectTextInEditor,
   toggleTask,
   typeInTableCell,
   undo,
@@ -168,7 +169,7 @@ export const runTextFormattingTest = async (
     await page.keyboard.type('Italic text');
 
     await expect(page.getByText('Italic text')).toBeVisible();
-    await page.getByText('Italic text').selectText();
+    await selectTextInEditor(page, 'Italic text');
     await applyTextFormatting(page, 'italic');
 
     await expect(page.getByText('Italic text')).toBeVisible();
@@ -180,7 +181,7 @@ export const runTextFormattingTest = async (
     await page.keyboard.type('inline code');
 
     await expect(page.getByText('inline code')).toBeVisible();
-    await page.getByText('inline code').selectText();
+    await selectTextInEditor(page, 'inline code');
     await applyTextFormatting(page, 'code');
 
     await expect(page.getByText('inline code')).toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -42,6 +42,7 @@ import {
 import { selectActiveGlossary } from '../../utils/glossary';
 import {
   createGlossaryTermRowDetails,
+  disableCsvJobsTrayInterception,
   fillGlossaryRowDetails,
   startCsvPreviewAndWaitForGrid,
   validateImportStatus,
@@ -133,6 +134,17 @@ test.describe('Glossary Bulk Import Export', () => {
 
   test.beforeEach(async ({ page }) => {
     await redirectToHomePage(page);
+
+    // Tests in this file run in parallel as the same admin user, so their CSV
+    // jobs arrive on this page's socket and auto-open the background jobs tray
+    // — a fixed-position panel at bottom-right, directly over the glossary
+    // right panel where the reviewer "Add" button sits. Playwright then retries
+    // the click against the overlay until the test timeout.
+    // startCsvPreviewAndWaitForGrid already neutralises the tray, but only once
+    // the import preview begins, which is after the reviewer edit.
+    // redirectToHomePage is the only hard navigation here, so injecting once at
+    // this point covers the whole test.
+    await disableCsvJobsTrayInterception(page);
   });
 
   test('Glossary Bulk Import Export', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/KnowledgeCenter.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/KnowledgeCenter.ts
@@ -608,6 +608,27 @@ export const applyTextFormatting = async (
   await page.keyboard.press(SHORTCUTS[format]);
 };
 
+/**
+ * Selects text inside the editor and waits until ProseMirror has actually
+ * ingested the selection.
+ *
+ * `locator.selectText()` assigns only the *DOM* selection. ProseMirror picks
+ * that up asynchronously through its DOM observer, so a formatting shortcut
+ * pressed immediately afterwards is applied against the previous (collapsed)
+ * editor selection: it toggles a stored mark, the range is never wrapped, and
+ * no <em>/<code> node is produced. Selecting via a keyboard shortcut does not
+ * have this problem, which is why the bold steps never flake.
+ *
+ * The bubble menu is rendered from `state.selection.empty`, so its appearance
+ * proves the editor state now holds the range. Requiring it hidden first makes
+ * this an edge trigger rather than a match against a stale selection.
+ */
+export const selectTextInEditor = async (page: Page, text: string) => {
+  await page.waitForSelector('.menu-wrapper', { state: 'hidden' });
+  await page.getByText(text).selectText();
+  await page.waitForSelector('.menu-wrapper', { state: 'visible' });
+};
+
 export const selectAllText = async (page: Page) => {
   await page.keyboard.press(SHORTCUTS.selectAll);
 };

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -76,7 +76,7 @@ const scrollIntoViewCenter = async (locator: Locator) => {
 // moment during a test (mid-fill, mid-modal, mid-drag) as background jobs
 // complete. Injecting pointer-events:none once disables click interception for
 // the entire page session — no need to poll or dismiss at every step.
-const disableCsvJobsTrayInterception = async (page: Page) => {
+export const disableCsvJobsTrayInterception = async (page: Page) => {
   await page.addStyleTag({
     content:
       '.csv-jobs-tray-popover, .csv-jobs-tray-launcher-wrap { pointer-events: none !important; }',


### PR DESCRIPTION
Continuing #31076 and #31095. Both fixes root-caused from the failing attempt's artifacts and verified locally.

| Test | Flaky | Verified |
|---|---|---|
| `Context Center Articles › Rich Text Editor › Text formatting` (×3 roles) | 6/16 | 9/9 |
| `Glossary Bulk Import Export` | 6/16 | 10/10 |

---

## 1. Wait for ProseMirror to ingest the selection before formatting

```
expect(locator).toBeVisible() failed
Locator: ... locator('code').filter({ hasText: 'inline code' })
Error: element(s) not found
```

### Root cause

`locator.selectText()` assigns only the **DOM** selection. ProseMirror ingests that asynchronously via its DOM observer, so the shortcut pressed immediately afterwards acts on the previous, still-collapsed editor selection — `toggleItalic`/`toggleCode` then merely set a *stored mark*, the range is never wrapped, and no `<em>`/`<code>` node appears.

### Evidence

- The failure snapshot shows the text present but **unwrapped**; the screenshot shows the range **visibly selected**, the editor focused, and the bubble menu open. The keystroke was delivered — it acted on a stale selection.
- The **two `selectText()` call sites in the entire suite are exactly the two assertions that flake.** The three keyboard-selection sites (`Mod+A`, `Mod+Shift+ArrowLeft`), which ProseMirror handles synchronously in its own keymap, never flake.

### Fix

Gate on the bubble menu, which is rendered from `state.selection.empty` and therefore proves the editor state holds the range. `createLink` already relies on this same gate for the same reason. Requiring it hidden first makes it an edge trigger rather than a match on a stale selection.

All three roles share one helper, so one change covers Admin, Data Steward and Data Consumer.

---

## 2. Neutralise the CSV jobs tray before the reviewer edit

```
Test timeout of 300000ms exceeded.
Error: page.click: ... waiting for locator('[data-testid="Add"]')
  ... <div class="csv-jobs-tray">…</div> subtree intercepts pointer events
```

### Root cause

Playwright names the interceptor outright. The tray is a fixed-position panel at bottom-right that auto-opens whenever any CSV job reaches a terminal state. Tests in this file run in parallel as the same admin user, so jobs started by **other workers** arrive on this page's socket and re-open it over the glossary right panel, where the reviewer Add button sits. The click was retried **471 times across ~235s**.

The intercepting element's own text named a fixture belonging to the sibling test *"Import partial success"* — direct proof the blocking content came from a different, concurrently running test.

### Fix

The file **already contains** the correct mitigation (`disableCsvJobsTrayInterception`), but its only call site is inside `startCsvPreviewAndWaitForGrid`, reached 21 lines *after* the failing click. Moving the injection into `beforeEach` covers the whole test — `redirectToHomePage` is the only hard navigation, so one injection survives, and it is idempotent with the existing call.

Step arithmetic confirms the click never resolved rather than being slow: `300000 − 57294 = 242706 ms`, matching the hanging step. A healthy run is 184s against a 300s budget, so **no timeout change is warranted**.

---

## Follow-ups, deliberately not bundled

- **Product:** `CsvJobsTray` auto-opens for any job that appears terminal on any refresh, including jobs the user never started — a real user with a second tab, or whose colleague exports, gets an unbidden overlay dropped over whatever they were clicking. Narrowing it to jobs this session observed as active would let the test-side `pointer-events` mitigation eventually be retired.
- **Structural:** ~37% of `Glossary Bulk Import Export`'s healthy runtime is 8 sequential UI round-trips creating and deleting 4 custom property types. Moving those to `apiContext` would cut the test to ~2 min and remove the surface where its three *older* flakes occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)