### PR TITLE
fix(tests): await the delete cascade in NamespaceCleanup instead of timing out

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
@@ -3,6 +3,8 @@ package org.openmetadata.it.util;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.openmetadata.it.util.TestNamespace.EntityRoot;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.network.HttpClient;
@@ -99,29 +101,35 @@ public final class NamespaceCleanup {
   private static boolean awaitGone(
       final HttpClient http, final String collection, final EntityRoot root) {
     final String path = "/v1/" + collection + "/" + root.id();
-    final long deadline = System.nanoTime() + CASCADE_TIMEOUT.toNanos();
-    while (System.nanoTime() < deadline) {
-      try {
-        http.execute(HttpMethod.GET, path, null, Object.class);
-      } catch (final OpenMetadataException e) {
-        if (e.getStatusCode() == 404) {
-          return true;
-        }
-        // Anything else (auth blip, 5xx mid-cascade) is not proof of deletion — keep polling.
-        LOG.debug("Cleanup poll for {} {} got {}", root.entityType(), root.id(), e.getStatusCode());
-      }
-      try {
-        Thread.sleep(CASCADE_POLL.toMillis());
-      } catch (final InterruptedException interrupted) {
-        Thread.currentThread().interrupt();
-        return false;
-      }
+    boolean gone = true;
+    try {
+      Awaitility.await("cleanup cascade for " + root.entityType() + " " + root.id())
+          .atMost(CASCADE_TIMEOUT)
+          .pollInterval(CASCADE_POLL)
+          .until(() -> isGone(http, path));
+    } catch (final ConditionTimeoutException stillRunning) {
+      LOG.warn(
+          "Cleanup cascade for {} {} still running after {} — the next test seeds on top of it",
+          root.entityType(),
+          root.id(),
+          CASCADE_TIMEOUT);
+      gone = false;
     }
-    LOG.warn(
-        "Cleanup cascade for {} {} still running after {} — the next test seeds on top of it",
-        root.entityType(),
-        root.id(),
-        CASCADE_TIMEOUT);
-    return false;
+    return gone;
+  }
+
+  /**
+   * A 404 is the only answer that proves the root is gone. A 5xx thrown mid-cascade, or a transient
+   * auth blip, must read as "keep polling" — treating any failure as success would hand the next
+   * test the very cluster state this wait exists to prevent.
+   */
+  private static boolean isGone(final HttpClient http, final String path) {
+    boolean gone = false;
+    try {
+      http.execute(HttpMethod.GET, path, null, Object.class);
+    } catch (final OpenMetadataException e) {
+      gone = e.getStatusCode() == 404;
+    }
+    return gone;
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
@@ -1,8 +1,10 @@
 package org.openmetadata.it.util;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import org.openmetadata.it.util.TestNamespace.EntityRoot;
+import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.network.HttpClient;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.Entity;
@@ -14,10 +16,25 @@ import org.slf4j.LoggerFactory;
  * TestNamespace#trackRoot}). Deleting a root cascades its children (a databaseService takes its
  * databases/schemas/tables/columns with it), so only roots are tracked and deleted. Best-effort:
  * failures are logged, never thrown, so cleanup never fails a green test.
+ *
+ * <p>Deletes go through the <b>async</b> endpoint and then block until the root is really gone. The
+ * synchronous path holds the request open for the whole cascade, which a 100k-table service runs
+ * clean past the client's read timeout — that surfaced as {@code Cleanup delete failed: Network
+ * error: timeout}, {@code deleted 0/1}, and an entire tree left behind for the next test in the JVM
+ * to seed on top of. Waiting for the cascade is the point: these suites share one cluster, so a
+ * cleanup that returns early does not save time, it just moves the cost onto the next test's seed.
  */
 public final class NamespaceCleanup {
 
   private static final Logger LOG = LoggerFactory.getLogger(NamespaceCleanup.class);
+
+  // How long to wait for a recursive hard delete to finish cascading. Sized for the scale suite's
+  // 100k-table service, whose cascade ran ~6 minutes on an unloaded cluster; small tests fall
+  // through on the first poll, so a generous cap costs them nothing. Override with
+  // -Djpw.cleanup.cascadeTimeoutMin.
+  private static final Duration CASCADE_TIMEOUT =
+      Duration.ofMinutes(Integer.getInteger("jpw.cleanup.cascadeTimeoutMin", 15));
+  private static final Duration CASCADE_POLL = Duration.ofSeconds(5);
 
   // OM entity type -> REST collection path. Only top-level (root) types need entries.
   private static final Map<String, String> COLLECTION_PATHS =
@@ -55,15 +72,56 @@ public final class NamespaceCleanup {
             "No cleanup collection mapping for entity type '{}' — skipping", root.entityType());
         continue;
       }
-      final String path = "/v1/" + collection + "/" + root.id() + "?hardDelete=true&recursive=true";
+      final String path =
+          "/v1/" + collection + "/async/" + root.id() + "?hardDelete=true&recursive=true";
       try {
         http.execute(HttpMethod.DELETE, path, null, Object.class);
-        deleted++;
+        if (awaitGone(http, collection, root)) {
+          deleted++;
+        }
       } catch (final RuntimeException e) {
         LOG.warn(
             "Cleanup delete failed for {} {}: {}", root.entityType(), root.id(), e.getMessage());
       }
     }
     LOG.info("Namespace cleanup deleted {}/{} root entities", deleted, roots.size());
