### PR TITLE
fix(ui): actually drop the removed column pair when removing a column-level lineage edge

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts
@@ -34,6 +34,7 @@ import {
   editLineage,
   editLineageClick,
   fitToScreen,
+  removeColumnLineage,
   visitLineageTab,
 } from '../../../utils/lineage';
 import { test } from '../../fixtures/pages';
@@ -692,6 +693,135 @@ test.describe('Lineage Interactions', PLAYWRIGHT_BASIC_TEST_TAG_OBJ, () => {
       }
 
       await editLineageClick(page);
+    });
+  });
+
+  test.describe('Edge removal persists across refresh', () => {
+    // Focused coverage for a bug where removing a column-level lineage
+    // edge only mutated local React state (setEntityLineage /
+    // removeEdgeById / setColumnsHavingLineage) while the PUT
+    // /api/v1/lineage silently sent the unchanged columnsLineage array
+    // back to the server — so the removed edge reappeared on refresh.
+    // The pattern here is: act via UI → reload → re-assert against a
+    // fresh /api/v1/lineage/getLineage response.
+    const sourceTable = new TableClass();
+    const targetTable = new TableClass();
+
+    let sourceFqn: string;
+    let targetFqn: string;
+    let sourceCol: string;
+    let targetCol: string;
+
+    test.beforeAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await getDefaultAdminAPIContext(
+        browser
+      );
+      await Promise.all([
+        sourceTable.create(apiContext),
+        targetTable.create(apiContext),
+      ]);
+
+      sourceFqn = get(sourceTable, 'entityResponseData.fullyQualifiedName');
+      targetFqn = get(targetTable, 'entityResponseData.fullyQualifiedName');
+      sourceCol = `${sourceFqn}.${get(
+        sourceTable,
+        'entityResponseData.columns[0].name'
+      )}`;
+      targetCol = `${targetFqn}.${get(
+        targetTable,
+        'entityResponseData.columns[0].name'
+      )}`;
+
+      await afterAction();
+    });
+
+    test.afterAll(async ({ browser }) => {
+      const { apiContext, afterAction } = await performAdminLogin(browser);
+      await Promise.all([
+        sourceTable.delete(apiContext),
+        targetTable.delete(apiContext),
+      ]);
+      await afterAction();
+    });
+
+    test('Node-to-node edge deletion persists across a page refresh', async ({
+      page,
+    }) => {
+      const { apiContext, afterAction } = await getApiContext(page);
+
+      try {
+        await connectEdgeBetweenNodesViaAPI(
+          apiContext,
+          { id: sourceTable.entityResponseData.id, type: 'table' },
+          { id: targetTable.entityResponseData.id, type: 'table' }
+        );
+
+        await sourceTable.visitEntityPage(page);
+        await visitLineageTab(page);
+        await fitToScreen(page);
+
+        await expect(
+          page.getByTestId(`edge-${sourceFqn}-${targetFqn}`)
+        ).toBeVisible();
+
+        await editLineage(page);
+        await clickEdgeBetweenNodes(page, sourceTable, targetTable, false);
+
+        await page.getByTestId('add-pipeline').click();
+        await page.getByTestId('remove-edge-button').click();
+
+        const deleteRes = page.waitForResponse('/api/v1/lineage/**');
+        await page.getByRole('button', { name: /confirm/i }).click();
+        await deleteRes;
+
+        // Reload to prove the server actually dropped the edge, not just
+        // that local state was optimistically updated.
+        const lineageRes = page.waitForResponse('/api/v1/lineage/getLineage?*');
+        await page.reload();
+        await lineageRes;
+
+        await expect(
+          page.getByTestId(`edge-${sourceFqn}-${targetFqn}`)
+        ).not.toBeVisible();
+      } finally {
+        await afterAction();
+      }
+    });
+
+    test('Column-level edge deletion persists across a page refresh', async ({
+      page,
+    }) => {
+      // Regression: before the fix in EntityLineageEdgeUtils.getColumnLineageData,
+      // this assertion would flip back to visible after the reload
+      // because the PUT body still contained the removed column pair.
+      const { apiContext, afterAction } = await getApiContext(page);
+
+      try {
+        await connectEdgeBetweenNodesViaAPI(
+          apiContext,
+          { id: sourceTable.entityResponseData.id, type: 'table' },
+          { id: targetTable.entityResponseData.id, type: 'table' },
+          [{ fromColumns: [sourceCol], toColumn: targetCol }]
+        );
+
+        await sourceTable.visitEntityPage(page);
+        await visitLineageTab(page);
+        await activateColumnLayer(page);
+        await fitToScreen(page);
+
+        await expect(
+          page.getByTestId(`column-edge-${sourceCol}-${targetCol}`)
+        ).toBeVisible();
+
+        await editLineageClick(page);
+
+        // removeColumnLineage reloads and re-asserts against a fresh
+        // getLineage response internally — that reload is the assertion
+        // that would have failed before the fix.
+        await removeColumnLineage(page, sourceCol, targetCol);
+      } finally {
+        await afterAction();
+      }
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts
@@ -631,7 +631,17 @@ export const removeColumnLineage = async (
     .click();
   await deleteRes;
 
-  await editLineageClick(page);
+  // Reload before asserting. removeColumnEdge optimistically mutates local
+  // React state (setEntityLineage / removeEdgeById / setColumnsHavingLineage),
+  // so the edge disappears from the DOM regardless of what the server did.
+  // Only a fresh /api/v1/lineage/getLineage response proves the removal
+  // actually persisted.
+  const lineageRes = page.waitForResponse('/api/v1/lineage/getLineage?*');
+  await page.reload();
+  await lineageRes;
+
+  await waitForAllLoadersToDisappear(page);
+  await activateColumnLayer(page);
 
   await expect(
     page.getByTestId(`column-edge-${fromColumnNode}-${toColumnNode}`)

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -1126,10 +1126,6 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
         edges: filteredEdges,
       };
     });
-
-    // Clear the selection so EdgeInteractionOverlay stops rendering the
-    // floating edit/delete button over the edge we just removed.
-    setSelectedEdge(undefined);
   };
 
   const removeColumnEdge = async (edge: Edge, confirmDelete: boolean) => {
@@ -1189,9 +1185,6 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
 
     setColumnsHavingLineage(updatedColumnsHavingLineage);
 
-    // Clear the selection so EdgeInteractionOverlay stops rendering the
-    // floating delete button at the position of the edge we just removed.
-    setSelectedEdge(undefined);
     setShowDeleteModal(false);
   };
 
