### PR TITLE
fix(ci): retry the Playwright per-shard results-JSON artifact upload

### DIFF
--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1336,30 +1336,41 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
-      # Retried (unlike a plain actions/upload-artifact step) because the
-      # downstream playwright-summary gate treats a missing results.json as
-      # "shard did not upload a usable Playwright results artifact" and
+      # The downstream playwright-summary gate treats a missing results.json
+      # as "shard did not upload a usable Playwright results artifact" and
       # fails the required check on it — even when every test in the shard
-      # passed. A transient 403 from the artifact backend here otherwise
-      # turns into a false-red merge-queue run. continue-on-error is kept
-      # as a last-resort fallback, matching every sibling upload step in
-      # this file, for the rare case retries are also exhausted.
+      # passed. A transient error from the artifact backend here (seen: 403
+      # on FinalizeArtifact) otherwise turns into a false-red merge-queue
+      # run. Retry once with a plain duplicate step rather than pulling in
+      # a third-party retry action — actions/upload-artifact is already
+      # trusted throughout this file, and `overwrite: true` makes a second
+      # attempt safe to re-run against the same artifact name.
       - name: Upload results JSON for summary
-        uses: Wandalen/wretry.action@v3
+        id: upload-results-json
+        uses: actions/upload-artifact@v6
         if: always()
         continue-on-error: true
         with:
-          action: actions/upload-artifact@v6
-          attempt_limit: 3
-          attempt_delay: 2000
-          with: |
-            name: playwright-results-json-${{ matrix.shardId }}
-            overwrite: true
-            path: |
-              openmetadata-ui/src/main/resources/ui/playwright/output/results.json
-              openmetadata-ui/src/main/resources/ui/playwright/output/ci-status.json
-            retention-days: 1
-            if-no-files-found: ignore
+          name: playwright-results-json-${{ matrix.shardId }}
+          overwrite: true
+          path: |
+            openmetadata-ui/src/main/resources/ui/playwright/output/results.json
+            openmetadata-ui/src/main/resources/ui/playwright/output/ci-status.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Retry upload results JSON for summary
+        if: always() && steps.upload-results-json.outcome == 'failure'
+        uses: actions/upload-artifact@v6
+        continue-on-error: true
+        with:
+          name: playwright-results-json-${{ matrix.shardId }}
+          overwrite: true
+          path: |
+            openmetadata-ui/src/main/resources/ui/playwright/output/results.json
+            openmetadata-ui/src/main/resources/ui/playwright/output/ci-status.json
+          retention-days: 1
+          if-no-files-found: ignore
 
       - name: Collect failure diagnostics
         if: failure() || cancelled()

--- a/.github/workflows/playwright-postgresql-e2e.yml
+++ b/.github/workflows/playwright-postgresql-e2e.yml
@@ -1336,17 +1336,30 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+      # Retried (unlike a plain actions/upload-artifact step) because the
+      # downstream playwright-summary gate treats a missing results.json as
+      # "shard did not upload a usable Playwright results artifact" and
+      # fails the required check on it — even when every test in the shard
+      # passed. A transient 403 from the artifact backend here otherwise
+      # turns into a false-red merge-queue run. continue-on-error is kept
+      # as a last-resort fallback, matching every sibling upload step in
+      # this file, for the rare case retries are also exhausted.
       - name: Upload results JSON for summary
-        uses: actions/upload-artifact@v6
+        uses: Wandalen/wretry.action@v3
         if: always()
+        continue-on-error: true
         with:
-          name: playwright-results-json-${{ matrix.shardId }}
-          overwrite: true
-          path: |
-            openmetadata-ui/src/main/resources/ui/playwright/output/results.json
-            openmetadata-ui/src/main/resources/ui/playwright/output/ci-status.json
-          retention-days: 1
-          if-no-files-found: ignore
+          action: actions/upload-artifact@v6
+          attempt_limit: 3
+          attempt_delay: 2000
+          with: |
+            name: playwright-results-json-${{ matrix.shardId }}
+            overwrite: true
+            path: |
+              openmetadata-ui/src/main/resources/ui/playwright/output/results.json
+              openmetadata-ui/src/main/resources/ui/playwright/output/ci-status.json
+            retention-days: 1
+            if-no-files-found: ignore
 
       - name: Collect failure diagnostics
         if: failure() || cancelled()


### PR DESCRIPTION
## Problem

`playwright-postgresql-e2e.yml`'s "Upload results JSON for summary" step (`actions/upload-artifact@v6`) is the only artifact-upload step in this workflow file without `continue-on-error: true` — every sibling upload step has it, this one was missed.

When the artifact backend returns a transient error (seen: `403 Forbidden` from `FinalizeArtifact`), this step fails outright and marks the whole shard job as `failure`, even though the actual Playwright test run inside that job passed. Because this one step uploads two files per shard (`results.json` + `ci-status.json`) in a single artifact, a single transient failure makes both go missing for that shard.

The downstream `playwright-summary` job's gate (`render_playwright_summary.cjs`) correctly refuses to report green when it can't find a shard's results — that's intentional, not a bug. But it means the missing upload turns into a false-red required check on the merge queue.

**Concrete case**: [run 31161353067](https://github.com/open-metadata/OpenMetadata/actions/runs/31161353067), a merge-queue attempt for #30210. Two shards (`chromium-12`, `chromium-17`) hit the 403 on this step. The summary job's own annotation read:

> `0 Playwright test failure(s); 4 CI/reporting failure(s).`

All 4 "CI/reporting failures" trace back to this exact step: 2 affected shards × 2 missing files (`results.json`, `ci-status.json`) each = 4. PR #30210 itself was fine; the merge queue just blocked on infra flakiness.

## Fix

Retry once with a plain duplicate `actions/upload-artifact@v6` step, gated on `steps.upload-results-json.outcome == 'failure'`. `overwrite: true` makes the retry safe to re-run against the same artifact name. `continue-on-error: true` is kept on both attempts as a last-resort fallback if the retry also fails, matching every other upload-artifact step in this file.

No new third-party action — `actions/upload-artifact` is already the trusted, widely-used action throughout this workflow, so this fixes the transient failure without adding a new dependency to vet/maintain.

Considered and rejected:
- **`Wandalen/wretry.action`** (or similar generic retry-wrapper actions) — works, but introduces a new third-party dependency for something a duplicate step handles just as well.
- **Relaxing the `playwright-summary` gate** to not fail on a reporting-only artifact miss — would mean the pipeline tolerates data loss instead of preventing it. The gate refusing to claim green without proof is the right instinct; the actual upload just needs to be reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)