### PR TITLE
fix(tests): unblock the 1.13 nightly Java UI ITs (DQ edit drawer + reindex fast-fail)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/SearchIndexAppPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/SearchIndexAppPage.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import java.time.Duration;
+import java.util.regex.Pattern;
 import org.openmetadata.it.search.ReindexHelpers;
 import org.openmetadata.playwright.ui.UiSession;
 
@@ -28,6 +29,12 @@ public final class SearchIndexAppPage extends PageObject {
   // An accepted trigger registers its run record within seconds; this only bounds the failure
   // (e.g. the trigger was rejected because another run still holds the app's execution lock).
   private static final Duration RUN_REGISTER_TIMEOUT = Duration.ofMinutes(2);
+  // Badge label is upperFirst(AppRunRecord.status); these are the statuses a run cannot leave.
+  // Mirrors ReindexHelpers' TERMINAL_STATUSES.
+  private static final Pattern TERMINAL_STATUS_TEXT =
+      Pattern.compile("Success|Completed|Failed|Stopped|ActiveError");
+  // The badge is already terminal when this is used — it only absorbs a re-render.
+  private static final Duration TERMINAL_ASSERT_TIMEOUT = Duration.ofSeconds(10);
 
   private SearchIndexAppPage(final Page page, final UiSession session) {
     super(page, session);
@@ -77,12 +84,26 @@ public final class SearchIndexAppPage extends PageObject {
     waitForLatestRunStatus(label, timeout);
   }
 
+  /**
+   * Waits for the latest run to reach a terminal status, then asserts it is {@code label}.
+   *
+   * <p>Two steps on purpose. Asserting {@code label} directly would keep re-polling a badge that
+   * already reads a terminal {@code Failed} for the whole timeout — one failed reindex then burns
+   * the full {@code reindexTimeoutMin} (60 min in external mode) before reporting, which is enough
+   * to blow the job's own timeout and take the suites queued behind it down with it. Waiting for
+   * <em>any</em> terminal status first reports the same assertion failure in seconds.
+   */
   public void waitForLatestRunStatus(final String label, final Duration timeout) {
+    PlaywrightAssertions.assertThat(latestRunStatus())
+        .containsText(
+            TERMINAL_STATUS_TEXT,
+            new com.microsoft.playwright.assertions.LocatorAssertions.ContainsTextOptions()
+                .setTimeout(timeout.toMillis()));
     PlaywrightAssertions.assertThat(latestRunStatus())
         .containsText(
             label,
             new com.microsoft.playwright.assertions.LocatorAssertions.ContainsTextOptions()
-                .setTimeout(timeout.toMillis()));
+                .setTimeout(TERMINAL_ASSERT_TIMEOUT.toMillis()));
   }
 
   @Override

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/TableDataQualityPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/TableDataQualityPage.java
@@ -26,6 +26,12 @@ public final class TableDataQualityPage extends PageObject {
   private static final String API_TEST_CASE_UPDATE_REGEX = ".*/api/v1/dataQuality/testCases/.+";
   private static final String API_TEST_DEFINITION_REGEX =
       ".*/api/v1/dataQuality/testDefinitions/.+";
+  // The edit drawer on 1.13 is still the legacy EditTestCaseModalV1, not the unified
+  // TestCaseFormV1 the create drawer uses. It submits via "update-btn" and its form is
+  // "edit-test-form" ("test-case-form-v1" exists there only as a CSS class, so waiting on
+  // that testid silently no-ops). Create-drawer helpers below keep create-btn/test-case-form-v1.
+  private static final String EDIT_SAVE_BTN = "update-btn";
+  private static final String EDIT_FORM = "edit-test-form";
 
   private TableDataQualityPage(final Page page, final UiSession session) {
     super(page, session);
@@ -184,8 +190,8 @@ public final class TableDataQualityPage extends PageObject {
         r ->
             r.url().matches(API_TEST_CASE_UPDATE_REGEX)
                 && (r.request().method().equals("PUT") || r.request().method().equals("PATCH")),
-        () -> byTestId("create-btn").click());
-    byTestId("test-case-form-v1")
+        () -> byTestId(EDIT_SAVE_BTN).click());
+    byTestId(EDIT_FORM)
         .waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.DETACHED));
     return this;
   }
