### PR TITLE
fix(search): exclude deleted entities from the search config preview (#30778) [1.13 backport]

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/search/SearchResource.java
@@ -416,6 +416,7 @@ public class SearchResource {
             .withFrom(previewRequest.getFrom())
             .withQueryFilter(previewRequest.getQueryFilter())
             .withPostFilter(previewRequest.getPostFilter())
+            .withDeleted(previewRequest.getDeleted())
             .withFetchSource(previewRequest.getFetchSource())
             .withTrackTotalHits(previewRequest.getTrackTotalHits())
             .withSortFieldParam(previewRequest.getSortField())

--- a/openmetadata-spec/src/main/resources/json/schema/api/search/previewSearchRequest.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/search/previewSearchRequest.json
@@ -47,6 +47,11 @@
     "postFilter": {
       "type": "string"
     },
+    "deleted": {
+      "type": "boolean",
+      "default": false,
+      "description": "Filter documents by deleted param. Defaults to false so the preview mirrors what Explore shows."
+    },
     "fetchSource": {
       "type": "boolean",
       "default": true

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/search/previewSearchRequest.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/search/previewSearchRequest.ts
@@ -14,6 +14,11 @@
  * Preview Search Results
  */
 export interface PreviewSearchRequest {
+    /**
+     * Filter documents by deleted param. Defaults to false so the preview mirrors what Explore
+     * shows.
+     */
+    deleted?:     boolean;
     explain?:     boolean;
     fetchSource?: boolean;
     /**


### PR DESCRIPTION
## Description

Backport of #30778 to the `1.13` branch.

`POST /v1/search/preview` never populated `SearchRequest.deleted`, and the deleted filter in `doSearch` is gated on that field, so the clause was skipped entirely and soft-deleted assets ranked in **Settings > Search** preview. Explore sends `deleted=false` and drops them, so the preview disagreed with the search it exists to predict.

This adds `deleted` to the `previewSearchRequest` schema with a `false` default and wires it through `SearchResource`. Clients that omit the field now get Explore's behaviour; `deleted=true` stays available for previewing soft-deleted assets. The default lives in the schema so it also reaches the OpenAPI spec and every generated client.

## Backport notes / conflict

The cherry-pick of `049dce9` conflicted only on the test files: the preview-IT harness (`SearchRelevancyPreviewIT`, `SearchSettingsTestHelper`, `RelevancyFixtures`) **does not exist on `1.13`** — it is main-only. Backporting those would require dragging in an entire new IT harness, out of scope for this fix. The two test files from the original PR are therefore omitted here; the **core fix is byte-for-byte identical** to the original PR (schema + `SearchResource` wiring + generated TS type).

## Changes

- `openmetadata-spec/.../previewSearchRequest.json` — add `deleted` (boolean, default `false`)
- `openmetadata-service/.../SearchResource.java` — `.withDeleted(previewRequest.getDeleted())`
- `openmetadata-ui/.../generated/api/search/previewSearchRequest.ts` — regenerated type

## Testing

- Local `mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → BUILD SUCCESS (POJO regenerated with the new `deleted` field; `SearchResource` compiles against `getDeleted()`).

Fixes #30743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
