### PR TITLE
test(e2e): restore the exploreTabName guard in verifyDomainPropagation

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -903,7 +903,16 @@ export const verifyDomainPropagation = async (
 ) => {
   const entityCard = page.getByTestId(`table-data-card_${childFqnSearchTerm}`);
   const domainLink = entityCard.getByTestId('domain-link').first();
-  const tabSelector = page.getByRole('menuitem', { name: exploreTabName });
+  // Only build the tab locator when a tab name was actually given. `{ name:
+  // undefined }` does not filter, so an unconditional locator matches every
+  // menuitem on the page — including the whole left sidebar — and the click in
+  // waitForSearchResult then fails strict mode. The `tabSelector?.` there
+  // cannot guard against it either: a Locator is a lazy handle, so it is always
+  // truthy even when it matches nothing (or everything). Only ApiEndpoint sets
+  // exploreTabName, so every other entity type hits this path.
+  const tabSelector = exploreTabName
+    ? page.getByRole('menuitem', { name: exploreTabName })
+    : undefined;
 
   await waitForSearchResult(page, childFqnSearchTerm, domainLink, tabSelector);
   await expect(entityCard).toBeVisible();


### PR DESCRIPTION
`Pages/Entity.spec.ts › Domain Propagation` is failing deterministically on `2.0` for every entity type except ApiEndpoint — **14 failures per run, on both attempts** (0 flaky). It is currently blocking every PR targeting `2.0`.

```
locator.click: Error: strict mode violation:
getByRole('menuitem') resolved to 11 elements:
  1) <li data-testid="side-bar-app-bar-item-my-data"> …
  2) <li data-testid="side-bar-app-bar-item-explore"> …
  3) <li data-testid="side-bar-app-bar-item-lineage"> …
```

## Cause

`verifyDomainPropagation` builds the tab locator unconditionally:

```ts
const tabSelector = page.getByRole('menuitem', { name: exploreTabName });
await waitForSearchResult(page, childFqnSearchTerm, domainLink, tabSelector);
```

`{ name: undefined }` **does not filter** — so with no tab name the locator matches every menuitem on the page, i.e. the entire left sidebar. The `await tabSelector?.click()` inside `waitForSearchResult` then fails strict mode.

The optional chain cannot guard against this. **A `Locator` is a lazy handle: it is always truthy, even when it matches nothing — or everything.** So `tabSelector?.click()` reads like a guard but never short-circuits.

Only `ApiEndpointClass` sets `exploreTabName`, so **27 of 28 entity classes** take this path.

A detail that confirms the sidebar is the match set: the count varies across failures — 11, 14, 15 — because the sidebar's submenus expand and collapse. A real dropdown would not drift.

## Why `main` is unaffected

The same change is correct there, guarding on the **string**:

```ts
if (exploreTabName) {
  await page.getByRole('menuitem', { name: exploreTabName }).click();
  await waitForAllLoadersToDisappear(page);
}
```

`verifyDomainPropagation` has diverged between the branches — `main` gates on the search API for eventual consistency, `2.0` still delegates to `waitForSearchResult` — so the change had to be re-expressed against a different shape on `2.0`. In that translation the string guard became a Locator guard, which never fires.

This is an easy substitution to make and it looks equivalent; the difference is only visible if you know `Locator` construction is lazy and total.

## Fix

Only construct the locator when a tab name is actually supplied:

```ts
const tabSelector = exploreTabName
  ? page.getByRole('menuitem', { name: exploreTabName })
  : undefined;
```

This restores `main`'s behaviour without disturbing `2.0`'s structure, and keeps the ApiEndpoint tab click working as intended. Reverting was considered and rejected — the change itself is correct and worth keeping; only the guard was lost.

## Verification

`prettier` clean, `tsc --noEmit` clean. The real check is CI on this PR: `Domain Propagation` should go from 14 hard failures to passing across all shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
