### PR TITLE
fix(ui): clip long domain & data product names with a full-name tooltip

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceItemCard/MarketplaceItemCard.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceItemCard/MarketplaceItemCard.component.tsx
@@ -13,6 +13,7 @@
 
 import { Card, Typography } from '@openmetadata/ui-core-components';
 import { ReactNode } from 'react';
+import { renderBreakableTooltip } from '../../../utils/TooltipUtils';
 
 interface MarketplaceItemCardProps {
   icon: ReactNode;
@@ -47,14 +48,14 @@ const MarketplaceItemCard = ({
       <div className="tw:flex tw:flex-col tw:min-w-0 tw:gap-0.5">
         <Typography
           as="span"
-          className="tw:font-semibold tw:text-sm tw:leading-5 tw:text-primary tw:truncate tw:block"
-          title={name}>
+          className="tw:font-semibold tw:text-sm tw:leading-5 tw:text-primary tw:truncate tw:block tw:text-left"
+          ellipsis={{ tooltip: renderBreakableTooltip(name) }}>
           {name}
         </Typography>
         <Typography
           as="span"
-          className="tw:text-xs tw:leading-[18px] tw:text-tertiary tw:truncate tw:block"
-          title={subtitle}>
+          className="tw:text-xs tw:leading-[18px] tw:text-tertiary tw:truncate tw:block tw:text-left"
+          ellipsis={{ tooltip: renderBreakableTooltip(subtitle) }}>
           {subtitle}
         </Typography>
       </div>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -44,10 +44,12 @@ import {
   getClassificationTags,
   getGlossaryTags,
 } from '../../utils/TagsPureUtils';
+import { renderBreakableTooltip } from '../../utils/TooltipUtils';
 import { useDelete } from '../common/atoms/actions/useDelete';
 import {
-  COMPACT_CELL_WRAP_CLASS,
-  NAME_CELL_WRAP_CLASS,
+  CLIPPED_NAME_CLASS,
+  COMPACT_CELL_CLIP_CLASS,
+  NAME_CELL_CLIP_CLASS,
 } from '../common/atoms/domain/ui/domainFieldRenderers';
 import { useDataProductFilters } from '../common/atoms/domain/ui/useDataProductFilters';
 import { useDomainCardTemplates } from '../common/atoms/domain/ui/useDomainCardTemplates';
@@ -198,16 +200,25 @@ const DataProductListPage = ({
           return (
             <Box
               align="center"
-              className={NAME_CELL_WRAP_CLASS}
+              className={NAME_CELL_CLIP_CLASS}
               direction="row"
               gap={3}>
               <Avatar size="md" {...getEntityAvatarProps(entity)} />
               <Box className="tw:min-w-0" direction="col">
-                <Typography size="text-sm" weight="medium">
+                <Typography
+                  className={CLIPPED_NAME_CLASS}
+                  ellipsis={{ tooltip: renderBreakableTooltip(entityName) }}
+                  size="text-sm"
+                  weight="medium">
                   {entityName}
                 </Typography>
                 {showName && (
-                  <Typography size="text-xs">{entity.name}</Typography>
+                  <Typography
+                    className={CLIPPED_NAME_CLASS}
+                    ellipsis={{ tooltip: renderBreakableTooltip(entity.name) }}
+                    size="text-xs">
+                    {entity.name}
+                  </Typography>
                 )}
               </Box>
             </Box>
@@ -234,11 +245,18 @@ const DataProductListPage = ({
           return (
             <Box
               align="center"
-              className={COMPACT_CELL_WRAP_CLASS}
+              className={COMPACT_CELL_CLIP_CLASS}
               direction="row"
               gap={1}>
               <Globe01 size={16} style={{ flexShrink: 0 }} />
-              <Typography size="text-sm">
+              <Typography
+                className={CLIPPED_NAME_CLASS}
+                ellipsis={{
+                  tooltip: renderBreakableTooltip(
+                    domain.displayName || domain.name
+                  ),
+                }}
+                size="text-sm">
                 {domain.displayName || domain.name}
               </Typography>
             </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx
@@ -818,18 +818,16 @@ const DataProductsDetailsPage = ({
           permissions={dataProductPermission}
           type={EntityType.DATA_PRODUCT}
           onUpdate={onUpdate}>
-          <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-start tw:justify-between">
+          <div className="tw:flex tw:flex-wrap tw:gap-y-3 tw:mx-5 tw:items-center tw:justify-between">
             <div className="tw:max-w-full tw:lg:max-w-[60%]">
               <EntityHeader
                 breadcrumb={[]}
-                displayNameClassName="entity-header-title-wrap"
                 entityData={{ ...dataProduct, displayName, name }}
                 entityType={EntityType.DATA_PRODUCT}
                 handleFollowingClick={handleFollowingClick}
                 icon={iconData}
                 isFollowing={isFollowing}
                 isFollowingLoading={isFollowingLoading}
-                nameClassName="entity-header-title-wrap"
                 serviceName=""
                 suffix={
                   <>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/DomainDetails/DomainDetails.component.tsx
@@ -987,14 +987,13 @@ const DomainDetails = ({
           />
         )}
         <Box
-          align="start"
+          align="center"
           className="entity-header tw:mx-5 tw:gap-y-3"
           justify="between"
           wrap="wrap">
           <div className="tw:max-w-full tw:lg:max-w-[60%]">
             <EntityHeader
               breadcrumb={[]}
-              displayNameClassName="entity-header-title-wrap"
               entityData={{ ...domain, displayName, name }}
               entityType={EntityType.DOMAIN}
               entityUrl={`${globalThis.location.origin}/domain/${urlEncodedFqn}`}
@@ -1002,7 +1001,6 @@ const DomainDetails = ({
               icon={iconData}
               isFollowing={isFollowing}
               isFollowingLoading={isFollowingLoading}
-              nameClassName="entity-header-title-wrap"
               serviceName=""
               suffix={
                 !isTreeView && (

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityHeaderTitle/entity-header-title.less
@@ -26,17 +26,6 @@
   }
 }
 
-// Opt-in modifier: lets a header title wrap onto multiple lines instead of
-// truncating with an ellipsis. Overrides antd's single-line ellipsis so a long
-// name stays fully visible within a width-capped container. Only active when a
-// consumer passes `entity-header-title-wrap` via nameClassName/displayNameClassName.
-.entity-header-title-wrap.ant-typography {
-  white-space: normal !important;
-  overflow: visible !important;
-  text-overflow: clip !important;
-  word-break: break-word;
-}
-
 .ant-btn.entity-follow-button {
   border-radius: var(--om-radius-2xl);
   background-color: @primary-button-background;

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/domainFieldRenderers.tsx
@@ -24,6 +24,7 @@ import {
   getClassificationTags,
   getGlossaryTags,
 } from '../../../../../utils/TagsPureUtils';
+import { renderBreakableTooltip } from '../../../../../utils/TooltipUtils';
 import { DomainTypeChip } from '../../../../DomainListing/components/DomainTypeChip';
 import { OwnerLabel } from '../../../OwnerLabel/OwnerLabel.component';
 import TagBadgeList from '../../../TagBadgeList/TagBadgeList.component';
@@ -38,25 +39,42 @@ interface OwnedEntity {
   owners?: EntityReference[];
 }
 
-// Long entity names (including no-space strings) must wrap within a capped
-// width instead of overflowing the row. `overflow-wrap:anywhere` both adds
-// break points and lets the flex item shrink below its content width.
-export const NAME_CELL_WRAP_CLASS =
-  'tw:max-w-[480px] tw:[overflow-wrap:anywhere]';
-export const COMPACT_CELL_WRAP_CLASS =
-  'tw:max-w-[320px] tw:[overflow-wrap:anywhere]';
-export const CARD_NAME_WRAP_CLASS = 'tw:min-w-0 tw:[overflow-wrap:anywhere]';
+// Long entity names must clip to a single line with a tooltip carrying the full
+// name. The table is `table-layout: auto`, so the max-width is what stops a long
+// name from widening the column - it is the clip boundary, not decoration.
+// `min-w-0` lets the name shrink below its content width so the ellipsis lands.
+export const NAME_CELL_CLIP_CLASS = 'tw:max-w-[480px] tw:min-w-0';
+export const COMPACT_CELL_CLIP_CLASS = 'tw:max-w-[320px] tw:min-w-0';
+export const CARD_NAME_CLIP_CLASS = 'tw:min-w-0';
+
+// `ellipsis` wraps the text in react-aria's TooltipTrigger, which renders a
+// `<button>` - and the UA stylesheet centers a button's text. The default
+// Typography element is an inline `<span>`, so `text-left` alone would not
+// apply; `block` makes it a block container so the left alignment takes effect.
+export const CLIPPED_NAME_CLASS = 'tw:block tw:text-left';
 
 export const renderDomainNameCell = (
   entity: Domain | DataProduct
-): ReactNode => (
-  <Box align="center" className={NAME_CELL_WRAP_CLASS} direction="row" gap={3}>
-    <Avatar size="md" {...getEntityAvatarProps(entity)} />
-    <Typography size="text-sm" weight="medium">
-      {getEntityName(entity)}
-    </Typography>
-  </Box>
-);
+): ReactNode => {
+  const entityName = getEntityName(entity);
+
+  return (
+    <Box
+      align="center"
+      className={NAME_CELL_CLIP_CLASS}
+      direction="row"
+      gap={3}>
+      <Avatar size="md" {...getEntityAvatarProps(entity)} />
+      <Typography
+        className={CLIPPED_NAME_CLASS}
+        ellipsis={{ tooltip: renderBreakableTooltip(entityName) }}
+        size="text-sm"
+        weight="medium">
+        {entityName}
+      </Typography>
+    </Box>
+  );
+};
 
 export const renderDomainTypeCell = (entity: Domain): ReactNode =>
   entity.domainType ? (

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/atoms/domain/ui/useDomainCardTemplates.tsx
@@ -23,9 +23,11 @@ import { DataProduct } from '../../../../../generated/entity/domains/dataProduct
 import { Domain } from '../../../../../generated/entity/domains/domain';
 import { getEntityName } from '../../../../../utils/EntityNameUtils';
 import { getEntityAvatarProps } from '../../../../../utils/IconUtils';
+import { renderBreakableTooltip } from '../../../../../utils/TooltipUtils';
 import { OwnerLabel } from '../../../OwnerLabel/OwnerLabel.component';
 import {
-  CARD_NAME_WRAP_CLASS,
+  CARD_NAME_CLIP_CLASS,
+  CLIPPED_NAME_CLASS,
   renderDomainClassificationTagsCell,
   renderDomainGlossaryTagsCell,
   renderDomainOwnersCell,
@@ -39,12 +41,18 @@ export const useDomainCardTemplates = () => {
     (entity: Domain): ReactNode => (
       <Box direction="col" gap={4}>
         <Box
-          align="start"
-          className={CARD_NAME_WRAP_CLASS}
+          align="center"
+          className={CARD_NAME_CLIP_CLASS}
           direction="row"
           gap={3}>
           <Avatar size="md" {...getEntityAvatarProps(entity)} />
-          <Typography size="text-sm" weight="medium">
+          <Typography
+            className={CLIPPED_NAME_CLASS}
+            ellipsis={{
+              tooltip: renderBreakableTooltip(getEntityName(entity)),
+            }}
+            size="text-sm"
+            weight="medium">
             {getEntityName(entity)}
           </Typography>
         </Box>
@@ -94,17 +102,26 @@ export const useDomainCardTemplates = () => {
       return (
         <Box direction="col" gap={4}>
           <Box
-            align="start"
-            className={CARD_NAME_WRAP_CLASS}
+            align="center"
+            className={CARD_NAME_CLIP_CLASS}
             direction="row"
             gap={3}>
             <Avatar size="md" {...getEntityAvatarProps(entity)} />
             <Box className="tw:min-w-0" direction="col">
-              <Typography size="text-sm" weight="medium">
+              <Typography
+                className={CLIPPED_NAME_CLASS}
+                ellipsis={{ tooltip: renderBreakableTooltip(entityName) }}
+                size="text-sm"
+                weight="medium">
                 {entityName}
               </Typography>
               {showName && (
-                <Typography size="text-xs">{entity.name}</Typography>
+                <Typography
+                  className={CLIPPED_NAME_CLASS}
+                  ellipsis={{ tooltip: renderBreakableTooltip(entity.name) }}
+                  size="text-xs">
+                  {entity.name}
+                </Typography>
               )}
             </Box>
           </Box>

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TooltipUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TooltipUtils.tsx
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { ReactNode } from 'react';
+
+/**
+ * Wraps tooltip text so a long entity name stays fully readable.
+ *
+ * The core Tooltip caps its bubble at `max-w-xs` (320px). Its default
+ * `overflow-wrap: break-word` only breaks at existing opportunities, so an
+ * unbroken name (`GlobalEnterpriseCustomer...`) has no break point, overflows
+ * the bubble, and gets visually clipped - defeating the point of the tooltip.
+ * `anywhere` adds break opportunities inside the token so the name wraps.
+ */
+export const renderBreakableTooltip = (text?: ReactNode): ReactNode => (
+  <span className="tw:block tw:max-w-full tw:[overflow-wrap:anywhere]">
+    {text}
+  </span>
+);


### PR DESCRIPTION
## Describe your changes

Long domain and data product names wrapped onto multiple lines. On the detail pages that made the header grow taller and pushed the page down; in the listing tables it produced uneven, very tall rows. This clips the name to a single line and puts the **complete name in a tooltip** on hover.

Surfaces covered:

| Surface | File |
|---|---|
| Domain detail header | `Domain/DomainDetails/DomainDetails.component.tsx` |
| Data Product detail header | `DataProducts/DataProductsDetailsPage/DataProductsDetailsPage.component.tsx` |
| Domains + Sub Domains tables, card view | `common/atoms/domain/ui/domainFieldRenderers.tsx`, `useDomainCardTemplates.tsx` |
| Data Products table + card view, Domains column | `DataProduct/DataProductListPage.tsx` |
| Data Marketplace cards | `DataMarketplace/MarketplaceItemCard/MarketplaceItemCard.component.tsx` |

The detail headers are a plain deletion: they were opting out of truncation via `entity-header-title-wrap` (added in #30335), so removing it lets the shared `EntityHeaderTitle`'s existing ellipsis and tooltip do their job. The header rows go back to `center` alignment now that the title no longer grows taller than the buttons beside it.

### Two things worth a reviewer's attention

**1. Left alignment.** `ellipsis` renders the text inside react-aria's `TooltipTrigger`, which is a `<button>` — and the UA stylesheet centers a button's text. Without a fix the names drift to the middle of the cell. `CLIPPED_NAME_CLASS` (`block` + `text-left`) restores the original alignment; `text-left` alone is not enough because the default Typography element is an inline `<span>`.

**2. The tooltip was clipping too.** The core Tooltip caps its bubble at `max-w-xs` (320px) and its `overflow-wrap: break-word` only breaks at *existing* opportunities, so an unbroken name (`GlobalEnterpriseCustomer…`) overflowed and got cut off inside the tooltip — measured 543px of content in a 320px box. `renderBreakableTooltip` (new, `utils/TooltipUtils.tsx`) wraps the content with `overflow-wrap: anywhere` so the full name stays readable.

The `max-w-[480px]`/`[320px]` caps are kept deliberately: the table is `table-layout: auto`, so the max-width is what stops a long name from widening the column — it is the clip boundary, not decoration.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

Verified against a local 2.0.0-rc1 backend with both a spaced long name and an unbroken no-space name, plus the existing short names.

### Domain detail page
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/before_domain_detail.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/after_domain_detail.png" width="470"> |

### Data Product detail page
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/before_dp_detail.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/after_dp_detail.png" width="470"> |

### Domains table
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/before_domains_table.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/after_domains_table.png" width="470"> |

### Data Products table
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/before_dp_table.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/after_dp_table.png" width="470"> |

### Data Marketplace
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/before_marketplace.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/after_marketplace.png" width="470"> |

### Tooltip carries the complete name
Unbroken names wrap inside the bubble rather than being cut off.

| Table | Marketplace card |
|---|---|
| <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/tooltip_table_tooltip.png" width="470"> | <img src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/clip-titles/tooltip_marketplace_tooltip.png" width="470"> |

## How was this tested

Manually against a local stack (backend `2.0.0-rc1`), with fixtures for a long spaced name, a long unbroken name, and the existing short names:

- Domain detail, Data Product detail, sub-domain detail — title clips, buttons stay flush right and vertically centred, tooltip shows the full name.
- Domains table, Sub Domains tab, Data Products table (name + Domains column), and both card/grid views — names clip, rows keep a uniform 72px height, every name's left edge measured at the same x (357px) so alignment matches the previous behaviour.
- Data Marketplace landing cards — clip plus a real tooltip in place of the native `title`.
- `tsc --noEmit`: no new type errors. ESLint/Prettier/organize-imports: clean, 0 errors.

**Not covered:** no automated test added — this is a CSS/alignment change and the local jest run is blocked in this worktree by an unrelated `@material/material-color-utilities` ESM issue in `ui-core-components`. Happy to add a Playwright assertion on the clip + tooltip if reviewers want one.

**Out of scope, noticed while testing:** the Data Products tab *inside* a domain renders `ExploreSearchCard`, which still shows the name untruncated. That component is shared with Explore across all entity types, so changing it reaches well beyond domains/data products — flagging rather than folding it in.
