### PR TITLE
fix(ui): supply the required fontSize to SelectContext in combobox/autocomplete

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/autocomplete/autocomplete.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/autocomplete/autocomplete.tsx
@@ -415,7 +415,10 @@ export const AutocompleteBase = ({
 
   useResizeObserver({ ref: triggerRef, onResize, box: 'border-box' });
 
-  const selectContextValue = useMemo(() => ({ size: 'sm' as const }), []);
+  const selectContextValue = useMemo(
+    () => ({ size: 'sm' as const, fontSize: 'sm' as const }),
+    []
+  );
 
   const autocompleteContextValue = useMemo(
     () => ({

--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/combobox.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/base/select/combobox.tsx
@@ -165,7 +165,7 @@ export const ComboBox = ({
   });
 
   return (
-    <SelectContext.Provider value={{ size }}>
+    <SelectContext.Provider value={{ size, fontSize: 'md' }}>
       <AriaComboBox menuTrigger="focus" {...otherProps}>
         {(state) => (
           <div className="tw:flex tw:flex-col tw:gap-1.5">


### PR DESCRIPTION
## The failure

The `1.13` image build fails type-check, so no Java IT suite runs at all ([run 31168241209](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31168241209)):

```
src/components/base/autocomplete/autocomplete.tsx(443,29): error TS2741:
  Property 'fontSize' is missing in type '{ size: "sm"; }' but required in type
  '{ size: "sm" | "md"; fontSize: "xs" | "sm" | "md" | "lg" | "xl"; }'
src/components/base/select/combobox.tsx(168,29): error TS2741: ... same
```

## Cause

[#27379](https://github.com/open-metadata/OpenMetadata/pull/27379) made `fontSize` **required** on `SelectContext` back in April, but only updated `Select`'s own provider. `ComboBox` and `Autocomplete` still pass just `{ size }`.

`main` and `2.0` both supply it — `ComboBox` via a `fontSize` prop defaulting to `'md'`, `Autocomplete` hardcoding `'sm'`. So this is `1.13` having missed that half of the change, not a new regression.

It only surfaced now because the recent `1.13` Java IT runs were dispatched with an explicit `imageTag` and **skipped the build entirely**. Run 31168241209 is the first to actually build `1.13` since.

## The change

Two lines. Mirror the values `main` already uses rather than inventing new ones:

- `ComboBox` → `'md'` (main's prop default)
- `Autocomplete` → `'sm'` (what main hardcodes)

Backporting ComboBox's full `fontSize` prop is deliberately left out — nothing on `1.13` sets it, so it would be dead surface.

## Verification

Ran `tsc --noEmit` in `openmetadata-ui-core-components` locally:

- **before** — reproduces both CI errors exactly, same files and same line:col (`443,29` and `168,29`)
- **after** — `exit=0`, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
