### PR TITLE
feat(ui): pass the list-page search into custom page headers

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -118,7 +118,7 @@ const DataProductListPage = ({
     <HeaderBreadcrumb noMargin items={breadcrumbItems} />
   );
 
-  const showHeaderSearch = isAiMode && !renderPageHeader;
+  const showHeaderSearch = isAiMode;
 
   const [searchInputValue, setSearchInputValue] = useState(
     dataProductListing.urlState.searchQuery ?? ''
@@ -150,6 +150,10 @@ const DataProductListPage = ({
     },
   };
 
+  const headerSearch = showHeaderSearch ? (
+    <Input className="tw:w-72" {...searchInputProps} />
+  ) : undefined;
+
   const { pageHeader } = usePageHeader({
     titleKey: 'label.data-product-plural',
     descriptionMessageKey: 'message.data-product-description',
@@ -158,9 +162,7 @@ const DataProductListPage = ({
     onAddClick: openDrawer,
     learningPageId: LEARNING_PAGE_IDS.DATA_PRODUCT,
     variant: isAiMode ? 'search' : undefined,
-    search: showHeaderSearch ? (
-      <Input className="tw:w-72" {...searchInputProps} />
-    ) : undefined,
+    search: headerSearch,
     breadcrumb: headerBreadcrumb,
   });
 
@@ -383,6 +385,7 @@ const DataProductListPage = ({
             createPermission: permissions.dataProduct?.Create || false,
             count: dataProductListing.totalEntities,
             breadcrumb: headerBreadcrumb,
+            search: headerSearch,
           })
         : pageHeader}
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
@@ -96,7 +96,7 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
     <HeaderBreadcrumb noMargin items={breadcrumbItems} />
   );
 
-  const showHeaderSearch = isAiMode && !renderPageHeader;
+  const showHeaderSearch = isAiMode;
 
   const [searchInputValue, setSearchInputValue] = useState(
     domainListing.urlState.searchQuery ?? ''
@@ -128,6 +128,10 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
     },
   };
 
+  const headerSearch = showHeaderSearch ? (
+    <Input className="tw:w-72" {...searchInputProps} />
+  ) : undefined;
+
   const { pageHeader } = usePageHeader({
     titleKey: 'label.domain-plural',
     descriptionMessageKey: 'message.domain-description',
@@ -137,9 +141,7 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
     onAddClick: openDrawer,
     learningPageId: LEARNING_PAGE_IDS.DOMAIN,
     variant: isAiMode ? 'search' : undefined,
-    search: showHeaderSearch ? (
-      <Input className="tw:w-72" {...searchInputProps} />
-    ) : undefined,
+    search: headerSearch,
     breadcrumb: headerBreadcrumb,
   });
 
@@ -301,6 +303,7 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
             createPermission: permissions.domain?.Create || false,
             count: domainListing.totalEntities,
             breadcrumb: headerBreadcrumb,
+            search: headerSearch,
           })
         : pageHeader}
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/PageHeaderRenderer.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/navigation/PageHeaderRenderer.interface.ts
@@ -18,6 +18,12 @@ export interface PageHeaderRenderProps {
   createPermission: boolean;
   count: number;
   breadcrumb?: ReactNode;
+  /**
+   * The list page's search input, already wired to the page's own search state
+   * and debounce. Custom headers must render this so the search stays in the
+   * header rather than falling back into the table's filter row.
+   */
+  search?: ReactNode;
 }
 
 export type PageHeaderRenderer = (props: PageHeaderRenderProps) => ReactNode;


### PR DESCRIPTION
## What & why

`#30317` moved the search into the page header and left-aligned the filters for **Domains** and **Data Products** in AI mode. It gated that on:

```ts
const showHeaderSearch = isAiMode && !renderPageHeader;
```

The `!renderPageHeader` term means a downstream app that supplies its own header (Collate's Data Marketplace does, for both list pages) **silently opts out** of the fix — the search input and the title/count stay in the table filter row, which pushes the quick filters right and wraps them onto extra lines.

A custom header can't fix this itself: `PageHeaderRenderProps` never carried the search node, and this page owns the search state plus its 300ms debounce.

## How

Thread the search node through the render-prop contract:

- `PageHeaderRenderProps` gains an optional `search?: ReactNode`.
- `showHeaderSearch` drops the `!renderPageHeader` term.
- Both list pages hoist the input into a `headerSearch` const and pass it to `usePageHeader` **and** `renderPageHeader`.

## No behaviour change inside OpenMetadata

No OM caller passes `renderPageHeader` to either list page — `AuthenticatedAppRouter.tsx:812` and `DomainRouter.tsx:21` mount them with `pageTitle` only. So `!renderPageHeader` was **always true** and the old gate was already equivalent to `isAiMode`. The consumer this unblocks lives in Collate.

### Classic mode is untouched

![Classic mode unchanged](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/v2-classic-unchanged.png)

Verified against a running stack — the two locators ~180 Playwright call sites depend on still resolve to **exactly one** element:

| Locator | Count |
|---|---|
| `[data-testid=page-layout-v1] input[placeholder=Search]` | 1 |
| `main input[placeholder=Search]` | 1 |

Rendering the search in the header *and* the filter row at once would be a strict-mode violation; the `showHeaderSearch` XOR keeps them mutually exclusive.

## Downstream effect (paired with Collate PR #5560)

These come from a locally rebuilt stack: this branch + latest Collate `main` + the paired Collate change.

### Domains

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/v2-before-domains.png) | ![after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/v2-after-domains.png) |

### Data Products — filters went from two wrapped rows to one

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/v2-before-dataproducts.png) | ![after](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/v2-after-dataproducts.png) |

## Sub Domains — no change needed here

The same batch of design feedback asked to drop the "Sub Domains" title/count from the Sub Domains table filter row and narrow its search bar. That already shipped in #30327 (`5a518818c1`, 2026-07-23):

```diff
-  const { titleAndCount } = useTitleAndCount({
-            {titleAndCount}
-              className="tw:max-w-86"
+              className="tw:max-w-60"
```

Verified live on this stack at `/domain/<fqn>/subdomains` — filter-row text is `OwnersTagsGlossary TermsDomain Type` (no title, no count badge) and the input renders at 240px. With the title gone, `Domain Type` no longer wraps to a second line either. `SubDomainsTable.component.tsx` has no `isAiMode` branch, so this is identical in both modes.

![Sub Domains on current main](https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets-ai-header-search/subdomains-current-main.png)

## Testing

- Ran both modes against a live backend on a rebuilt UI (latest OM `main` + latest Collate `main`, core-components rebuilt).
- **AI mode:** search renders in the header; filters flush-left; exactly one search input on the page.
- **Classic mode:** unchanged — title/count + search + filters in the filter row.
- Header search is functional, not just repositioned: typing `Finance` filtered 6 domains → 1 and set `?q=Finance&page=1`, so the debounce and URL-state wiring survive the move.
- `prettier --check` clean on all three files.

> ESLint could not run in this worktree — `eslint-plugin-sonarjs` (a newer dep on `main`) isn't present in either sibling checkout I had available, so I'm relying on CI for the lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
