### PR TITLE
Fixes #31070: let any authenticated user read glossary term relation types

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
@@ -119,10 +119,13 @@ public class GlossaryTermRelationSettingsPermissionsIT {
     assertEquals(401, response.statusCode(), "Unauthenticated reads must still be rejected");
   }
 
+  // The write-attempt tests below take the lock in READ_WRITE mode even though they expect a 403:
+  // if the admin gate ever regresses the request lands, and an exclusive lock keeps that mutation
+  // from corrupting shared settings under tests that hold the READ lock.
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
-      mode = ResourceAccessMode.READ)
+      mode = ResourceAccessMode.READ_WRITE)
   void test_createRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
         send("POST", RELATION_TYPES_PATH, RELATION_TYPE_BODY, "application/json");
@@ -134,7 +137,7 @@ public class GlossaryTermRelationSettingsPermissionsIT {
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
-      mode = ResourceAccessMode.READ)
+      mode = ResourceAccessMode.READ_WRITE)
   void test_updateRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
         send("PUT", RELATION_TYPES_PATH + "/relatedTo", RELATION_TYPE_BODY, "application/json");
@@ -146,7 +149,7 @@ public class GlossaryTermRelationSettingsPermissionsIT {
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
-      mode = ResourceAccessMode.READ)
+      mode = ResourceAccessMode.READ_WRITE)
   void test_deleteRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
         send("DELETE", RELATION_TYPES_PATH + "/relatedTo", null, "application/json");
