### PR TITLE
Backport #30965: prevent reindex OOM under AutoTune and stop ingestion_pipeline field explosion (2.0)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/HeapBackpressure.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/HeapBackpressure.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.apps.bundles.searchIndex;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runtime heap backpressure for the reindex reader.
+ *
+ * <p>AutoTune sizes batch/queue once at job start from a fixed per-entity estimate. Real
+ * entities (wide tables, vector embeddings, large status history) and anything else sharing the pod
+ * push actual heap far past any single estimate, so a static count-based buffer silently overflows a
+ * heap — a 748 MB pod OOM'd on 2026-08-03 seconds after AutoTune upsized its queue to 1840 entities.
+ * No formula can predict runtime pressure; the only thing that works in all situations is to react
+ * to it.
+ *
+ * <p>This gate pauses the calling reader — never the in-flight writes — while used heap is above
+ * {@link #PAUSE_ABOVE}, letting in-flight docs drain and GC reclaim before the reader allocates the
+ * next batch. It is a no-op on a healthy heap (the common case), so it costs nothing until the pod
+ * is actually close to OOM.
+ */
+@Slf4j
+public final class HeapBackpressure {
+  private HeapBackpressure() {}
+
+  /** Pause reading at/above this fraction of max heap. */
+  static final double PAUSE_ABOVE = 0.80;
+
+  /** Resume once heap drains below this fraction (hysteresis avoids pause/resume flapping). */
+  static final double RESUME_BELOW = 0.68;
+
+  private static final long POLL_MS = 250;
+  private static final long MAX_WAIT_MS = 30_000;
+
+  private static final MemoryMXBean MEMORY = ManagementFactory.getMemoryMXBean();
+
+  /** True when used heap is at/above the pause threshold. Unknown max ({@code <= 0}) is never a pause. */
+  static boolean underPressure(long usedBytes, long maxBytes) {
+    return maxBytes > 0 && (double) usedBytes / maxBytes >= PAUSE_ABOVE;
+  }
+
+  /** True when used heap is below the resume threshold, or max is unknown. */
+  static boolean hasHeadroom(long usedBytes, long maxBytes) {
+    return maxBytes <= 0 || (double) usedBytes / maxBytes < RESUME_BELOW;
+  }
+
+  /**
+   * Blocks the caller while heap is under pressure, up to {@link #MAX_WAIT_MS}, so a burst of large
+   * entities cannot push the heap into OOM. Returns immediately on a healthy heap.
+   */
+  public static void awaitHeadroom() {
+    MemoryUsage usage = MEMORY.getHeapMemoryUsage();
+    if (underPressure(usage.getUsed(), usage.getMax())) {
+      drainUntilHeadroom(usage.getMax());
+    }
+  }
+
+  private static void drainUntilHeadroom(long maxBytes) {
+    LOG.warn(
+        "Reindex reader pausing: heap at {}% of {} MB (>= {}% threshold); draining in-flight work",
+        percentUsed(MEMORY.getHeapMemoryUsage().getUsed(), maxBytes),
+        maxBytes / (1024 * 1024),
+        Math.round(PAUSE_ABOVE * 100));
+    long waited = 0;
+    long usedBytes = maxBytes;
+    while (waited < MAX_WAIT_MS && !Thread.currentThread().isInterrupted()) {
+      sleep(POLL_MS);
+      waited += POLL_MS;
+      usedBytes = MEMORY.getHeapMemoryUsage().getUsed();
+      if (hasHeadroom(usedBytes, maxBytes)) {
+        break;
+      }
+    }
+    logResume(usedBytes, maxBytes, waited);
+  }
+
+  private static void logResume(long usedBytes, long maxBytes, long waited) {
+    if (hasHeadroom(usedBytes, maxBytes)) {
+      LOG.info(
+          "Reindex reader resuming after {} ms; heap back to {}%",
+          waited, percentUsed(usedBytes, maxBytes));
+    } else {
+      LOG.warn(
+          "Reindex reader proceeding after {} ms; heap still {}% — GC could not free enough. "
+              + "Reduce batch/queue size or raise the heap for this reindex.",
+          waited, percentUsed(usedBytes, maxBytes));
+    }
+  }
+
+  private static long percentUsed(long usedBytes, long maxBytes) {
+    return maxBytes > 0 ? Math.round(100.0 * usedBytes / maxBytes) : 0;
+  }
+
+  private static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/PartitionWorker.java
@@ -28,6 +28,7 @@ import org.openmetadata.schema.system.EntityError;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.searchIndex.BulkSink;
+import org.openmetadata.service.apps.bundles.searchIndex.HeapBackpressure;
 import org.openmetadata.service.apps.bundles.searchIndex.IndexingFailureRecorder;
 import org.openmetadata.service.apps.bundles.searchIndex.ReindexingConfiguration;
 import org.openmetadata.service.apps.bundles.searchIndex.SearchIndexEntityTypes;
@@ -183,6 +184,13 @@ public class PartitionWorker {
       while (currentOffset < rangeEnd
           && !stopped.get()
           && !Thread.currentThread().isInterrupted()) {
+        // Yield before pulling the next batch when the pod's heap is tight. AutoTune sizes batch
+        // and
+        // queue once at start from a fixed per-entity estimate; real entities (embeddings, wide
+        // tables) or co-tenant work can exceed it and OOM a small heap. Pausing the reader — not
+        // the
+        // writes — lets in-flight docs drain and GC reclaim, so reindex adapts to any pod size.
+        HeapBackpressure.awaitHeadroom();
         int currentBatchSize = (int) Math.min(batchSize, rangeEnd - currentOffset);
 
         try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClusterMetrics.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClusterMetrics.java
@@ -42,10 +42,16 @@ public class SearchClusterMetrics {
   // payloads. Bulk buffers are off-heap, so they escape -Xmx and count against the cgroup limit.
   public static final double INFLIGHT_MEMORY_SAFETY_FACTOR = 0.5;
   // Conservative per-entity heap footprint, used to bound the buffered entity queue by bytes rather
-  // than a flat count. Wide tables / large descriptions / sampleData run far above a naive 10 KB;
-  // genuinely huge entities are still caught by the bulk sink's runtime backpressure.
-  public static final long ESTIMATED_ENTITY_BYTES = 100 * 1024L;
+  // than a flat count. 100 KB proved wildly optimistic: an `all` reindex with vector embeddings
+  // OOM'd a 748 MB pod after AutoTune sized an 1840-entity queue at the old estimate. Wide tables,
+  // embeddings, and status history run 250 KB - several MB; 256 KB is a calibrated middle ground.
+  // The runtime guard is HeapBackpressure; this only right-sizes the initial queue.
+  public static final long ESTIMATED_ENTITY_BYTES = 256 * 1024L;
   public static final double QUEUE_HEAP_FRACTION = 0.25;
+  // Floor for the heap-bounded queue: a tiny heap still gets a modest buffer, but never the old
+  // flat
+  // 1000 (which alone was ~256 MB at 256 KB/entity and could OOM a sub-1 GB pod by itself).
+  static final int MIN_HEAP_BOUNDED_QUEUE = 250;
 
   public static SearchClusterMetrics fetchClusterMetrics(
       SearchRepository searchRepository, long totalEntities, int maxDbConnections) {
@@ -462,12 +468,16 @@ public class SearchClusterMetrics {
   static int boundQueueSizeToHeap(int queueSize, long maxHeapBytes) {
     long heapBudget = (long) (maxHeapBytes * QUEUE_HEAP_FRACTION);
     long budgeted = heapBudget / ESTIMATED_ENTITY_BYTES;
-    if (budgeted < 1000) {
+    if (budgeted < MIN_HEAP_BOUNDED_QUEUE) {
       LOG.info(
-          "Queue floor of 1000 entities exceeds heap budget (~{} fit {}% of heap at {} KB/entity); heap is very small",
-          budgeted, (int) (QUEUE_HEAP_FRACTION * 100), ESTIMATED_ENTITY_BYTES / 1024);
+          "Heap-bounded queue floored at {} entities (~{} fit {}% of {} MB heap at {} KB/entity); heap is small",
+          MIN_HEAP_BOUNDED_QUEUE,
+          budgeted,
+          (int) (QUEUE_HEAP_FRACTION * 100),
+          maxHeapBytes / (1024 * 1024),
+          ESTIMATED_ENTITY_BYTES / 1024);
     }
-    int maxByHeap = (int) Math.max(1000, budgeted);
+    int maxByHeap = (int) Math.max(MIN_HEAP_BOUNDED_QUEUE, budgeted);
     return Math.min(queueSize, maxByHeap);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/IngestionPipelineIndex.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/indexes/IngestionPipelineIndex.java
@@ -18,10 +18,15 @@ public class IngestionPipelineIndex implements TaggableIndex, ServiceBackedIndex
   final Set<String> excludeFields = Set.of("sourceConfig", "openMetadataServerConnection");
 
   /**
-   * Free-form per-run map fields on a {@link PipelineStatus} that are not searched and whose
-   * arbitrary keys must never reach the index (see {@link #searchableStatus}).
+   * Non-searchable fields on a {@link PipelineStatus} whose arbitrary/unbounded keys must never reach
+   * the index (see {@link #searchableStatus}). {@code config}/{@code metadata} are free-form per-run
+   * maps; {@code status} is the per-step telemetry whose {@code operationMetrics}/{@code progress}
+   * nest one key per API endpoint, query, or entity type — thousands of distinct keys that get
+   * dynamically mapped one-field-each and push the index past its total-fields limit. None are
+   * searched (only {@code pipelineState} and the run timestamps are).
    */
-  private static final Set<String> NON_SEARCHABLE_STATUS_FIELDS = Set.of("config", "metadata");
+  private static final Set<String> NON_SEARCHABLE_STATUS_FIELDS =
+      Set.of("config", "metadata", "status");
 
   public IngestionPipelineIndex(IngestionPipeline ingestionPipeline) {
     this.ingestionPipeline = ingestionPipeline;
@@ -84,13 +89,14 @@ public class IngestionPipelineIndex implements TaggableIndex, ServiceBackedIndex
   }
 
   /**
-   * Drops the free-form {@code config} and {@code metadata} blobs from the run status before
-   * indexing. Both are arbitrary per-run key/value maps (a {@code map} in the schema): they are not
-   * searched (only the derived {@code applicationType} is), can be large, and dynamically mapping
-   * their arbitrary keys previously triggered type conflicts (a key seen first as a string then as an
-   * object) and can push the index past its total-fields limit — either of which rejects the whole
-   * document. The searchable status fields (state, runId, timestamps) are preserved. Returns a copy
-   * so the entity is not mutated.
+   * Drops the non-searchable blobs ({@code config}, {@code metadata}, {@code status}) from a run
+   * before indexing. {@code config}/{@code metadata} are arbitrary per-run key/value maps; {@code
+   * status} is per-step telemetry whose {@code operationMetrics}/{@code progress} nest one key per API
+   * endpoint or entity type. None are searched (only the run state and timestamps are), yet their
+   * arbitrary keys are dynamically mapped one-field-each and push the index past its total-fields
+   * limit ("Limit of total fields [1000] has been exceeded"), which rejects the whole document. The
+   * searchable status fields (state, runId, timestamps) are preserved. Returns a copy so the entity
+   * is not mutated.
    */
   private Map<String, Object> searchableStatus(PipelineStatus status) {
     Map<String, Object> result = null;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/HeapBackpressureTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/HeapBackpressureTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2024 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.apps.bundles.searchIndex;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class HeapBackpressureTest {
+
+  @Test
+  void underPressure_atOrAboveThreshold() {
+    assertTrue(HeapBackpressure.underPressure(80, 100), "80% == 0.80 threshold must pause");
+    assertTrue(HeapBackpressure.underPressure(95, 100));
+    assertTrue(HeapBackpressure.underPressure(100, 100));
+  }
+
+  @Test
+  void underPressure_belowThreshold() {
+    assertFalse(HeapBackpressure.underPressure(79, 100));
+    assertFalse(HeapBackpressure.underPressure(0, 100));
+  }
+
+  @Test
+  void underPressure_falseWhenMaxUnknown() {
+    // Some GCs report max = -1; an unknown ceiling must never wedge the reader.
+    assertFalse(HeapBackpressure.underPressure(1_000_000, -1));
+    assertFalse(HeapBackpressure.underPressure(1_000_000, 0));
+  }
+
+  @Test
+  void hasHeadroom_belowResumeThreshold() {
+    assertTrue(HeapBackpressure.hasHeadroom(67, 100), "below 0.68 must resume");
+    assertTrue(HeapBackpressure.hasHeadroom(0, 100));
+    assertTrue(HeapBackpressure.hasHeadroom(1_000_000, -1), "unknown max must resume, never hang");
+  }
+
+  @Test
+  void hasHeadroom_atOrAboveResumeThreshold() {
+    assertFalse(HeapBackpressure.hasHeadroom(68, 100));
+    assertFalse(HeapBackpressure.hasHeadroom(80, 100));
+  }
+
+  @Test
+  void hysteresisGap_holdsStateBetweenThresholds() {
+    // Between resume (0.68) and pause (0.80) the reader neither pauses nor is declared recovered,
+    // so it can't flap once it has paused. 75% must be in that band.
+    assertFalse(HeapBackpressure.underPressure(75, 100));
+    assertFalse(HeapBackpressure.hasHeadroom(75, 100));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchClusterMetricsTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchClusterMetricsTest.java
@@ -62,17 +62,21 @@ public class SearchClusterMetricsTest {
   @Test
   void boundsQueueSizeToHeapBudget() {
     assertEquals(
-        10000,
+        4096,
         SearchClusterMetrics.boundQueueSizeToHeap(10000, 4L * 1024 * 1024 * 1024),
-        "4 GB heap has room for the full queue");
+        "4 GB heap / 256 KB entity caps the 10000 request at 25% of heap");
     assertEquals(
-        2621,
+        1024,
         SearchClusterMetrics.boundQueueSizeToHeap(10000, 1024L * 1024 * 1024),
-        "1 GB heap / 100 KB entity caps the queue well below 10000");
+        "1 GB heap / 256 KB entity caps the queue well below 10000");
     assertEquals(
-        1000,
+        748,
+        SearchClusterMetrics.boundQueueSizeToHeap(1840, 748L * 1024 * 1024),
+        "the 748 MB pod that OOM'd: AutoTune's 1840-entity queue capped to ~25% of heap");
+    assertEquals(
+        250,
         SearchClusterMetrics.boundQueueSizeToHeap(10000, 128L * 1024 * 1024),
-        "tiny heap floors at 1000 rather than zero");
+        "tiny heap floors at the small-heap minimum, not the old flat 1000");
   }
 
   @BeforeEach

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/IngestionPipelineIndexTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/indexes/IngestionPipelineIndexTest.java
@@ -15,17 +15,20 @@ package org.openmetadata.service.search.indexes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.SearchRepository;
 
@@ -44,14 +47,42 @@ class IngestionPipelineIndexTest {
     Entity.setSearchRepository(previousRepository);
   }
 
+  /** Fields the {@code pipelineStatuses} index mapping declares; nothing else may reach the doc. */
+  private static final Set<String> MAPPED_STATUS_FIELDS =
+      Set.of("runId", "pipelineState", "timestamp", "startDate", "endDate");
+
   @Test
-  void buildDoc_stripsFreeFormFieldsFromPipelineStatuses_keepsOtherFields() {
-    PipelineStatus status =
-        new PipelineStatus()
-            .withRunId("run-1")
-            .withConfig(
-                Map.of("appConfig", Map.of("actions", Map.of("customProperties", "jointure"))))
-            .withMetadata(Map.of("arbitraryKey", Map.of("nested", "value")));
+  void buildDoc_stripsFreeFormAndTelemetryFromPipelineStatuses_keepsScalars() {
+    // A single run carrying every shape that has blown up the ingestion_pipeline mapping: the
+    // free-form config/metadata maps and the per-step status[].operationMetrics keyed by API
+    // endpoint. Each distinct key is dynamically mapped one-field-each; unstripped, a handful of
+    // runs trip "Limit of total fields [1000] has been exceeded" during reindex.
+    String statusJson =
+        """
+        {
+          "runId": "run-1",
+          "pipelineState": "success",
+          "timestamp": 1785801779432,
+          "startDate": 1785801779432,
+          "endDate": 1785801884749,
+          "status": [
+            {
+              "name": "Fivetran",
+              "records": 254,
+              "operationMetrics": {
+                "source_api_calls": {
+                  "GET:/connectors/cork_had": {"fivetran": {"count": 1, "totalTimeMs": 256.3}},
+                  "GET:/connectors/bunt_ashen": {"fivetran": {"count": 1, "totalTimeMs": 249.4}},
+                  "GET:/connectors/cork_had/schemas": {"fivetran": {"count": 1, "totalTimeMs": 495.9}}
+                }
+              }
+            }
+          ],
+          "config": {"appConfig": {"actions": {"customProperties": "jointure"}}},
+          "metadata": {"arbitraryKey": {"nested": "value"}}
+        }
+        """;
+    PipelineStatus status = JsonUtils.readValue(statusJson, PipelineStatus.class);
     IngestionPipeline pipeline =
         new IngestionPipeline()
             .withName("p1")
@@ -66,9 +97,22 @@ class IngestionPipelineIndexTest {
     List<?> statuses = (List<?>) pipelineStatuses;
     assertEquals(1, statuses.size());
     Map<?, ?> statusMap = (Map<?, ?>) statuses.getFirst();
+
     assertFalse(statusMap.containsKey("config"), "free-form config must be stripped from the doc");
     assertFalse(
         statusMap.containsKey("metadata"), "free-form metadata must be stripped from the doc");
+    assertFalse(
+        statusMap.containsKey("status"),
+        "per-step telemetry (operationMetrics) must be stripped — its per-endpoint keys explode the mapping");
+    // The catch-all guard: anything outside the mapped scalar set would be dynamically mapped and
+    // is
+    // a field-explosion risk. Fails if a future free-form field is added to PipelineStatus
+    // unstripped.
+    assertTrue(
+        MAPPED_STATUS_FIELDS.containsAll(statusMap.keySet()),
+        "indexed pipelineStatus must contain only mapped scalar fields, but had: "
+            + statusMap.keySet());
     assertEquals("run-1", statusMap.get("runId"), "searchable status fields must be preserved");
+    assertEquals("success", statusMap.get("pipelineState"), "pipelineState must be preserved");
   }
 }

--- a/openmetadata-spec/src/main/resources/elasticsearch/en/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/en/ingestion_pipeline_index_mapping.json
@@ -378,6 +378,7 @@
         "normalizer": "lowercase_normalizer"
       },
       "pipelineStatuses": {
+        "dynamic": false,
         "properties": {
           "pipelineState": {
             "type": "keyword"

--- a/openmetadata-spec/src/main/resources/elasticsearch/jp/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/jp/ingestion_pipeline_index_mapping.json
@@ -371,6 +371,7 @@
         "normalizer": "lowercase_normalizer"
       },
       "pipelineStatuses": {
+        "dynamic": false,
         "properties": {
           "pipelineState": {
             "type": "keyword"

--- a/openmetadata-spec/src/main/resources/elasticsearch/ru/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/ru/ingestion_pipeline_index_mapping.json
@@ -391,6 +391,7 @@
         "normalizer": "lowercase_normalizer"
       },
       "pipelineStatuses": {
+        "dynamic": false,
         "properties": {
           "pipelineState": {
             "type": "keyword"

--- a/openmetadata-spec/src/main/resources/elasticsearch/zh/ingestion_pipeline_index_mapping.json
+++ b/openmetadata-spec/src/main/resources/elasticsearch/zh/ingestion_pipeline_index_mapping.json
@@ -370,6 +370,7 @@
         "normalizer": "lowercase_normalizer"
       },
       "pipelineStatuses": {
+        "dynamic": false,
         "properties": {
           "pipelineState": {
             "type": "keyword"


### PR DESCRIPTION
Backport of #30965 to **2.0**.

Cherry-picked the squash-merge commit `025ca74` cleanly (zero conflicts) — all 11 files are **byte-identical** to the version merged to `main` and already passing CI there.

### What it fixes (both root-caused from the same S&P Global / Earnin reindex incident)

1. **`ingestion_pipeline` field explosion** — reindex rejected documents with `Limit of total fields [1000] has been exceeded`. Each `PipelineStatus.status[]` carries an `operationMetrics` map keyed by API endpoint — one dynamic mapping field per key, hundreds per run. Adds `status` to `NON_SEARCHABLE_STATUS_FIELDS` (stripped before indexing) and pins `"dynamic": false` on the `pipelineStatuses` mapping object in all four locales (en/jp/ru/zh) as a guardrail. Only `pipelineState` is read from this index, so no consumer loses data.

2. **AutoTune reindex OOM** — an `all` reindex with vector embeddings OOM'd a 748 MB pod seconds after AutoTune upsized the reader queue to 1840 entities at a flat 100 KB/entity estimate. Adds a runtime `HeapBackpressure` gate (pauses the reader — never in-flight writes — while heap ≥ 80%, resumes < 68%, bounded 30 s) and right-sizes the initial queue (`ESTIMATED_ENTITY_BYTES` 100 KB → 256 KB, heap-bounded queue floor 1000 → 250). Batch size is deliberately left unchanged.

### Tests
- `IngestionPipelineIndexTest`, `HeapBackpressureTest`, `SearchClusterMetricsTest` — carried over unchanged from the original PR (2.0 shapes `pipelineStatuses` as a `List`, identical to `main`).

See #30965 for full design rationale.
