### PR TITLE
fix(ui): marketplace widget sub-header to 14px / regular / text-secondary

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceDataProductsWidget/MarketplaceDataProductsWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceDataProductsWidget/MarketplaceDataProductsWidget.component.tsx
@@ -225,7 +225,9 @@ const MarketplaceDataProductsWidget = ({
           </Typography>
           <Typography
             as="span"
-            className="tw:text-sm tw:font-medium tw:text-text-primary">
+            className="tw:text-text-secondary"
+            size="text-sm"
+            weight="regular">
             {t('label.recently-created-entity', {
               entity: t('label.data-product-plural'),
             })}

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceDomainsWidget/MarketplaceDomainsWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceDomainsWidget/MarketplaceDomainsWidget.component.tsx
@@ -208,7 +208,9 @@ const MarketplaceDomainsWidget = ({
           </Typography>
           <Typography
             as="span"
-            className="tw:text-sm tw:font-medium tw:text-text-primary">
+            className="tw:text-text-secondary"
+            size="text-sm"
+            weight="regular">
             {t('label.recently-created-entity', {
               entity: t('label.domain-plural'),
             })}


### PR DESCRIPTION
### Describe your changes:

The "Recently Created …" line under **New Data Products** / **New Domains** on the Data Marketplace landing page rendered at 14px / weight **500** / `text-primary` — the same colour and nearly the same weight as the heading directly above it, so it read as a second title rather than supporting copy. It now renders at **14px / weight 400 / text-secondary**, matching the design spec.

- `MarketplaceDataProductsWidget.component.tsx`
- `MarketplaceDomainsWidget.component.tsx`

Size and weight move onto the `Typography` `size`/`weight` props, matching the sibling `h5` heading and `AnnouncementsWidgetV2`; the colour class uses the same `tw:text-text-*` form as the heading right above it. No core-component change.

#
### Type of change:
- [x] Improvement

#
### High-level design:

N/A — three-line style change in two components.

#
### Tests:

#### Use cases covered
- Data Marketplace landing page (`/data-marketplace`): the "Recently Created Data Products" and "Recently Created Domains" sub-headers render as 14px / 400 / `#414651`.
- `tw:text-text-secondary` is theme-aware, so the same line follows `--color-text-secondary` to gray-300 in dark mode (the previous `tw:text-text-primary` also was; this only changes which token it points at).

#### Unit tests
- [x] Not applicable — no logic change. A test asserting the className/props would be brittle and would not catch a real regression; the styling is verified by measured computed style below.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — no behavioural change; nothing new to drive.

#### Manual testing performed
1. Ran the UI dev server from this branch against a local backend, logged in as admin, opened **Data Marketplace**.
2. Measured the live computed style of both sub-headers, on the same running stack, with and without this commit applied:

   | | `font-size` | `font-weight` | `color` |
   |---|---|---|---|
   | Before | 14px | 500 | `rgb(24, 29, 39)` — `#181d27` |
   | After  | 14px | 400 | `rgb(65, 70, 81)` — `#414651` |

3. Confirmed the generated utilities resolve as intended by compiling `src/styles/tailwind.css` with the project's own Tailwind: `tw:text-sm` → `calc(4px * 3.5)` = 14px, `tw:font-normal` → 400, `tw:text-text-secondary` → `--color-text-secondary` → `#414651`.

#
### UI screen recording / screenshots:

| | Before — 14px / 500 / `#181d27` | After — 14px / 400 / `#414651` |
|---|---|---|
| **Data Products** | <img width="422" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31160-before-dp.png"> | <img width="422" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31160-after-dp.png"> |
| **Domains** | <img width="352" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31160-before-domains.png"> | <img width="352" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/31160-after-domains.png"> |

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue; follows the same convention as #30312, which set this sub-header's previous style.
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: I attached before/after screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
