### PR TITLE
fix(auth): stop OIDC confidential login loop on session loss (1.13 hotfix)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -481,7 +481,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         // A 500 strands the browser on a dead cookie in a login loop; clear the cookie and
         // send the user to interactive signin instead.
         LOG.warn("No session found for callback, clearing session cookie, redirecting to signin");
-        clearSessionCookie(resp);
+        clearSessionCookie(req, resp);
         resp.sendRedirect(serverUrl + "/signin");
         return;
       }
@@ -590,7 +590,7 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
         // Respond 401 (not 500) and clear the dead cookie so the frontend re-logins cleanly
         // instead of looping on a cookie that can never resolve again.
         LOG.warn("No session found for refresh, clearing session cookie, responding 401");
-        clearSessionCookie(httpServletResponse);
+        clearSessionCookie(httpServletRequest, httpServletResponse);
         respondRefreshUnauthorized(httpServletResponse);
         return;
       }
@@ -881,15 +881,21 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
   }
 
   private static void respondRefreshUnauthorized(HttpServletResponse response) throws IOException {
+    // Write the body directly: SecurityUtil.writeJsonResponse ends with setStatus(SC_OK),
+    // which would silently turn this 401 into a 200 on an uncommitted response.
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-    writeJsonResponse(response, "{\"error\":\"Session expired. Please login again.\"}");
+    response.setContentType("application/json");
+    response.setCharacterEncoding("UTF-8");
+    response.getOutputStream().print("{\"error\":\"Session expired. Please login again.\"}");
+    response.getOutputStream().flush();
   }
 