+  }
+
+  /**
+   * Blocks until the root is actually gone. The next test in the JVM seeds into this same cluster,
+   * so returning while a recursive hard delete is still cascading just hands the cost to that
+   * test's seed phase — at 100k tables that showed up as a seed going from ~31 minutes to 95-314,
+   * and then as ServiceDeleteSearchCleanupScaleIT missing its own 5-minute search-cleanup budget.
+   *
+   * <p>Best-effort, like the delete itself: a cascade still running at the cap is logged, not
+   * thrown, so cleanup never fails an otherwise green test.
+   */
+  private static boolean awaitGone(
+      final HttpClient http, final String collection, final EntityRoot root) {
+    final String path = "/v1/" + collection + "/" + root.id();
+    final long deadline = System.nanoTime() + CASCADE_TIMEOUT.toNanos();
+    while (System.nanoTime() < deadline) {
+      try {
+        http.execute(HttpMethod.GET, path, null, Object.class);
+      } catch (final OpenMetadataException e) {
+        if (e.getStatusCode() == 404) {
+          return true;
+        }
+        // Anything else (auth blip, 5xx mid-cascade) is not proof of deletion — keep polling.
+        LOG.debug("Cleanup poll for {} {} got {}", root.entityType(), root.id(), e.getStatusCode());
+      }
+      try {
+        Thread.sleep(CASCADE_POLL.toMillis());
+      } catch (final InterruptedException interrupted) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    }
+    LOG.warn(
+        "Cleanup cascade for {} {} still running after {} — the next test seeds on top of it",
+        root.entityType(),
+        root.id(),
+        CASCADE_TIMEOUT);
+    return false;
   }
 }


### PR DESCRIPTION
Fixes the `ServiceDeleteSearchCleanupScaleIT` failure that has been red on **main, 2.0 and 1.13** since 2026-08-03.

## What actually fails

The symptom looks like a broken delete cascade:

```
ServiceDeleteSearchCleanupScaleIT.recursiveServiceHardDelete_clearsTableAndColumnDocsAtScale:133
  ConditionTimeout ... 'count(<ns>_table_search_index) for service <id> == 0'
  didn't complete within 5 minutes
  expected: 0L but was: 100000L
```

It isn't. On the last green run that same delete cleared search in **116 seconds**. What changed is the state of the cluster it inherits.

## Cause

`NamespaceCleanup.deleteRoots` deleted roots through the **synchronous** endpoint, which holds the request open for the entire recursive hard delete. A 100k-table `databaseService` runs clean past the client's read timeout:

```
Cleanup delete failed for databaseService <id>: Network error: timeout
Namespace cleanup deleted 0/1 root entities
```

…leaving the whole tree in the cluster.

`ServiceDeleteSearchCleanupScaleIT` already knew about this trap — its own `recursiveHardDelete` uses the async endpoint and says so in a comment:

> *"a synchronous 100k-table delete can exceed a proxied cluster's gateway timeout"*

Cleanup never got the same treatment.

## Why that lands on this one test

The scale suite shares one cluster and runs `SAME_THREAD`, so leftovers land on whichever test runs next — and `ServiceDeleteSearchCleanupScaleIT` sorts **last**:

| run | left behind by earlier tests | its seed time | result |
|---|---|---|---|
| 2.0 Aug 3 00:45 | none | **31 min** | **PASS** — cleared in 116s |
| 2.0 Aug 6 | none | 65 min | FAIL |
| 2.0 Aug 7 | 100k | 95 min | FAIL |
| 1.13 Aug 6 | 150k (2 timeouts) | **314 min** | FAIL |

`EntityLoader` does the same 100k tables in a flat ~28 min in every one of those runs, which is what rules out general cluster slowness — the divergence is specific to what this test inherits.

By the time it triggers its own delete, the cluster is carrying its own 100k plus everything the previous tests couldn't remove, and a 5-minute budget — 116s of work on a clean cluster — is nowhere near enough.

## The change

Use the async endpoint (202 immediately, no client timeout), then poll until the root really is gone.

Waiting is the point: these suites share a cluster, so a cleanup that returns early doesn't save time, it moves the cost onto the next test's seed phase. Small tests fall through on the first poll, so the generous cap costs them nothing.

404 is matched on `OpenMetadataException.getStatusCode()` rather than by swallowing every exception, so a 5xx mid-cascade keeps polling instead of reading as "deleted". Cap is 15 min, overridable via `-Djpw.cleanup.cascadeTimeoutMin`. Best-effort contract is unchanged — a cascade still running at the cap is logged, never thrown.

All 17 root types in `COLLECTION_PATHS` expose `/async/{id}`; verified per resource.

## Honest scope

This removes a proven, major contributor. It is **not** proof the test goes green: one run (2.0 Aug 3 13:08) had every cleanup report `1/1` and still seeded for 103 minutes, so there's a second factor in cluster throughput this doesn't address. Worth re-running the scale suite before assuming it's closed.

## Verification

`mvn test-compile -pl openmetadata-integration-tests` — BUILD SUCCESS. Behaviour needs the nightly scale run; it can't be exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
