### PR TITLE
fix(tests): fail fast when a reindex run ends in a terminal non-success status

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/SearchIndexAppPage.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/playwright/ui/pages/SearchIndexAppPage.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.Page;
 import com.microsoft.playwright.assertions.PlaywrightAssertions;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import java.time.Duration;
+import java.util.regex.Pattern;
 import org.openmetadata.it.search.ReindexHelpers;
 import org.openmetadata.playwright.ui.UiSession;
 
@@ -28,6 +29,12 @@ public final class SearchIndexAppPage extends PageObject {
   // An accepted trigger registers its run record within seconds; this only bounds the failure
   // (e.g. the trigger was rejected because another run still holds the app's execution lock).
   private static final Duration RUN_REGISTER_TIMEOUT = Duration.ofMinutes(2);
+  // Badge label is upperFirst(AppRunRecord.status); these are the statuses a run cannot leave.
+  // Mirrors ReindexHelpers' TERMINAL_STATUSES.
+  private static final Pattern TERMINAL_STATUS_TEXT =
+      Pattern.compile("Success|Completed|Failed|Stopped|ActiveError");
+  // The badge is already terminal when this is used — it only absorbs a re-render.
+  private static final Duration TERMINAL_ASSERT_TIMEOUT = Duration.ofSeconds(10);
 
   private SearchIndexAppPage(final Page page, final UiSession session) {
     super(page, session);
@@ -77,12 +84,26 @@ public final class SearchIndexAppPage extends PageObject {
     waitForLatestRunStatus(label, timeout);
   }
 
+  /**
+   * Waits for the latest run to reach a terminal status, then asserts it is {@code label}.
+   *
+   * <p>Two steps on purpose. Asserting {@code label} directly would keep re-polling a badge that
+   * already reads a terminal {@code Failed} for the whole timeout — one failed reindex then burns
+   * the full {@code reindexTimeoutMin} (60 min in external mode) before reporting, which is enough
+   * to blow the job's own timeout and take the suites queued behind it down with it. Waiting for
+   * <em>any</em> terminal status first reports the same assertion failure in seconds.
+   */
   public void waitForLatestRunStatus(final String label, final Duration timeout) {
+    PlaywrightAssertions.assertThat(latestRunStatus())
+        .containsText(
+            TERMINAL_STATUS_TEXT,
+            new com.microsoft.playwright.assertions.LocatorAssertions.ContainsTextOptions()
+                .setTimeout(timeout.toMillis()));
     PlaywrightAssertions.assertThat(latestRunStatus())
         .containsText(
             label,
             new com.microsoft.playwright.assertions.LocatorAssertions.ContainsTextOptions()
-                .setTimeout(timeout.toMillis()));
+                .setTimeout(TERMINAL_ASSERT_TIMEOUT.toMillis()));
   }
 
   @Override


### PR DESCRIPTION
Companion to #31125 (1.13). Test-harness only — no product code.

## What breaks

`SearchIndexAppPage.waitForLatestRunStatus` asserted `containsText("Success")` directly. Playwright keeps re-evaluating that until it matches or the timeout expires — so a run that had **already** settled on the terminal `Failed` kept getting polled for the whole budget: 60 minutes in external mode.

On `2.0` that turned a single failed reindex into a whole-run outage. From [run 31060569969](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31060569969):

```
SelectiveFieldReindexUIIT.selectiveFieldReindexPreservesUiCriticalFields -- Time elapsed: 3888 s <<< FAILURE!
  Locator expected to contain text: Success
  Received: Failed
    5 x locator resolved to <div class="status-badge running"  ...>  - unexpected value "Running"
 3594 x locator resolved to <div class="status-badge failure" ...>  - unexpected value "Failed"
```

3594 polls against a badge that was never going to change. The `ui-it` job then hit its own 2h cap, and `search-it` and `scale-it` were cancelled behind it and inherited a server mid-reindex — the "fresh runs are accepted but fail within seconds with an empty failureContext" window that `ReindexHelpers` already documents. Roughly six hours to report something the badge showed in seconds.

## The change

Wait for **any** terminal status first, then assert it is the expected one. Same assertion, same failure message, seconds instead of an hour. The terminal set mirrors `ReindexHelpers.TERMINAL_STATUSES`; badge text is `upperFirst(AppRunRecord.status)`.

## Scope

This is the amplifier, not the cause. The underlying reindex failure on `main` + `2.0` is #30364 un-gating the staged chunk recreate, so every full reindex now runs `preflightEmbedding()` -> Bedrock `InvokeModel` -> 403 on a cluster whose node role has no `bedrock:InvokeModel`. That is fixed separately by pointing the Java IT deployment at DJL (in-process) embeddings. This PR just makes the failure legible when it does happen.

## Test plan

- [ ] `workflow_dispatch` of `k8s-java-it.yml` after the DJL change lands; `SelectiveFieldReindexUIIT` should either pass or fail in seconds, never in ~65 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