@@ -212,8 +218,8 @@ public final class TableDataQualityPage extends PageObject {
         r ->
             r.url().matches(API_TEST_CASE_UPDATE_REGEX)
                 && (r.request().method().equals("PUT") || r.request().method().equals("PATCH")),
-        () -> byTestId("create-btn").click());
-    byTestId("test-case-form-v1")
+        () -> byTestId(EDIT_SAVE_BTN).click());
+    byTestId(EDIT_FORM)
         .waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.DETACHED));
     return this;
   }
@@ -221,7 +227,7 @@ public final class TableDataQualityPage extends PageObject {
   /** Click Cancel to close the OPEN edit drawer. */
   public TableDataQualityPage cancelEditDrawer() {
     page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel")).click();
-    byTestId("test-case-form-v1")
+    byTestId(EDIT_FORM)
         .waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.DETACHED));
     return this;
   }
@@ -234,7 +240,7 @@ public final class TableDataQualityPage extends PageObject {
         .waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE));
     final String value = page.locator(selector).inputValue();
     page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Cancel")).click();
-    byTestId("test-case-form-v1")
+    byTestId(EDIT_FORM)
         .waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.DETACHED));
     return value;
   }


### PR DESCRIPTION
Two fixes for the `(nightly) Java IT — Ephemeral Cluster` run on `1.13`, which has been red on every run.

## 1. DataQuality edit-drawer testids (the 3 actual failures)

[Run 31060632856](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31060632856) — `Tests run: 39, Failures: 0, Errors: 3`, all three the same `Timeout 60000ms` waiting for `create-btn`:

```
DataQualityArrayParamsReindexUIIT.arrayParamsSurviveReindex:81
DataQualityColumnTestCaseCrudReindexUIIT.columnTestCaseCrudSurvivesReindex:81
DataQualityTableTestCaseCrudReindexUIIT.crudFlowSurvivesReindexBetweenMutations:84
```

`1.13`'s edit drawer is still `EditTestCaseModalV1` — submit is `update-btn`, form is `edit-test-form`. `main` and `2.0` unified editing onto `TestCaseFormV1` (`create-btn` / `test-case-form-v1`). `TableDataQualityPage` was only half-adapted here: the param field ids correctly kept the legacy `tableTestForm_params_*` pattern, but the save click and detach waits still pointed at the unified form.

Also worth noting: `test-case-form-v1` is only a **CSS class** on the legacy modal, never a testid, so the `DETACHED` waits in `cancelEditDrawer` / `readParam` were passing vacuously — they never actually observed the drawer close. Those now wait on the real element.

Create-drawer helpers are untouched — create genuinely is `TestCaseFormV1` on `1.13`.

## 2. Fast-fail on a terminal reindex status

`waitForLatestRunStatus` asserted `containsText("Success")` directly, so a run already settled on `Failed` kept getting re-polled for the full timeout (60 min in external mode). It has not bitten `1.13` yet only because reindex is healthy here; it is the same latent bug that cost `2.0` about six hours per run. Included so all three branches stay in sync.

## Test plan

- [ ] `mvn verify -P ui-it` against a deployed cluster, or a `workflow_dispatch` of `k8s-java-it.yml` with `ref: 1.13`, `runSearchIt: false`, `runScaleIt: false`.

Scale-it (`ServiceDeleteSearchCleanupScaleIT`) is still failing on `1.13` and is **not** addressed here — it is a separate, branch-independent problem (that test's own seeder went from 31 min to 314 min for 100k tables while `EntityLoader` held flat at ~28 min in the same jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)