### PR TITLE
fix(glossary): honor the global domain filter on the glossary list endpoint

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/GlossaryResourceIT.java
@@ -182,6 +182,36 @@ public class GlossaryResourceIT extends BaseEntityIT<Glossary, CreateGlossary> {
   // ===================================================================
 
   @Test
+  void list_filterByDomain_scopesResults(TestNamespace ns) {
+    // Reported bug: GlossaryResource.list ignored the global `?domain=` filter, so a
+    // glossary belonging to one domain still showed up when a different domain was
+    // selected. The listing must be scoped to the requested domain.
+    Glossary glossary =
+        createEntity(
+            new CreateGlossary()
+                .withName(ns.prefix("domainScopedGlossary"))
+                .withDescription("Glossary assigned to a single domain")
+                .withDomains(List.of(testDomain().getFullyQualifiedName())));
+
+    ListParams sameDomain =
+        new ListParams().setLimit(1000).setDomain(testDomain().getFullyQualifiedName());
+    assertTrue(
+        listContainsGlossary(sameDomain, glossary.getId()),
+        "Glossary must appear when filtering by its own domain");
+
+    ListParams otherDomain =
+        new ListParams().setLimit(1000).setDomain(testSubDomain().getFullyQualifiedName());
+    assertFalse(
+        listContainsGlossary(otherDomain, glossary.getId()),
+        "Glossary must not appear when filtering by a different domain");
+  }
+
+  private boolean listContainsGlossary(ListParams params, UUID glossaryId) {
+    return listEntities(params).getData().stream()
+        .anyMatch(candidate -> glossaryId.equals(candidate.getId()));
+  }
+
+  @Test
   void test_createGlossaryWithDisplayName(TestNamespace ns) {
     OpenMetadataClient client = SdkClients.adminClient();
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/glossary/GlossaryResource.java
@@ -13,6 +13,8 @@
 
 package org.openmetadata.service.resources.glossary;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -52,6 +54,7 @@ import org.openmetadata.schema.api.data.RestoreEntity;
 import org.openmetadata.schema.entity.data.Glossary;
 import org.openmetadata.schema.type.ChangeEvent;
 import org.openmetadata.schema.type.EntityHistory;
+import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.MetadataOperation;
 import org.openmetadata.schema.type.csv.CsvImportResult;
@@ -125,6 +128,11 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
               schema = @Schema(type = "string", example = FIELDS))
           @QueryParam("fields")
           String fieldsParam,
+      @Parameter(
+              description = "Filter glossaries by domain name",
+              schema = @Schema(type = "string", example = "Marketing"))
+          @QueryParam("domain")
+          String domain,
       @Parameter(description = "Limit the number glossaries returned. (1 to 1000000, default = 10)")
           @DefaultValue("10")
           @Min(value = 0, message = "must be greater than or equal to 0")
@@ -148,6 +156,11 @@ public class GlossaryResource extends EntityResource<Glossary, GlossaryRepositor
           @DefaultValue("non-deleted")
           Include include) {
     ListFilter filter = new ListFilter(include);
+    if (!nullOrEmpty(domain)) {
+      EntityReference domainReference =
+          Entity.getEntityReferenceByName(Entity.DOMAIN, domain, Include.NON_DELETED);
+      filter.addQueryParam("domainId", String.format("'%s'", domainReference.getId()));
+    }
     return super.listInternal(
         uriInfo, securityContext, fieldsParam, filter, limitParam, before, after);
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryDomainFilter.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryDomainFilter.spec.ts
@@ -1,0 +1,222 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import { expect, Page, test as base } from '@playwright/test';
+import { SidebarItem } from '../../constant/sidebar';
+import { Domain } from '../../support/domain/Domain';
+import { Glossary } from '../../support/glossary/Glossary';
+import { UserClass } from '../../support/user/UserClass';
+import { performAdminLogin } from '../../utils/admin';
+import { redirectToHomePage } from '../../utils/common';
+import { selectDomainFromNavbar } from '../../utils/domain';
+import {
+  assignDomainOnlyAccess,
+  safeDelete,
+} from '../../utils/domainIsolationUtils';
+import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { sidebarClick } from '../../utils/sidebar';
+
+// Experian-reported (Slack, 2026-08-06): a glossary that belongs to Domain A stays
+// visible in the Glossary left panel even when Domain B is selected in the global
+// (navbar) domain filter. The global filter should scope every list view, but
+// GET /api/v1/glossaries does not honour the `domain` query param the UI sends.
+// This spec exercises both the global-selector path (admin) and the RBAC path
+// (DomainOnlyAccessRole users) so the two mechanisms are told apart empirically.
+const adminUser = new UserClass();
+const userA = new UserClass();
+const userB = new UserClass();
+const userAB = new UserClass();
+const domainA = new Domain();
+const domainB = new Domain();
+const glossaryA = new Glossary();
+const glossaryB = new Glossary();
+
+const test = base.extend<{
+  adminPage: Page;
+  userAPage: Page;
+  userBPage: Page;
+  userABPage: Page;
+}>({
+  adminPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    await adminUser.login(page);
+    await use(page);
+    await page.close();
+  },
+  userAPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    await userA.login(page);
+    await use(page);
+    await page.close();
+  },
+  userBPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    await userB.login(page);
+    await use(page);
+    await page.close();
+  },
+  userABPage: async ({ browser }, use) => {
+    const page = await browser.newPage();
+    await userAB.login(page);
+    await use(page);
+    await page.close();
+  },
+});
+
+const assignDomainToGlossary = async (
+  apiContext: Parameters<typeof assignDomainOnlyAccess>[0],
+  glossary: Glossary,
+  domain: Domain
+) => {
+  await glossary.patch(apiContext, [
+    {
+      op: 'add',
+      path: '/domains',
+      value: [
+        {
+          id: domain.responseData.id,
+          type: 'domain',
+          name: domain.responseData.name,
+          fullyQualifiedName: domain.responseData.fullyQualifiedName,
+        },
+      ],
+    },
+  ]);
+};
+
+const waitForGlossaryList = (page: Page) =>
+  page.waitForResponse(
+    (response) =>
+      response.request().method() === 'GET' &&
+      response.url().includes('/api/v1/glossaries?') &&
+      response.status() === 200
+  );
+
+const openGlossaryList = async (page: Page) => {
+  const listResponse = waitForGlossaryList(page);
+  await sidebarClick(page, SidebarItem.GLOSSARY);
+  await listResponse;
+  await waitForAllLoadersToDisappear(page);
+};
+
+// The navbar domain dropdown (`data-testid="domain-dropdown"`) is hidden on the
+// home page (NavBar.tsx: `!isHomePage && ...`), so it can only be operated from a
+// non-home page such as the Glossary page. After switching the domain we reload so
+// the glossary list is re-fetched with the `?domain=` param the interceptor adds.
+const applyNavbarDomainOnGlossary = async (
+  page: Page,
+  domain: Domain['responseData']
+) => {
+  await selectDomainFromNavbar(page, domain);
+  const listResponse = waitForGlossaryList(page);
+  await page.reload();
+  await listResponse;
+  await waitForAllLoadersToDisappear(page);
+};
+
+const glossaryItem = (page: Page, glossary: Glossary) =>
+  page
+    .getByTestId('glossary-left-panel')
+    .getByRole('menuitem', { name: glossary.data.displayName, exact: true });
+
+test.describe('Glossary global domain filter', () => {
+  test.slow(true);
+
+  test.beforeAll('Setup domains, glossaries, users', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await adminUser.create(apiContext);
+    await adminUser.setAdminRole(apiContext);
+    await userA.create(apiContext);
+    await userB.create(apiContext);
+    await userAB.create(apiContext);
+
+    await domainA.create(apiContext);
+    await domainB.create(apiContext);
+    await glossaryA.create(apiContext);
+    await glossaryB.create(apiContext);
+
+    await assignDomainToGlossary(apiContext, glossaryA, domainA);
+    await assignDomainToGlossary(apiContext, glossaryB, domainB);
+
+    await assignDomainOnlyAccess(apiContext, userA, [domainA]);
+    await assignDomainOnlyAccess(apiContext, userB, [domainB]);
+    await assignDomainOnlyAccess(apiContext, userAB, [domainA, domainB]);
+
+    await afterAction();
+  });
+
+  test.afterAll('Cleanup', async ({ browser }) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+
+    await safeDelete(() => glossaryA.delete(apiContext));
+    await safeDelete(() => glossaryB.delete(apiContext));
+    await safeDelete(() => domainA.delete(apiContext));
+    await safeDelete(() => domainB.delete(apiContext));
+    await safeDelete(() => userA.delete(apiContext));
+    await safeDelete(() => userB.delete(apiContext));
+    await safeDelete(() => userAB.delete(apiContext));
+    await safeDelete(() => adminUser.delete(apiContext));
+
+    await afterAction();
+  });
+
+  test('Admin: navbar domain selector filters the glossary list', async ({
+    adminPage,
+  }) => {
+    await test.step('All Domains shows both glossaries', async () => {
+      await redirectToHomePage(adminPage);
+      await openGlossaryList(adminPage);
+
+      await expect(glossaryItem(adminPage, glossaryA)).toBeVisible();
+      await expect(glossaryItem(adminPage, glossaryB)).toBeVisible();
+    });
+
+    await test.step('Selecting Domain B hides the Domain A glossary', async () => {
+      await applyNavbarDomainOnGlossary(adminPage, domainB.responseData);
+
+      await expect(glossaryItem(adminPage, glossaryB)).toBeVisible();
+      await expect(glossaryItem(adminPage, glossaryA)).toHaveCount(0);
+    });
+  });
+
+  test('DomainOnlyAccess userA sees only Domain A glossary', async ({
+    userAPage,
+  }) => {
+    await redirectToHomePage(userAPage);
+    await openGlossaryList(userAPage);
+
+    await expect(glossaryItem(userAPage, glossaryA)).toBeVisible();
+    await expect(glossaryItem(userAPage, glossaryB)).toHaveCount(0);
+  });
+
+  test('DomainOnlyAccess userB sees only Domain B glossary', async ({
+    userBPage,
+  }) => {
+    await redirectToHomePage(userBPage);
+    await openGlossaryList(userBPage);
+
+    await expect(glossaryItem(userBPage, glossaryB)).toBeVisible();
+    await expect(glossaryItem(userBPage, glossaryA)).toHaveCount(0);
+  });
+
+  test('DomainOnlyAccess userAB: navbar selector narrows within assigned domains', async ({
+    userABPage,
+  }) => {
+    await redirectToHomePage(userABPage);
+    await openGlossaryList(userABPage);
+    await applyNavbarDomainOnGlossary(userABPage, domainB.responseData);
+
+    await expect(glossaryItem(userABPage, glossaryB)).toBeVisible();
+    await expect(glossaryItem(userABPage, glossaryA)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
### Describe your changes:

Fixes #31173

`GlossaryResource.list()` did not honor the global **Domain** filter. The UI's `withDomainFilter` interceptor appends `?domain=<fqn>` to `GET /api/v1/glossaries`, but the endpoint declared no `@QueryParam("domain")` and built a bare `ListFilter`, so the parameter was silently dropped and the Govern → Glossary left panel showed glossaries from every domain regardless of the selected domain.

This change adds the `domain` query parameter and resolves it into the `ListFilter` `domainId` condition — the same pattern already used by `DataProductResource` and the service resources (`ServiceEntityResource`). The RBAC `DomainOnlyAccessRole` filter (`EntityUtil.addDomainQueryParam`, applied inside `listInternal`) still runs afterwards and overwrites `domainId` for domain-restricted users, so the navbar selection can never widen a restricted user's scope.

#
### Type of change:
- [x] Bug fix

#
### Frontend Preview (Screenshots)

N/A — backend fix. The domain selector UI is unchanged.

#
### Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR includes unit/integration tests for the fix.

#
### Tests

**Backend integration test** — `GlossaryResourceIT.list_filterByDomain_scopesResults`: a glossary assigned to domain A appears when listing `?domain=A` and is absent when listing `?domain=B`. Fails without the fix.

**Playwright E2E** — `GlossaryDomainFilter.spec.ts`: the admin navbar-selector case plus three `DomainOnlyAccessRole` cases (single-domain isolation for two users, and a multi-domain user where the navbar must narrow within the assigned domains).

#
### Manual testing

Reproduced and verified on a local `2.0.0-rc1` Docker stack:

- **Before:** `GET /glossaries?domain=<A>` and `?domain=<B>` returned the identical set (the param was ignored) — a "Customer Domain" glossary appeared while "Manufacturing" was selected, matching the customer report.
- `GET /databaseServices?domain=<B>` filtered correctly, confirming the gap was specific to the glossary endpoint.
- In-browser (current UI) the glossary stayed visible in the left panel after switching the navbar domain; the two `DomainOnlyAccessRole` isolation cases passed (RBAC filtering works).
