### PR TITLE
fix(search): submit child field propagation as async update-by-query

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
@@ -33,6 +33,7 @@ import es.co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
 import es.co.elastic.clients.elasticsearch.core.DeleteResponse;
 import es.co.elastic.clients.elasticsearch.core.GetResponse;
 import es.co.elastic.clients.elasticsearch.core.SearchResponse;
+import es.co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
 import es.co.elastic.clients.elasticsearch.core.UpdateByQueryResponse;
 import es.co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import es.co.elastic.clients.elasticsearch.core.search.Hit;
@@ -473,22 +474,11 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
     }
 
     try {
-      Map<String, JsonData> params =
-          convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
-
-      client.updateByQuery(
-          u ->
-              u.index(Entity.getSearchRepository().getIndexOrAliasName(indexName))
-                  .query(exactFieldQuery(fieldAndValue))
-                  .conflicts(Conflicts.Proceed)
-                  .script(
-                      s ->
-                          s.source(ss -> ss.scriptString(updates.getKey()))
-                              .lang(ScriptLanguage.Painless)
-                              .params(params))
-                  .refresh(true));
-
-      LOG.info("Successfully updated children in ElasticSearch for index: {}", indexName);
+      submitChildUpdate(
+          List.of(Entity.getSearchRepository().getIndexOrAliasName(indexName)),
+          fieldAndValue,
+          updates);
+      LOG.info("Successfully submitted child update in ElasticSearch for index: {}", indexName);
     } catch (IOException | ElasticsearchException e) {
       SearchIndexRetryQueue.enqueue(
           null, fieldAndValue.getValue(), SearchIndexRetryQueue.failureReason("updateChildren", e));
@@ -506,22 +496,44 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
       LOG.error("ElasticSearch client is not available. Cannot update children for indices.");
       return;
     }
