### PR TITLE
test(e2e): create BulkEdit custom properties via API in beforeAll (2.0 backport of #31177)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -10,12 +10,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, test } from '@playwright/test';
+import { APIRequestContext, expect, test } from '@playwright/test';
 
 import { RDG_ACTIVE_CELL_SELECTOR } from '../../constant/bulkImportExport';
 import { SERVICE_TYPE } from '../../constant/service';
-import { GlobalSettingOptions } from '../../constant/settings';
 import { Domain } from '../../support/domain/Domain';
+import { EntityTypeEndpoint } from '../../support/entity/Entity.interface';
 import { TableClass } from '../../support/entity/TableClass';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
@@ -31,7 +31,7 @@ import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { selectActiveGlossaryTerm } from '../../utils/glossary';
 import {
   createColumnRowDetails,
-  createCustomPropertiesForEntity,
+  createCustomPropertiesForEntityViaApi,
   createDatabaseRowDetails,
   createDatabaseSchemaRowDetails,
   createGlossaryTermRowDetails,
@@ -63,6 +63,17 @@ let glossary: Glossary;
 let glossaryTerm: GlossaryTerm;
 let domain1: Domain;
 let domain2: Domain;
+
+let databaseCustomProperties: Record<string, string> = {};
+let databaseSchemaCustomProperties: Record<string, string> = {};
+let tableCustomProperties: Record<string, string> = {};
+let glossaryTermCustomProperties: Record<string, string> = {};
+
+type CustomPropertyCleanupFn = (apiContext: APIRequestContext) => Promise<void>;
+let databaseCustomPropertiesCleanup: CustomPropertyCleanupFn;
+let databaseSchemaCustomPropertiesCleanup: CustomPropertyCleanupFn;
+let tableCustomPropertiesCleanup: CustomPropertyCleanupFn;
+let glossaryTermCustomPropertiesCleanup: CustomPropertyCleanupFn;
 
 let glossaryDetails: GlossaryDetails;
 let databaseSchemaDetails1: ReturnType<
@@ -111,6 +122,33 @@ test.describe('Bulk Edit Entity', () => {
     await domain1.create(apiContext);
     await domain2.create(apiContext);
 
+    const [
+      databaseResult,
+      databaseSchemaResult,
+      tableResult,
+      glossaryTermResult,
+    ] = await Promise.all([
+      createCustomPropertiesForEntityViaApi(apiContext, EntityTypeEndpoint.Database),
+      createCustomPropertiesForEntityViaApi(
+        apiContext,
+        EntityTypeEndpoint.DatabaseSchema
+      ),
+      createCustomPropertiesForEntityViaApi(apiContext, EntityTypeEndpoint.Table),
+      createCustomPropertiesForEntityViaApi(
+        apiContext,
+        EntityTypeEndpoint.GlossaryTerm
+      ),
+    ]);
+
+    databaseCustomProperties = databaseResult.propertyListName;
+    databaseCustomPropertiesCleanup = databaseResult.cleanup;
+    databaseSchemaCustomProperties = databaseSchemaResult.propertyListName;
+    databaseSchemaCustomPropertiesCleanup = databaseSchemaResult.cleanup;
+    tableCustomProperties = tableResult.propertyListName;
+    tableCustomPropertiesCleanup = tableResult.cleanup;
+    glossaryTermCustomProperties = glossaryTermResult.propertyListName;
+    glossaryTermCustomPropertiesCleanup = glossaryTermResult.cleanup;
+
     await afterAction();
   });
 
@@ -118,21 +156,24 @@ test.describe('Bulk Edit Entity', () => {
     await redirectToHomePage(page);
   });
 
+  test.afterAll('cleanup custom properties', async ({ browser }) => {
+    const { apiContext, afterAction } = await createNewPage(browser);
+    await Promise.all([
+      databaseCustomPropertiesCleanup(apiContext),
+      databaseSchemaCustomPropertiesCleanup(apiContext),
+      tableCustomPropertiesCleanup(apiContext),
+      glossaryTermCustomPropertiesCleanup(apiContext),
+    ]);
+    await afterAction();
+  });
+
   test('Database service', async ({ page }) => {
     test.slow(true);
 
     const table = new TableClass();
-    let customPropertyRecord: Record<string, string> = {};
 
     const { apiContext, afterAction } = await getApiContext(page);
     await table.create(apiContext);
-
-    await test.step('create custom properties for extension edit', async () => {
-      customPropertyRecord = await createCustomPropertiesForEntity(
-        page,
-        GlobalSettingOptions.DATABASES
-      );
-    });
 
     await test.step('Perform bulk edit action', async () => {
       const databaseDetails = {
@@ -183,7 +224,7 @@ test.describe('Bulk Edit Entity', () => {
           sourceUrl: undefined,
         },
         page,
-        customPropertyRecord,
+        databaseCustomProperties,
         true,
         true
       );
@@ -266,18 +307,10 @@ test.describe('Bulk Edit Entity', () => {
 
   test('Database', async ({ page }) => {
     test.slow(true);
-    let customPropertyRecord: Record<string, string> = {};
     const table = new TableClass();
 
     const { apiContext, afterAction } = await getApiContext(page);
     await table.create(apiContext);
-
-    await test.step('create custom properties for extension edit', async () => {
-      customPropertyRecord = await createCustomPropertiesForEntity(
-        page,
-        GlobalSettingOptions.DATABASE_SCHEMA
-      );
-    });
 
     await test.step('Perform bulk edit action', async () => {
       // visit entity Page
@@ -328,7 +361,7 @@ test.describe('Bulk Edit Entity', () => {
           domains: domain1.responseData,
         },
         page,
-        customPropertyRecord,
+        databaseSchemaCustomProperties,
         undefined,
         true
       );
@@ -423,18 +456,10 @@ test.describe('Bulk Edit Entity', () => {
 
   test('Database Schema', async ({ page }) => {
     test.slow(true);
-    let customPropertyRecord: Record<string, string> = {};
     const table = new TableClass();
 
     const { apiContext, afterAction } = await getApiContext(page);
     await table.create(apiContext);
-
-    await test.step('create custom properties for extension edit', async () => {
-      customPropertyRecord = await createCustomPropertiesForEntity(
-        page,
-        GlobalSettingOptions.TABLES
-      );
-    });
 
     await test.step('Perform bulk edit action', async () => {
       // visit entity page
@@ -489,7 +514,7 @@ test.describe('Bulk Edit Entity', () => {
           domains: domain1.responseData,
         },
         page,
-        customPropertyRecord,
+        tableCustomProperties,
         true,
         true
       );
@@ -684,8 +709,6 @@ test.describe('Bulk Edit Entity', () => {
   test('Glossary', async ({ page }) => {
     test.slow();
 
-    let customPropertyRecord: Record<string, string> = {};
-
     const additionalGlossaryTerm = createGlossaryTermRowDetails();
     const glossary = new Glossary();
     const glossaryTerm = new GlossaryTerm(glossary);
@@ -705,13 +728,6 @@ test.describe('Bulk Edit Entity', () => {
       glossaryTerm.responseData.fullyQualifiedName,
       'glossary_term_search_index'
     );
-
-    await test.step('create custom properties for extension edit', async () => {
-      customPropertyRecord = await createCustomPropertiesForEntity(
-        page,
-        GlobalSettingOptions.GLOSSARY_TERM
-      );
-    });
 
     await test.step('Perform bulk edit action', async () => {
       await glossary.visitEntityPage(page);
@@ -743,7 +759,7 @@ test.describe('Bulk Edit Entity', () => {
           },
         },
         page,
-        customPropertyRecord,
+        glossaryTermCustomProperties,
         true
       );
 
@@ -810,7 +826,7 @@ test.describe('Bulk Edit Entity', () => {
       await page.click('[data-testid="custom_properties"]');
       await waitForAllLoadersToDisappear(page);
 
-      for (const propertyName of Object.values(customPropertyRecord)) {
+      for (const propertyName of Object.values(glossaryTermCustomProperties)) {
         await expect(page.getByText(propertyName)).toBeVisible();
       }
     });
@@ -821,8 +837,6 @@ test.describe('Bulk Edit Entity', () => {
 
   test('Glossary Term (Nested)', async ({ page }) => {
     test.slow();
-
-    let customPropertyRecord: Record<string, string> = {};
 
     const additionalNestedGlossaryTerm = createGlossaryTermRowDetails();
     const glossary = new Glossary();
@@ -847,13 +861,6 @@ test.describe('Bulk Edit Entity', () => {
       nestedGlossaryTerm.responseData.fullyQualifiedName,
       'glossary_term_search_index'
     );
-
-    await test.step('create custom properties for extension edit', async () => {
-      customPropertyRecord = await createCustomPropertiesForEntity(
-        page,
-        GlobalSettingOptions.GLOSSARY_TERM
-      );
-    });
 
     await test.step('Perform bulk edit action on nested glossary term', async () => {
       // Navigate to the parent glossary term page
@@ -906,7 +913,7 @@ test.describe('Bulk Edit Entity', () => {
           },
         },
         page,
-        customPropertyRecord,
+        glossaryTermCustomProperties,
         true
       );
 
@@ -962,7 +969,7 @@ test.describe('Bulk Edit Entity', () => {
       await page.click('[data-testid="custom_properties"]');
       await waitForAllLoadersToDisappear(page);
 
-      for (const propertyName of Object.values(customPropertyRecord)) {
+      for (const propertyName of Object.values(glossaryTermCustomProperties)) {
         await expect(page.getByText(propertyName)).toBeVisible();
       }
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/BulkEditEntity.spec.ts
@@ -128,12 +128,18 @@ test.describe('Bulk Edit Entity', () => {
       tableResult,
       glossaryTermResult,
     ] = await Promise.all([
-      createCustomPropertiesForEntityViaApi(apiContext, EntityTypeEndpoint.Database),
+      createCustomPropertiesForEntityViaApi(
+        apiContext,
+        EntityTypeEndpoint.Database
+      ),
       createCustomPropertiesForEntityViaApi(
         apiContext,
         EntityTypeEndpoint.DatabaseSchema
       ),
-      createCustomPropertiesForEntityViaApi(apiContext, EntityTypeEndpoint.Table),
+      createCustomPropertiesForEntityViaApi(
+        apiContext,
+        EntityTypeEndpoint.Table
+      ),
       createCustomPropertiesForEntityViaApi(
         apiContext,
         EntityTypeEndpoint.GlossaryTerm
@@ -159,10 +165,10 @@ test.describe('Bulk Edit Entity', () => {
   test.afterAll('cleanup custom properties', async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
     await Promise.all([
-      databaseCustomPropertiesCleanup(apiContext),
-      databaseSchemaCustomPropertiesCleanup(apiContext),
-      tableCustomPropertiesCleanup(apiContext),
-      glossaryTermCustomPropertiesCleanup(apiContext),
+      databaseCustomPropertiesCleanup?.(apiContext),
+      databaseSchemaCustomPropertiesCleanup?.(apiContext),
+      tableCustomPropertiesCleanup?.(apiContext),
+      glossaryTermCustomPropertiesCleanup?.(apiContext),
     ]);
     await afterAction();
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -1466,7 +1466,9 @@ export const createCustomPropertiesForEntityViaApi = async (
   const entitySchema = await entitySchemaResponse.json();
   const entityTypeId: string = entitySchema.id;
 
-  const typeMapping: Array<[string, string, Record<string, unknown> | undefined]> = [
+  const typeMapping: Array<
+    [string, string, Record<string, unknown> | undefined]
+  > = [
     [CUSTOM_PROPERTIES_TYPES.STRING, 'string', undefined],
     [CUSTOM_PROPERTIES_TYPES.MARKDOWN, 'markdown', undefined],
     [CUSTOM_PROPERTIES_TYPES.SQL_QUERY, 'sqlQuery', undefined],
@@ -1519,7 +1521,9 @@ export const createCustomPropertiesForEntityViaApi = async (
     await Promise.all(
       Object.values(propertyListName).map((propertyName) =>
         cleanupApiContext.delete(
-          `/api/v1/metadata/types/${entityTypeId}/customProperties/${encodeURIComponent(propertyName)}`
+          `/api/v1/metadata/types/${entityTypeId}/customProperties/${encodeURIComponent(
+            propertyName
+          )}`
         )
       )
     );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -1443,12 +1443,26 @@ export const createCustomPropertiesForEntityViaApi = async (
   const propertiesResponse = await apiContext.get(
     '/api/v1/metadata/types?category=field&limit=20'
   );
+
+  if (!propertiesResponse.ok()) {
+    throw new Error(
+      `Failed to fetch field types: ${propertiesResponse.status()} ${propertiesResponse.statusText()}`
+    );
+  }
+
   const properties = await propertiesResponse.json();
 
   const entityTypeName = ENTITY_PATH[endpoint as keyof typeof ENTITY_PATH];
   const entitySchemaResponse = await apiContext.get(
     `/api/v1/metadata/types/name/${entityTypeName}`
   );
+
+  if (!entitySchemaResponse.ok()) {
+    throw new Error(
+      `Failed to fetch entity schema for "${entityTypeName}": ${entitySchemaResponse.status()} ${entitySchemaResponse.statusText()}`
+    );
+  }
+
   const entitySchema = await entitySchemaResponse.json();
   const entityTypeId: string = entitySchema.id;
 
@@ -1480,14 +1494,23 @@ export const createCustomPropertiesForEntityViaApi = async (
 
     const propertyName = `pwcustomproperty${entityTypeName}test${uuid()}`;
 
-    await apiContext.put(`/api/v1/metadata/types/${entityTypeId}`, {
-      data: {
-        name: propertyName,
-        description: propertyName,
-        propertyType: { id: typeInfo.id, type: 'type' },
-        ...(extraConfig ?? {}),
-      },
-    });
+    const putResponse = await apiContext.put(
+      `/api/v1/metadata/types/${entityTypeId}`,
+      {
+        data: {
+          name: propertyName,
+          description: propertyName,
+          propertyType: { id: typeInfo.id, type: 'type' },
+          ...(extraConfig ?? {}),
+        },
+      }
+    );
+
+    if (!putResponse.ok()) {
+      throw new Error(
+        `Failed to create custom property "${propertyName}" (${apiTypeName}): ${putResponse.status()} ${putResponse.statusText()}`
+      );
+    }
 
     propertyListName[displayName] = propertyName;
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { expect, Locator, Page } from '@playwright/test';
+import { APIRequestContext, expect, Locator, Page } from '@playwright/test';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -25,6 +25,10 @@ import {
   FIELD_VALUES_CUSTOM_PROPERTIES,
 } from '../constant/glossaryImportExport';
 import { GlobalSettingOptions } from '../constant/settings';
+import {
+  EntityTypeEndpoint,
+  ENTITY_PATH,
+} from '../support/entity/Entity.interface';
 import {
   clickOutside,
   descriptionBox,
@@ -1427,6 +1431,78 @@ export const createCustomPropertiesForEntity = async (
   }
 
   return propertyListName;
+};
+
+export const createCustomPropertiesForEntityViaApi = async (
+  apiContext: APIRequestContext,
+  endpoint: EntityTypeEndpoint
+): Promise<{
+  propertyListName: Record<string, string>;
+  cleanup: (apiContext: APIRequestContext) => Promise<void>;
+}> => {
+  const propertiesResponse = await apiContext.get(
+    '/api/v1/metadata/types?category=field&limit=20'
+  );
+  const properties = await propertiesResponse.json();
+
+  const entityTypeName = ENTITY_PATH[endpoint as keyof typeof ENTITY_PATH];
+  const entitySchemaResponse = await apiContext.get(
+    `/api/v1/metadata/types/name/${entityTypeName}`
+  );
+  const entitySchema = await entitySchemaResponse.json();
+  const entityTypeId: string = entitySchema.id;
+
+  const typeMapping: Array<[string, string, Record<string, unknown> | undefined]> = [
+    [CUSTOM_PROPERTIES_TYPES.STRING, 'string', undefined],
+    [CUSTOM_PROPERTIES_TYPES.MARKDOWN, 'markdown', undefined],
+    [CUSTOM_PROPERTIES_TYPES.SQL_QUERY, 'sqlQuery', undefined],
+    [
+      CUSTOM_PROPERTIES_TYPES.TABLE,
+      'table-cp',
+      {
+        customPropertyConfig: {
+          config: { columns: FIELD_VALUES_CUSTOM_PROPERTIES.TABLE.columns },
+        },
+      },
+    ],
+  ];
+
+  const propertyListName: Record<string, string> = {};
+
+  for (const [displayName, apiTypeName, extraConfig] of typeMapping) {
+    const typeInfo = properties.data.find(
+      (item: { name: string }) => item.name === apiTypeName
+    );
+
+    if (!typeInfo) {
+      continue;
+    }
+
+    const propertyName = `pwcustomproperty${entityTypeName}test${uuid()}`;
+
+    await apiContext.put(`/api/v1/metadata/types/${entityTypeId}`, {
+      data: {
+        name: propertyName,
+        description: propertyName,
+        propertyType: { id: typeInfo.id, type: 'type' },
+        ...(extraConfig ?? {}),
+      },
+    });
+
+    propertyListName[displayName] = propertyName;
+  }
+
+  const cleanup = async (cleanupApiContext: APIRequestContext) => {
+    await Promise.all(
+      Object.values(propertyListName).map((propertyName) =>
+        cleanupApiContext.delete(
+          `/api/v1/metadata/types/${entityTypeId}/customProperties/${encodeURIComponent(propertyName)}`
+        )
+      )
+    );
+  };
+
+  return { propertyListName, cleanup };
 };
 
 export const fillRecursiveEntityTypeFQNDetails = async (


### PR DESCRIPTION
## Describe your changes

**2.0 backport of #31177** by @Rohit0301 — cherry-picked, not re-authored. All four commits keep their original authorship.

| | |
|---|---|
| Source PR | #31177 (base `main`) |
| Commits | `2501d58` → `b3b2d63`, `911674d` → `3b3ddb6`, `996ec6e` → `d384866`, `5429a64` → `45a80c1` |
| Merge commit | skipped (`--no-merges`; it only pulled `main` into the topic branch) |

### Fidelity

The backport's net diff against `2.0` is **byte-identical** to the source PR's net diff against its merge base — 222 changed lines on both sides, zero lines unique to either:

```
PR changed lines: 222 | backport changed lines: 222
only in PR:       0
only in backport: 0
```

`BulkEditEntity.spec.ts` is identical between `main` and `2.0`. `importUtils.ts` differs by one line between the two bases; git auto-merged that hunk during the pick, and the byte-identical net diff above confirms it landed correctly.

## Type of change

- [x] Test / CI change (no product code touched)

## Tests

Not independently re-run here — this is a straight cherry-pick whose net diff provably matches #31177, so the validation that applies is the source PR's.

CI selection is confirmed to cover it: `BulkEditEntity.spec.ts` is a directly changed spec, so the selector picks it up automatically.

```
directChangedSpecs: ['playwright/e2e/Features/BulkEditEntity.spec.ts']
total selected: 22
```

## Note for reviewers

**#31177 is still open and unmerged on `main`.** If review changes it before it lands, this backport will need the delta re-applied — it is a snapshot of the head as of the cherry-pick, not of whatever finally merges. Worth holding this until #31177 merges, or re-syncing afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
