### PR TITLE
fix(auth): OIDC login-loop hardening — interactive fallback on login_required, preserve pending logins (2.0)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -478,15 +478,17 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           AuthenticationResponseParser.parse(new URI(computedCallbackUrl), parameters);
 
       if (response instanceof AuthenticationErrorResponse authenticationErrorResponse) {
-        LOG.error(
-            "Bad authentication response, error={}", authenticationErrorResponse.getErrorObject());
         // login_required & friends are the IdP's spec-defined "silent auth not possible"
         // replies (e.g. prompt=none with no IdP session). Fall back to interactive signin
         // instead of a 500 the frontend cannot recover from.
-        if (SILENT_AUTH_ERRORS.contains(authenticationErrorResponse.getErrorObject().getCode())) {
+        String errorCode = authenticationErrorResponse.getErrorObject().getCode();
+        if (SILENT_AUTH_ERRORS.contains(errorCode)) {
+          LOG.warn("Silent auth not possible (error={}), redirecting to signin", errorCode);
           resp.sendRedirect(serverUrl + "/signin");
           return;
         }
+        LOG.error(
+            "Bad authentication response, error={}", authenticationErrorResponse.getErrorObject());
         throw new TechnicalException("Bad authentication response");
       }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -121,6 +121,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           ClientAuthenticationMethod.PRIVATE_KEY_JWT,
           ClientAuthenticationMethod.NONE);
 
+  // OIDC spec error codes meaning "silent auth not possible; interactive login required"
+  private static final Set<String> SILENT_AUTH_ERRORS =
+      Set.of(
+          "login_required",
+          "interaction_required",
+          "consent_required",
+          "account_selection_required");
+
   public static final String DEFAULT_PRINCIPAL_DOMAIN = "openmetadata.org";
   public static final String REDIRECT_URI_KEY = "redirectUri";
 