+    submitChildUpdate(indexNames, fieldAndValue, updates);
+    LOG.info("Successfully submitted child update in ElasticSearch for indices: {}", indexNames);
+  }
+
+  private void submitChildUpdate(
+      List<String> indexNames,
+      Pair<String, String> fieldAndValue,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    client.updateByQuery(buildUpdateChildrenRequest(indexNames, fieldAndValue, updates));
+  }
+
+  /**
+   * Builds the inherited-field child propagation as an async update-by-query
+   * ({@code wait_for_completion=false}). A synchronous update-by-query over a large child set (for
+   * example a test suite with thousands of test cases) holds one socket open for the entire scan
+   * and trips {@code socketTimeoutSecs} with a {@link java.net.SocketTimeoutException}; submitting
+   * it as a background task returns immediately and lets the cluster finish the propagation and the
+   * post-task {@code refresh} on its own.
+   */
+  UpdateByQueryRequest buildUpdateChildrenRequest(
+      List<String> indexNames,
+      Pair<String, String> fieldAndValue,
+      Pair<String, Map<String, Object>> updates) {
     Map<String, JsonData> params =
         convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
-
-    client.updateByQuery(
+    return UpdateByQueryRequest.of(
         u ->
             u.index(indexNames)
                 .query(exactFieldQuery(fieldAndValue))
                 .conflicts(Conflicts.Proceed)
+                .waitForCompletion(false)
                 .script(
                     s ->
                         s.source(ss -> ss.scriptString(updates.getKey()))
                             .lang(ScriptLanguage.Painless)
                             .params(params))
                 .refresh(true));
-
-    LOG.info("Successfully updated children in ElasticSearch for indices: {}", indexNames);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
@@ -75,6 +75,7 @@ import os.org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import os.org.opensearch.client.opensearch.core.DeleteResponse;
 import os.org.opensearch.client.opensearch.core.GetResponse;
 import os.org.opensearch.client.opensearch.core.SearchResponse;
+import os.org.opensearch.client.opensearch.core.UpdateByQueryRequest;
 import os.org.opensearch.client.opensearch.core.UpdateByQueryResponse;
 import os.org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import os.org.opensearch.client.opensearch.core.search.Hit;
@@ -508,29 +509,11 @@ public class OpenSearchEntityManager implements EntityManagementClient {
     }
 
     try {
-      Map<String, JsonData> params =
-          convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
-
-      client.updateByQuery(
-          u ->
-              u.index(Entity.getSearchRepository().getIndexOrAliasName(indexName))
-                  .query(exactFieldQuery(fieldAndValue))
-                  .conflicts(Conflicts.Proceed)
-                  .script(
-                      s ->
-                          s.inline(
-                              inline ->
-                                  inline
-                                      .lang(
-                                          l ->
-                                              l.builtin(
-                                                  os.org.opensearch.client.opensearch._types
-                                                      .BuiltinScriptLanguage.Painless))
-                                      .source(updates.getKey())
-                                      .params(params)))
-                  .refresh(Refresh.True));
-
-      LOG.info("Successfully updated children in OpenSearch for index: {}", indexName);
+      submitChildUpdate(
+          List.of(Entity.getSearchRepository().getIndexOrAliasName(indexName)),
+          fieldAndValue,
+          updates);
+      LOG.info("Successfully submitted child update in OpenSearch for index: {}", indexName);
     } catch (IOException | OpenSearchException e) {
       SearchIndexRetryQueue.enqueue(
           null, fieldAndValue.getValue(), SearchIndexRetryQueue.failureReason("updateChildren", e));
@@ -548,15 +531,38 @@ public class OpenSearchEntityManager implements EntityManagementClient {
       LOG.error("OpenSearch client is not available. Cannot update children for indices.");
       return;
     }
+    submitChildUpdate(indexNames, fieldAndValue, updates);
+    LOG.info("Successfully submitted child update in OpenSearch for indices: {}", indexNames);
+  }
 
+  private void submitChildUpdate(
+      List<String> indexNames,
+      Pair<String, String> fieldAndValue,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    client.updateByQuery(buildUpdateChildrenRequest(indexNames, fieldAndValue, updates));
+  }
+
+  /**
+   * Builds the inherited-field child propagation as an async update-by-query
+   * ({@code wait_for_completion=false}). A synchronous update-by-query over a large child set (for
+   * example a test suite with thousands of test cases) holds one HC5 socket open for the entire
+   * scan and trips {@code socketTimeoutSecs} with a {@link java.net.SocketTimeoutException};
+   * submitting it as a background task returns immediately and lets the cluster finish the
+   * propagation and the post-task {@code refresh} on its own.
+   */
+  UpdateByQueryRequest buildUpdateChildrenRequest(
+      List<String> indexNames,
+      Pair<String, String> fieldAndValue,
+      Pair<String, Map<String, Object>> updates) {
     Map<String, JsonData> params =
         convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
-
-    client.updateByQuery(
+    return UpdateByQueryRequest.of(
         u ->
             u.index(indexNames)
                 .query(exactFieldQuery(fieldAndValue))
                 .conflicts(Conflicts.Proceed)
+                .waitForCompletion(false)
                 .script(
                     s ->
                         s.inline(
@@ -570,8 +576,6 @@ public class OpenSearchEntityManager implements EntityManagementClient {
                                     .source(updates.getKey())
                                     .params(params)))
                 .refresh(Refresh.True));
-
-    LOG.info("Successfully updated children in OpenSearch for indices: {}", indexNames);
   }
 
   @Override

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManagerUpdateChildrenTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManagerUpdateChildrenTest.java
@@ -1,0 +1,43 @@
+package org.openmetadata.service.search.elasticsearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import es.co.elastic.clients.elasticsearch.core.UpdateByQueryRequest;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+class ElasticSearchEntityManagerUpdateChildrenTest {
+
+  private final ElasticSearchEntityManager entityManager = new ElasticSearchEntityManager(null);
+
+  /**
+   * Inherited-field propagation must submit the update-by-query as a background task
+   * ({@code wait_for_completion=false}). A synchronous update-by-query over a large child set (e.g.
+   * a test suite with thousands of test cases) holds one socket open for the whole scan and trips
+   * {@code socketTimeoutSecs} with a {@code SocketTimeoutException} — the reported failure. This is
+   * the regression guard: it fails if the async submission is reverted to the blocking default.
+   */
+  @Test
+  void updateChildrenSubmitsAsyncTask() {
+    UpdateByQueryRequest request =
+        entityManager.buildUpdateChildrenRequest(
+            List.of("test_case_search_index"),
+            Pair.of("testSuite.id", "11111111-1111-1111-1111-111111111111"),
+            Pair.of("ctx._source.owners = params.owners;", Map.of("owners", List.of())));
+
+    assertNotNull(
+        request.waitForCompletion(),
+        "waitForCompletion must be set explicitly, not left to the blocking default");
+    assertFalse(
+        request.waitForCompletion(),
+        "child propagation must run as an async task so a large child set cannot trip socketTimeoutSecs");
+    assertEquals(
+        Boolean.TRUE,
+        request.refresh(),
+        "children must still be refreshed once the async task completes");
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManagerUpdateChildrenTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManagerUpdateChildrenTest.java
@@ -1,0 +1,44 @@
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import os.org.opensearch.client.opensearch._types.Refresh;
+import os.org.opensearch.client.opensearch.core.UpdateByQueryRequest;
+
+class OpenSearchEntityManagerUpdateChildrenTest {
+
+  private final OpenSearchEntityManager entityManager = new OpenSearchEntityManager(null);
+
+  /**
+   * Inherited-field propagation must submit the update-by-query as a background task
+   * ({@code wait_for_completion=false}). A synchronous update-by-query over a large child set (e.g.
+   * a test suite with thousands of test cases) holds one socket open for the whole scan and trips
+   * {@code socketTimeoutSecs} with a {@code SocketTimeoutException} — the reported failure. This is
+   * the regression guard: it fails if the async submission is reverted to the blocking default.
+   */
+  @Test
+  void updateChildrenSubmitsAsyncTask() {
+    UpdateByQueryRequest request =
+        entityManager.buildUpdateChildrenRequest(
+            List.of("test_case_search_index"),
+            Pair.of("testSuite.id", "11111111-1111-1111-1111-111111111111"),
+            Pair.of("ctx._source.owners = params.owners;", Map.of("owners", List.of())));
+
+    assertNotNull(
+        request.waitForCompletion(),
+        "waitForCompletion must be set explicitly, not left to the blocking default");
+    assertFalse(
+        request.waitForCompletion(),
+        "child propagation must run as an async task so a large child set cannot trip socketTimeoutSecs");
+    assertEquals(
+        Refresh.True,
+        request.refresh(),
+        "children must still be refreshed once the async task completes");
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/UpdateChildrenAsyncPropagationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/opensearch/UpdateChildrenAsyncPropagationTest.java
@@ -1,0 +1,147 @@
+/*
+ *  Copyright 2024 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.search.opensearch;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.service.configuration.elasticsearch.ElasticSearchConfiguration;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+import os.org.opensearch.client.opensearch._types.FieldValue;
+import os.org.opensearch.client.opensearch.core.UpdateByQueryRequest;
+import os.org.opensearch.client.opensearch.core.UpdateByQueryResponse;
+
+/**
+ * Reproduces the production {@code SocketTimeoutException} raised when inherited-field propagation
+ * ({@link OpenSearchEntityManager#updateChildren}) ran a <b>blocking</b> update-by-query over a
+ * large child set (a test suite completing with thousands of test cases) and outran
+ * {@code socketTimeoutSecs}.
+ *
+ * <p>Against a real OpenSearch node this proves the fix: the child propagation is now submitted as
+ * a background task ({@code wait_for_completion=false}), so the client call returns a task id
+ * immediately instead of holding the socket open for the whole scan — and the propagation still
+ * lands (the async task's {@code refresh=true} makes the children visible).
+ */
+class UpdateChildrenAsyncPropagationTest {
+
+  private static final int CHILD_COUNT = 50;
+
+  private static GenericContainer<?> opensearch;
+  private static OpenSearchClient osClient;
+
+  @BeforeAll
+  static void startOpenSearch() {
+    assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker is required");
+    opensearch =
+        new GenericContainer<>(DockerImageName.parse("opensearchproject/opensearch:2.13.0"))
+            .withEnv("discovery.type", "single-node")
+            .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+            .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+            .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms1g -Xmx1g")
+            .withExposedPorts(9200)
+            .waitingFor(Wait.forHttp("/").forPort(9200).forStatusCode(200))
+            .withStartupTimeout(Duration.ofMinutes(3));
+    opensearch.start();
+    ElasticSearchConfiguration cfg =
+        new ElasticSearchConfiguration()
+            .withHost(opensearch.getHost())
+            .withPort(opensearch.getMappedPort(9200))
+            .withScheme("http")
+            .withConnectionTimeoutSecs(10)
+            .withSocketTimeoutSecs(60)
+            .withBatchSize(10)
+            .withClusterAlias("")
+            .withSearchType(ElasticSearchConfiguration.SearchType.OPENSEARCH);
+    osClient = new OpenSearchClient(cfg);
+  }
+
+  @AfterAll
+  static void stopOpenSearch() {
+    if (osClient != null) {
+      osClient.close();
+    }
+    if (opensearch != null) {
+      opensearch.stop();
+    }
+  }
+
+  @Test
+  void updateChildrenSubmitsAsyncTaskAndPropagates() throws Exception {
+    var lowLevel = osClient.getNewClient();
+    String index = "repro_children";
+    String parentId = UUID.randomUUID().toString();
+    String ownerId = UUID.randomUUID().toString();
+
+    for (int i = 0; i < CHILD_COUNT; i++) {
+      String id = String.valueOf(i);
+      lowLevel.index(
+          idx ->
+              idx.index(index)
+                  .id(id)
+                  .document(Map.of("name", "child-" + id, "entityType", Map.of("id", parentId))));
+    }
+    lowLevel.indices().refresh(r -> r.index(index));
+
+    UpdateByQueryRequest request =
+        new OpenSearchEntityManager(lowLevel)
+            .buildUpdateChildrenRequest(
+                List.of(index),
+                Pair.of("entityType.id", parentId),
+                Pair.of(
+                    "ctx._source.owners = params.owners;",
+                    Map.of("owners", List.of(Map.of("id", ownerId, "type", "user")))));
+
+    UpdateByQueryResponse response = lowLevel.updateByQuery(request);
+
+    // The crux of the fix: wait_for_completion=false makes OpenSearch return a task id up front
+    // instead of holding the socket open for the whole scan. A synchronous (reverted) request
+    // returns a null task with the counts populated instead, which fails this assertion.
+    assertNotNull(
+        response.task(),
+        "child propagation must be submitted as an async task (wait_for_completion=false) so a "
+            + "large child set cannot trip socketTimeoutSecs; got a synchronous response instead");
+
+    Awaitility.await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(500))
+        .until(
+            () ->
+                lowLevel
+                        .count(
+                            c ->
+                                c.index(index)
+                                    .query(
+                                        q ->
+                                            q.term(
+                                                t ->
+                                                    t.field("owners.id.keyword")
+                                                        .value(FieldValue.of(ownerId)))))
+                        .count()
+                    == CHILD_COUNT);
+
+    lowLevel.indices().delete(d -> d.index(index));
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #31114

Inherited-field propagation (owners/domains/displayName) to child entities ran a **blocking** `update_by_query` (`wait_for_completion=true`) with `refresh=true`; over a large child set — e.g. a test suite completing with thousands of test cases — it outran `elasticSearch.socketTimeoutSecs` and threw `SocketTimeoutException`, after which the entity was re-enqueued and the same query re-ran as a retry storm. This submits the by-query as a background task (`wait_for_completion=false`) at the shared build point in `OpenSearchEntityManager`/`ElasticSearchEntityManager`, so the client returns immediately and the cluster finishes the propagation and the post-task `refresh` on its own — propagation is fire-and-forget denormalization on a background lane, so nothing reads-its-own-write on the blocking result.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Small, localized change to the two search `EntityManager`s. Both `updateChildren` overloads now route through a shared `buildUpdateChildrenRequest(...)` that sets `wait_for_completion=false`. `refresh=true` is retained and is compatible with async (the refresh runs after the task completes; only `refresh=wait_for` is unsupported with async per the OpenSearch docs).

#
### Tests:

#### Use cases covered
- A test-suite ingestion pipeline completing with a large number of test cases no longer times out while propagating inherited fields to its child test cases.
- Owner/domain/displayName inheritance still propagates to child search documents.

#### Unit tests
- [x] Added.
- Files: `OpenSearchEntityManagerUpdateChildrenTest.java`, `ElasticSearchEntityManagerUpdateChildrenTest.java` — assert the child-propagation request is built with `wait_for_completion=false`.

#### Backend integration tests
- [x] Added a Docker-gated real-OpenSearch reproduction.
- Files: `UpdateChildrenAsyncPropagationTest.java` — against a live OpenSearch node, asserts the production request returns a task id (async submission) and that all children actually receive the propagated field.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
- Verified RED→GREEN: reverting to `wait_for_completion=true` fails both the unit test (`expected <false> but was <true>`) and the container test (null `response.task()`); restoring the fix makes all three green.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