@@ -158,7 +161,7 @@ public class GlossaryTermRelationSettingsPermissionsIT {
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
-      mode = ResourceAccessMode.READ)
+      mode = ResourceAccessMode.READ_WRITE)
   void test_putSettings_dataConsumer_returns403() throws Exception {
     String body =
         """
@@ -174,7 +177,7 @@ public class GlossaryTermRelationSettingsPermissionsIT {
   @Test
   @ResourceLock(
       value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
-      mode = ResourceAccessMode.READ)
+      mode = ResourceAccessMode.READ_WRITE)
   void test_patchSettings_dataConsumer_returns403() throws Exception {
     String patch = "[{\"op\":\"remove\",\"path\":\"/relationTypes/0\"}]";
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
@@ -1,0 +1,221 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.openmetadata.it.auth.JwtAuthProvider;
+import org.openmetadata.it.factories.UserTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.SharedResourceLocks;
+import org.openmetadata.it.util.TestNamespaceExtension;
+
+/**
+ * Verifies the authorization split on glossary term relation settings (issue #31070): every
+ * authenticated user can read the configured relation types — the Related Terms dropdown and the
+ * ontology explorer need them — while creating, updating and deleting them stays admin-only.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class GlossaryTermRelationSettingsPermissionsIT {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final HttpClient HTTP_CLIENT =
+      HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+  private static final String SETTINGS_PATH = "/v1/system/settings/glossaryTermRelationSettings";
+  private static final String RELATION_TYPES_PATH = SETTINGS_PATH + "/relationTypes";
+  private static final String ADMIN_ONLY_SETTINGS_PATH = "/v1/system/settings/searchSettings";
+  private static final String JSON_PATCH_MEDIA_TYPE = "application/json-patch+json";
+
+  private static final String RELATION_TYPE_BODY =
+      """
+      {"name":"itRelationTypeForbidden","displayName":"IT Relation Type",\
+      "description":"created by a non-admin, must never be persisted"}\
+      """;
+
+  // The dataConsumer JWT is resolved through SubjectCache during authorization; if the user has not
+  // been materialized in this JVM session the lookup throws EntityNotFound (404) and short-circuits
+  // the authorizer before it can return the expected 403.
+  @BeforeAll
+  static void ensureDataConsumerUser() {
+    UserTestFactory.getDataConsumer(null);
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_getSettings_dataConsumer_returns200() throws Exception {
+    HttpResponse<String> response = get(SETTINGS_PATH, dataConsumerToken());
+
+    assertEquals(
+        200, response.statusCode(), "DataConsumer should be able to read the relation settings");
+    JsonNode relationTypes =
+        MAPPER.readTree(response.body()).path("config_value").path("relationTypes");
+    assertTrue(relationTypes.isArray(), "relationTypes should be an array");
+    assertFalse(relationTypes.isEmpty(), "DataConsumer should see the configured relation types");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_listRelationTypes_dataConsumer_returns200() throws Exception {
+    HttpResponse<String> response = get(RELATION_TYPES_PATH + "?limit=100", dataConsumerToken());
+
+    assertEquals(
+        200, response.statusCode(), "DataConsumer should be able to list the relation types");
+    JsonNode relationTypes = MAPPER.readTree(response.body()).path("data");
+    assertTrue(relationTypes.isArray(), "data should be an array");
+    assertFalse(relationTypes.isEmpty(), "DataConsumer should see the configured relation types");
+  }
+
+  @Test
+  void test_getAdminOnlySetting_dataConsumer_returns403() throws Exception {
+    HttpResponse<String> response = get(ADMIN_ONLY_SETTINGS_PATH, dataConsumerToken());
+
+    assertEquals(
+        403, response.statusCode(), "Only glossary/lineage settings are readable by non-admins");
+  }
+
+  @Test
+  void test_getSettings_noAuth_returns401() throws Exception {
+    HttpResponse<String> response = get(SETTINGS_PATH, null);
+
+    assertEquals(401, response.statusCode(), "Unauthenticated reads must still be rejected");
+  }
+
+  @Test
+  void test_listRelationTypes_noAuth_returns401() throws Exception {
+    HttpResponse<String> response = get(RELATION_TYPES_PATH, null);
+
+    assertEquals(401, response.statusCode(), "Unauthenticated reads must still be rejected");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_createRelationType_dataConsumer_returns403() throws Exception {
+    HttpResponse<String> response =
+        send("POST", RELATION_TYPES_PATH, RELATION_TYPE_BODY, "application/json");
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer should not be able to add relation types");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_updateRelationType_dataConsumer_returns403() throws Exception {
+    HttpResponse<String> response =
+        send("PUT", RELATION_TYPES_PATH + "/relatedTo", RELATION_TYPE_BODY, "application/json");
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer should not be able to edit relation types");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_deleteRelationType_dataConsumer_returns403() throws Exception {
+    HttpResponse<String> response =
+        send("DELETE", RELATION_TYPES_PATH + "/relatedTo", null, "application/json");
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer should not be able to delete relation types");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_putSettings_dataConsumer_returns403() throws Exception {
+    String body =
+        """
+        {"config_type":"glossaryTermRelationSettings","config_value":{"relationTypes":[]}}\
+        """;
+
+    HttpResponse<String> response = send("PUT", "/v1/system/settings", body, "application/json");
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer should not be able to overwrite the settings");
+  }
+
+  @Test
+  @ResourceLock(
+      value = SharedResourceLocks.GLOSSARY_TERM_RELATION_SETTINGS,
+      mode = ResourceAccessMode.READ)
+  void test_patchSettings_dataConsumer_returns403() throws Exception {
+    String patch = "[{\"op\":\"remove\",\"path\":\"/relationTypes/0\"}]";
+
+    HttpResponse<String> response = send("PATCH", SETTINGS_PATH, patch, JSON_PATCH_MEDIA_TYPE);
+
+    assertEquals(
+        403, response.statusCode(), "DataConsumer should not be able to patch the settings");
+  }
+
+  private static String dataConsumerToken() {
+    return JwtAuthProvider.tokenFor(
+        "data-consumer@open-metadata.org",
+        "data-consumer@open-metadata.org",
+        new String[] {"DataConsumer"},
+        3600);
+  }
+
+  private static HttpResponse<String> get(String path, String token) throws Exception {
+    HttpRequest.Builder builder =
+        HttpRequest.newBuilder().uri(URI.create(SdkClients.getServerUrl() + path)).GET();
+    if (token != null) {
+      builder.header("Authorization", "Bearer " + token);
+    }
+
+    return HTTP_CLIENT.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> send(
+      String method, String path, String body, String contentType) throws Exception {
+    HttpRequest.BodyPublisher publisher =
+        body == null
+            ? HttpRequest.BodyPublishers.noBody()
+            : HttpRequest.BodyPublishers.ofString(body);
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(SdkClients.getServerUrl() + path))
+            .header("Authorization", "Bearer " + dataConsumerToken())
+            .header("Content-Type", contentType)
+            .method(method, publisher)
+            .build();
+
+    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+  }
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java
@@ -53,11 +53,24 @@ public class GlossaryTermRelationSettingsPermissionsIT {
   private static final String RELATION_TYPES_PATH = SETTINGS_PATH + "/relationTypes";
   private static final String ADMIN_ONLY_SETTINGS_PATH = "/v1/system/settings/searchSettings";
   private static final String JSON_PATCH_MEDIA_TYPE = "application/json-patch+json";
+  private static final String SYSTEM_RELATION_TYPE = "relatedTo";
 
-  private static final String RELATION_TYPE_BODY =
+  // Jersey runs @Valid bean validation before the resource method body, so a payload missing any
+  // @NotNull field of GlossaryTermRelationType (name, displayName, category) is rejected with 400
+  // and never reaches authorizeAdmin. These bodies must stay schema-valid or the write tests below
+  // silently stop proving anything about authorization.
+  private static final String NEW_RELATION_TYPE_BODY =
       """
       {"name":"itRelationTypeForbidden","displayName":"IT Relation Type",\
-      "description":"created by a non-admin, must never be persisted"}\
+      "description":"created by a non-admin, must never be persisted",\
+      "category":"associative"}\
+      """;
+
+  private static final String EXISTING_RELATION_TYPE_BODY =
+      """
+      {"name":"relatedTo","displayName":"Renamed By A Non-Admin",\
+      "description":"edited by a non-admin, must never be persisted",\
+      "category":"associative"}\
       """;
 
   // The dataConsumer JWT is resolved through SubjectCache during authorization; if the user has not
@@ -128,10 +141,12 @@ public class GlossaryTermRelationSettingsPermissionsIT {
       mode = ResourceAccessMode.READ_WRITE)
   void test_createRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
-        send("POST", RELATION_TYPES_PATH, RELATION_TYPE_BODY, "application/json");
+        send("POST", RELATION_TYPES_PATH, NEW_RELATION_TYPE_BODY, "application/json");
 
     assertEquals(
-        403, response.statusCode(), "DataConsumer should not be able to add relation types");
+        403,
+        response.statusCode(),
+        "DataConsumer should not be able to add relation types: " + response.body());
   }
 
   @Test
@@ -140,10 +155,16 @@ public class GlossaryTermRelationSettingsPermissionsIT {
       mode = ResourceAccessMode.READ_WRITE)
   void test_updateRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
-        send("PUT", RELATION_TYPES_PATH + "/relatedTo", RELATION_TYPE_BODY, "application/json");
+        send(
+            "PUT",
+            RELATION_TYPES_PATH + "/" + SYSTEM_RELATION_TYPE,
+            EXISTING_RELATION_TYPE_BODY,
+            "application/json");
 
     assertEquals(
-        403, response.statusCode(), "DataConsumer should not be able to edit relation types");
+        403,
+        response.statusCode(),
+        "DataConsumer should not be able to edit relation types: " + response.body());
   }
 
   @Test
@@ -152,10 +173,12 @@ public class GlossaryTermRelationSettingsPermissionsIT {
       mode = ResourceAccessMode.READ_WRITE)
   void test_deleteRelationType_dataConsumer_returns403() throws Exception {
     HttpResponse<String> response =
-        send("DELETE", RELATION_TYPES_PATH + "/relatedTo", null, "application/json");
+        send("DELETE", RELATION_TYPES_PATH + "/" + SYSTEM_RELATION_TYPE, null, "application/json");
 
     assertEquals(
-        403, response.statusCode(), "DataConsumer should not be able to delete relation types");
+        403,
+        response.statusCode(),
+        "DataConsumer should not be able to delete relation types: " + response.body());
   }
 
   @Test
@@ -171,7 +194,9 @@ public class GlossaryTermRelationSettingsPermissionsIT {
     HttpResponse<String> response = send("PUT", "/v1/system/settings", body, "application/json");
 
     assertEquals(
-        403, response.statusCode(), "DataConsumer should not be able to overwrite the settings");
+        403,
+        response.statusCode(),
+        "DataConsumer should not be able to overwrite the settings: " + response.body());
   }
 
   @Test
@@ -184,7 +209,9 @@ public class GlossaryTermRelationSettingsPermissionsIT {
     HttpResponse<String> response = send("PATCH", SETTINGS_PATH, patch, JSON_PATCH_MEDIA_TYPE);
 
     assertEquals(
-        403, response.statusCode(), "DataConsumer should not be able to patch the settings");
+        403,
+        response.statusCode(),
+        "DataConsumer should not be able to patch the settings: " + response.body());
   }
 
   private static String dataConsumerToken() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -46,7 +46,9 @@ import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -121,6 +123,14 @@ import org.openmetadata.service.util.email.EmailUtil;
 public class SystemResource {
   public static final String COLLECTION_PATH = "/v1/system";
   private static final long SEARCH_FITNESS_TIMEOUT_SECONDS = 30;
+
+  // Settings that hold no secrets and that the UI must read to render entity pages for every
+  // authenticated user — glossary term relation types populate the Related Terms dropdown and the
+  // ontology explorer legend. Creating, updating and deleting them stays admin-only.
+  private static final Set<String> USER_READABLE_SETTINGS =
+      Set.of(
+          LINEAGE_SETTINGS.value().toLowerCase(Locale.ROOT),
+          GLOSSARY_TERM_RELATION_SETTINGS.value().toLowerCase(Locale.ROOT));
   private static final ExecutorService SEARCH_FITNESS_EXECUTOR =
       Executors.newFixedThreadPool(
           2,
@@ -264,7 +274,7 @@ public class SystemResource {
           "Access to authentication and authorizer configurations is not allowed through this endpoint");
     }
 
-    if (!name.equalsIgnoreCase(LINEAGE_SETTINGS.toString())) {
+    if (!isUserReadableSetting(name)) {
       authorizer.authorizeAdmin(securityContext);
     }
     return systemRepository.getConfigWithKey(name);
@@ -275,7 +285,9 @@ public class SystemResource {
   @Operation(
       operationId = "listGlossaryTermRelationTypes",
       summary = "List glossary term relation types",
-      description = "Get a paginated list of configured glossary term relation types.")
+      description =
+          "Get a paginated list of configured glossary term relation types. Readable by any "
+              + "authenticated user; only admins can create, update or delete relation types.")
   public ResultList<GlossaryTermRelationType> listGlossaryTermRelationTypes(
       @Context SecurityContext securityContext,
       @Parameter(description = "Limit records. (1 to 100, default = 15)")
@@ -290,7 +302,6 @@ public class SystemResource {
           @Min(0)
           @Max(1000000)
           int offset) {
-    authorizer.authorizeAdmin(securityContext);
     List<GlossaryTermRelationType> relationTypes =
         SettingsCache.getSetting(
                 GLOSSARY_TERM_RELATION_SETTINGS, GlossaryTermRelationSettings.class)
@@ -1437,6 +1448,10 @@ public class SystemResource {
       message.setLength(message.length() - 2);
       throw new SystemSettingsException(message.toString());
     }
+  }
+
+  private boolean isUserReadableSetting(String name) {
+    return USER_READABLE_SETTINGS.contains(name.toLowerCase(Locale.ROOT));
   }
 
   private GlossaryTermRelationSettings getGlossaryTermRelationSettings() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceSettingsAuthorizationTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceSettingsAuthorizationTest.java
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.resources.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import jakarta.ws.rs.core.SecurityContext;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.configuration.GlossaryTermRelationSettings;
+import org.openmetadata.schema.configuration.GlossaryTermRelationType;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.schema.settings.SettingsType;
+import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.SystemRepository;
+import org.openmetadata.service.resources.settings.SettingsCache;
+import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.Authorizer;
+
+/**
+ * Glossary term relation types are vocabulary every user needs to read to render the Related Terms
+ * tab, so reads are open to any authenticated principal while writes stay admin-only (issue
+ * #31070). The authorizer here rejects every admin check, standing in for a non-admin caller.
+ */
+class SystemResourceSettingsAuthorizationTest {
+  private static final String GLOSSARY_RELATION_SETTINGS =
+      SettingsType.GLOSSARY_TERM_RELATION_SETTINGS.value();
+  private static final String RELATION_TYPE_NAME = "relatedTo";
+
+  private MockedStatic<Entity> entityMock;
+  private MockedStatic<SettingsCache> settingsCacheMock;
+  private SystemRepository systemRepository;
+  private SecurityContext securityContext;
+  private SystemResource systemResource;
+
+  @BeforeEach
+  void setup() {
+    entityMock = mockStatic(Entity.class);
+    settingsCacheMock = mockStatic(SettingsCache.class);
+    systemRepository = mock(SystemRepository.class);
+    entityMock.when(Entity::getSystemRepository).thenReturn(systemRepository);
+    settingsCacheMock
+        .when(
+            () ->
+                SettingsCache.getSetting(
+                    SettingsType.GLOSSARY_TERM_RELATION_SETTINGS,
+                    GlossaryTermRelationSettings.class))
+        .thenReturn(relationSettings());
+
+    Authorizer nonAdminAuthorizer = mock(Authorizer.class);
+    doThrow(new AuthorizationException("Principal: is not admin"))
+        .when(nonAdminAuthorizer)
+        .authorizeAdmin(any(SecurityContext.class));
+    securityContext = mock(SecurityContext.class);
+    systemResource = new SystemResource(nonAdminAuthorizer);
+  }
+
+  @AfterEach
+  void tearDown() {
+    settingsCacheMock.close();
+    entityMock.close();
+  }
+
+  @Test
+  void nonAdminReadsGlossaryTermRelationSettings() {
+    Settings stored = storedRelationSettings();
+    when(systemRepository.getConfigWithKey(GLOSSARY_RELATION_SETTINGS)).thenReturn(stored);
+
+    Settings settings =
+        systemResource.getSettingByName(null, securityContext, GLOSSARY_RELATION_SETTINGS);
+
+    assertSame(stored, settings);
+  }
+
+  @Test
+  void nonAdminListsGlossaryTermRelationTypes() {
+    ResultList<GlossaryTermRelationType> relationTypes =
+        systemResource.listGlossaryTermRelationTypes(securityContext, 15, 0);
+
+    assertEquals(2, relationTypes.getData().size());
+    assertEquals(RELATION_TYPE_NAME, relationTypes.getData().get(0).getName());
+  }
+
+  @Test
+  void nonAdminCannotReadOtherSettings() {
+    assertThrows(
+        AuthorizationException.class,
+        () ->
+            systemResource.getSettingByName(
+                null, securityContext, SettingsType.SEARCH_SETTINGS.value()));
+  }
+
+  @Test
+  void nonAdminCannotCreateRelationType() {
+    GlossaryTermRelationType relationType =
+        new GlossaryTermRelationType().withName("prescribes").withDisplayName("Prescribes");
+
+    assertThrows(
+        AuthorizationException.class,
+        () -> systemResource.createGlossaryTermRelationType(securityContext, relationType));
+  }
+
+  @Test
+  void nonAdminCannotUpdateRelationType() {
+    GlossaryTermRelationType relationType =
+        new GlossaryTermRelationType().withName(RELATION_TYPE_NAME).withDisplayName("Renamed");
+
+    assertThrows(
+        AuthorizationException.class,
+        () ->
+            systemResource.updateGlossaryTermRelationType(
+                securityContext, RELATION_TYPE_NAME, relationType));
+  }
+
+  @Test
+  void nonAdminCannotDeleteRelationType() {
+    assertThrows(
+        AuthorizationException.class,
+        () -> systemResource.deleteGlossaryTermRelationType(securityContext, RELATION_TYPE_NAME));
+  }
+
+  private GlossaryTermRelationSettings relationSettings() {
+    return new GlossaryTermRelationSettings()
+        .withRelationTypes(
+            List.of(
+                new GlossaryTermRelationType()
+                    .withName(RELATION_TYPE_NAME)
+                    .withDisplayName("Related To"),
+                new GlossaryTermRelationType()
+                    .withName("synonymOf")
+                    .withDisplayName("Synonym Of")));
+  }
+
+  private Settings storedRelationSettings() {
+    return new Settings()
+        .withConfigType(SettingsType.GLOSSARY_TERM_RELATION_SETTINGS)
+        .withConfigValue(relationSettings());
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #31070

The Related Terms dropdown and the ontology explorer both fetch `glossaryTermRelationSettings`, but the read was gated behind `authorizer.authorizeAdmin`. Non-admins got a `403 ... is not admin`, the UI silently fell back to `DEFAULT_GLOSSARY_TERM_RELATION_TYPES_FALLBACK` (a single entry), and the relation-type dropdown offered only "Related To". I made reads open to any authenticated principal while every write stays admin-only.

Relation types are a global vocabulary — there is no owner or resource to evaluate a policy against, and the payload carries no secrets (`prepareFetchedSettings` only masks email/auth configs) — so reads now get the same treatment `lineageSettings` already had, via a `USER_READABLE_SETTINGS` allowlist that replaces the ad-hoc single-name check. Creating, updating and deleting relation types (and every other setting) is unchanged and still requires admin.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (3 files, one authorization rule).

#
### Tests:

#### Use cases covered
- A non-admin user opening a glossary term's **Related Terms** tab sees every configured relation type, not just "Related To"
- A non-admin user can `GET /system/settings/glossaryTermRelationSettings` and `GET /system/settings/glossaryTermRelationSettings/relationTypes`
- A non-admin user is still denied `POST`/`PUT`/`DELETE .../relationTypes`, `PUT /system/settings`, and `PATCH /system/settings/{name}`
- A non-admin user is still denied every other setting (`searchSettings` asserted explicitly, so the allowlist can't silently widen)
- Unauthenticated requests still get 401

#### Unit tests
- [x] Added `openmetadata-service/src/test/java/org/openmetadata/service/resources/system/SystemResourceSettingsAuthorizationTest.java` (6 tests) — the authorizer rejects every admin check, standing in for a non-admin caller.
- **Fails without the fix**: `Tests run: 6, Errors: 2` — both reads throw `AuthorizationException: Principal: is not admin`, reproducing the reported 403. **Passes with it**: `Tests run: 6, Failures: 0, Errors: 0`.
- Coverage (jacoco, this test alone) on the changed lines: `isUserReadableSetting` 1/1, `listGlossaryTermRelationTypes` 10/11 (uncovered line is the pre-existing `relationTypes == null` fallback), `getSettingByName` 4/6 (uncovered lines are the pre-existing auth-config rejection branch). Whole-class coverage is not meaningful here — `SystemResource` is ~1450 lines covered mostly by the IT suite, which doesn't run in this surefire session.

#### Backend integration tests
- [x] Added `openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryTermRelationSettingsPermissionsIT.java` (10 tests) — same read/write split over real HTTP with a DataConsumer JWT, plus the `searchSettings` 403 and unauthenticated 401 guards. Compiles clean; it needs the Testcontainers stack, which I did not spin up locally, so it has not been executed outside CI.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — no UI files changed. The dropdown populates once the existing fetch stops returning 403.

#### Manual testing performed
No live stack run — verification was the automated RED/GREEN above. To reproduce by hand:
1. Create a non-admin user (any role, e.g. DataConsumer) and get its JWT.
2. `curl -H "Authorization: Bearer $TOKEN" $HOST/api/v1/system/settings/glossaryTermRelationSettings` → 200 with the full `relationTypes` array (was 403).
3. `curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{"name":"test"}' $HOST/api/v1/system/settings/glossaryTermRelationSettings/relationTypes` → still 403.
4. As that user, open a glossary term → Related Terms → Add: the relation-type dropdown lists every configured type.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema changes.
- [x] For UI changes: not applicable — no UI changes.
- [x] I have added tests (unit / integration) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing (issue #31070 is referenced in both new test classes).

> Note for reviewers: `1.13` carries the same gate (`SystemResource.java:259-260, 285`) and needs the same backport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)