-  private static void clearSessionCookie(HttpServletResponse response) {
+  private static void clearSessionCookie(HttpServletRequest request, HttpServletResponse response) {
     Cookie deadCookie = new Cookie("JSESSIONID", "");
     deadCookie.setPath("/");
     deadCookie.setMaxAge(0);
     deadCookie.setHttpOnly(true);
+    deadCookie.setSecure(request.isSecure());
     response.addCookie(deadCookie);
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -56,6 +56,7 @@ import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import com.nimbusds.openid.connect.sdk.validators.BadJWTExceptions;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -128,6 +129,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
           ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
           ClientAuthenticationMethod.PRIVATE_KEY_JWT,
           ClientAuthenticationMethod.NONE);
+
+  // OIDC spec error codes meaning "silent auth not possible; interactive login required"
+  private static final Set<String> SILENT_AUTH_ERRORS =
+      Set.of(
+          "login_required",
+          "interaction_required",
+          "consent_required",
+          "account_selection_required");
 
   public static final String DEFAULT_PRINCIPAL_DOMAIN = "openmetadata.org";
   public static final String OIDC_CREDENTIAL_PROFILE = "oidcCredentialProfile";
@@ -468,8 +477,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     try {
       HttpSession session = getHttpSession(req, false);
       if (session == null) {
-        LOG.error("No session found for callback, redirecting to login");
-        throw new TechnicalException("No session found for callback, redirecting to login");
+        // Hotfix #30304: the session backing this cookie is gone (invalidated or restarted).
+        // A 500 strands the browser on a dead cookie in a login loop; clear the cookie and
+        // send the user to interactive signin instead.
+        LOG.warn("No session found for callback, clearing session cookie, redirecting to signin");
+        clearSessionCookie(resp);
+        resp.sendRedirect(serverUrl + "/signin");
+        return;
       }
 
       LOG.debug("Performing Auth Callback For User Session: {} ", session.getId());
@@ -490,6 +504,14 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       if (response instanceof AuthenticationErrorResponse authenticationErrorResponse) {
         LOG.error(
             "Bad authentication response, error={}", authenticationErrorResponse.getErrorObject());
+        // Hotfix #30304: login_required & friends are the IdP's spec-defined "silent auth not
+        // possible" replies (e.g. prompt=none with no IdP session). Fall back to interactive
+        // signin instead of a 500 the frontend cannot recover from.
+        String errorCode = authenticationErrorResponse.getErrorObject().getCode();
+        if (SILENT_AUTH_ERRORS.contains(errorCode)) {
+          resp.sendRedirect(serverUrl + "/signin");
+          return;
+        }
         throw new TechnicalException("Bad authentication response");
       }
 
@@ -564,8 +586,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     try {
       HttpSession session = getHttpSession(httpServletRequest, false);
       if (session == null) {
-        LOG.error("No session found for refresh, redirecting to login");
-        throw new TechnicalException("No session found for refresh, redirecting to login");
+        // Hotfix #30304: no server-side session for this cookie (invalidated or restarted).
+        // Respond 401 (not 500) and clear the dead cookie so the frontend re-logins cleanly
+        // instead of looping on a cookie that can never resolve again.
+        LOG.warn("No session found for refresh, clearing session cookie, responding 401");
+        clearSessionCookie(httpServletResponse);
+        respondRefreshUnauthorized(httpServletResponse);
+        return;
       }
 
       LOG.debug("Performing Auth Refresh For User Session: {} ", session.getId());
@@ -584,9 +611,13 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
                 .getEpochSecond());
         writeJsonResponse(httpServletResponse, JsonUtils.pojoToJson(jwtResponse));
       } else {
-        LOG.debug(
-            "Credentials Not Found For User Session: {}, Redirect to Logout ", session.getId());
-        this.handleLogout(httpServletRequest, httpServletResponse);
+        // Hotfix #30304: do NOT logout/invalidate here. A login may be in flight on this very
+        // session (the cookie is set at /login but credentials only arrive at /callback); a
+        // concurrent tab's refresh timer landing in that window would invalidate the pending
+        // login and loop the user (Okta/WebAuthn completes -> callback finds no session).
+        // Respond 401 and leave the session AND cookie intact.
+        LOG.warn("Credentials not found for user session: {}, responding 401", session.getId());
+        respondRefreshUnauthorized(httpServletResponse);
       }
     } catch (Exception e) {
       getErrorMessage(httpServletResponse, new TechnicalException(e));
@@ -847,6 +878,19 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
     LOG.error("[Auth Callback Servlet] Failed in Auth Login", e);
     resp.getOutputStream()
         .println("<p> [Auth Callback Servlet] Authentication failed. Please try again. </p>");
+  }
+
+  private static void respondRefreshUnauthorized(HttpServletResponse response) throws IOException {
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    writeJsonResponse(response, "{\"error\":\"Session expired. Please login again.\"}");
+  }
+
+  private static void clearSessionCookie(HttpServletResponse response) {
+    Cookie deadCookie = new Cookie("JSESSIONID", "");
+    deadCookie.setPath("/");
+    deadCookie.setMaxAge(0);
+    deadCookie.setHttpOnly(true);
+    response.addCookie(deadCookie);
   }
 
   private void sendRedirectWithToken(


### PR DESCRIPTION
Fixes #30304 for the 1.13 line (in-memory HttpSession architecture — the DB-backed SessionService of 2.0 cannot be backported).

## Root cause — reproduced end-to-end on `server:1.13.1` + mock OIDC provider (confidential client, `offline_access`)
1.13 keeps OIDC credentials only in the in-memory Jetty `HttpSession`, and the session cookie is written at `/login` while credentials only arrive at `/callback`. Two failure paths, both reproduced with byte-identical log signatures from the customer incident:
- A `/refresh` that finds a session without credentials (e.g. a concurrent tab's expiry timer firing while the user is at Okta/WebAuthn) called `handleLogout → session.invalidate()` — destroying the in-flight login. The user completes Okta and their own callback then 500s ("No session found for callback"). The dead cookie was never cleared → **login loop**.
- `login_required` & friends at `/callback` (silent-auth refusal, e.g. `prompt=none` with no IdP session) → 500 with no recovery.

## Changes (single file, `AuthenticationCodeFlowHandler`)
- `/refresh` with session but no credentials → **401**, do NOT logout/invalidate (pending login survives).
- `/refresh` with no session → **401 + clear `JSESSIONID`** (was 500 with the dead cookie looping forever).
- `/callback` with no session → clear cookie + **302 `/signin`** (was 500).
- `/callback` with `login_required`/`interaction_required`/`consent_required`/`account_selection_required` → **302 `/signin`** (was 500).

## Verification (local rig: `server:1.13.1` container + repo mock OIDC provider, patched jar swapped in)
| Sequence | Stock 1.13.1 | Patched |
|---|---|---|
| refresh during pending login → complete Okta | invalidate → callback 500 → loop | 401 (session intact) → callback 200 → refresh 200 — **ends logged in** |
| dead cookie replay (restart/invalidate) | 500 forever | 401 + cookie cleared |
| `login_required` callback | 500 | 302 `/signin` |
| healthy login + refresh (`prompt=consent`, refresh-token grant) | 200 | 200 (no regression) |

Sibling PRs: main #31181, 2.0 #31182 (same semantics in the SessionService architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)