@@ -1512,7 +1505,15 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
         await removeEdgeHandler(selectedEdge as Edge, true);
       }
 
+      // Close the modal and drop the selection in the same batch so the
+      // floating edit/delete button in EdgeInteractionOverlay unmounts
+      // right after removal. Doing this here (rather than inside the
+      // handlers) keeps `selectedEdge` populated while the confirmation
+      // modal is still mounted — getModalBodyText() destructures it
+      // during render and would crash the LineageProvider tree if
+      // `selectedEdge` were cleared before the modal unmounts.
       setShowDeleteModal(false);
+      setSelectedEdge(undefined);
     } catch (err) {
       showErrorToast(err as AxiosError);
     } finally {
@@ -2224,7 +2225,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
           </SlideoutMenu>
         )}
 
-        {showDeleteModal && (
+        {showDeleteModal && selectedEdge && (
           <ModalOverlay
             isDismissable={!deletionState.loading}
             isOpen={showDeleteModal}
@@ -2238,7 +2239,7 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
               <Dialog data-testid="delete-edge-confirmation-modal" width={400}>
                 <Dialog.Header title={t('message.remove-lineage-edge')} />
                 <Dialog.Content>
-                  {getModalBodyText(selectedEdge as Edge)}
+                  {getModalBodyText(selectedEdge)}
                 </Dialog.Content>
                 <Dialog.Footer>
                   <Button

--- a/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/LineageProvider/LineageProvider.tsx
@@ -1126,6 +1126,10 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
         edges: filteredEdges,
       };
     });
+
+    // Clear the selection so EdgeInteractionOverlay stops rendering the
+    // floating edit/delete button over the edge we just removed.
+    setSelectedEdge(undefined);
   };
 
   const removeColumnEdge = async (edge: Edge, confirmDelete: boolean) => {
@@ -1185,6 +1189,9 @@ const LineageProvider = ({ children }: LineageProviderProps) => {
 
     setColumnsHavingLineage(updatedColumnsHavingLineage);
 
+    // Clear the selection so EdgeInteractionOverlay stops rendering the
+    // floating delete button at the position of the edge we just removed.
+    setSelectedEdge(undefined);
     setShowDeleteModal(false);
   };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageEdgeUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageEdgeUtils.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { Edge } from 'reactflow';
+import { ColumnLineage } from '../generated/type/entityLineage';
+import { getColumnLineageData } from './EntityLineageEdgeUtils';
+
+const COL_A = 'db.s.from.col_a';
+const COL_B = 'db.s.from.col_b';
+const COL_C = 'db.s.from.col_c';
+const COL_X = 'db.t.to.col_x';
+const COL_Y = 'db.t.to.col_y';
+
+// React Flow puts the column FQNs used to identify a column edge on the
+// TOP LEVEL of the edge object as `sourceHandle` / `targetHandle`. Column
+// edges are constructed that way in createColumnEdgesAndMaps
+// (EntityLineageEdgeUtils.ts). Building a minimal fake here mirrors that
+// shape — the earlier bug was reading these handles from `edge.data`,
+// where they don't exist, so the filter never matched and every column
+// pair survived the "removal".
+const buildColumnEdge = (sourceHandle: string, targetHandle: string): Edge =>
+  ({
+    id: `column-${sourceHandle}-${targetHandle}-edge-s-t`,
+    source: 's',
+    target: 't',
+    sourceHandle,
+    targetHandle,
+    data: { isColumnLineage: true },
+  } as unknown as Edge);
+
+describe('getColumnLineageData', () => {
+  it('drops the only fromColumn on a lineage entry and removes the entry', () => {
+    const columns: ColumnLineage[] = [
+      { fromColumns: [COL_A], toColumn: COL_X },
+    ];
+    const edge = buildColumnEdge(COL_A, COL_X);
+
+    const result = getColumnLineageData(columns, edge);
+
+    expect(result).toEqual([]);
+  });
+
+  it('keeps the entry when there are still other fromColumns after removal', () => {
+    const columns: ColumnLineage[] = [
+      { fromColumns: [COL_A, COL_B], toColumn: COL_X },
+    ];
+    const edge = buildColumnEdge(COL_A, COL_X);
+
+    const result = getColumnLineageData(columns, edge);
+
+    expect(result).toEqual([{ fromColumns: [COL_B], toColumn: COL_X }]);
+  });
+
+  it('leaves other toColumn entries untouched', () => {
+    const columns: ColumnLineage[] = [
+      { fromColumns: [COL_A], toColumn: COL_X },
+      { fromColumns: [COL_C], toColumn: COL_Y },
+    ];
+    const edge = buildColumnEdge(COL_A, COL_X);
+
+    const result = getColumnLineageData(columns, edge);
+
+    expect(result).toEqual([{ fromColumns: [COL_C], toColumn: COL_Y }]);
+  });
+
+  it('reads sourceHandle/targetHandle from the top level of the edge, not edge.data', () => {
+    // Regression: previously the function read `data.data?.sourceHandle`
+    // (always undefined for React Flow edges), so the filter matched
+    // nothing and the "removed" pair stayed in the returned array. The
+    // fake edge here intentionally leaves `data` without `sourceHandle`
+    // /`targetHandle` — the function must still drop the entry.
+    const columns: ColumnLineage[] = [
+      { fromColumns: [COL_A], toColumn: COL_X },
+    ];
+    const edge = buildColumnEdge(COL_A, COL_X);
+
+    const result = getColumnLineageData(columns, edge);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageEdgeUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityLineageEdgeUtils.ts
@@ -322,8 +322,14 @@ export const getColumnLineageData = (
   data: Edge
 ) => {
   const columnsLineage = columnsData?.reduce((col, curr) => {
-    const sourceHandle = data.data?.sourceHandle;
-    const targetHandle = data.data?.targetHandle;
+    // React Flow stores sourceHandle/targetHandle at the top level of the
+    // edge object — not nested under `data`. Reading them from `data.data`
+    // silently returned undefined, so the filter never matched and the
+    // caller PUT the unchanged columnsLineage back to the server, making
+    // column-edge removal look successful in the UI while the edge
+    // reappeared on refresh.
+    const sourceHandle = data.sourceHandle;
+    const targetHandle = data.targetHandle;
 
     if (curr.toColumn === targetHandle) {
       const newCol = {


### PR DESCRIPTION
Fix: https://github.com/open-metadata/OpenMetadata/issues/31109

### Describe your changes:

`getColumnLineageData` was reading `sourceHandle`/`targetHandle` from `edge.data.*`, but React Flow stores those handles at the top level of the edge — so both reads returned `undefined`, the filter never matched, and the "trimmed" `columnsLineage` array was actually the original array. `removeColumnEdge` then PUT that unchanged array to `/api/v1/lineage`, whose backend upsert (`ON DUPLICATE KEY UPDATE json = :json`) fully replaces `LineageDetails` — so the same set of columns was written back. The UI looked correct because `LineageProvider` optimistically updated local state (`setEntityLineage` / `removeEdgeById` / `setColumnsHavingLineage`), but a refresh brought the removed edge back.

The Playwright `removeColumnLineage` helper missed this because it asserted `not.toBeVisible()` immediately after the click, against the same optimistically-mutated DOM. It now reloads, waits for a fresh `/api/v1/lineage/getLineage?*` response, and re-asserts — so every caller (including the cross-entity sweep in `DataAssetLineage.spec.ts`) now validates server state, not local state.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- User in edit mode clicks the delete button on a column-level lineage edge; after saving and refreshing, the edge stays gone.
- User deletes a node-to-node lineage edge; the deletion persists across a page refresh.

#### Playwright (UI) tests
- Added `Edge removal persists across refresh` describe in `openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Lineage/LineageInteraction.spec.ts` with two focused tests:
  - `Node-to-node edge deletion persists across a page refresh`
  - `Column-level edge deletion persists across a page refresh` (regression for this bug)
- Hardened `removeColumnLineage` in `openmetadata-ui/src/main/resources/ui/playwright/utils/lineage.ts` to reload + re-fetch `getLineage` + re-assert.

#### Manual testing performed
1. Attached a column-level lineage edge in edit mode, saved, refreshed — edge stays.
2. Removed the same edge in edit mode, saved, refreshed — edge is gone (previously came back).
3. Ran the two new Playwright tests locally against the fixed code — both pass; reverting only the client fix flips the column-edge test to fail on the post-reload assertion.

#
### UI screen recording / screenshots:

https://github.com/user-attachments/assets/9a0ec4cb-ecc6-4e47-ae42-8f407f991c01




#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)