### PR TITLE
fix: map MONEY and BIT columns to concrete SQLAlchemy types in profiler (#29459)

### DIFF
--- a/ingestion/src/metadata/profiler/orm/converter/azuresql/converter.py
+++ b/ingestion/src/metadata/profiler/orm/converter/azuresql/converter.py
@@ -10,13 +10,18 @@
 #  limitations under the License.
 
 """
-Map Types to convert/cast mssql related data types to relevant data types
+Map Types to convert/cast azuresql related data types to relevant data types
 """
 
-from sqlalchemy import NVARCHAR, TEXT
+from typing import Any
 
+import sqlalchemy
+from sqlalchemy import NVARCHAR, TEXT
+from sqlalchemy.sql.sqltypes import TypeEngine
+
+from metadata.generated.schema.entity.data.table import DataType
 from metadata.profiler.orm.converter.common import CommonMapTypes
-from metadata.profiler.orm.registry import CustomImage, CustomTypes, DataType
+from metadata.profiler.orm.registry import CustomImage, CustomTypes
 
 cast_dict = {
     CustomImage: "VARBINARY(max)",
@@ -30,9 +35,21 @@ class AzureSqlMapTypes(CommonMapTypes):
     AzureSql type mapper
     """
 
-    def __init__(self) -> None:
-        self._TYPE_MAP.update(
-            {
-                DataType.TIMESTAMP: CustomTypes.TIMESTAMP.value,
-            }
-        )
+    _TYPE_MAP_OVERRIDE = {  # noqa: RUF012
+        DataType.TIMESTAMP: CustomTypes.TIMESTAMP.value,
+        DataType.MONEY: sqlalchemy.NUMERIC,
+        DataType.BIT: sqlalchemy.BOOLEAN,
+    }
+    _TYPE_MAP = {  # noqa: RUF012
+        **CommonMapTypes._TYPE_MAP,
+        **_TYPE_MAP_OVERRIDE,
+    }
+
+    @staticmethod
+    def map_sqa_to_om_types() -> dict[TypeEngine, set[DataType]]:
+        """returns an ORM type"""
+        # Derived from _TYPE_MAP_OVERRIDE so the forward and reverse maps cannot drift.
+        mapping: dict[Any, set[DataType]] = dict(CommonMapTypes.map_sqa_to_om_types())
+        for om_type, sqa_type in AzureSqlMapTypes._TYPE_MAP_OVERRIDE.items():
+            mapping[sqa_type] = mapping.get(sqa_type, set()) | {om_type}
+        return mapping

--- a/ingestion/src/metadata/profiler/orm/converter/mssql/converter.py
+++ b/ingestion/src/metadata/profiler/orm/converter/mssql/converter.py
@@ -13,10 +13,15 @@
 Map Types to convert/cast mssql related data types to relevant data types
 """
 
-from sqlalchemy import NVARCHAR, TEXT
+from typing import Any
 
+import sqlalchemy
+from sqlalchemy import NVARCHAR, TEXT
+from sqlalchemy.sql.sqltypes import TypeEngine
+
+from metadata.generated.schema.entity.data.table import DataType
 from metadata.profiler.orm.converter.common import CommonMapTypes
-from metadata.profiler.orm.registry import CustomImage, CustomTypes, DataType
+from metadata.profiler.orm.registry import CustomImage, CustomTypes
 
 cast_dict = {
     CustomImage: "VARBINARY(max)",
@@ -30,9 +35,21 @@ class MssqlMapTypes(CommonMapTypes):
     Mssql type mapper
     """
 
-    def __init__(self) -> None:
-        self._TYPE_MAP.update(
-            {
-                DataType.TIMESTAMP: CustomTypes.TIMESTAMP.value,
-            }
-        )
+    _TYPE_MAP_OVERRIDE = {  # noqa: RUF012
+        DataType.TIMESTAMP: CustomTypes.TIMESTAMP.value,
+        DataType.MONEY: sqlalchemy.NUMERIC,
+        DataType.BIT: sqlalchemy.BOOLEAN,
+    }
+    _TYPE_MAP = {  # noqa: RUF012
+        **CommonMapTypes._TYPE_MAP,
+        **_TYPE_MAP_OVERRIDE,
+    }
+
+    @staticmethod
+    def map_sqa_to_om_types() -> dict[TypeEngine, set[DataType]]:
+        """returns an ORM type"""
+        # Derived from _TYPE_MAP_OVERRIDE so the forward and reverse maps cannot drift.
+        mapping: dict[Any, set[DataType]] = dict(CommonMapTypes.map_sqa_to_om_types())
+        for om_type, sqa_type in MssqlMapTypes._TYPE_MAP_OVERRIDE.items():
+            mapping[sqa_type] = mapping.get(sqa_type, set()) | {om_type}
+        return mapping

--- a/ingestion/tests/unit/observability/profiler/test_converter.py
+++ b/ingestion/tests/unit/observability/profiler/test_converter.py
@@ -16,13 +16,18 @@ Test ometa to orm converter
 from unittest.mock import patch
 from uuid import UUID
 
+import sqlalchemy
 from pytest import mark
 
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
 from metadata.generated.schema.entity.services.databaseService import (
     DatabaseServiceType,
 )
+from metadata.profiler.orm.converter.azuresql.converter import AzureSqlMapTypes
 from metadata.profiler.orm.converter.base import ometa_to_sqa_orm
+from metadata.profiler.orm.converter.common import CommonMapTypes
+from metadata.profiler.orm.converter.mssql.converter import MssqlMapTypes
+from metadata.profiler.orm.registry import CustomTypes
 
 
 @patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="schema")
@@ -119,3 +124,69 @@ def test_metadata_column(mock_schema, mock_database):
     assert orm_table.__table_args__["schema"] == "schema"
     for name, _ in column_definition:
         assert hasattr(orm_table, name)
+
+
+@patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="schema")
+@patch("metadata.profiler.orm.converter.base.get_orm_database", return_value="database")
+@mark.parametrize(
+    "service_type, table_name",
+    [
+        (DatabaseServiceType.Mssql, "mssql_money_and_bit_table"),
+        (DatabaseServiceType.AzureSQL, "azuresql_money_and_bit_table"),
+    ],
+)
+def test_money_and_bit_types_are_mapped(mock_schema, mock_database, service_type, table_name):
+    """MONEY and BIT columns (e.g. from MSSQL) must resolve to a concrete SQLAlchemy
+    type instead of falling back to CustomTypes.UNDETERMINED, which skips profiling
+    and renders sample data as the literal string "OPENMETADATA_UNDETERMIND[value]".
+
+    Each case needs its own table name: ometa_to_sqa_orm keys the generated declarative
+    class on it, so reusing one collides in the shared registry.
+    """
+    column_definition = [
+        ("amount", DataType.MONEY),
+        ("flag", DataType.BIT),
+    ]
+
+    columns = [Column(name=name, dataType=data_type) for name, data_type in column_definition]
+
+    table = Table(
+        id=UUID("1f8c1222-09a0-11ed-871b-ca4e864bb16a"),
+        name=table_name,
+        columns=columns,
+        serviceType=service_type,
+    )
+
+    orm_table = ometa_to_sqa_orm(table, None)
+
+    undetermined_type = CustomTypes.UNDETERMINED.value
+    amount_type = orm_table.__table__.columns["amount"].type
+    flag_type = orm_table.__table__.columns["flag"].type
+
+    assert not isinstance(amount_type, undetermined_type)
+    assert isinstance(amount_type, sqlalchemy.NUMERIC)
+    assert not isinstance(flag_type, undetermined_type)
+    assert isinstance(flag_type, sqlalchemy.BOOLEAN)
+
+
+@mark.parametrize("mapper", [MssqlMapTypes, AzureSqlMapTypes])
+def test_money_and_bit_reverse_map(mapper):
+    """The reverse map drives metric_filter's decision on which metrics to run, so
+    MONEY and BIT must be added to the existing entries rather than replacing them.
+    """
+    reverse_map = mapper.map_sqa_to_om_types()
+
+    assert reverse_map[sqlalchemy.NUMERIC] == {DataType.NUMBER, DataType.NUMERIC, DataType.MONEY}
+    assert reverse_map[sqlalchemy.BOOLEAN] == {DataType.BOOLEAN, DataType.BIT}
+
+
+def test_money_and_bit_stay_out_of_the_common_mapper():
+    """These are T-SQL types: mapping them on CommonMapTypes would apply them to every
+    connector, including ones where BIT is a bit-string rather than a boolean.
+    """
+    assert DataType.MONEY not in CommonMapTypes._TYPE_MAP
+    assert DataType.BIT not in CommonMapTypes._TYPE_MAP
+
+    common_reverse_map = CommonMapTypes.map_sqa_to_om_types()
+    assert DataType.MONEY not in common_reverse_map[sqlalchemy.NUMERIC]
+    assert DataType.BIT not in common_reverse_map[sqlalchemy.BOOLEAN]


### PR DESCRIPTION
Cherry-pick of #30210 (which fixed #29459) onto `2.0`.

`CommonMapTypes._TYPE_MAP` has no entries for `DataType.MONEY` or `DataType.BIT`, so MSSQL/AzureSQL columns of those types fall back to `CustomTypes.UNDETERMINED`. That type is in the profiler's `NOT_COMPUTE` set, so profiling is skipped and sample data renders as the literal string `OPENMETADATA_UNDETERMIND[value]`.

Since MONEY and BIT are T-SQL-specific, the mapping is scoped to the SQL Server converters rather than added to `CommonMapTypes`: `MssqlMapTypes` and `AzureSqlMapTypes` declare a class-level `_TYPE_MAP_OVERRIDE` (MONEY -> `NUMERIC`, BIT -> `BOOLEAN`) and derive their `map_sqa_to_om_types()` reverse map from it, so forward and reverse maps cannot drift.

Clean cherry-pick, no conflicts; diff is identical to the commit on `main`.
