### PR TITLE
fix(search): don't fail the reindex when the embedding provider is unreachable

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/vector/OpenSearchVectorService.java
@@ -434,11 +434,27 @@ public class OpenSearchVectorService implements VectorIndexService {
   /**
    * Begins a staged recreate for a full-recreate run: pre-flights the embedding client (a broken
    * client would make the whole run pointless), sweeps generations orphaned by crashed runs, and
-   * creates the next generation bare — no aliases, so reads keep hitting the old chunks. Throws on
-   * any failure; nothing has been destroyed at that point.
+   * creates the next generation bare — no aliases, so reads keep hitting the old chunks.
+   *
+   * <p>Returns {@code null} when the embedding client cannot serve a request, meaning "not staged":
+   * the caller carries on with a normal in-place reindex and the existing chunks stay live, exactly
+   * as they do for a partial recreate. An unreachable embedding provider is a reason not to stage a
+   * generation we could never finish — it is not a reason to fail the entity reindex, which does
+   * not need embeddings at all. Note the provider is only exercised here: client construction makes
+   * no call to it, and live indexing logs and continues on embedding errors, so a deployment with
+   * semantic search enabled but no working provider looks healthy right up until a reindex.
+   *
+   * <p>Still throws on genuine staging failures (indeterminate live-target probe, index create) —
+   * those mean the cluster is in a state where continuing could destroy live chunks.
    */
   public String beginStagedChunkRecreate() {
-    preflightEmbedding();
+    if (!isEmbeddingAvailable()) {
+      LOG.warn(
+          "Embedding pre-flight failed — skipping the staged chunk recreate. The entity reindex "
+              + "continues and existing chunks stay live; orphaned chunks, if any, are swept by the "
+              + "next recreate that runs with a working embedding provider.");
+      return null;
+    }
     synchronized (stagedChunkLock) {
       String base = getChunkIndexName();
       String liveTarget = requireResolvedLiveChunkTarget(base);
@@ -479,12 +495,18 @@ public class OpenSearchVectorService implements VectorIndexService {
     }
   }
 
-  private void preflightEmbedding() {
+  /**
+   * Whether the embedding client can actually serve a request. Logged rather than thrown: the only
+   * caller treats an unavailable provider as "do not stage", and the stack trace belongs in the log
+   * next to the provider's own error, not wrapped in a reindex failure.
+   */
+  private boolean isEmbeddingAvailable() {
     try {
       embeddingClient.embedQuery("chunk index recreate pre-flight");
+      return true;
     } catch (Exception e) {
-      throw new RuntimeException(
-          "Refusing to start a staged chunk-index recreate: embedding client pre-flight failed", e);
+      LOG.warn("Embedding client pre-flight failed: {}", e.getMessage(), e);
+      return false;
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceChunkStagingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/vector/OpenSearchVectorServiceChunkStagingTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.search.vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -111,6 +112,28 @@ class OpenSearchVectorServiceChunkStagingTest {
     assertTrue(
         failure.getMessage().contains("live chunk target"),
         "abort must name the unresolved live target. Got: " + failure.getMessage());
+    verify(client, never()).generic();
+  }
+
+  @Test
+  void beginStagedChunkRecreate_skipsStagingWhenTheEmbeddingProviderIsUnavailable()
+      throws IOException {
+    // An unreachable embedding provider must not fail the reindex. Semantic search ships enabled
+    // with the provider defaulting to bedrock, and the client constructs without ever calling it,
+    // so any deployment that never set Bedrock up reaches this pre-flight — and the entity reindex
+    // it would abort does not need embeddings at all. Skip staging, leave the old chunks live, and
+    // touch nothing in the cluster.
+    OpenSearchClient client = mock(OpenSearchClient.class);
+    EmbeddingClient embeddingClient = mock(EmbeddingClient.class);
+    when(embeddingClient.embedQuery(any(String.class)))
+        .thenThrow(new RuntimeException("Bedrock embedding generation failed (AWS service error)"));
+
+    OpenSearchVectorService service = new OpenSearchVectorService(client, embeddingClient);
+
+    assertNull(
+        service.beginStagedChunkRecreate(),
+        "an unavailable embedding provider must read as 'not staged', not as a failure");
+    verify(client, never()).indices();
     verify(client, never()).generic();
   }
 }


### PR DESCRIPTION
Follows up [#30364](https://github.com/open-metadata/OpenMetadata/pull/30364), which is on `main` and the `2.0` release branch.

## What happens today

#30364 un-gated the staged chunk recreate, so every job-driven full recreate now calls `beginStagedChunkRecreate()`, which opens with a pre-flight embed. That pre-flight rethrows, and the exception fails the entire `SearchIndexApp` run — so **a reindex that needs no embeddings at all is blocked by an optional AI provider being unreachable**.

## Why this is not a narrow case

Collate ships `naturalLanguageSearch.semanticSearchEnabled=true` by default, while `llmConfiguration.embeddings.provider` defaults to `bedrock`. And `BedrockEmbeddingClient`'s constructor never calls AWS — it validates model id, dimension and region, then builds the SDK client.

So on any deployment where a region resolves (anything running on AWS) but `bedrock:InvokeModel` was never granted:

1. the client constructs happily,
2. `initializeVectorSearchService` reports success,
3. and the first full reindex dies:

```
User: arn:aws:sts::...:assumed-role/... is not authorized to perform:
bedrock:InvokeModel on resource: .../amazon.titan-embed-text-v2:0
(Service: BedrockRuntime, Status Code: 403)
```

surfacing as `status='failed'` within seconds with an **empty** `failureContext`.

The misconfiguration is otherwise invisible. Live indexing logs embedding errors and carries on, so the deployment looks healthy right up until someone reindexes. OSS is unaffected — `semanticSearchEnabled` defaults to `false` there, so the vector service never initialises and the gate returns early.

This is what has been failing the nightly Java IT reindex suites on `main` and `2.0` since 2026-08-04.

## The change

Treat an unavailable provider as *"do not stage"* rather than *"fail"*: return `null`, which the caller already handles as the partial-recreate outcome — existing chunks stay live and get swept by the next recreate that runs with a working provider. `markEntityTypeReindexed` already ignores marks from a run without staging (the "unbound chunk-type mark" branch), so this reuses a supported state rather than inventing one.

The pre-flight's intent is preserved: it still refuses to stage a generation it could never finish. It just no longer takes the entity reindex down with it.

**Genuine staging failures still throw** — an indeterminate live-target probe, a failed index create — because those mean continuing could destroy live chunks. The existing `beginStagedChunkRecreate_abortsWhenTheLiveTargetProbeIsIndeterminate` test still passes unchanged.

## Test plan

- [x] `OpenSearchVectorServiceChunkStagingTest` — 8/8 pass, including a new case asserting an unavailable provider returns `null` and touches nothing in the cluster (`verify(client, never()).indices()` / `.generic()`).
- [x] `RecreateWithEmbeddingsTest` — 7/7 pass.
- [ ] Nightly Java IT once merged.

Unit tests were executed on `main`; the `2.0` change is character-identical (verified by diffing the two patches) but its module could not be built locally offline.

## Related

- open-metadata/openmetadata-nightly#285 — points the Java IT cluster at DJL in-process embeddings, so CI stops depending on Bedrock at all. Complementary: that fixes the environment, this stops the environment from being able to break reindex.
- open-metadata/OpenMetadata#31126 / #31127 — the harness bug that turned this failure into a 60-minute poll and cascading job timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
