### PR TITLE
Fixes 29674: stop EntityNotFoundException from aborting alert evaluation for deleted entities

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
@@ -1,0 +1,326 @@
+/*
+ *  Copyright 2025 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openmetadata.service.security.policyevaluator.CompiledRule.parseExpression;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.bootstrap.SharedEntities;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.data.CreateDatabase;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
+import org.openmetadata.schema.api.domains.CreateDomain;
+import org.openmetadata.schema.api.domains.CreateDomain.DomainType;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.api.tests.CreateTestCase;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
+import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.schema.tests.TestCase;
+import org.openmetadata.schema.tests.TestCaseParameterValue;
+import org.openmetadata.schema.tests.type.TestCaseResult;
+import org.openmetadata.schema.tests.type.TestCaseStatus;
+import org.openmetadata.schema.type.ChangeDescription;
+import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EventType;
+import org.openmetadata.schema.type.FieldChange;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.subscription.AlertsRuleEvaluator;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+
+/**
+ * Regression tests for open-metadata/OpenMetadata#29674.
+ *
+ * <p>{@code matchAnyDomain}, {@code matchAnyOwnerName} and {@code getTestCaseStatusIfInTestSuite}
+ * re-read the change-event entity from the store to reach fields the serialized payload does not
+ * carry. Alerts are evaluated asynchronously, so a delete event routinely reaches the evaluator
+ * after the entity is gone — the re-read then threw {@code EntityNotFoundException} and aborted the
+ * whole subscription instead of simply not matching. The re-read also used {@code NON_DELETED},
+ * which made every soft-delete event throw as well.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class AlertsRuleEvaluatorDeletedEntityIT {
+
+  private static final Map<String, String> HARD_DELETE =
+      Map.of("hardDelete", "true", "recursive", "true");
+  private static final String UNRELATED_FQN = "unrelated.fqn";
+
+  @Test
+  void matchAnyDomain_hardDeletedEntity_fallsBackToChangeEventPayload(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Domain domain = createDomain(ns);
+    Table table = createTable(ns, createDomainAssignment(domain), null);
+
+    ChangeEvent changeEvent =
+        deleteEvent(Entity.TABLE, client.tables().get(table.getId().toString(), "domains"));
+    client.tables().delete(table.getId().toString(), HARD_DELETE);
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertTrue(
+        evaluate("matchAnyDomain({'" + domain.getFullyQualifiedName() + "'})", context),
+        "domain carried by the delete event payload must still match once the row is gone");
+    assertFalse(evaluate("matchAnyDomain({'" + UNRELATED_FQN + "'})", context));
+  }
+
+  @Test
+  void matchAnyDomain_softDeletedEntity_resolvesDomainFromStore(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Domain domain = createDomain(ns);
+    Table table = createTable(ns, createDomainAssignment(domain), null);
+
+    ChangeEvent changeEvent = deleteEvent(Entity.TABLE, payloadWithoutRelationships(table));
+    client.tables().delete(table.getId().toString());
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertTrue(
+        evaluate("matchAnyDomain({'" + domain.getFullyQualifiedName() + "'})", context),
+        "a soft-deleted entity must still resolve its domains from the store");
+    assertFalse(evaluate("matchAnyDomain({'" + UNRELATED_FQN + "'})", context));
+  }
+
+  @Test
+  void matchAnyDomain_liveEntity_resolvesDomainFromStore(TestNamespace ns) {
+    Domain domain = createDomain(ns);
+    Table table = createTable(ns, createDomainAssignment(domain), null);
+
+    EvaluationContext context =
+        contextFor(updateEvent(Entity.TABLE, payloadWithoutRelationships(table)));
+    assertTrue(evaluate("matchAnyDomain({'" + domain.getFullyQualifiedName() + "'})", context));
+    assertFalse(evaluate("matchAnyDomain({'" + UNRELATED_FQN + "'})", context));
+  }
+
+  @Test
+  void matchAnyOwnerName_hardDeletedEntity_doesNotAbortEvaluation(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, null, List.of(SharedEntities.get().USER1_REF));
+
+    ChangeEvent changeEvent = deleteEvent(Entity.TABLE, payloadWithoutRelationships(table));
+    client.tables().delete(table.getId().toString(), HARD_DELETE);
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertFalse(
+        evaluate("matchAnyOwnerName({'" + SharedEntities.get().USER1.getName() + "'})", context),
+        "a hard-deleted entity has no resolvable owner, so the filter must not match");
+  }
+
+  @Test
+  void matchAnyOwnerName_softDeletedEntity_resolvesOwnerFromStore(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, null, List.of(SharedEntities.get().USER1_REF));
+
+    ChangeEvent changeEvent = deleteEvent(Entity.TABLE, payloadWithoutRelationships(table));
+    client.tables().delete(table.getId().toString());
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertTrue(
+        evaluate("matchAnyOwnerName({'" + SharedEntities.get().USER1.getName() + "'})", context),
+        "a soft-deleted entity must still resolve its owners from the store");
+    assertFalse(evaluate("matchAnyOwnerName({'nonExistentOwner'})", context));
+  }
+
+  @Test
+  void matchAnyOwnerName_hardDeletedOwner_doesNotAbortEvaluation(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    User owner = createUser(ns);
+    Table table = createTable(ns, null, List.of(ownerReference(owner)));
+
+    ChangeEvent changeEvent =
+        updateEvent(Entity.TABLE, client.tables().get(table.getId().toString(), "owners"));
+    client.users().delete(owner.getId().toString(), HARD_DELETE);
+
+    assertFalse(
+        evaluate("matchAnyOwnerName({'" + owner.getName() + "'})", contextFor(changeEvent)),
+        "an owner reference pointing at a deleted user must not match");
+  }
+
+  @Test
+  void getTestCaseStatusIfInTestSuite_hardDeletedTestCase_fallsBackToChangeEventPayload(
+      TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, null, null);
+    TestCase testCase = createTestCase(ns, table);
+    String testSuiteFqn = testCase.getTestSuites().getFirst().getFullyQualifiedName();
+
+    ChangeEvent changeEvent = deleteEvent(Entity.TEST_CASE, testCase);
+    changeEvent.setChangeDescription(successResultChange());
+    client.testCases().delete(testCase.getId().toString(), HARD_DELETE);
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertTrue(
+        evaluate("getTestCaseStatusIfInTestSuite({'Success'}, {'" + testSuiteFqn + "'})", context),
+        "test suites carried by the delete event payload must still match once the row is gone");
+    assertFalse(
+        evaluate(
+            "getTestCaseStatusIfInTestSuite({'Success'}, {'" + UNRELATED_FQN + "'})", context));
+  }
+
+  @Test
+  void getTestCaseStatusIfInTestSuite_softDeletedTestCase_resolvesTestSuiteFromStore(
+      TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Table table = createTable(ns, null, null);
+    TestCase testCase = createTestCase(ns, table);
+    String testSuiteFqn = testCase.getTestSuites().getFirst().getFullyQualifiedName();
+
+    ChangeEvent changeEvent =
+        deleteEvent(
+            Entity.TEST_CASE,
+            new TestCase()
+                .withId(testCase.getId())
+                .withName(testCase.getName())
+                .withFullyQualifiedName(testCase.getFullyQualifiedName()));
+    changeEvent.setChangeDescription(successResultChange());
+    client.testCases().delete(testCase.getId().toString());
+
+    EvaluationContext context = contextFor(changeEvent);
+    assertTrue(
+        evaluate("getTestCaseStatusIfInTestSuite({'Success'}, {'" + testSuiteFqn + "'})", context),
+        "a soft-deleted test case must still resolve its test suites from the store");
+    assertFalse(
+        evaluate("getTestCaseStatusIfInTestSuite({'Failed'}, {'" + testSuiteFqn + "'})", context));
+  }
+
+  private Domain createDomain(TestNamespace ns) {
+    return SdkClients.adminClient()
+        .domains()
+        .create(
+            new CreateDomain()
+                .withName(ns.prefix("alertDomain"))
+                .withDomainType(DomainType.AGGREGATE)
+                .withDescription("Domain for deleted-entity alert filtering"));
+  }
+
+  private List<String> createDomainAssignment(Domain domain) {
+    return List.of(domain.getFullyQualifiedName());
+  }
+
+  private User createUser(TestNamespace ns) {
+    String name = "alertOwner" + ns.uniqueShortId();
+    return SdkClients.adminClient()
+        .users()
+        .create(new CreateUser().withName(name).withEmail(name + "@test.openmetadata.org"));
+  }
+
+  private EntityReference ownerReference(User user) {
+    return new EntityReference().withId(user.getId()).withType(Entity.USER);
+  }
+
+  private Table createTable(
+      TestNamespace ns, List<String> domainFqns, List<EntityReference> owners) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String id = ns.uniqueShortId();
+    Database database =
+        client
+            .databases()
+            .create(
+                new CreateDatabase()
+                    .withName("alertDb_" + id)
+                    .withService(SharedEntities.get().MYSQL_SERVICE.getFullyQualifiedName()));
+    DatabaseSchema schema =
+        client
+            .databaseSchemas()
+            .create(
+                new CreateDatabaseSchema()
+                    .withName("alertSc_" + id)
+                    .withDatabase(database.getFullyQualifiedName()));
+    return client
+        .tables()
+        .create(
+            new CreateTable()
+                .withName("alertTb_" + id)
+                .withDatabaseSchema(schema.getFullyQualifiedName())
+                .withDomains(domainFqns)
+                .withOwners(owners)
+                .withColumns(
+                    List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT))));
+  }
+
+  private TestCase createTestCase(TestNamespace ns, Table table) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    TestCase created =
+        client
+            .testCases()
+            .create(
+                new CreateTestCase()
+                    .withName("alertTc_" + ns.uniqueShortId())
+                    .withEntityLink("<#E::table::" + table.getFullyQualifiedName() + ">")
+                    .withTestDefinition("tableRowCountToEqual")
+                    .withParameterValues(
+                        List.of(new TestCaseParameterValue().withName("value").withValue("100"))));
+    return client.testCases().get(created.getId().toString(), "testSuites");
+  }
+
+  /**
+   * Mirrors the shape of a change-event payload that carries only core fields: relationship fields
+   * such as owners and domains are absent, forcing the evaluator down the store re-read path.
+   */
+  private Table payloadWithoutRelationships(Table table) {
+    return new Table()
+        .withId(table.getId())
+        .withName(table.getName())
+        .withFullyQualifiedName(table.getFullyQualifiedName());
+  }
+
+  private ChangeEvent deleteEvent(String entityType, Object entity) {
+    return new ChangeEvent()
+        .withEventType(EventType.ENTITY_DELETED)
+        .withEntityType(entityType)
+        .withEntity(entity);
+  }
+
+  private ChangeEvent updateEvent(String entityType, Object entity) {
+    return new ChangeEvent()
+        .withEventType(EventType.ENTITY_UPDATED)
+        .withEntityType(entityType)
+        .withEntity(entity);
+  }
+
+  private ChangeDescription successResultChange() {
+    return new ChangeDescription()
+        .withFieldsUpdated(
+            List.of(
+                new FieldChange()
+                    .withName("testCaseResult")
+                    .withNewValue(
+                        new TestCaseResult().withTestCaseStatus(TestCaseStatus.Success))));
+  }
+
+  private EvaluationContext contextFor(ChangeEvent changeEvent) {
+    return SimpleEvaluationContext.forReadOnlyDataBinding()
+        .withInstanceMethods()
+        .withRootObject(new AlertsRuleEvaluator(changeEvent))
+        .build();
+  }
+
+  private Boolean evaluate(String condition, EvaluationContext evaluationContext) {
+    return parseExpression(condition).getValue(evaluationContext, Boolean.class);
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java
@@ -16,8 +16,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openmetadata.service.security.policyevaluator.CompiledRule.parseExpression;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -37,6 +40,10 @@ import org.openmetadata.schema.entity.data.Database;
 import org.openmetadata.schema.entity.data.DatabaseSchema;
 import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.events.ArgumentsInput;
+import org.openmetadata.schema.entity.events.EventFilterRule;
+import org.openmetadata.schema.entity.events.EventSubscription;
+import org.openmetadata.schema.entity.events.FilteringRules;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestCaseParameterValue;
@@ -51,6 +58,7 @@ import org.openmetadata.schema.type.EventType;
 import org.openmetadata.schema.type.FieldChange;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.events.subscription.AlertUtil;
 import org.openmetadata.service.events.subscription.AlertsRuleEvaluator;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
@@ -115,6 +123,54 @@ public class AlertsRuleEvaluatorDeletedEntityIT {
         contextFor(updateEvent(Entity.TABLE, payloadWithoutRelationships(table)));
     assertTrue(evaluate("matchAnyDomain({'" + domain.getFullyQualifiedName() + "'})", context));
     assertFalse(evaluate("matchAnyDomain({'" + UNRELATED_FQN + "'})", context));
+  }
+
+  /**
+   * The observable the ticket is actually about: one un-evaluatable event must not take the rest of
+   * the batch with it. {@code AlertUtil.getFilteredEvents} streams every event through
+   * {@code checkIfChangeEventIsAllowed}, so a throw anywhere in the stream drops the whole batch —
+   * which is what {@code AbstractEventConsumer.publishEvents} hands to the destinations.
+   */
+  @Test
+  void getFilteredEvents_deletedEntityInBatch_stillDeliversTheLiveEvent(TestNamespace ns) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    Domain domain = createDomain(ns);
+    Table liveTable = createTable(ns, createDomainAssignment(domain), null);
+    Table deletedTable = createTable(ns, createDomainAssignment(domain), null);
+
+    ChangeEvent liveEvent =
+        updateEvent(Entity.TABLE, payloadWithoutRelationships(liveTable)).withId(UUID.randomUUID());
+    ChangeEvent deletedEvent =
+        deleteEvent(Entity.TABLE, payloadWithoutRelationships(deletedTable))
+            .withId(UUID.randomUUID());
+    client.tables().delete(deletedTable.getId().toString(), HARD_DELETE);
+
+    Map<ChangeEvent, Set<UUID>> batch = new LinkedHashMap<>();
+    batch.put(deletedEvent, Set.of(UUID.randomUUID()));
+    batch.put(liveEvent, Set.of(UUID.randomUUID()));
+
+    Map<ChangeEvent, Set<UUID>> delivered =
+        AlertUtil.getFilteredEvents(
+            subscriptionFilteringOnDomain(domain.getFullyQualifiedName()), batch);
+
+    assertTrue(
+        delivered.containsKey(liveEvent),
+        "the live event must survive a batch that also contains a hard-deleted entity");
+    assertFalse(
+        delivered.containsKey(deletedEvent),
+        "the hard-deleted entity no longer resolves a domain, so its event must not match");
+  }
+
+  private EventSubscription subscriptionFilteringOnDomain(String domainFqn) {
+    EventFilterRule rule =
+        new EventFilterRule()
+            .withName("matchAnyDomain")
+            .withEffect(ArgumentsInput.Effect.INCLUDE)
+            .withCondition("matchAnyDomain({'" + domainFqn + "'})");
+    return new EventSubscription()
+        .withName("alertDomainSubscription")
+        .withFilteringRules(
+            new FilteringRules().withResources(List.of(Entity.TABLE)).withRules(List.of(rule)));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -647,6 +647,23 @@ public final class Entity {
     }
   }
 
