### PR TITLE
Fixes 31167: align the AI-mode Data Marketplace header gap with the other marketplace pages

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataMarketplacePage/DataMarketplacePage.component.tsx
@@ -45,6 +45,13 @@ const ReactGridLayout = WidthProvider(RGL) as ComponentType<
   ReactGridLayoutProps & { children?: ReactNode }
 >;
 
+// In AI mode the caller's `HeaderShell` owns the 20px gap to the content below
+// through its own bottom margin, matching the Domains/Data Products list pages —
+// the grid must not stack another offset on top of it. The classic hero keeps
+// the original 8px offset it was designed against.
+const AI_MODE_GRID_STYLE = { marginTop: 0 };
+const CLASSIC_GRID_STYLE = { marginTop: 8 };
+
 const normalizeLayout = (l: WidgetConfig[]) =>
   l
     .map((widget) => ({
@@ -144,7 +151,7 @@ const DataMarketplacePage = ({
       <div className="tw:mb-8">
         {renderPageHeader ? (
           <div className={gridWrapperClassName} dir="ltr">
-            <div className="tw:p-2">{renderPageHeader()}</div>
+            <div className="tw:px-2 tw:pt-2">{renderPageHeader()}</div>
           </div>
         ) : (
           <div
@@ -172,7 +179,7 @@ const DataMarketplacePage = ({
             isResizable={false}
             margin={[16, 30]}
             rowHeight={156}
-            style={{ marginTop: 8 }}>
+            style={renderPageHeader ? AI_MODE_GRID_STYLE : CLASSIC_GRID_STYLE}>
             {widgets}
           </ReactGridLayout>
         </div>


### PR DESCRIPTION
### Describe your changes:

Fixes #31167

In AI mode the Data Marketplace overview stacked three vertical offsets under the page header — the header wrapper's `tw:p-2` bottom padding (8px), `HeaderShell`'s own `tw:mb-5` (20px), and the widget grid's inline `marginTop: 8` (8px) — so the header sat 36px above the first content block (28px with an announcement, where the announcement's margin collapses with the grid's).

The fix lets `HeaderShell`'s bottom margin own that gap, matching the Domains and Data Products list pages: the AI-mode header wrapper drops to `tw:px-2 tw:pt-2`, and the widget grid takes a 0 top offset in the AI branch. The classic hero layout keeps the 8px grid offset it was designed against.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — three-line spacing fix in one page component, no API change.

#
### Tests:

#### Use cases covered
- AI-mode marketplace overview with no announcements: header → first widget card is 20px.
- AI-mode marketplace overview with an active announcement: header → announcements is 20px, and announcements → widget grid stays 20px.
- Classic (non-AI) marketplace overview: hero → first card offset unchanged at 8px.

#### Unit tests
- [x] Not applicable — `DataMarketplacePage` has no existing test file, and the change is a pure CSS-spacing adjustment with no logic to assert beyond the class/style literals themselves. Verified by live DOM measurement instead (numbers below).

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — the AI-mode header that supplies `renderPageHeader` lives downstream, so this branch is not reachable from the OSS Playwright suite. The classic branch this repo *can* drive is unchanged.

#### Manual testing performed
Measured on a running stack (admin, 1600x1000 viewport) with `getBoundingClientRect()` on the live DOM, before and after the patch, in both announcement states:

| Scenario | Before | After |
|---|---|---|
| AI mode, no announcements — header → first widget card | 36px | **20px** |
| AI mode, with announcement — header → announcements | 28px | **20px** |
| AI mode, with announcement — announcements → widget grid | 20px | 20px |
| Classic mode — hero → first card | 8px | 8px (unchanged) |

Reference: the AI-mode Domains list page measures 20px from `[data-testid=list-page-header]` to the block below it — the target this page now matches.

#
### UI screen recording / screenshots:

**AI mode, no announcements** — header → first widget card, 36px → 20px

| Before | After |
|---|---|
| <img width="1230" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-before-no-ann.png" /> | <img width="1230" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-after-no-ann.png" /> |

**AI mode, with an active announcement** — header → announcements, 28px → 20px

| Before | After |
|---|---|
| <img width="1230" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-before-with-ann.png" /> | <img width="1230" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-after-with-ann.png" /> |

<details>
<summary>Full-page before/after</summary>

**No announcements — before**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/before-no-ann.png" />

**No announcements — after**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/after-no-ann.png" />

**With announcement — before**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/before-with-ann.png" />

**With announcement — after**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/after-with-ann.png" />

</details>


**Classic (non-AI) mode — unchanged.** Hero → first card stays at 8px. The two viewport captures below are **pixel-identical** (`ImageChops.difference(...).getbbox()` returns `None`), which is the point of the screenshots: the AI branch is the only thing this PR moves.

| Before | After |
|---|---|
| <img width="1372" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-before-classic.png" /> | <img width="1372" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/seam-after-classic.png" /> |

<details>
<summary>Full-page classic before/after</summary>

**Classic — before**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/before-classic.png" />

**Classic — after**

<img width="1600" src="https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/marketplace-header-gap-20px/after-classic.png" />

</details>

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: I attached before/after screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
