### PR TITLE
Fixed context center bugs

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/drive/ContextFileExtractionService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/drive/ContextFileExtractionService.java
@@ -1,6 +1,5 @@
 package org.openmetadata.service.drive;
 
-import static org.openmetadata.service.Entity.ADMIN_USER_NAME;
 import static org.openmetadata.service.jdbi3.ContextFileContentRepository.CONTEXT_FILE_CONTENT_ENTITY;
 import static org.openmetadata.service.jdbi3.ContextFileRepository.CONTEXT_FILE_ENTITY;
 
@@ -299,7 +298,7 @@ public class ContextFileExtractionService {
         return false;
       }
       try {
-        repository.updateIfCurrent(null, current, updated, ADMIN_USER_NAME);
+        repository.updateIfCurrent(null, current, updated, current.getUpdatedBy());
         return true;
       } catch (PreconditionFailedException e) {
         LOG.debug("Context file {} changed during extraction update", fileId);
@@ -325,7 +324,9 @@ public class ContextFileExtractionService {
         return false;
       }
       try {
-        repository.getContentRepository().updateIfCurrent(null, current, updated, ADMIN_USER_NAME);
+        repository
+            .getContentRepository()
+            .updateIfCurrent(null, current, updated, current.getUpdatedBy());
         return true;
       } catch (PreconditionFailedException e) {
         LOG.debug("Context file content {} changed during extraction update", contentId);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
@@ -51,7 +51,7 @@ import org.openmetadata.service.jdbi3.ContextFileRepository;
 @ExtendWith(MockitoExtension.class)
 class ContextFileExtractionServiceTest {
 
-  private static final String UPLOADER = "rohit.jain";
+  private static final String UPLOADER = "test.user";
 
   @Mock private ContextFileRepository repository;
   @Mock private ContextFileContentRepository contentRepository;

--- a/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/drive/ContextFileExtractionServiceTest.java
@@ -51,6 +51,8 @@ import org.openmetadata.service.jdbi3.ContextFileRepository;
 @ExtendWith(MockitoExtension.class)
 class ContextFileExtractionServiceTest {
 
+  private static final String UPLOADER = "rohit.jain";
+
   @Mock private ContextFileRepository repository;
   @Mock private ContextFileContentRepository contentRepository;
   @Mock private AssetRepository assetRepository;
@@ -78,7 +80,8 @@ class ContextFileExtractionServiceTest {
             .withFileType(ContextFileType.PDF)
             .withFileExtension("pdf")
             .withHeadContentId(contentId.toString())
-            .withProcessingStatus(ProcessingStatus.Uploaded);
+            .withProcessingStatus(ProcessingStatus.Uploaded)
+            .withUpdatedBy(UPLOADER);
 
     content =
         new ContextFileContent()
@@ -86,7 +89,8 @@ class ContextFileExtractionServiceTest {
             .withName("v1")
             .withAssetId("asset-1")
             .withContextFile(file.getEntityReference())
-            .withProcessingStatus(ProcessingStatus.Uploaded);
+            .withProcessingStatus(ProcessingStatus.Uploaded)
+            .withUpdatedBy(UPLOADER);
 
     asset = new Asset();
     asset.setId("asset-1");
@@ -112,9 +116,9 @@ class ContextFileExtractionServiceTest {
     service(Runnable::run, () -> assetService).process(fileId, contentId);
 
     verify(repository, times(2))
-        .updateIfCurrent(isNull(), same(file), updatedFileCaptor.capture(), anyString());
+        .updateIfCurrent(isNull(), same(file), updatedFileCaptor.capture(), eq(UPLOADER));
     verify(contentRepository, times(2))
-        .updateIfCurrent(isNull(), same(content), updatedContentCaptor.capture(), anyString());
+        .updateIfCurrent(isNull(), same(content), updatedContentCaptor.capture(), eq(UPLOADER));
 
     List<ContextFile> fileUpdates = updatedFileCaptor.getAllValues();
     assertEquals(ProcessingStatus.Analyzing, fileUpdates.get(0).getProcessingStatus());

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -33,8 +33,8 @@ dotenv.config();
  */
 const isH2Mode = process.env.PW_PROTOCOL === 'h2';
 const defaultBaseURL = isH2Mode
-  ? 'https://localhost:3000'
-  : 'http://localhost:3000';
+  ? 'https://localhost:8585'
+  : 'http://localhost:8585';
 
 const shardPlan = process.env.PW_SHARD_PLAN
   ? JSON.parse(readFileSync(process.env.PW_SHARD_PLAN, 'utf8'))

--- a/openmetadata-ui/src/main/resources/ui/playwright.config.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright.config.ts
@@ -33,8 +33,8 @@ dotenv.config();
  */
 const isH2Mode = process.env.PW_PROTOCOL === 'h2';
 const defaultBaseURL = isH2Mode
-  ? 'https://localhost:8585'
-  : 'http://localhost:8585';
+  ? 'https://localhost:3000'
+  : 'http://localhost:3000';
 
 const shardPlan = process.env.PW_SHARD_PLAN
   ? JSON.parse(readFileSync(process.env.PW_SHARD_PLAN, 'utf8'))

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
@@ -308,9 +308,7 @@ test.describe('Context Center - Dashboard', () => {
 
       const panel = page.getByTestId('document-preview-panel');
       await expect(panel).toBeVisible();
-      await expect(panel.getByTestId('preview-file-name')).toHaveText(
-        fileName
-      );
+      await expect(panel.getByTestId('preview-file-name')).toHaveText(fileName);
     });
   });
 
@@ -399,19 +397,29 @@ test.describe('Context Center - Dashboard', () => {
 
       await test.step('Articles card redirects to /context-center/articles', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('article-detail-card').getByRole('button', { name: 'View All Articles' }).click();
+        await page
+          .getByTestId('article-detail-card')
+          .getByRole('button', { name: 'View All Articles' })
+          .click();
         await expect(page).toHaveURL(/\/context-center\/articles/);
       });
 
       await test.step('Documents card redirects to /context-center/documents', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('document-detail-card').getByRole('button', { name: 'View All Documents' }).first().click();
+        await page
+          .getByTestId('document-detail-card')
+          .getByRole('button', { name: 'View All Documents' })
+          .first()
+          .click();
         await expect(page).toHaveURL(/\/context-center\/documents/);
       });
 
       await test.step('Memories card redirects to /context-center/memories', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('memory-detail-card').getByRole('button', { name: 'View All Memories' }).click();
+        await page
+          .getByTestId('memory-detail-card')
+          .getByRole('button', { name: 'View All Memories' })
+          .click();
         await expect(page).toHaveURL(/\/context-center\/memories/);
         await waitForAllLoadersToDisappear(page);
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
@@ -301,13 +301,16 @@ test.describe('Context Center - Dashboard', () => {
       const childRow = tree.getByRole('row', { name: fileName });
       await expect(childRow).toBeVisible();
 
-      await navigateToDashboard(page);
+      await childRow.getByRole('button', { name: fileName }).click();
+      await expect(page).toHaveURL(
+        new RegExp(`/context-center/documents\\?document=${file.id}`)
+      );
 
-      const folderNameLink = tree
-        .getByRole('row', { name: folderName })
-        .getByRole('button', { name: folderName });
-      await folderNameLink.click();
-      await expect(page).toHaveURL(/\/context-center\/documents\?folder=/);
+      const panel = page.getByTestId('document-preview-panel');
+      await expect(panel).toBeVisible();
+      await expect(panel.getByTestId('preview-file-name')).toHaveText(
+        fileName
+      );
     });
   });
 
@@ -396,19 +399,19 @@ test.describe('Context Center - Dashboard', () => {
 
       await test.step('Articles card redirects to /context-center/articles', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('article-detail-card').click();
+        await page.getByTestId('article-detail-card').getByRole('button', { name: 'View All Articles' }).click();
         await expect(page).toHaveURL(/\/context-center\/articles/);
       });
 
       await test.step('Documents card redirects to /context-center/documents', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('document-detail-card').click();
+        await page.getByTestId('document-detail-card').getByRole('button', { name: 'View All Documents' }).first().click();
         await expect(page).toHaveURL(/\/context-center\/documents/);
       });
 
       await test.step('Memories card redirects to /context-center/memories', async () => {
         await navigateToDashboard(page);
-        await page.getByTestId('memory-detail-card').click();
+        await page.getByTestId('memory-detail-card').getByRole('button', { name: 'View All Memories' }).click();
         await expect(page).toHaveURL(/\/context-center\/memories/);
         await waitForAllLoadersToDisappear(page);
       });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDashboard.spec.ts
@@ -124,6 +124,8 @@ test.describe('Context Center - Dashboard', () => {
         .catch(() => false);
       if (isStillInTopThree) {
         await expect(seededDocument).toBeVisible();
+        await seededDocument.click();
+        await expect(page).toHaveURL(/\/context-center\/documents\?document=/);
       }
     });
 
@@ -156,6 +158,8 @@ test.describe('Context Center - Dashboard', () => {
         .catch(() => false);
       if (isStillInTopThree) {
         await expect(seededMemory).toBeVisible();
+        await seededMemory.click();
+        await expect(page).toHaveURL(/\/context-center\/memories\?memory=/);
       }
     });
   });
@@ -184,7 +188,13 @@ test.describe('Context Center - Dashboard', () => {
 
       const recentlyViewedCard = page.getByTestId('recently-viewed-card');
       await expect(recentlyViewedCard).toBeVisible();
-      await expect(recentlyViewedCard.getByText(displayName)).toBeVisible();
+
+      const recentlyViewedItem = recentlyViewedCard.getByText(displayName);
+      await expect(recentlyViewedItem).toBeVisible();
+      await recentlyViewedItem.click();
+      await expect(page).toHaveURL(
+        new RegExp(`/context-center/articles/${article.fullyQualifiedName}`)
+      );
     });
   });
 