+  /**
+   * Same as {@link #getEntity(String, UUID, String, Include)} but yields {@code null} instead of
+   * throwing when the entity is gone. Use it on best-effort paths that run after the entity may have
+   * been deleted — asynchronous alert filtering, for instance — where a missing entity is an
+   * expected outcome rather than an error.
+   */
+  public static <T> T getEntityOrNull(String entityType, UUID id, String fields, Include include) {
+    T entity;
+    try {
+      entity = getEntity(entityType, id, fields, include);
+    } catch (EntityNotFoundException e) {
+      LOG.debug("{} {} not found while reading fields '{}'", entityType, id, fields);
+      entity = null;
+    }
+    return entity;
+  }
+
   public static <T> T getEntity(EntityLink link, String fields, Include include) {
     return getEntityByName(link.getEntityType(), link.getEntityFQN(), fields, include);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/Entity.java
@@ -84,6 +84,7 @@ import org.openmetadata.service.search.capability.EntityIndexCapability;
 import org.openmetadata.service.search.capability.EntityIndexCapabilityRegistry;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.util.EntityUtil.Fields;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 @Slf4j
@@ -654,9 +655,24 @@ public final class Entity {
    * expected outcome rather than an error.
    */
   public static <T> T getEntityOrNull(String entityType, UUID id, String fields, Include include) {
+    return getEntityOrNull(entityType, id, fields, RelationIncludes.fromInclude(include));
+  }
+
+  /**
+   * Same as {@link #getEntityOrNull(String, UUID, String, Include)} but with per-relation include
+   * control, so a caller can tolerate a deleted subject entity without also widening which related
+   * entities its relationship fields resolve to.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T getEntityOrNull(
+      String entityType, UUID id, String fields, RelationIncludes relationIncludes) {
+    EntityRepository<?> entityRepository = Entity.getEntityRepository(entityType);
     T entity;
     try {
-      entity = getEntity(entityType, id, fields, include);
+      entity =
+          (T)
+              entityRepository.get(
+                  null, id, entityRepository.getFields(fields), relationIncludes, true);
     } catch (EntityNotFoundException e) {
       LOG.debug("{} {} not found while reading fields '{}'", entityType, id, fields);
       entity = null;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -56,6 +56,10 @@ import org.openmetadata.service.util.FullyQualifiedName;
 
 @Slf4j
 public class AlertsRuleEvaluator {
+  private static final String FIELD_TEST_SUITES = "testSuites";
+  private static final String FIELD_TEST_SUITES_AND_OWNERS =
+      FIELD_TEST_SUITES + "," + Entity.FIELD_OWNERS;
+
   private final ChangeEvent changeEvent;
 
   public AlertsRuleEvaluator(ChangeEvent event) {
@@ -96,40 +100,39 @@ public class AlertsRuleEvaluator {
       examples = {"matchAnyOwnerName({'Owner1', 'Owner2'})"},
       paramInputType = SPECIFIC_INDEX_ELASTIC_SEARCH)
   public boolean matchAnyOwnerName(List<String> ownerNameList) {
-    if (changeEvent == null || changeEvent.getEntity() == null) {
-      return false;
+    boolean matched = false;
+    if (changeEvent != null && changeEvent.getEntity() != null) {
+      // Filter does not apply to Thread Change Events
+      matched =
+          THREAD.equals(changeEvent.getEntityType())
+              || matchesEntityOrTestSuiteOwner(getEntity(changeEvent), ownerNameList);
     }
+    return matched;
+  }
 
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
-    }
-
-    EntityInterface entity = getEntity(changeEvent);
-    List<EntityReference> ownerReferences = entity.getOwners();
-    if (nullOrEmpty(ownerReferences)) {
-      entity =
-          Entity.getEntity(
-              changeEvent.getEntityType(), entity.getId(), "owners", Include.NON_DELETED);
-      ownerReferences = entity.getOwners();
-    }
+  private boolean matchesEntityOrTestSuiteOwner(
+      EntityInterface entity, List<String> ownerNameList) {
+    List<EntityReference> ownerReferences = resolveOwners(entity);
+    boolean matched = false;
     if (!nullOrEmpty(ownerReferences)) {
-      return matchOwners(ownerReferences, ownerNameList);
-    }
-
-    if (changeEvent.getEntityType().equals(TEST_CASE)) {
+      matched = matchOwners(ownerReferences, ownerNameList);
+    } else if (TEST_CASE.equals(changeEvent.getEntityType())) {
       // If we did not match on the owner name and are dealing with a test case,
       // check if the match happens on the test suite owner name
-      TestCase testCase =
-          Entity.getEntity(
-              changeEvent.getEntityType(),
-              entity.getId(),
-              "testSuites,owners",
-              Include.NON_DELETED);
-      Optional<List<TestSuite>> testSuites = Optional.ofNullable(testCase.getTestSuites());
-      return testSuites.filter(suites -> testSuiteOwnerMatcher(suites, ownerNameList)).isPresent();
+      matched =
+          testSuiteOwnerMatcher(
+              resolveTestSuites(entity, FIELD_TEST_SUITES_AND_OWNERS), ownerNameList);
     }
-    return false;
+    return matched;
+  }
+
+  private List<EntityReference> resolveOwners(EntityInterface entity) {
+    List<EntityReference> ownerReferences = entity.getOwners();
+    if (nullOrEmpty(ownerReferences)) {
+      EntityInterface storedEntity = readStoredEntity(entity, Entity.FIELD_OWNERS);
+      ownerReferences = storedEntity == null ? ownerReferences : storedEntity.getOwners();
+    }
+    return ownerReferences;
   }
 
   @Function(
@@ -322,29 +325,20 @@ public class AlertsRuleEvaluator {
       paramInputType = READ_FROM_PARAM_CONTEXT)
   public boolean getTestCaseStatusIfInTestSuite(
       List<String> testResults, List<String> testSuiteList) {
-    if (changeEvent == null || changeEvent.getChangeDescription() == null) {
-      return false;
+    boolean matched = false;
+    // Trigger requires a test case result; non-test-case events (incl. THREAD) cannot fire it.
+    if (changeEvent != null
+        && changeEvent.getChangeDescription() != null
+        && TEST_CASE.equals(changeEvent.getEntityType())) {
+      List<TestSuite> testSuites = resolveTestSuites(getEntity(changeEvent), FIELD_TEST_SUITES);
+      matched = matchesAnyTestSuiteFqn(testSuites, testSuiteList) && matchTestResult(testResults);
     }
-    if (!changeEvent.getEntityType().equals(TEST_CASE)) {
-      // Trigger requires a test case result; non-test-case events (incl. THREAD) cannot fire it.
-      return false;
-    }
+    return matched;
+  }
 
-    // we need to handle both fields updated and fields added
-    EntityInterface entity = getEntity(changeEvent);
-    TestCase entityWithTestSuite =
-        Entity.getEntity(
-            changeEvent.getEntityType(), entity.getId(), "testSuites", Include.NON_DELETED);
-    boolean testSuiteFiltering =
-        listOrEmpty(entityWithTestSuite.getTestSuites()).stream()
-            .anyMatch(
-                testSuite ->
-                    testSuiteList.stream()
-                        .anyMatch(name -> testSuite.getFullyQualifiedName().equals(name)));
-    if (testSuiteFiltering) {
-      return matchTestResult(testResults);
-    }
-    return false;
+  private boolean matchesAnyTestSuiteFqn(List<TestSuite> testSuites, List<String> testSuiteFqns) {
+    return testSuites.stream()
+        .anyMatch(testSuite -> testSuiteFqns.contains(testSuite.getFullyQualifiedName()));
   }
 
   @Function(
@@ -476,37 +470,59 @@ public class AlertsRuleEvaluator {
       examples = {"matchAnyDomain({'domain1', 'domain2'})"},
       paramInputType = SPECIFIC_INDEX_ELASTIC_SEARCH)
   public boolean matchAnyDomain(List<String> fieldChangeUpdate) {
-    if (changeEvent == null) {
-      return false;
+    boolean matched = false;
+    if (changeEvent != null) {
+      // Filter does not apply to Thread Change Events
+      matched =
+          THREAD.equals(changeEvent.getEntityType())
+              || matchesEntityOrTestSuiteDomain(getEntity(changeEvent), fieldChangeUpdate);
     }
+    return matched;
+  }
 
-    // Filter does not apply to Thread Change Events
-    if (changeEvent.getEntityType().equals(THREAD)) {
-      return true;
-    }
-
-    EntityInterface entity = getEntity(changeEvent);
-    EntityInterface entityWithDomainData =
-        Entity.getEntity(
-            changeEvent.getEntityType(), entity.getId(), "domains", Include.NON_DELETED);
-    if (!nullOrEmpty(entityWithDomainData.getDomains())) {
-      for (String name : fieldChangeUpdate) {
-        for (EntityReference domain : entityWithDomainData.getDomains()) {
-          if (domain.getFullyQualifiedName().equals(name)) {
-            return true;
-          }
-        }
-      }
-    }
-
-    if (changeEvent.getEntityType().equals(TEST_CASE)) {
+  private boolean matchesEntityOrTestSuiteDomain(EntityInterface entity, List<String> domainFqns) {
+    EntityInterface storedEntity = readStoredEntity(entity, Entity.FIELD_DOMAINS);
+    List<EntityReference> domains =
+        storedEntity == null ? entity.getDomains() : storedEntity.getDomains();
+    boolean matched = matchesAnyDomainFqn(domains, domainFqns);
+    if (!matched && TEST_CASE.equals(changeEvent.getEntityType())) {
       // If we did not match on the domain and are dealing with a test case,
       // check if the match happens on the test suite domain
-      TestCase testCase = ((TestCase) entity);
-      Optional<List<TestSuite>> testSuites = Optional.ofNullable(testCase.getTestSuites());
-      return testSuites.filter(suites -> testSuiteMatcher(suites, fieldChangeUpdate)).isPresent();
+      matched = testSuiteMatcher(listOrEmpty(((TestCase) entity).getTestSuites()), domainFqns);
     }
-    return false;
+    return matched;
+  }
+
+  private boolean matchesAnyDomainFqn(List<EntityReference> domains, List<String> domainFqns) {
+    boolean matched = false;
+    for (EntityReference domain : listOrEmpty(domains)) {
+      if (domainFqns.contains(domain.getFullyQualifiedName())) {
+        matched = true;
+        break;
+      }
+    }
+    return matched;
+  }
+
+  /**
+   * Re-reads the change-event entity from the store to pick up fields the serialized payload does
+   * not carry, yielding {@code null} once the entity has been hard-deleted. Alerts are evaluated
+   * asynchronously, so a delete event routinely reaches the evaluator after its entity is gone; the
+   * lookup must not abort the whole subscription then (issue #29674) and callers fall back to the
+   * payload instead. {@link Include#ALL} keeps soft-deleted entities resolvable, since their
+   * domains, owners and test suites are still the ones the alert should be filtered on.
+   */
+  private <T extends EntityInterface> T readStoredEntity(EntityInterface entity, String fields) {
+    return Entity.getEntityOrNull(changeEvent.getEntityType(), entity.getId(), fields, Include.ALL);
+  }
+
+  private List<TestSuite> resolveTestSuites(EntityInterface entity, String fields) {
+    TestCase storedTestCase = readStoredEntity(entity, fields);
+    List<TestSuite> testSuites =
+        storedTestCase == null
+            ? ((TestCase) entity).getTestSuites()
+            : storedTestCase.getTestSuites();
+    return listOrEmpty(testSuites);
   }
 
   public static EntityInterface getEntity(ChangeEvent event) {
@@ -702,14 +718,16 @@ public class AlertsRuleEvaluator {
     return false;
   }
 
+  // Owner references can come from a change-event payload that outlived the owner it points at, so
+  // an unresolvable owner must simply not match (issue #29674).
   private String resolveOwnerName(EntityReference owner) {
     String ownerName = null;
     if (USER.equals(owner.getType())) {
-      User user = Entity.getEntity(Entity.USER, owner.getId(), "", Include.NON_DELETED);
-      ownerName = user.getName();
+      User user = Entity.getEntityOrNull(Entity.USER, owner.getId(), "", Include.NON_DELETED);
+      ownerName = user == null ? null : user.getName();
     } else if (TEAM.equals(owner.getType())) {
-      Team team = Entity.getEntity(Entity.TEAM, owner.getId(), "", Include.NON_DELETED);
-      ownerName = team.getName();
+      Team team = Entity.getEntityOrNull(Entity.TEAM, owner.getId(), "", Include.NON_DELETED);
+      ownerName = team == null ? null : team.getName();
     }
     return ownerName;
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -18,6 +18,7 @@ import static org.openmetadata.service.Entity.THREAD;
 import static org.openmetadata.service.Entity.USER;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -52,13 +53,29 @@ import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.formatter.util.FormatterUtil;
 import org.openmetadata.service.jdbi3.TaskRepository;
 import org.openmetadata.service.resources.feeds.MessageParser;
+import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 import org.openmetadata.service.util.FullyQualifiedName;
 
 @Slf4j
 public class AlertsRuleEvaluator {
-  private static final String FIELD_TEST_SUITES = "testSuites";
   private static final String FIELD_TEST_SUITES_AND_OWNERS =
-      FIELD_TEST_SUITES + "," + Entity.FIELD_OWNERS;
+      Entity.FIELD_TEST_SUITES + "," + Entity.FIELD_OWNERS;
+
+  /**
+   * Resolves the change-event entity itself even once it is soft-deleted — a delete event must still
+   * be able to match on its domains, owners and test suites — while pinning its relationship fields
+   * to live targets. Widening the subject include alone must not widen which alerts fire, and
+   * {@link Include#NON_DELETED} is also the only include for which
+   * {@code EntityRepository.getOwners}/{@code getDomains} consult and populate the relationship
+   * cache, which this evaluator runs against on the change-event hot path.
+   */
+  private static final RelationIncludes DELETED_TOLERANT_SUBJECT =
+      new RelationIncludes(
+          Include.ALL,
+          Map.of(
+              Entity.FIELD_OWNERS, Include.NON_DELETED,
+              Entity.FIELD_DOMAINS, Include.NON_DELETED,
+              Entity.FIELD_TEST_SUITES, Include.NON_DELETED));
 
   private final ChangeEvent changeEvent;
 
@@ -121,7 +138,7 @@ public class AlertsRuleEvaluator {
       // check if the match happens on the test suite owner name
       matched =
           testSuiteOwnerMatcher(
-              resolveTestSuites(entity, FIELD_TEST_SUITES_AND_OWNERS), ownerNameList);
+              resolveTestSuites((TestCase) entity, FIELD_TEST_SUITES_AND_OWNERS), ownerNameList);
     }
     return matched;
   }
@@ -129,7 +146,7 @@ public class AlertsRuleEvaluator {
   private List<EntityReference> resolveOwners(EntityInterface entity) {
     List<EntityReference> ownerReferences = entity.getOwners();
     if (nullOrEmpty(ownerReferences)) {
-      EntityInterface storedEntity = readStoredEntity(entity, Entity.FIELD_OWNERS);
+      EntityInterface storedEntity = readStoredEntity(entity.getId(), Entity.FIELD_OWNERS);
       ownerReferences = storedEntity == null ? ownerReferences : storedEntity.getOwners();
     }
     return ownerReferences;
@@ -330,7 +347,8 @@ public class AlertsRuleEvaluator {
     if (changeEvent != null
         && changeEvent.getChangeDescription() != null
         && TEST_CASE.equals(changeEvent.getEntityType())) {
-      List<TestSuite> testSuites = resolveTestSuites(getEntity(changeEvent), FIELD_TEST_SUITES);
+      List<TestSuite> testSuites =
+          resolveTestSuites((TestCase) getEntity(changeEvent), Entity.FIELD_TEST_SUITES);
       matched = matchesAnyTestSuiteFqn(testSuites, testSuiteList) && matchTestResult(testResults);
     }
     return matched;
@@ -481,7 +499,7 @@ public class AlertsRuleEvaluator {
   }
 
   private boolean matchesEntityOrTestSuiteDomain(EntityInterface entity, List<String> domainFqns) {
-    EntityInterface storedEntity = readStoredEntity(entity, Entity.FIELD_DOMAINS);
+    EntityInterface storedEntity = readStoredEntity(entity.getId(), Entity.FIELD_DOMAINS);
     List<EntityReference> domains =
         storedEntity == null ? entity.getDomains() : storedEntity.getDomains();
     boolean matched = matchesAnyDomainFqn(domains, domainFqns);
@@ -509,19 +527,17 @@ public class AlertsRuleEvaluator {
    * not carry, yielding {@code null} once the entity has been hard-deleted. Alerts are evaluated
    * asynchronously, so a delete event routinely reaches the evaluator after its entity is gone; the
    * lookup must not abort the whole subscription then (issue #29674) and callers fall back to the
-   * payload instead. {@link Include#ALL} keeps soft-deleted entities resolvable, since their
-   * domains, owners and test suites are still the ones the alert should be filtered on.
+   * payload instead.
    */
-  private <T extends EntityInterface> T readStoredEntity(EntityInterface entity, String fields) {
-    return Entity.getEntityOrNull(changeEvent.getEntityType(), entity.getId(), fields, Include.ALL);
+  private <T extends EntityInterface> T readStoredEntity(UUID entityId, String fields) {
+    return Entity.getEntityOrNull(
+        changeEvent.getEntityType(), entityId, fields, DELETED_TOLERANT_SUBJECT);
   }
 
-  private List<TestSuite> resolveTestSuites(EntityInterface entity, String fields) {
-    TestCase storedTestCase = readStoredEntity(entity, fields);
+  private List<TestSuite> resolveTestSuites(TestCase testCase, String fields) {
+    TestCase storedTestCase = readStoredEntity(testCase.getId(), fields);
     List<TestSuite> testSuites =
-        storedTestCase == null
-            ? ((TestCase) entity).getTestSuites()
-            : storedTestCase.getTestSuites();
+        storedTestCase == null ? testCase.getTestSuites() : storedTestCase.getTestSuites();
     return listOrEmpty(testSuites);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/events/subscription/AlertsRuleEvaluator.java
@@ -63,19 +63,23 @@ public class AlertsRuleEvaluator {
 
   /**
    * Resolves the change-event entity itself even once it is soft-deleted — a delete event must still
-   * be able to match on its domains, owners and test suites — while pinning its relationship fields
-   * to live targets. Widening the subject include alone must not widen which alerts fire, and
+   * be able to match on its domains, owners and test suites — while pinning owners and domains to
+   * live targets. Widening the subject include alone must not widen which alerts fire, and
    * {@link Include#NON_DELETED} is also the only include for which
    * {@code EntityRepository.getOwners}/{@code getDomains} consult and populate the relationship
    * cache, which this evaluator runs against on the change-event hot path.
+   *
+   * <p>Test suites are deliberately absent: {@code TestCaseRepository.getTestSuites} hardcodes
+   * {@link Include#ALL} and never consults {@link RelationIncludes}, so a soft-deleted test suite
+   * resolves either way and an entry here would be inert. Making that path include-aware is a
+   * separate change.
    */
   private static final RelationIncludes DELETED_TOLERANT_SUBJECT =
       new RelationIncludes(
           Include.ALL,
           Map.of(
               Entity.FIELD_OWNERS, Include.NON_DELETED,
-              Entity.FIELD_DOMAINS, Include.NON_DELETED,
-              Entity.FIELD_TEST_SUITES, Include.NON_DELETED));
+              Entity.FIELD_DOMAINS, Include.NON_DELETED));
 
   private final ChangeEvent changeEvent;
 


### PR DESCRIPTION
### Describe your changes:

Fixes #29674

I worked on `AlertsRuleEvaluator` because deleting a test case (or any entity) made alert evaluation throw `EntityNotFoundException`, and the impact is larger than the issue reports: `AlertUtil.getFilteredEvents` filters events through a `Stream.filter` with no try/catch, so **one un-evaluable event discards the entire batch** for that subscription — including unrelated, perfectly deliverable events.

**Root cause.** Several rule functions deserialize the entity from the `ChangeEvent` payload (safe, no DB hit) and then immediately re-read it from the store to reach relationship fields the payload lacks (`owners`, `domains`, `testSuites`). Alert evaluation is asynchronous, so by the time it runs the row is frequently gone:

- `matchAnyDomain` — the exact site in the reported stack trace
- `matchAnyOwnerName`
- `getTestCaseStatusIfInTestSuite`
- `resolveOwnerName` — a fourth site with the same defect, reachable when the *owner* is deleted while an event referencing it is still queued

**The reported failure was a soft delete, not a hard delete.** The two exception shapes are distinguishable: `"Entity not found: %s %s"` means the row is genuinely absent (hard delete), while `"%s instance for %s not found"` means the row exists but the `Include` filter rejected it. The issue reports `testCase instance for <UUID> not found` — the soft-delete signature. So a null-safe guard *alone* would have converted the crash into a silent non-match and lost every `entitySoftDeleted` notification carrying a domain/owner filter. Three of the eight RED cases are soft-delete.

**Approach.** Null-safe lookups matching the existing `isBot()` precedent in the same class, plus reading the subject entity at `Include.ALL` so soft-deleted entities still resolve. The relationship *targets* stay pinned to `NON_DELETED` via `RelationIncludes`, so which alerts fire is unchanged — this is a crash fix, not a semantics change.

**Alternative rejected.** The issue suggests embedding everything needed in the `ChangeEvent` payload so no re-fetch happens. That would change what ~60 repositories write into `ChangeEvent.entity`, cannot repair events already queued, and has far more blast radius than the defect. The payload fallback added here is effective in practice: `EntityRepository.putFields` already includes `owners` and `domains`, and delete events are built from `loadForDelete(id)` hydrated with `putFields`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (3 files; 2 production files, +223/−76).

#
### Tests:

#### Use cases covered
- An alert with a **domain** filter evaluates a change event for a hard-deleted entity without throwing.
- Same for a **soft-deleted** entity — and the filter still *matches*, so `entitySoftDeleted` notifications are not lost.
- Same for **owner** filters, including when the owner user/team itself was deleted.
- Same for a **test-case status + test-suite** filter on a deleted test case.
- A batch containing a deleted-entity event still delivers the other events in that batch.
- A live entity continues to resolve its domain from the store (control — this passes on unfixed code, so an "always return false" fix would fail it).

#### Unit tests
- [x] Covered by integration tests instead (see below) — the defect is in cross-component behaviour with the real store, not in isolated logic.
- Existing suites re-run green: `AlertUtilTest`, `AlertsRuleEvaluatorTaskMentionsTest`, `EventSubscriptionScheduler*Test`, `EntityLifecycleEventDispatcherTest`, `OrderedLaneExecutorTest`, `SearchIndexHandlerTest` → **104 tests, 0 failures**.
- Coverage note: both changed classes live in `openmetadata-service` while the new tests live in `openmetadata-integration-tests`, so the jacoco changed-class gate for `openmetadata-service` will not attribute them. That placement is required by the repo's own rule that backend API integration tests live in `openmetadata-integration-tests/`.

#### Backend integration tests
- [x] I added integration tests in `openmetadata-integration-tests/`.
- File added: `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/AlertsRuleEvaluatorDeletedEntityIT.java` (+382, 9 tests)
- `mvn -pl openmetadata-integration-tests verify -Dit.test=AlertsRuleEvaluatorDeletedEntityIT` → **9 run, 0 failures**
- Regression sweep: `AlertsRuleEvaluator*IT, EventSubscription*IT, ChangeEventParserResourceIT, IncidentTaskNotificationIT, TestCaseDeleteResilienceIT, BulkAssetChangeEventUserIT` → **322 run, 0 failures**. Pre-existing `AlertsRuleEvaluatorResourceIT` 61/61 still green.
- **Verified RED before GREEN:** with the two production files reverted to base and the tests kept, the class reports 8 errors + 1 passing control, every error an `EntityNotFoundException`, reproducing the issue's stack trace path (`matchAnyDomain` → `Entity.getEntity` → `EntityRepository.find`).
- Every assertion is on the `Boolean` the compiled SpEL expression returns — the exact value `AlertUtil.evaluateAlertConditions` consumes — or on the output of `AlertUtil.getFilteredEvents`. Setup goes through the real REST API via `SdkClients`, so "deleted" is a genuine `DELETE /api/v1/...` against real DB and index state. No mocks, no `verify()`, no `Thread.sleep()`, no exact-collection-size assertions. Six of nine tests pair a positive with a negative assertion so neither an always-true nor an always-false regression survives.

> Note for reviewers: this is a **failsafe** test. `mvn test -Dtest=…` reports *"No tests matching pattern"* and exits 0 — that is the wrong plugin, not missing tests. Use `mvn -pl openmetadata-integration-tests verify -Dit.test=AlertsRuleEvaluatorDeletedEntityIT` (requires Docker).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Written from the code paths and **NOT VERIFIED** by execution — the ITs above are the executed evidence. Prerequisites: a local stack built from this branch (`./docker/run_local_docker.sh -m ui -d mysql`) and an admin JWT in `$TOKEN`.

1. `POST /api/v1/domains` with `{"name":"AlertDomain","domainType":"Aggregate","description":"d"}`.
2. Create a table and assign it that domain.
3. Settings → Notifications → Add Alert: source *Table*, trigger *All events*, **Filter → Domain** = `AlertDomain`, destination any webhook. Confirm status *Active*.
4. Update the table's description. **Expected:** the webhook receives the event and the alert stays green.
5. Hard-delete the table: `DELETE /api/v1/tables/{id}?hardDelete=true&recursive=true`.
6. Immediately update a *second*, still-live domain-tagged table so both events land in the same poller batch, and watch the server log. **Expected on this branch:** no `EntityNotFoundException`; the delete event is simply not delivered while the live table's event *is*. **On `main`:** `EntityNotFoundException: table instance for <UUID> not found` at `AlertsRuleEvaluator.matchAnyDomain`, and **the whole batch is dropped** — including the live table's event.
7. Repeat with a **soft** delete on a third domain-tagged table. **Expected on this branch:** the webhook *does* receive the `entitySoftDeleted` event. **On `main`:** the same exception.
8. Repeat with a **Filter → Owner** condition, and with a *Test Case* alert using **Filter → Test Suite + status** on a test case that is then hard-deleted.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema change, so no migration needed.
- [x] For UI changes: N/A — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

#
### Deliberately out of scope

- **`AlertUtil.evaluateAlertConditions` still has no top-level guard**, so any *other* runtime exception from a rule function will still drop a batch. A general "one bad event must not stall a subscription" guard is a separate design decision.
- **`TestCaseRepository.getTestSuites` hardcodes `Include.ALL`** and ignores `RelationIncludes`, so a soft-deleted test suite resolves either way — unchanged by this PR, and documented in the `DELETED_TOLERANT_SUBJECT` javadoc so the comment does not claim an invariant the code does not enforce.
- **`matchesEntityOrTestSuiteDomain`'s test-suite fallback** is uncovered; reaching it requires a suite carrying a domain the table lacks.
- **`AlertsRuleEvaluator` class size** (763 → 801 lines) remains over the 500-line guideline. Pre-existing; splitting it is a refactor with its own regression surface and no relation to this crash. Local compliance did improve — every method introduced here is single-return, ≤15 lines and ≤3 levels of nesting, and three previously multi-return rule functions were restructured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
