### PR TITLE
fix(ui): match glossary terms table spacing with the classification table

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Glossary/GlossaryTermTab/GlossaryTermTab.component.tsx
@@ -133,7 +133,7 @@ const WorkflowHistory = withSuspenseFallback(
 
 const GLOSSARY_TERM_DRAG_TYPE = 'application/x-om-glossary-term';
 
-const GLOSSARY_TABLE_SCROLL = { y: 'calc(100vh - 350px)' };
+const GLOSSARY_TABLE_SCROLL = { x: 'max-content', y: 'calc(100vh - 350px)' };
 
 const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   const navigate = useNavigate();
@@ -142,7 +142,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const draggedGlossaryTermRef = useRef<GlossaryTerm>();
   const fetchRequestSeqRef = useRef(0);
-  const [containerWidth, setContainerWidth] = useState(0);
   const {
     activeGlossary,
     glossaryChildTerms,
@@ -654,10 +653,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     return null;
   }, [isGlossary, activeGlossary]);
 
-  const tableColumnsWidth = useMemo(
-    () => glossaryTermTableColumnsWidth(containerWidth, permissions.Create),
-    [permissions.Create, containerWidth]
-  );
+  const tableColumnsWidth = useMemo(() => glossaryTermTableColumnsWidth(), []);
 
   const updateGlossaryTermStatus = (
     terms: ModifiedGlossary[],
@@ -1026,6 +1022,7 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
         title: t('label.action-plural'),
         dataIndex: GLOSSARY_TERM_TABLE_COLUMNS_KEYS.ACTIONS,
         key: GLOSSARY_TERM_TABLE_COLUMNS_KEYS.ACTIONS,
+        width: 120,
         render: (_, record) => {
           const isLoadMoreRow = record.isLoadMoreButton;
 
@@ -1709,13 +1706,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
     };
   }, [isDraggingTerm, moveDraggedGlossaryTermToRoot]);
 
-  useEffect(() => {
-    if (!tableContainerRef.current) {
-      return;
-    }
-    setContainerWidth(tableContainerRef.current.offsetWidth);
-  }, []);
-
   // Trigger new fetch when search term or status filter changes
   useEffect(() => {
     if (
@@ -1799,7 +1789,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
             <>
               <TableCard.Root size="sm">
                 <Table
-                  resizableColumns
                   columns={columns}
                   containerClassName="glossary-terms-table drop-over-background"
                   data-testid="glossary-terms-table"
@@ -1828,7 +1817,6 @@ const GlossaryTermTab = ({ isGlossary, className }: GlossaryTermTabProps) => {
             // This keeps the search bar and filters visible
             <TableCard.Root size="sm">
               <Table
-                resizableColumns
                 columns={columns}
                 containerClassName="glossary-terms-table"
                 data-testid="glossary-terms-table"

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryPureUtils.ts
@@ -26,7 +26,6 @@ import type { Task } from '../generated/entity/tasks/task';
 import type { User } from '../generated/entity/teams/user';
 import Fqn from './Fqn';
 import i18n from './i18next/LocalUtil';
-import { calculatePercentageFromValue } from './NumberUtils';
 import { getGlossaryPath } from './RouterUtils';
 
 export const buildTree = (data: GlossaryTerm[]): GlossaryTerm[] => {
@@ -315,20 +314,17 @@ export const findAndUpdateNested = (
   });
 };
 
-export const glossaryTermTableColumnsWidth = (
-  tableWidth: number,
-  havingCreatePermission: boolean
-) => {
+// Fixed pixel column widths (with horizontal scroll) so the glossary terms
+// table has the same consistent cell spacing as the classification table,
+// instead of columns squeezing/stretching with the container width.
+export const glossaryTermTableColumnsWidth = () => {
   return {
-    name: calculatePercentageFromValue(tableWidth, 30),
-    description: calculatePercentageFromValue(
-      tableWidth,
-      havingCreatePermission ? 21 : 33
-    ),
-    reviewers: calculatePercentageFromValue(tableWidth, 33),
-    synonyms: calculatePercentageFromValue(tableWidth, 33),
-    owners: calculatePercentageFromValue(tableWidth, 17),
-    status: calculatePercentageFromValue(tableWidth, 20),
+    name: 250,
+    description: 350,
+    reviewers: 220,
+    synonyms: 220,
+    owners: 280,
+    status: 150,
   };
 };
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/GlossaryUtils.test.ts
@@ -405,29 +405,16 @@ describe('Glossary Utils - findAndUpdateNested', () => {
 });
 
 describe('Glossary Utils - glossaryTermTableColumnsWidth', () => {
-  it('should return columnsWidth object based on Table width', () => {
-    const columnWidthObject = glossaryTermTableColumnsWidth(1000, true);
+  it('should return fixed pixel column widths matching the classification table', () => {
+    const columnWidthObject = glossaryTermTableColumnsWidth();
 
     expect(columnWidthObject).toEqual({
-      description: 210,
-      name: 300,
-      owners: 170,
-      reviewers: 330,
-      status: 200,
-      synonyms: 330,
-    });
-  });
-
-  it('should return columnsWidth object based on Table width when not having create permission', () => {
-    const columnWidthObject = glossaryTermTableColumnsWidth(1000, false);
-
-    expect(columnWidthObject).toEqual({
-      description: 330,
-      name: 300,
-      owners: 170,
-      reviewers: 330,
-      status: 200,
-      synonyms: 330,
+      description: 350,
+      name: 250,
+      owners: 280,
+      reviewers: 220,
+      status: 150,
+      synonyms: 220,
     });
   });
 


### PR DESCRIPTION
## Description

The glossary terms table used **percentage-of-container column widths** together with **resizable columns**. React Aria's resizable table squeezes every column to fit the container, so:

- the **Description** column was too narrow — long descriptions wrapped into tall, uneven rows and could overlap the **Owners** column, and
- the table never showed a horizontal scrollbar when space ran out.

This aligns the glossary terms table with the **classification table**: fixed pixel column widths + horizontal scroll.

https://github.com/user-attachments/assets/7f2569a6-fb3e-4c6c-8e5f-2547a154309e




## Changes

- `glossaryTermTableColumnsWidth()` now returns **fixed px widths** (name 250 · description 350 · status 150 · reviewers 220 · synonyms 220 · owners 280) instead of computing percentages of the container width.
- **Removed `resizableColumns`** from the terms table so the fixed widths hold and the table can overflow its container.
- Added `scroll={{ x: 'max-content' }}` so a **horizontal scrollbar** appears when there isn't enough space, instead of squeezing columns.
- Gave the **Actions** column a fixed width.
- Removed the now-dead `containerWidth` state + resize effect that fed the old percentage math.

## Behaviour

| Before | After |
|---|---|
| Columns squeeze to fit; Description cramped, tall/uneven rows, can overlap Owners | Consistent fixed-width cells; wide-enough Description |
| No horizontal scroll (columns just shrink) | Horizontal scrollbar when the container is too narrow |

Trade-off: columns are now fixed-width (no drag-to-resize), same as the classification table.

## Tests

- Updated `GlossaryUtils.test.ts` for the new fixed-width return value.
- `GlossaryTermTab` + `GlossaryUtils` Jest suites pass (44 + 23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)