### PR TITLE
Fixes 27060: delete test case results once on hard delete, and drop the redundant executor

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -43,8 +43,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -134,9 +132,6 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
       "internal.testCase.testSuitesRevision";
   public static final String TEST_SUITES_REVISION_FIELD = "testSuitesRevision";
   private static final String TEST_SUITES_REVISION_SCHEMA = "testSuitesRevision";
-  private final ExecutorService asyncExecutor =
-      Executors.newFixedThreadPool(
-          1, java.lang.Thread.ofPlatform().name("om-test-case-async").factory());
 
   public TestCaseRepository() {
     super(
@@ -1138,15 +1133,15 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   private void deleteAllTestCaseResults(String fqn) {
     TestCaseResultRepository testCaseResultRepository =
         (TestCaseResultRepository) Entity.getEntityTimeSeriesRepository(TEST_CASE_RESULT);
-    testCaseResultRepository.deleteAllTestCaseResults(fqn);
-    asyncExecutor.submit(
-        () -> {
-          try {
-            testCaseResultRepository.deleteAllTestCaseResults(fqn);
-          } catch (Exception e) {
-            LOG.error("Error deleting test case results for test case {}", fqn, e);
-          }
-        });
+    AsyncService.getInstance()
+        .execute(
+            () -> {
+              try {
+                testCaseResultRepository.deleteAllTestCaseResults(fqn);
+              } catch (RuntimeException e) {
+                LOG.error("Error deleting test case results for test case {}", fqn, e);
+              }
+            });
   }
 
   @SneakyThrows

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -1,27 +1,42 @@
 package org.openmetadata.service.jdbi3;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.openmetadata.schema.tests.TestCase;
 import org.openmetadata.schema.tests.TestSuite;
+import org.openmetadata.schema.tests.type.TestCaseDimensionResult;
+import org.openmetadata.schema.tests.type.TestCaseResult;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.rdf.RdfUpdater;
+import org.openmetadata.service.search.SearchRepository;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.EntityUtil.RelationIncludes;
 
 class TestCaseRepositoryTest {
+
+  private static final String TEST_CASE_FQN = "service.database.schema.table.row_count";
+  private static final String ASYNC_DELETE_THREAD_NAME = "om-test-case-async";
 
   @Test
   void readsPersistedTestSuiteRelationshipRevisions() {
@@ -91,11 +106,98 @@ class TestCaseRepositoryTest {
     }
   }
 
+  @Test
+  void hardDeleteCleanupDeletesTestCaseResultsExactlyOnce() {
+    DeleteBoundaries boundaries = new DeleteBoundaries(TEST_CASE_FQN);
+
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+      TestCaseRepository repository = boundaries.registerRepositories(entity);
+
+      String callingThread = Thread.currentThread().getName();
+      repository.entitySpecificCleanup(
+          testCase(UUID.randomUUID(), "delete me", entityReference(Entity.TEST_SUITE, "suite")));
+
+      await().atMost(Duration.ofSeconds(5)).until(() -> boundaries.timeSeriesDeletes.get() > 0);
+      // A redundant second delete would push these past one, so the counts must *hold* at one for a
+      // window rather than merely reach it.
+      await()
+          .during(Duration.ofSeconds(1))
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () -> {
+                assertEquals(
+                    1, boundaries.timeSeriesDeletes.get(), "test case result rows deleted");
+                assertEquals(1, boundaries.dimensionDeletes.get(), "dimension result rows deleted");
+                assertEquals(1, boundaries.searchDeletes.get(), "search index deletes issued");
+              });
+      assertTrue(
+          boundaries.deleteThreadNames.stream().noneMatch(callingThread::equals),
+          "delete must be dispatched asynchronously, never run on the calling thread");
+      assertTrue(
+          Thread.getAllStackTraces().keySet().stream()
+              .noneMatch(thread -> ASYNC_DELETE_THREAD_NAME.equals(thread.getName())),
+          "async delete must use the shared AsyncService, not a private thread pool");
+    }
+  }
+
+  /**
+   * Mocks of the two boundaries a test case result delete reaches — the JDBI DAOs (the database) and
+   * {@link SearchRepository} (the search cluster) — each counting how many times it is called.
+   */
+  private static class DeleteBoundaries {
+    private final AtomicInteger timeSeriesDeletes = new AtomicInteger();
+    private final AtomicInteger dimensionDeletes = new AtomicInteger();
+    private final AtomicInteger searchDeletes = new AtomicInteger();
+    private final Set<String> deleteThreadNames = ConcurrentHashMap.newKeySet();
+    private final CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    private final SearchRepository searchRepository = mock(SearchRepository.class);
+
+    private DeleteBoundaries(String testCaseFqn) {
+      CollectionDAO.DataQualityDataTimeSeriesDAO dataQualityDao =
+          mock(CollectionDAO.DataQualityDataTimeSeriesDAO.class);
+      CollectionDAO.TestCaseDimensionResultTimeSeriesDAO dimensionDao =
+          mock(CollectionDAO.TestCaseDimensionResultTimeSeriesDAO.class);
+      when(collectionDAO.testCaseDAO()).thenReturn(mock(CollectionDAO.TestCaseDAO.class));
+      when(collectionDAO.testCaseResultTimeSeriesDao())
+          .thenReturn(mock(CollectionDAO.TestCaseResultTimeSeriesDAO.class));
+      when(collectionDAO.dataQualityDataTimeSeriesDao()).thenReturn(dataQualityDao);
+      when(collectionDAO.testCaseDimensionResultTimeSeriesDao()).thenReturn(dimensionDao);
+      doAnswer(
+              invocation -> {
+                deleteThreadNames.add(Thread.currentThread().getName());
+                return timeSeriesDeletes.incrementAndGet();
+              })
+          .when(dataQualityDao)
+          .deleteAll(testCaseFqn);
+      doAnswer(invocation -> dimensionDeletes.incrementAndGet())
+          .when(dimensionDao)
+          .deleteAll(testCaseFqn);
+      doAnswer(invocation -> searchDeletes.incrementAndGet())
+          .when(searchRepository)
+          .deleteByScript(eq(Entity.TEST_CASE_RESULT), anyString(), anyMap());
+    }
+
+    private TestCaseRepository registerRepositories(MockedStatic<Entity> entity) {
+      entity.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+      entity.when(Entity::getSearchRepository).thenReturn(searchRepository);
+      entity.when(() -> Entity.getEntityFields(TestCase.class)).thenCallRealMethod();
+      entity.when(() -> Entity.getEntityFields(TestCaseResult.class)).thenCallRealMethod();
+      entity.when(() -> Entity.getEntityFields(TestCaseDimensionResult.class)).thenCallRealMethod();
+      // Built before stubbing starts: its constructor itself drives Mockito, which would otherwise
+      // interleave with the in-progress when(...) call.
+      TestCaseResultRepository testCaseResultRepository = new TestCaseResultRepository();
+      entity
+          .when(() -> Entity.getEntityTimeSeriesRepository(Entity.TEST_CASE_RESULT))
+          .thenReturn(testCaseResultRepository);
+      return new TestCaseRepository();
+    }
+  }
+
   private static TestCase testCase(UUID id, String description, EntityReference basicSuiteRef) {
     return new TestCase()
         .withId(id)
         .withName("row_count")
-        .withFullyQualifiedName("service.database.schema.table.row_count")
+        .withFullyQualifiedName(TEST_CASE_FQN)
         .withDescription(description)
         .withEntityLink("<#E::table::service.database.schema.table>")
         .withTestSuite(basicSuiteRef);


### PR DESCRIPTION
### Describe your changes:

Fixes #27060

> **Reviewer note — the issue is half stale.** The O(N²) nested loop quoted in #27060 **no longer exists**; it was fixed by `44fd6c3226` (#30156), which collapsed it into a single O(N) loop and hoisted the repository lookup out. The dead `hardDelete ? "hard" : "soft"` ternary is gone too. If you go looking for a nested loop you will correctly find only one loop. **This PR addresses the issue's *second* reported defect**, which is still present verbatim.

I worked on `TestCaseRepository.deleteAllTestCaseResults` because it performed the same delete twice on every test-case hard delete:

```java
testCaseResultRepository.deleteAllTestCaseResults(fqn);      // sync
asyncExecutor.submit(() -> {                                 // duplicate
  try { testCaseResultRepository.deleteAllTestCaseResults(fqn); }
  catch (Exception e) { LOG.error(...); }
});
```

**Origin.** `d8e6219200` (#19390, "MINOR - Async test case result deletion") is `+11/−1`: it *added* the `asyncExecutor.submit(...)` but never removed the synchronous call it was meant to replace, despite a commit message stating a move was intended.

**Cost per hard delete:** a redundant `DELETE ... WHERE entityFQNHash=:fqn`, a redundant `dimensionResultRepository.deleteAllByTestCase(fqn)`, and a redundant Elasticsearch delete-by-query. Idempotent, so this was waste rather than incorrectness.

**This PR completes the move #19390 started** — the duplicate is removed and the **asynchronous** path is the one retained, so result deletion is consistent with how the rest of this repository handles time-series cleanup. `deleteChildren`, twenty lines above, already dispatches via `AsyncService`:

```java
private void deleteAllTestCaseResults(String fqn) {
  TestCaseResultRepository testCaseResultRepository =
      (TestCaseResultRepository) Entity.getEntityTimeSeriesRepository(TEST_CASE_RESULT);
  AsyncService.getInstance()
      .execute(
          () -> {
            try {
              testCaseResultRepository.deleteAllTestCaseResults(fqn);
            } catch (RuntimeException e) {
              LOG.error("Error deleting test case results for test case {}", fqn, e);
            }
          });
}
```

The dispatch now goes through the shared virtual-thread `AsyncService` singleton rather than a private per-instance pool, matching `deleteChildren` on all four points: repository resolved outside the lambda, `AsyncService.getInstance().execute(Runnable)`, try/catch inside the lambda, and a contextual `LOG.error`. It catches `RuntimeException` rather than `Exception` because `.claude/rules/java.md` forbids the bare catch — and that is the complete set here: the two JDBI DAO calls throw unchecked `JdbiException`, and `SearchRepository.deleteByScript` (`:3159-3169`) swallows and logs its own exceptions internally.

**Accepted trade — stated explicitly.** `EntityRepository.cleanup()` (`:4909-4915`) wraps `entitySpecificCleanup` in `Entity.getJdbi().inTransaction(...)`. The retained async delete therefore runs **outside** that transaction on a separate pooled connection, with failures logged rather than propagated. Result deletion is **eventually consistent**: the API response can return before the rows and ES documents are gone, a rollback of the outer transaction can orphan the deletion, and there is no ordering guarantee against concurrent writes. This is the deliberate trade for consistency with the rest of the class, not an oversight.

Note the transactional difference only ever applied to the single-entity route: the second entry point, `bulkEntitySpecificCleanup(List<T>)` (`:7022`) called from `bulkHardDeleteSubtreeChunk` (`:6843`), was never transactional (its own javadoc notes a `@Transaction` annotation "would be inert" there).

**The private `asyncExecutor` field is removed**, not just its duplicate call. It was a private, per-instance, never-shut-down *platform* fixed pool — exactly the anti-pattern `AsyncService` exists to replace. Because `newFixedThreadPool` starts workers lazily on first submit, it leaked a platform thread per repository instance that *actually performed a hard delete*, not per instantiation. The two orphaned imports (`ExecutorService`, `Executors`) go with it, and the removed block contained a `catch (Exception e)`, so the deletion is a net rules-compliance gain.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (13 lines removed from production, 2 files).

#
### Tests:

#### Use cases covered
- Hard-deleting a test case deletes its results exactly once — one SQL delete and one Elasticsearch delete-by-query, not two of each.
- The delete is dispatched asynchronously and never runs on the calling thread.
- Hard-delete cleanup starts no private thread pool (it uses the shared `AsyncService`).

#### Unit tests
- [x] I added a unit test for the changed logic.
- File updated: `openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java` — `hardDeleteCleanupDeletesTestCaseResultsExactlyOnce`
- `mvn test -pl openmetadata-service -Dtest='TestCaseRepositoryTest'` → **3 run, 0 failures**
- `mvn test -pl openmetadata-service -Dtest='org.openmetadata.service.jdbi3.*Test'` → **505 run, 0 failures**

**Verified RED before GREEN, per assertion.** Because the count assertion short-circuits, each was isolated by neutralising the ones ahead of it:

| # | Assertion | Observed failure pre-fix |
|---|---|---|
| 1 | counts hold at 1 | `expected: <1> but was: <2>` |
| 2 | never on calling thread | `delete must be dispatched asynchronously, never run on the calling thread ==> expected: <true> but was: <false>` |
| 3 | no private pool | `async delete must use the shared AsyncService, not a private thread pool ==> expected: <true> but was: <false>` |

**On asserting invocation counts.** For a redundancy defect, *how many times an external side effect fires* is the behaviour under test. Row-count and index-state assertions provably cannot distinguish "deleted once" from "deleted twice", because the delete is idempotent and the final state is identical either way. So the test counts calls at the two real boundaries — the JDBI DAO interfaces (database) and `SearchRepository` (search cluster). Neither class under test is mocked: `TestCaseRepository` and `TestCaseResultRepository` are both real instances, and there are no `verify()` calls on our own internals. `MockedStatic<Entity>` is a service-locator seam, mirroring the harness the two pre-existing tests in this file already use.

Because the delete is asynchronous, the test uses Awaitility `until(count > 0)` to prove it happened, then `during(1s).untilAsserted(count == 1)` to prove it happened once — never `Thread.sleep`. The anti-regression matrix holds in all four directions: a duplicate reintroduced on the SQL path or the search path pushes a counter to 2; deleting the cleanup entirely makes `until` time out at 0; moving the delete back onto the calling thread fails assertion 2.

#### Backend integration tests
- [x] Not applicable — no API surface changed. Existing `TestCaseDeleteResilienceIT` and `TestCaseRelationshipRetentionCleanupIT` already cover hard-delete cascade correctness and are unaffected.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

1. `grep -n "asyncExecutor" .../TestCaseRepository.java` → **no output** (field and its only usage gone).
2. `grep -n "ExecutorService\|Executors" .../TestCaseRepository.java` → **no output** (both imports orphaned by the removal, deleted).
3. Diff `deleteAllTestCaseResults` against `deleteChildren` (~:1106-1126) → same four-point idiom: repository hoisted out of the lambda, `AsyncService.getInstance().execute(...)`, try/catch inside, contextual `LOG.error`.
4. `mvn test -pl openmetadata-service -Dtest='TestCaseRepositoryTest'` → `Tests run: 3, Failures: 0, Errors: 0`.
5. Optional end-to-end (**NOT VERIFIED** — no Docker stack was run): with SQL logging on, `DELETE /api/v1/dataQuality/testCases/{id}?hardDelete=true&recursive=true` → exactly one `DELETE FROM data_quality_data_time_series …` and one ES delete-by-query against the `test_case_result` index; and no thread named `om-test-case-async` in a `jstack` of the server.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema change, so no migration needed.
- [x] For UI changes: N/A — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

#
### Known limitations / residual risk

- **Eventual consistency (accepted).** As above: the response can return before the rows and ES documents are gone; a rollback of the outer transaction can orphan the deletion; there is no ordering guarantee against concurrent writes.
- **Failures surface only in logs (accepted).** No retry, no metric, no dead-letter queue. Operators should alert on `Error deleting test case results for test case`.
- Neither the rollback window nor the `catch` branch is exercised by a test.

#
### Deliberately out of scope

- **Batch-deleting in `deleteChildren`.** Replacing the remaining O(N) `deleteById` loop with `TestCaseResolutionStatusTimeSeriesDAO.delete(fqn)` would be faster, but `EntityTimeSeriesRepository.deleteById` also performs `relationshipDAO().deleteAll(id, entityType)` cleanup and the `postDelete` hook — and that relationship cleanup was the entire point of `44fd6c3226`. Doing it correctly needs a batched relationship cleanup too. Worth a separate issue; the current loop is correct, only sub-optimal.
- **`TestCaseResultRepository.deleteAllTestCaseResults` (`:338-350`) carries code-restating comments** (`// Delete all the test case results`) that violate the comments rule. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