@@ -450,10 +458,16 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   // Callback
   public void handleCallback(HttpServletRequest req, HttpServletResponse resp) {
     try {
-      UserSession pendingSession =
-          sessionService
-              .getPendingSession(req, resp)
-              .orElseThrow(() -> new TechnicalException("No pending session found for callback"));
+      Optional<UserSession> maybePendingSession = sessionService.getPendingSession(req, resp);
+      if (maybePendingSession.isEmpty()) {
+        // The cookie points at no live pending session (invalidated, restarted, or already
+        // consumed). A 500 here strands the browser in a login loop; getPendingSession has
+        // already cleared the stale cookie, so route the user to interactive signin instead.
+        LOG.warn("No pending session found for callback, redirecting to signin");
+        resp.sendRedirect(serverUrl + "/signin");
+        return;
+      }
+      UserSession pendingSession = maybePendingSession.get();
 
       LOG.debug(
           "Performing Auth Callback For User Session: {} ",
@@ -466,6 +480,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       if (response instanceof AuthenticationErrorResponse authenticationErrorResponse) {
         LOG.error(
             "Bad authentication response, error={}", authenticationErrorResponse.getErrorObject());
+        // login_required & friends are the IdP's spec-defined "silent auth not possible"
+        // replies (e.g. prompt=none with no IdP session). Fall back to interactive signin
+        // instead of a 500 the frontend cannot recover from.
+        if (SILENT_AUTH_ERRORS.contains(authenticationErrorResponse.getErrorObject().getCode())) {
+          resp.sendRedirect(serverUrl + "/signin");
+          return;
+        }
         throw new TechnicalException("Bad authentication response");
       }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/session/SessionService.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/session/SessionService.java
@@ -318,6 +318,13 @@ public class SessionService implements Managed {
     int maxAttempts = 5;
     for (int attempt = 0; attempt < maxAttempts && current != null; attempt++) {
       long now = now();
+      if (current.getStatus() == SessionStatus.PENDING && !current.isExpired(now)) {
+        // A login is in flight on this session: the cookie is written at /login but the
+        // session only becomes ACTIVE at /callback. A concurrent refresh (another tab's
+        // expiry timer) must not clear the cookie, or it breaks the pending login at the
+        // IdP round-trip and loops the user. Report "no active session" and leave it be.
+        return Optional.empty();
+      }
       if (current.isExpired(now)
           || current.getStatus() == SessionStatus.REVOKED
           || current.getStatus() == SessionStatus.EXPIRED

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/AuthenticationCodeFlowHandlerTest.java
@@ -108,17 +108,69 @@ class AuthenticationCodeFlowHandlerTest {
   }
 
   @Test
-  void handleCallback_noPendingSession_writesErrorResponse() throws Exception {
+  void handleCallback_noPendingSession_redirectsToSignin() throws Exception {
     when(sessionService.getPendingSession(request, response)).thenReturn(Optional.empty());
 
     AuthenticationCodeFlowHandler handler =
         createHandlerWithMockedInternals(sessionService, oidcClient);
+    setField(handler, "serverUrl", TEST_SERVER_URL);
+
+    handler.handleCallback(request, response);
+
+    verify(response).sendRedirect(TEST_SERVER_URL + "/signin");
+    verify(response, never()).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void handleCallback_silentAuthError_redirectsToSignin() throws Exception {
+    UserSession pendingSession =
+        UserSession.builder().id("pending-session").state("state-abc").build();
+    when(sessionService.getPendingSession(request, response))
+        .thenReturn(Optional.of(pendingSession));
+    when(oidcClient.getCallbackUrl()).thenReturn(TEST_SERVER_URL + "/callback");
+    when(request.getParameterMap())
+        .thenReturn(
+            Map.of(
+                "state", new String[] {"state-abc"},
+                "error", new String[] {"login_required"},
+                "error_description",
+                    new String[] {
+                      "The client specified not to prompt, but the user is not logged in."
+                    }));
+
+    AuthenticationCodeFlowHandler handler =
+        createHandlerWithMockedInternals(sessionService, oidcClient);
+    setField(handler, "serverUrl", TEST_SERVER_URL);
+
+    handler.handleCallback(request, response);
+
+    verify(response).sendRedirect(TEST_SERVER_URL + "/signin");
+    verify(response, never()).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void handleCallback_nonSilentAuthError_writesErrorResponse() throws Exception {
+    UserSession pendingSession =
+        UserSession.builder().id("pending-session").state("state-abc").build();
+    when(sessionService.getPendingSession(request, response))
+        .thenReturn(Optional.of(pendingSession));
+    when(oidcClient.getCallbackUrl()).thenReturn(TEST_SERVER_URL + "/callback");
+    when(request.getParameterMap())
+        .thenReturn(
+            Map.of(
+                "state", new String[] {"state-abc"},
+                "error", new String[] {"server_error"}));
+
+    AuthenticationCodeFlowHandler handler =
+        createHandlerWithMockedInternals(sessionService, oidcClient);
+    setField(handler, "serverUrl", TEST_SERVER_URL);
 
     handler.handleCallback(request, response);
 
     verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     String body = captureOutputStream.getCapturedOutput();
-    assertTrue(body.contains("No pending session found for callback"));
+    assertTrue(body.contains("Bad authentication response"));
+    verify(response, never()).sendRedirect(anyString());
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/session/SessionServiceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/session/SessionServiceTest.java
@@ -267,6 +267,30 @@ class SessionServiceTest {
   }
 
   @Test
+  void acquireRefreshLease_pendingLogin_returnsEmptyWithoutClearingCookieOrSession() {
+    String sessionId = validSessionId('g');
+    long now = System.currentTimeMillis();
+    UserSession pendingLogin =
+        UserSession.builder()
+            .id(sessionId)
+            .status(SessionStatus.PENDING)
+            .state("state")
+            .version(0L)
+            .expiresAt(now + 60_000)
+            .idleExpiresAt(now + 60_000)
+            .build();
+
+    when(request.getCookies()).thenReturn(new Cookie[] {new Cookie("OM_SESSION", sessionId)});
+    when(repository.findById(sessionId)).thenReturn(Optional.of(pendingLogin));
+
+    // A concurrent refresh (another tab's expiry timer) while the login round-trip is at the
+    // IdP must not break the pending login: no lease, no cookie clearing, no session mutation.
+    assertTrue(sessionService.acquireRefreshLease(request, response).isEmpty());
+    verify(response, never()).addHeader(eq("Set-Cookie"), any());
+    verify(repository, never()).updateIfVersion(any(UserSession.class), anyLong());
+  }
+
+  @Test
   void acquireRefreshLease_reclaimsStaleLease() {
     String sessionId = validSessionId('s');
     long now = System.currentTimeMillis();


### PR DESCRIPTION
Cherry-pick of #31181 onto 2.0 (files are identical between main and 2.0). Part of #30304.

- `handleCallback`: `login_required`/`interaction_required`/`consent_required`/`account_selection_required` → 302 `/signin` instead of 500.
- `handleCallback`: missing pending session (stale cookie) → 302 `/signin` instead of 500.
- `SessionService.acquireRefreshLease`: PENDING (in-flight) login → 401 **without clearing the session cookie**, so a concurrent tab's refresh no longer breaks the login round-trip at the IdP.

Includes the regression test `acquireRefreshLease_pendingLogin_returnsEmptyWithoutClearingCookieOrSession` (SessionServiceTest 32/32 green on main).

Sibling PRs: main #31181, plus the 1.13 hotfix for the in-memory HttpSession architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)