@@ -227,6 +237,10 @@ test.describe('Context Center - Dashboard', () => {
 
       const firstItem = mostCitedCard.getByTestId('most-cited-count').first();
       await expect(firstItem).toContainText('Cited 999999 times');
+
+      const firstItemRow = mostCitedCard.getByRole('button').first();
+      await firstItemRow.click();
+      await expect(page).toHaveURL(/\/context-center\/memories\?memory=/);
     });
   });
 
@@ -286,6 +300,14 @@ test.describe('Context Center - Dashboard', () => {
 
       const childRow = tree.getByRole('row', { name: fileName });
       await expect(childRow).toBeVisible();
+
+      await navigateToDashboard(page);
+
+      const folderNameLink = tree
+        .getByRole('row', { name: folderName })
+        .getByRole('button', { name: folderName });
+      await folderNameLink.click();
+      await expect(page).toHaveURL(/\/context-center\/documents\?folder=/);
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterPermission.spec.ts
@@ -38,6 +38,7 @@ import {
   navigateToMemories,
   scrollHierarchyToNode,
   scrollListingToCard,
+  searchAndGetDocumentRow,
   searchAndGetMemoryRow,
   uploadDisposableDocument,
   waitForDocumentInArchive,
@@ -1240,6 +1241,19 @@ test.describe('Context Center Permissions', () => {
         const { apiContext, afterAction } = await getDefaultAdminAPIContext(
           browser
         );
+
+        await waitForDocumentProcessingComplete(apiContext, uploadedData.id);
+
+        await createAllPage.reload();
+        await waitForAllLoadersToDisappear(createAllPage);
+        await navigateToDocuments(createAllPage);
+
+        const row = await searchAndGetDocumentRow(createAllPage, fileName);
+        await expect(row).toBeVisible();
+        await expect(row.getByTestId('document-updated-by')).toHaveText(
+          createAllUser.responseData.name
+        );
+
         await apiContext
           .delete(
             `/api/v1/contextCenter/drive/files/${uploadedData.id}?hardDelete=true`

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArchiveView/ArchiveView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ArchiveView/ArchiveView.component.tsx
@@ -68,7 +68,7 @@ const ArchiveRow: FC<ArchiveRowProps> = ({
   return (
     <Box
       align="center"
-      className="tw:px-4 tw:py-3 tw:border-b tw:border-secondary tw:last:border-0"
+      className="tw:px-4 tw:py-3 tw:border-b tw:border-secondary"
       data-testid={`archive-row-${item.id}`}
       gap={4}>
       <FileIcon

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
@@ -22,7 +22,7 @@ import {
 } from '@openmetadata/ui-core-components';
 import { ArrowNarrowRight } from '@untitledui/icons';
 import classNames from 'classnames';
-import { FC, Fragment } from 'react';
+import { FC, Fragment, KeyboardEvent, MouseEvent } from 'react';
 import {
   ContextKnowledgePillarCardProps,
   PillarRecentItem,
@@ -35,8 +35,30 @@ function RecentItem({
   readonly Icon: FC<{ className?: string }>;
   readonly item: PillarRecentItem;
 }) {
+
+  const handleClick = (e: MouseEvent) => {
+    e.stopPropagation();
+    item?.onClick();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      item.onClick();
+    }
+  };
+
   return (
-    <Box align="center" className="tw:py-1.5" gap={2}>
+    <Box
+      align="center"
+      className=
+        'tw:py-1.5 tw:cursor-pointer tw:rounded tw:hover:bg-primary_hover'
+      gap={2}
+      role={'button'}
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}>
       {item.icon ? (
         item.icon
       ) : (

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.component.tsx
@@ -35,10 +35,9 @@ function RecentItem({
   readonly Icon: FC<{ className?: string }>;
   readonly item: PillarRecentItem;
 }) {
-
   const handleClick = (e: MouseEvent) => {
     e.stopPropagation();
-    item?.onClick();
+    item.onClick();
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -52,10 +51,9 @@ function RecentItem({
   return (
     <Box
       align="center"
-      className=
-        'tw:py-1.5 tw:cursor-pointer tw:rounded tw:hover:bg-primary_hover'
+      className="tw:py-1.5 tw:cursor-pointer tw:rounded tw:hover:bg-primary_hover"
       gap={2}
-      role={'button'}
+      role="button"
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.interface.ts
@@ -19,6 +19,7 @@ export interface PillarRecentItem {
   title: string;
   meta: string[];
   icon?: ReactElement;
+  onClick: () => void;
 }
 
 export interface ContextKnowledgePillarCardProps {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.test.tsx
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ReactComponent as FileIcon } from '../../../assets/svg/common/file.svg';
+import ContextKnowledgePillarCard from './ContextKnowledgePillarCard.component';
+import { PillarRecentItem } from './ContextKnowledgePillarCard.interface';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const baseProps = {
+  cta: 'View all',
+  icon: FileIcon,
+  stat: '5',
+  statSub: 'items',
+  subtitle: 'subtitle',
+  title: 'Articles',
+};
+
+describe('ContextKnowledgePillarCard', () => {
+  it('calls onClick when the card body is clicked', () => {
+    const onClick = jest.fn();
+    render(
+      <ContextKnowledgePillarCard
+        {...baseProps}
+        dataTestId="article-detail-card"
+        recent={[{ meta: [], title: 'Item 1' }]}
+        onClick={onClick}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('article-detail-card'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the item onClick and not the card onClick when a recent item with onClick is clicked', () => {
+    const onCardClick = jest.fn();
+    const onItemClick = jest.fn();
+    const recent: PillarRecentItem[] = [
+      { meta: [], onClick: onItemClick, title: 'Item 1' },
+    ];
+    render(
+      <ContextKnowledgePillarCard
+        {...baseProps}
+        dataTestId="article-detail-card"
+        recent={recent}
+        onClick={onCardClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Item 1' }));
+
+    expect(onItemClick).toHaveBeenCalledTimes(1);
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it('renders a recent item without onClick as non-interactive', () => {
+    const onCardClick = jest.fn();
+    const recent: PillarRecentItem[] = [{ meta: [], title: 'Item 1' }];
+    render(
+      <ContextKnowledgePillarCard
+        {...baseProps}
+        dataTestId="article-detail-card"
+        recent={recent}
+        onClick={onCardClick}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Item 1' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+  });
+
+  it('calls onClick when the CTA button is clicked, without double-firing from the card', () => {
+    const onClick = jest.fn();
+    render(
+      <ContextKnowledgePillarCard
+        {...baseProps}
+        dataTestId="article-detail-card"
+        recent={[{ meta: [], title: 'Item 1' }]}
+        onClick={onClick}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'View all' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextKnowledgePillarCard/ContextKnowledgePillarCard.test.tsx
@@ -36,7 +36,7 @@ describe('ContextKnowledgePillarCard', () => {
       <ContextKnowledgePillarCard
         {...baseProps}
         dataTestId="article-detail-card"
-        recent={[{ meta: [], title: 'Item 1' }]}
+        recent={[{ meta: [], onClick: jest.fn(), title: 'Item 1' }]}
         onClick={onClick}
       />
     );
@@ -67,31 +67,13 @@ describe('ContextKnowledgePillarCard', () => {
     expect(onCardClick).not.toHaveBeenCalled();
   });
 
-  it('renders a recent item without onClick as non-interactive', () => {
-    const onCardClick = jest.fn();
-    const recent: PillarRecentItem[] = [{ meta: [], title: 'Item 1' }];
-    render(
-      <ContextKnowledgePillarCard
-        {...baseProps}
-        dataTestId="article-detail-card"
-        recent={recent}
-        onClick={onCardClick}
-      />
-    );
-
-    expect(
-      screen.queryByRole('button', { name: 'Item 1' })
-    ).not.toBeInTheDocument();
-    expect(screen.getByText('Item 1')).toBeInTheDocument();
-  });
-
   it('calls onClick when the CTA button is clicked, without double-firing from the card', () => {
     const onClick = jest.fn();
     render(
       <ContextKnowledgePillarCard
         {...baseProps}
         dataTestId="article-detail-card"
-        recent={[{ meta: [], title: 'Item 1' }]}
+        recent={[{ meta: [], onClick: jest.fn(), title: 'Item 1' }]}
         onClick={onClick}
       />
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextSimplePillarCard/ContextSimplePillarCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/ContextSimplePillarCard/ContextSimplePillarCard.component.tsx
@@ -57,7 +57,7 @@ const ContextSimplePillarCard: FC<ContextSimplePillarCardProps> = ({
 
       <div className="tw:relative tw:flex-1 tw:min-h-0 tw:overflow-y-auto">
         {isLoading ? (
-          <Box direction="col" gap={2}>
+          <Box className="tw:px-4" direction="col" gap={2}>
             <Skeleton height="14px" variant="rounded" width="80%" />
             <Skeleton height="14px" variant="rounded" width="60%" />
             <Skeleton height="14px" variant="rounded" width="70%" />

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -202,7 +202,7 @@ const EmptyTags: FC = () => {
   const { t } = useTranslation();
 
   return (
-    <Typography className="tw:text-utility-gray-400" size='text-xs'>
+    <Typography className="tw:text-utility-gray-400" size="text-xs">
       {t('label.no-tags-added')}
     </Typography>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -198,6 +198,16 @@ const EmptyLinkedAssets: FC = () => {
   );
 };
 
+const EmptyTags: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Typography className="tw:text-utility-gray-400" size='text-xs'>
+      {t('label.no-tags-added')}
+    </Typography>
+  );
+};
+
 const LinkedAssetsReadOnly: FC<{ assets: DataAssetOption[] }> = ({
   assets,
 }) => {
@@ -966,6 +976,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               </Typography>
                             </div>
                             <div className="tw:flex tw:items-center tw:gap-1.5 tw:flex-wrap tw:flex-1">
+                              {selectedTags.length === 0 && <EmptyTags />}
                               {selectedTags.map((tag) =>
                                 isViewOnly ? (
                                   <Badge

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -976,7 +976,7 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               </Typography>
                             </div>
                             <div className="tw:flex tw:items-center tw:gap-1.5 tw:flex-wrap tw:flex-1">
-                              {selectedTags.length === 0 && <EmptyTags />}
+                              {isViewOnly && selectedTags.length === 0 && <EmptyTags />}
                               {selectedTags.map((tag) =>
                                 isViewOnly ? (
                                   <Badge

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/CreateMemoryModal/CreateMemoryModal.component.tsx
@@ -976,7 +976,9 @@ const CreateMemoryModal: FC<CreateMemoryModalProps> = ({
                               </Typography>
                             </div>
                             <div className="tw:flex tw:items-center tw:gap-1.5 tw:flex-wrap tw:flex-1">
-                              {isViewOnly && selectedTags.length === 0 && <EmptyTags />}
+                              {isViewOnly && selectedTags.length === 0 && (
+                                <EmptyTags />
+                              )}
                               {selectedTags.map((tag) =>
                                 isViewOnly ? (
                                   <Badge

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
@@ -84,7 +84,7 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
   const handleClick = (e: MouseEvent, folderId: string) => {
     e.stopPropagation();
     onOpenFolder(folderId);
-  }
+  };
 
   const handleKeyDown = (e: KeyboardEvent, folderId: string) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -92,7 +92,7 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
       e.stopPropagation();
       onOpenFolder(folderId);
     }
-  }
+  };
 
   return (
     <ContextSimplePillarCard
@@ -138,7 +138,9 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
                     role="button"
                     tabIndex={0}
                     onClick={(e: MouseEvent) => handleClick(e, folder.id)}
-                    onKeyDown={(e: KeyboardEvent) => handleKeyDown(e, folder.id)}>
+                    onKeyDown={(e: KeyboardEvent) =>
+                      handleKeyDown(e, folder.id)
+                    }>
                     <FolderIcon className="tw:size-4 tw:shrink-0 tw:text-quaternary" />
                     <div className="tw:min-w-0">
                       <Typography

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
@@ -19,8 +19,14 @@ import {
 } from '@openmetadata/ui-core-components';
 import { Plus } from '@untitledui/icons';
 import { AxiosError } from 'axios';
-import classNames from 'classnames';
-import { FC, useCallback, useEffect, useState } from 'react';
+import {
+  FC,
+  KeyboardEvent,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as FolderIcon } from '../../../assets/svg/common/folder.svg';
 import { FOLDER_CARD_CHILDREN_LIMIT } from '../../../constants/ContextCenter.constants';
@@ -35,6 +41,7 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
   folders,
   isLoading = false,
   onCreateFolder,
+  onOpenFolder,
 }) => {
   const { t } = useTranslation();
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
@@ -74,6 +81,19 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
     }
   };
 
+  const handleClick = (e: MouseEvent, folderId: string) => {
+    e.stopPropagation();
+    onOpenFolder(folderId);
+  }
+
+  const handleKeyDown = (e: KeyboardEvent, folderId: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onOpenFolder(folderId);
+    }
+  }
+
   return (
     <ContextSimplePillarCard
       dataTestId="dashboard-folders-card"
@@ -105,15 +125,20 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
               id={folder.id}
               key={folder.id}
               textValue={getEntityName(folder)}>
-              <Tree.ItemContent
-                hasChildItems={hasChildItems}
-                showExpandIcon={false}>
+              <Tree.ItemContent hasChildItems={hasChildItems}>
                 <Box
                   align="center"
                   className="tw:flex-1 tw:min-w-0"
                   gap={3}
                   justify="between">
-                  <Box align="center" className="tw:min-w-0" gap={2}>
+                  <Box
+                    align="center"
+                    className="tw:min-w-0 tw:flex-1 tw:cursor-pointer tw:rounded tw:hover:bg-primary_hover"
+                    gap={2}
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e: MouseEvent) => handleClick(e, folder.id)}
+                    onKeyDown={(e: KeyboardEvent) => handleKeyDown(e, folder.id)}>
                     <FolderIcon className="tw:size-4 tw:shrink-0 tw:text-quaternary" />
                     <div className="tw:min-w-0">
                       <Typography
@@ -125,16 +150,9 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
                       </Typography>
                     </div>
                   </Box>
-                  <Box align="center" gap={2}>
-                    <Badge size="xs" type="color">
-                      {folder.childrenCount ?? 0}
-                    </Badge>
-                    <Tree.ExpandButton
-                      className={classNames(
-                        !hasChildItems && 'tw:invisible tw:pointer-events-none'
-                      )}
-                    />
-                  </Box>
+                  <Badge size="xs" type="color">
+                    {folder.childrenCount ?? 0}
+                  </Badge>
                 </Box>
               </Tree.ItemContent>
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.component.tsx
@@ -19,6 +19,7 @@ import {
 } from '@openmetadata/ui-core-components';
 import { Plus } from '@untitledui/icons';
 import { AxiosError } from 'axios';
+import classNames from 'classnames';
 import {
   FC,
   KeyboardEvent,
@@ -41,7 +42,7 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
   folders,
   isLoading = false,
   onCreateFolder,
-  onOpenFolder,
+  onOpenFile,
 }) => {
   const { t } = useTranslation();
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
@@ -81,16 +82,39 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
     }
   };
 
-  const handleClick = (e: MouseEvent, folderId: string) => {
-    e.stopPropagation();
-    onOpenFolder(folderId);
+  const toggleExpanded = (folderId: string) => {
+    const next = new Set(expandedKeys);
+    if (next.has(folderId)) {
+      next.delete(folderId);
+    } else {
+      next.add(folderId);
+    }
+    handleExpandedChange(next);
   };
 
-  const handleKeyDown = (e: KeyboardEvent, folderId: string) => {
+  const handleToggleExpand = (e: MouseEvent, folderId: string) => {
+    e.stopPropagation();
+    toggleExpanded(folderId);
+  };
+
+  const handleToggleExpandKeyDown = (e: KeyboardEvent, folderId: string) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       e.stopPropagation();
-      onOpenFolder(folderId);
+      toggleExpanded(folderId);
+    }
+  };
+
+  const handleOpenFile = (e: MouseEvent, fileId: string) => {
+    e.stopPropagation();
+    onOpenFile(fileId);
+  };
+
+  const handleOpenFileKeyDown = (e: KeyboardEvent, fileId: string) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      e.stopPropagation();
+      onOpenFile(fileId);
     }
   };
 
@@ -125,7 +149,10 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
               id={folder.id}
               key={folder.id}
               textValue={getEntityName(folder)}>
-              <Tree.ItemContent hasChildItems={hasChildItems}>
+              <Tree.ItemContent
+                className="tw:pr-0"
+                hasChildItems={hasChildItems}
+                showExpandIcon={false}>
                 <Box
                   align="center"
                   className="tw:flex-1 tw:min-w-0"
@@ -137,9 +164,11 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
                     gap={2}
                     role="button"
                     tabIndex={0}
-                    onClick={(e: MouseEvent) => handleClick(e, folder.id)}
+                    onClick={(e: MouseEvent) =>
+                      handleToggleExpand(e, folder.id)
+                    }
                     onKeyDown={(e: KeyboardEvent) =>
-                      handleKeyDown(e, folder.id)
+                      handleToggleExpandKeyDown(e, folder.id)
                     }>
                     <FolderIcon className="tw:size-4 tw:shrink-0 tw:text-quaternary" />
                     <div className="tw:min-w-0">
@@ -155,6 +184,11 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
                   <Badge size="xs" type="color">
                     {folder.childrenCount ?? 0}
                   </Badge>
+                  <Tree.ExpandButton
+                    className={classNames(
+                      !hasChildItems && 'tw:invisible tw:pointer-events-none'
+                    )}
+                  />
                 </Box>
               </Tree.ItemContent>
 
@@ -164,18 +198,29 @@ const DashboardFoldersCard: FC<DashboardFoldersCardProps> = ({
                   key={file.id}
                   textValue={getEntityName(file)}>
                   <Tree.ItemContent className="tw:ml-6!" showExpandIcon={false}>
-                    <FileIcon
-                      className="tw:size-4 tw:shrink-0"
-                      theme="light"
-                      type={file.fileExtension ?? ''}
-                      variant="default"
-                    />
-                    <Typography
-                      ellipsis
-                      className="tw:truncate tw:text-secondary"
-                      size="text-xs">
-                      {getEntityName(file)}
-                    </Typography>
+                    <Box
+                      align="center"
+                      className="tw:min-w-0 tw:flex-1 tw:cursor-pointer tw:rounded tw:hover:bg-primary_hover"
+                      gap={2}
+                      role="button"
+                      tabIndex={0}
+                      onClick={(e: MouseEvent) => handleOpenFile(e, file.id)}
+                      onKeyDown={(e: KeyboardEvent) =>
+                        handleOpenFileKeyDown(e, file.id)
+                      }>
+                      <FileIcon
+                        className="tw:size-4 tw:shrink-0"
+                        theme="light"
+                        type={file.fileExtension ?? ''}
+                        variant="default"
+                      />
+                      <Typography
+                        ellipsis
+                        className="tw:truncate tw:text-secondary"
+                        size="text-xs">
+                        {getEntityName(file)}
+                      </Typography>
+                    </Box>
                   </Tree.ItemContent>
                 </Tree.Item>
               ))}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
@@ -16,4 +16,5 @@ export interface DashboardFoldersCardProps {
   folders: Folder[];
   isLoading?: boolean;
   onCreateFolder?: () => void;
+  onOpenFolder: (folderId: string) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
@@ -16,5 +16,6 @@ export interface DashboardFoldersCardProps {
   folders: Folder[];
   isLoading?: boolean;
   onCreateFolder?: () => void;
+  onOpenFile: (fileId: string) => void;
   onOpenFolder: (folderId: string) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.interface.ts
@@ -17,5 +17,4 @@ export interface DashboardFoldersCardProps {
   isLoading?: boolean;
   onCreateFolder?: () => void;
   onOpenFile: (fileId: string) => void;
-  onOpenFolder: (folderId: string) => void;
 }

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
@@ -42,10 +42,7 @@ const MOCK_FOLDERS: Folder[] = [
 describe('DashboardFoldersCard', () => {
   it('renders the folder list with children count badges', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFolder={jest.fn()} />
     );
 
     expect(screen.getByText('Reports')).toBeInTheDocument();
@@ -84,10 +81,7 @@ describe('DashboardFoldersCard', () => {
 
   it('does not fetch children until a folder is expanded', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFolder={jest.fn()} />
     );
 
     expect(listContextFiles).not.toHaveBeenCalled();

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
@@ -41,7 +41,12 @@ const MOCK_FOLDERS: Folder[] = [
 
 describe('DashboardFoldersCard', () => {
   it('renders the folder list with children count badges', () => {
-    render(<DashboardFoldersCard folders={MOCK_FOLDERS} />);
+    render(
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFolder={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('Reports')).toBeInTheDocument();
     expect(screen.getByText('Archive')).toBeInTheDocument();
@@ -49,7 +54,7 @@ describe('DashboardFoldersCard', () => {
   });
 
   it('renders the empty state when there are no folders', () => {
-    render(<DashboardFoldersCard folders={[]} />);
+    render(<DashboardFoldersCard folders={[]} onOpenFolder={jest.fn()} />);
 
     expect(
       screen.getByText('message.no-folders-yet-create-one')
@@ -59,7 +64,11 @@ describe('DashboardFoldersCard', () => {
   it('renders the New Folder action with a leading icon and triggers onCreateFolder on click', () => {
     const onCreateFolder = jest.fn();
     render(
-      <DashboardFoldersCard folders={[]} onCreateFolder={onCreateFolder} />
+      <DashboardFoldersCard
+        folders={[]}
+        onCreateFolder={onCreateFolder}
+        onOpenFolder={jest.fn()}
+      />
     );
 
     const newFolderButton = screen.getByRole('button', {
@@ -74,8 +83,53 @@ describe('DashboardFoldersCard', () => {
   });
 
   it('does not fetch children until a folder is expanded', () => {
-    render(<DashboardFoldersCard folders={MOCK_FOLDERS} />);
+    render(
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFolder={jest.fn()}
+      />
+    );
 
     expect(listContextFiles).not.toHaveBeenCalled();
+  });
+
+  it('calls onOpenFolder when the folder name is clicked, without expanding it', () => {
+    const onOpenFolder = jest.fn();
+    render(
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFolder={onOpenFolder}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+
+    expect(onOpenFolder).toHaveBeenCalledWith('folder-1');
+    expect(listContextFiles).not.toHaveBeenCalled();
+  });
+
+  it('fetches children when the expand button is clicked, without calling onOpenFolder', () => {
+    const onOpenFolder = jest.fn();
+    render(
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFolder={onOpenFolder}
+      />
+    );
+
+    const folderNameButton = screen.getByRole('button', { name: 'Reports' });
+    const folderRow = folderNameButton.closest('[role="row"]') as HTMLElement;
+    const rowButtons = Array.from(folderRow.querySelectorAll('button'));
+    const expandButton = rowButtons.find((btn) => btn !== folderNameButton);
+
+    expect(expandButton).toBeDefined();
+
+    fireEvent.click(expandButton as HTMLButtonElement);
+
+    expect(onOpenFolder).not.toHaveBeenCalled();
+    expect(listContextFiles).toHaveBeenCalledWith({
+      folderId: 'folder-1',
+      limit: expect.any(Number),
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
@@ -17,7 +17,16 @@ import { listContextFiles } from '../../../rest/assetAPI';
 import DashboardFoldersCard from './DashboardFoldersCard.component';
 
 jest.mock('../../../rest/assetAPI', () => ({
-  listContextFiles: jest.fn().mockResolvedValue({ data: [], paging: {} }),
+  listContextFiles: jest.fn().mockResolvedValue({
+    data: [
+      {
+        id: 'file-1',
+        name: 'report.pdf',
+        displayName: 'report.pdf',
+      },
+    ],
+    paging: {},
+  }),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -42,7 +51,11 @@ const MOCK_FOLDERS: Folder[] = [
 describe('DashboardFoldersCard', () => {
   it('renders the folder list with children count badges', () => {
     render(
-      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFolder={jest.fn()} />
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFile={jest.fn()}
+        onOpenFolder={jest.fn()}
+      />
     );
 
     expect(screen.getByText('Reports')).toBeInTheDocument();
@@ -51,7 +64,13 @@ describe('DashboardFoldersCard', () => {
   });
 
   it('renders the empty state when there are no folders', () => {
-    render(<DashboardFoldersCard folders={[]} onOpenFolder={jest.fn()} />);
+    render(
+      <DashboardFoldersCard
+        folders={[]}
+        onOpenFile={jest.fn()}
+        onOpenFolder={jest.fn()}
+      />
+    );
 
     expect(
       screen.getByText('message.no-folders-yet-create-one')
@@ -64,6 +83,7 @@ describe('DashboardFoldersCard', () => {
       <DashboardFoldersCard
         folders={[]}
         onCreateFolder={onCreateFolder}
+        onOpenFile={jest.fn()}
         onOpenFolder={jest.fn()}
       />
     );
@@ -81,33 +101,39 @@ describe('DashboardFoldersCard', () => {
 
   it('does not fetch children until a folder is expanded', () => {
     render(
-      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFolder={jest.fn()} />
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFile={jest.fn()}
+        onOpenFolder={jest.fn()}
+      />
     );
 
     expect(listContextFiles).not.toHaveBeenCalled();
   });
 
-  it('calls onOpenFolder when the folder name is clicked, without expanding it', () => {
-    const onOpenFolder = jest.fn();
+  it('fetches children when the folder name/row is clicked', () => {
     render(
       <DashboardFoldersCard
         folders={MOCK_FOLDERS}
-        onOpenFolder={onOpenFolder}
+        onOpenFile={jest.fn()}
+        onOpenFolder={jest.fn()}
       />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
 
-    expect(onOpenFolder).toHaveBeenCalledWith('folder-1');
-    expect(listContextFiles).not.toHaveBeenCalled();
+    expect(listContextFiles).toHaveBeenCalledWith({
+      folderId: 'folder-1',
+      limit: expect.any(Number),
+    });
   });
 
-  it('fetches children when the expand button is clicked, without calling onOpenFolder', () => {
-    const onOpenFolder = jest.fn();
+  it('fetches children when the expand chevron is clicked', () => {
     render(
       <DashboardFoldersCard
         folders={MOCK_FOLDERS}
-        onOpenFolder={onOpenFolder}
+        onOpenFile={jest.fn()}
+        onOpenFolder={jest.fn()}
       />
     );
 
@@ -120,10 +146,29 @@ describe('DashboardFoldersCard', () => {
 
     fireEvent.click(expandButton as HTMLButtonElement);
 
-    expect(onOpenFolder).not.toHaveBeenCalled();
     expect(listContextFiles).toHaveBeenCalledWith({
       folderId: 'folder-1',
       limit: expect.any(Number),
     });
+  });
+
+  it('calls onOpenFile with the file id when a child file row is clicked', async () => {
+    const onOpenFile = jest.fn();
+    render(
+      <DashboardFoldersCard
+        folders={MOCK_FOLDERS}
+        onOpenFile={onOpenFile}
+        onOpenFolder={jest.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
+
+    const fileButton = await screen.findByRole('button', {
+      name: 'report.pdf',
+    });
+    fireEvent.click(fileButton);
+
+    expect(onOpenFile).toHaveBeenCalledWith('file-1');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/DashboardFoldersCard/DashboardFoldersCard.test.tsx
@@ -51,11 +51,7 @@ const MOCK_FOLDERS: Folder[] = [
 describe('DashboardFoldersCard', () => {
   it('renders the folder list with children count badges', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFile={jest.fn()} />
     );
 
     expect(screen.getByText('Reports')).toBeInTheDocument();
@@ -64,13 +60,7 @@ describe('DashboardFoldersCard', () => {
   });
 
   it('renders the empty state when there are no folders', () => {
-    render(
-      <DashboardFoldersCard
-        folders={[]}
-        onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
-      />
-    );
+    render(<DashboardFoldersCard folders={[]} onOpenFile={jest.fn()} />);
 
     expect(
       screen.getByText('message.no-folders-yet-create-one')
@@ -84,7 +74,6 @@ describe('DashboardFoldersCard', () => {
         folders={[]}
         onCreateFolder={onCreateFolder}
         onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
       />
     );
 
@@ -101,11 +90,7 @@ describe('DashboardFoldersCard', () => {
 
   it('does not fetch children until a folder is expanded', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFile={jest.fn()} />
     );
 
     expect(listContextFiles).not.toHaveBeenCalled();
@@ -113,11 +98,7 @@ describe('DashboardFoldersCard', () => {
 
   it('fetches children when the folder name/row is clicked', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFile={jest.fn()} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Reports' }));
@@ -130,11 +111,7 @@ describe('DashboardFoldersCard', () => {
 
   it('fetches children when the expand chevron is clicked', () => {
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFile={jest.fn()}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFile={jest.fn()} />
     );
 
     const folderNameButton = screen.getByRole('button', { name: 'Reports' });
@@ -155,11 +132,7 @@ describe('DashboardFoldersCard', () => {
   it('calls onOpenFile with the file id when a child file row is clicked', async () => {
     const onOpenFile = jest.fn();
     render(
-      <DashboardFoldersCard
-        folders={MOCK_FOLDERS}
-        onOpenFile={onOpenFile}
-        onOpenFolder={jest.fn()}
-      />
+      <DashboardFoldersCard folders={MOCK_FOLDERS} onOpenFile={onOpenFile} />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Reports' }));

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.component.tsx
@@ -19,6 +19,7 @@ import {
   Modal,
   ModalOverlay,
 } from '@openmetadata/ui-core-components';
+import { AxiosError } from 'axios';
 import { FC, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { v4 as uuidv4 } from 'uuid';
@@ -26,7 +27,7 @@ import { DOCUMENT_MAX_FILE_SIZE } from '../../../constants/ContextCenter.constan
 import { ContextFile } from '../../../generated/entity/data/contextFile';
 import { uploadDriveFile } from '../../../rest/assetAPI';
 import { runWithConcurrencyLimit } from '../../../utils/AsyncUtils';
-import { showSuccessToast } from '../../../utils/ToastUtils';
+import { showErrorToast, showSuccessToast } from '../../../utils/ToastUtils';
 import {
   QueuedFile,
   UploadDocumentModalProps,
@@ -92,12 +93,13 @@ const UploadDocumentModal: FC<UploadDocumentModalProps> = ({
   ): Promise<ContextFile | null> => {
     try {
       return await uploadDriveFile(entry.file, folderFqn);
-    } catch {
+    } catch (err) {
       setFiles((prev) =>
         prev.map((f) =>
           f.id === entry.id ? { ...f, progress: 0, status: 'error' } : f
         )
       );
+      showErrorToast(err as AxiosError, t('message.upload-failed'));
 
       return null;
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ContextCenter/UploadDocumentModal/UploadDocumentModal.test.tsx
@@ -19,6 +19,7 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { uploadDriveFile } from '../../../rest/assetAPI';
+import { showErrorToast } from '../../../utils/ToastUtils';
 import UploadDocumentModal from './UploadDocumentModal.component';
 
 jest.mock('rest/assetAPI', () => ({
@@ -26,6 +27,7 @@ jest.mock('rest/assetAPI', () => ({
 }));
 
 jest.mock('utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
   showSuccessToast: jest.fn(),
 }));
 
@@ -318,6 +320,10 @@ describe('UploadDocumentModal', () => {
     const bar = await screen.findByTestId('progress-bar-fail.pdf');
 
     expect(bar).toHaveAttribute('data-failed', 'true');
+    expect(showErrorToast).toHaveBeenCalledWith(
+      new Error('upload failed'),
+      'message.upload-failed'
+    );
   });
 
   it('shows retry button for failed uploads', async () => {
@@ -334,6 +340,10 @@ describe('UploadDocumentModal', () => {
     fireEvent.click(screen.getByText(/attach-file-plural/i));
 
     expect(await screen.findByTestId('retry-fail.pdf')).toBeInTheDocument();
+    expect(showErrorToast).toHaveBeenCalledWith(
+      new Error('upload failed'),
+      'message.upload-failed'
+    );
   });
 
   it('retries a failed upload when the retry button is clicked', async () => {
@@ -356,6 +366,31 @@ describe('UploadDocumentModal', () => {
     await waitFor(() => expect(uploadDriveFile).toHaveBeenCalledTimes(2));
     await waitFor(() =>
       expect(defaultProps.onUploaded).toHaveBeenCalledWith([mockAsset])
+    );
+  });
+
+  it('shows an error toast again when a retried upload also fails', async () => {
+    (uploadDriveFile as jest.Mock)
+      .mockRejectedValueOnce(new Error('first attempt failed'))
+      .mockRejectedValueOnce(new Error('retry failed'));
+
+    render(<UploadDocumentModal {...defaultProps} />);
+
+    act(() => {
+      mockOnDropFiles!(makeFileList(new File(['content'], 'fail.pdf')));
+    });
+
+    fireEvent.click(screen.getByText(/attach-file-plural/i));
+
+    const retryBtn = await screen.findByTestId('retry-fail.pdf');
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => expect(uploadDriveFile).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(showErrorToast).toHaveBeenCalledWith(
+        new Error('retry failed'),
+        'message.upload-failed'
+      )
     );
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetSelectList/DataAssetPickerShell.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetSelectList/DataAssetPickerShell.tsx
@@ -232,7 +232,7 @@ const DataAssetPickerShell: FC<DataAssetPickerShellProps> = ({
                   t('label.search-entity', { entity: t('label.asset-plural') })
                 }
                 value={searchText}
-                wrapperClassName="tw:rounded-none tw:bg-transparent tw:shadow-none"
+                wrapperClassName="tw:rounded-none tw:bg-transparent tw:shadow-none tw:focus-within:outline-hidden"
                 onChange={(value) => onSearchChange?.(value)}
               />
             </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetSelectList/DataAssetPickerShell.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataAssets/DataAssetSelectList/DataAssetPickerShell.tsx
@@ -232,7 +232,7 @@ const DataAssetPickerShell: FC<DataAssetPickerShellProps> = ({
                   t('label.search-entity', { entity: t('label.asset-plural') })
                 }
                 value={searchText}
-                wrapperClassName="tw:rounded-none tw:bg-transparent tw:shadow-none tw:focus-within:outline-hidden"
+                wrapperClassName="tw:rounded-none tw:bg-transparent! tw:shadow-none! tw:outline-0!"
                 onChange={(value) => onSearchChange?.(value)}
               />
             </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageListComponent/KnowledgePageListComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageListComponent/KnowledgePageListComponent.tsx
@@ -39,7 +39,6 @@ import { useNavigate } from 'react-router-dom';
 import { ReactComponent as AddPlaceHolderIcon } from '../../../assets/svg/add-placeholder.svg';
 import { ReactComponent as NoSearchResultIcon } from '../../../assets/svg/common/no-search-result.svg';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
-import Loader from '../../../components/common/Loader/Loader';
 import { VotingDataProps } from '../../../components/Entity/Voting/voting.interface';
 import {
   CREATE_PAGE_HASH,
@@ -73,6 +72,7 @@ import { searchQuery as fetchSearchResults } from '../../../rest/searchAPI';
 import contextCenterClassBase from '../../../utils/ContextCenterClassBase';
 import { Transi18next } from '../../../utils/i18next/LocalUtil';
 import { showErrorToast } from '../../../utils/ToastUtils';
+import Loader from '../../common/Loader/Loader';
 import KnowledgeCard from '../KnowledgeCard/KnowledgeCard';
 import KnowledgePageListRightPanel from '../KnowledgePageListRightPanel/KnowledgePageListRightPanel';
 import {
@@ -603,7 +603,7 @@ const KnowledgePageListComponent = forwardRef<
             </Col>
           ))}
         </Row>
-        {isLoadingMore ? <Loader /> : null}
+        {isLoadingMore ? <Loader className='tw:shrink-0' /> : null}
         <div
           className="w-full"
           data-testid="observer-element"

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageListComponent/KnowledgePageListComponent.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageListComponent/KnowledgePageListComponent.tsx
@@ -603,7 +603,7 @@ const KnowledgePageListComponent = forwardRef<
             </Col>
           ))}
         </Row>
-        {isLoadingMore ? <Loader className='tw:shrink-0' /> : null}
+        {isLoadingMore ? <Loader className="tw:shrink-0" /> : null}
         <div
           className="w-full"
           data-testid="observer-element"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArchivePage/ContextCenterArchivePage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArchivePage/ContextCenterArchivePage.tsx
@@ -219,7 +219,7 @@ const ContextCenterArchivePage: FC = () => {
         />
       </div>
       <div className="context-center-content-section tw:flex tw:flex-col tw:flex-1 tw:min-h-0 tw:px-5 tw:pb-5">
-        {!isLoading && (hasEverHadItems || items.length > 0) && (
+        {(hasEverHadItems || items.length > 0) && (
           <div className="tw:pb-5">
             <Tabs
               className="tw:w-max"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
@@ -60,6 +60,7 @@ import {
   CreateKnowledgePage,
   KnowledgePage,
   PageType,
+  QuickLink,
   RecentlyViewedQuickLinks,
 } from '../../../interface/knowledge-center.interface';
 import { listContextFiles, listFolders } from '../../../rest/assetAPI';
@@ -93,9 +94,7 @@ const ContextCenterDashboardPage: FC = () => {
   const [documentsCount, setDocumentsCount] = useState(0);
   const [folders, setFolders] = useState<Folder[]>([]);
   const [folderCount, setFolderCount] = useState(0);
-  const [memories, setMemories] = useState<
-    Array<{ title: string; meta: string[] }>
-  >([]);
+  const [memories, setMemories] = useState<ContextMemory[]>([]);
   const [memoriesCount, setMemoriesCount] = useState(0);
   const [mostCitedMemories, setMostCitedMemories] = useState<ContextMemory[]>(
     []
@@ -221,12 +220,7 @@ const ContextCenterDashboardPage: FC = () => {
         sortOrder: 'desc',
       });
       setMemoriesCount(response.paging.total ?? response.data.length);
-      setMemories(
-        response.data.map((m) => ({
-          title: m.title ?? m.name,
-          meta: [`cited ${m.usageCount}×`],
-        }))
-      );
+      setMemories(response.data);
     } catch (err) {
       showErrorToast(err as AxiosError);
     } finally {
@@ -286,6 +280,55 @@ const ContextCenterDashboardPage: FC = () => {
     fetchFolders();
   }, [fetchFolders]);
 
+  const handleOpenKnowledgePage = useCallback(
+    (page: Pick<KnowledgePage, 'pageType' | 'page' | 'fullyQualifiedName'>) => {
+      if (page.pageType === PageType.QUICK_LINK) {
+        window.open(
+          (page.page as QuickLink).url,
+          '_blank',
+          'noopener,noreferrer'
+        );
+
+        return;
+      }
+      navigate(contextCenterClassBase.getArticlePath(page.fullyQualifiedName));
+    },
+    [navigate]
+  );
+
+  const handleOpenDocument = useCallback(
+    (documentId: string) => {
+      navigate(
+        `${contextCenterClassBase.getDocumentsListPath()}?document=${encodeURIComponent(
+          documentId
+        )}`
+      );
+    },
+    [navigate]
+  );
+
+  const handleOpenMemory = useCallback(
+    (memoryName: string) => {
+      navigate(
+        `${contextCenterClassBase.getMemoriesListPath()}?memory=${encodeURIComponent(
+          memoryName
+        )}`
+      );
+    },
+    [navigate]
+  );
+
+  const handleOpenFolder = useCallback(
+    (folderId: string) => {
+      navigate(
+        `${contextCenterClassBase.getDocumentsListPath()}?folder=${encodeURIComponent(
+          folderId
+        )}`
+      );
+    },
+    [navigate]
+  );
+
   const articlesRecentItems = useMemo(
     () =>
       articles.map((article) => {
@@ -303,9 +346,10 @@ const ContextCenterDashboardPage: FC = () => {
           icon,
           meta: metaParts,
           title: getEntityName(article),
+          onClick: () => handleOpenKnowledgePage(article),
         };
       }),
-    [articles]
+    [articles, handleOpenKnowledgePage]
   );
 
   const documentsRecentItems = useMemo(
@@ -314,11 +358,15 @@ const ContextCenterDashboardPage: FC = () => {
         const metaParts = [
           doc.updatedBy,
           getShortRelativeTime(doc.updatedAt),
-        ].filter(Boolean);
+        ].filter((part): part is string => Boolean(part));
 
-        return { title: getEntityName(doc), meta: metaParts };
+        return {
+          title: getEntityName(doc),
+          meta: metaParts,
+          onClick: () => handleOpenDocument(doc.id),
+        };
       }),
-    [documents]
+    [documents, handleOpenDocument]
   );
 
   const recentlyViewedItems = useMemo(() => {
@@ -330,8 +378,19 @@ const ContextCenterDashboardPage: FC = () => {
       title: getEntityName(page),
       pageType: page.pageType,
       time: page.timestamp ? getShortRelativeTime(page.timestamp) : '',
+      onClick: () => handleOpenKnowledgePage(page),
     }));
-  }, [recentlyViewedQuickLinks]);
+  }, [recentlyViewedQuickLinks, handleOpenKnowledgePage]);
+
+  const memoriesRecentItems = useMemo(
+    () =>
+      memories.map((memory) => ({
+        title: memory.title ?? getEntityName(memory),
+        meta: [`cited ${memory.usageCount}×`],
+        onClick: () => handleOpenMemory(memory.name),
+      })),
+    [memories, handleOpenMemory]
+  );
 
   const mostCitedItems = useMemo(
     () =>
@@ -339,8 +398,9 @@ const ContextCenterDashboardPage: FC = () => {
         id: memory.id,
         title: memory.title ?? getEntityName(memory),
         citedCount: memory.usageCount ?? 0,
+        onClick: () => handleOpenMemory(memory.name),
       })),
-    [mostCitedMemories]
+    [mostCitedMemories, handleOpenMemory]
   );
 
   return (
@@ -498,7 +558,7 @@ const ContextCenterDashboardPage: FC = () => {
                 dataTestId="memory-detail-card"
                 icon={MemoryIcon}
                 isLoading={isMemoriesLoading}
-                recent={memories}
+                recent={memoriesRecentItems}
                 stat={String(memoriesCount)}
                 statSub={t('label.memory-plural')}
                 subtitle={t('message.atomic-facts-ai-should-remember')}
@@ -520,9 +580,18 @@ const ContextCenterDashboardPage: FC = () => {
                   {recentlyViewedItems.map((item) => (
                     <Box
                       align="center"
-                      className="tw:py-1.5"
+                      className="tw:cursor-pointer tw:rounded tw:py-1.5 tw:hover:bg-primary_hover"
                       gap={2}
-                      key={item.id}>
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={item.onClick}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          item.onClick();
+                        }
+                      }}>
                       {item.pageType === PageType.QUICK_LINK ? (
                         <QuickLinkIcon className="tw:size-4 tw:text-quaternary tw:shrink-0" />
                       ) : (
@@ -566,6 +635,7 @@ const ContextCenterDashboardPage: FC = () => {
                     ? () => setIsCreateFolderModalOpen(true)
                     : undefined
                 }
+                onOpenFolder={handleOpenFolder}
               />
 
               <ContextSimplePillarCard
@@ -579,9 +649,18 @@ const ContextCenterDashboardPage: FC = () => {
                   {mostCitedItems.map((item) => (
                     <Box
                       align="center"
-                      className="tw:py-1.5"
+                      className="tw:cursor-pointer tw:rounded tw:py-1.5 tw:hover:bg-primary_hover"
                       gap={2}
-                      key={item.id}>
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={item.onClick}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault();
+                          item.onClick();
+                        }
+                      }}>
                       <MemoryIcon className="tw:size-4 tw:text-quaternary tw:shrink-0" />
                       <Box
                         align="center"

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
@@ -635,6 +635,7 @@ const ContextCenterDashboardPage: FC = () => {
                     ? () => setIsCreateFolderModalOpen(true)
                     : undefined
                 }
+                onOpenFile={handleOpenDocument}
                 onOpenFolder={handleOpenFolder}
               />
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDashboardPage/ContextCenterDashboardPage.tsx
@@ -318,17 +318,6 @@ const ContextCenterDashboardPage: FC = () => {
     [navigate]
   );
 
-  const handleOpenFolder = useCallback(
-    (folderId: string) => {
-      navigate(
-        `${contextCenterClassBase.getDocumentsListPath()}?folder=${encodeURIComponent(
-          folderId
-        )}`
-      );
-    },
-    [navigate]
-  );
-
   const articlesRecentItems = useMemo(
     () =>
       articles.map((article) => {
@@ -636,7 +625,6 @@ const ContextCenterDashboardPage: FC = () => {
                     : undefined
                 }
                 onOpenFile={handleOpenDocument}
-                onOpenFolder={handleOpenFolder}
               />
 
               <ContextSimplePillarCard

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -340,6 +340,14 @@ const ContextCenterDocumentsPage: FC = () => {
     setSearchParams,
   ]);
 
+  useEffect(() => {
+    const folderId = searchParams.get('folder');
+    if (!folderId || isFoldersLoading || selectedFolderId) {
+      return;
+    }
+    setSelectedFolderId(folderId);
+  }, [isFoldersLoading, selectedFolderId, searchParams]);
+
   const handleDeleteFile = useCallback((file: ContextFile) => {
     setFileToDelete(file);
   }, []);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -346,7 +346,12 @@ const ContextCenterDocumentsPage: FC = () => {
       return;
     }
     setSelectedFolderId(folderId);
-  }, [isFoldersLoading, selectedFolderId, searchParams]);
+    setSearchParams((prev) => {
+      prev.delete('folder');
+
+      return prev;
+    });
+  }, [isFoldersLoading, selectedFolderId, searchParams, setSearchParams]);
 
   const handleDeleteFile = useCallback((file: ContextFile) => {
     setFileToDelete(file);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:


https://github.com/user-attachments/assets/5e669454-a225-4c65-b0fc-8226a6b4424d


https://github.com/user-attachments/assets/e7e5916e-5939-4181-be87-48334c5d943e

<img width="580" height="150" alt="Screenshot 2026-08-07 at 8 00 10 PM" src="https://github.com/user-attachments/assets/50a2ff6b-f1d4-444b-8a48-0c46b076f71c" />
<img width="399" height="491" alt="Screenshot 2026-08-07 at 8 00 53 PM" src="https://github.com/user-attachments/assets/a00393f4-aef2-4a1a-aa05-4209155ab485" />
<img width="896" height="718" alt="Screenshot 2026-08-07 at 8 17 10 PM" src="https://github.com/user-attachments/assets/77e13fce-2cd7-448b-b72f-4e598e8bc6c3" />


Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Context Center Dashboard & Navigation:**
    - Added click handlers and navigation across dashboard cards for documents, folders, articles, and memories (`ContextCenterDashboardPage.tsx`, `DashboardFoldersCard.tsx`, `ContextKnowledgePillarCard.tsx`).
- **Error Handling & UI States:**
    - Handled file upload errors with error toasts and retry handling (`UploadDocumentModal.component.tsx`).
- **Backend Services:**
    - Preserved updater user during context file extraction updates instead of defaulting to admin (`ContextFileExtractionService.java`).

<sub>This will update automatically on new commits.</sub>