### PR TITLE
fix(search): route column search through the structured builder so counts match results (#31106) [1.13 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
@@ -93,6 +93,42 @@ public class ColumnSearchIndexIT {
     }
 
     @Test
+    @DisplayName("FQN search on tableColumn matches only that column, not its siblings")
+    void testColumnFqnSearchIsPrecise(TestNamespace ns) throws Exception {
+      OpenMetadataClient client = SdkClients.adminClient();
+      Table table = createTableWithColumns(ns, "col_fqn_precise");
+      String userIdFqn =
+          table.getColumns().stream()
+              .filter(c -> c.getName().equals(ns.prefix("user_id")))
+              .findFirst()
+              .orElseThrow()
+              .getFullyQualifiedName();
+
+      // Wait for indexing
+      TimeUnit.SECONDS.sleep(2);
+
+      // Searching a column's full FQN must return only that column. The permissive OR builder
+      // also matched sibling columns (user_email, created_at) that share the service/db/schema/
+      // table tokens, inflating the count (the "count 1 vs results 7381" bug); the structured
+      // builder (operator AND over fqnParts) matches just the one column.
+      String response =
+          client
+              .search()
+              .query(userIdFqn)
+              .index("column_search_index")
+              .size(50)
+              .deleted(false)
+              .execute();
+      JsonNode root = OBJECT_MAPPER.readTree(response);
+      int total = root.path("hits").path("total").path("value").asInt();
+      assertEquals(1, total, "FQN search should match one column, response: " + response);
+      assertEquals(
+          userIdFqn,
+          root.path("hits").path("hits").get(0).path("_source").path("fullyQualifiedName").asText(),
+          "The single hit should be the searched column");
+    }
+
+    @Test
     @DisplayName("Should return columns with parent table reference")
     void testColumnHasTableReference(TestNamespace ns) throws Exception {
       OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
@@ -31,7 +31,6 @@ import org.openmetadata.schema.api.search.TermBoost;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.CustomPropertySearchFields;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.indexes.TestCaseIndex;
 import org.openmetadata.service.search.indexes.TestCaseResolutionStatusIndex;
@@ -326,7 +325,12 @@ public class ElasticSearchSourceBuilderFactory
     }
 
     if (isColumnIndex(indexName)) {
-      return buildColumnSearchBuilderV2(searchQuery, fromOffset, size);
+      // Column docs carry fqnParts and structured search fields (the "tableColumn"
+      // AssetTypeConfiguration). Route through the data-asset builder so an FQN query
+      // matches precisely (operator AND over fqnParts) instead of OR-matching every
+      // column that merely shares a parent-name token.
+      return buildDataAssetSearchBuilderV2(
+          indexName, searchQuery, fromOffset, size, includeExplain, includeAggregations);
     }
 
     if (isServiceIndex(indexName)) {
@@ -367,27 +371,6 @@ public class ElasticSearchSourceBuilderFactory
           query, from, size);
       default -> buildAggregateSearchBuilderV2(query, from, size);
     };
-  }
-
-  public ElasticSearchRequestBuilder buildColumnSearchBuilderV2(String query, int from, int size) {
-    es.co.elastic.clients.elasticsearch._types.query_dsl.Query queryBuilder;
-    if (nullOrEmpty(query) || "*".equals(query.trim())) {
-      queryBuilder =
-          es.co.elastic.clients.elasticsearch._types.query_dsl.Query.of(q -> q.matchAll(m -> m));
-    } else {
-      Map<String, Float> fields = ColumnSearchIndex.getFields();
-      queryBuilder =
-          ElasticQueryBuilder.multiMatchQuery(
-              query,
-              fields,
-              es.co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType.BestFields,
-              es.co.elastic.clients.elasticsearch._types.query_dsl.Operator.Or,
-              String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
-    }
-    es.co.elastic.clients.elasticsearch.core.search.Highlight hb =
-        buildHighlightsV2(List.of("name", "displayName", "description"));
-    return searchBuilderV2(queryBuilder, hb, from, size);
   }
 
   public ElasticSearchRequestBuilder buildServiceSearchBuilderV2(String query, int from, int size) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
@@ -28,7 +28,6 @@ import org.openmetadata.schema.api.search.TermBoost;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.CustomPropertySearchFields;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.indexes.TestCaseIndex;
 import org.openmetadata.service.search.indexes.TestCaseResolutionStatusIndex;
@@ -307,7 +306,12 @@ public class OpenSearchSourceBuilderFactory
     }
 
     if (isColumnIndex(indexName)) {
-      return buildColumnSearchBuilderV2(searchQuery, fromOffset, size);
+      // Column docs carry fqnParts and structured search fields (the "tableColumn"
+      // AssetTypeConfiguration). Route through the data-asset builder so an FQN query
+      // matches precisely (operator AND over fqnParts) instead of OR-matching every
+      // column that merely shares a parent-name token.
+      return buildDataAssetSearchBuilderV2(
+          indexName, searchQuery, fromOffset, size, includeExplain, includeAggregations);
     }
 
     if (isServiceIndex(indexName)) {
@@ -366,27 +370,6 @@ public class OpenSearchSourceBuilderFactory
         buildSearchQueryBuilderV2(query, TestCaseResultIndex.getFields());
     os.org.opensearch.client.opensearch.core.search.Highlight highlighter =
         buildHighlightsV2(new ArrayList<>());
-    return searchBuilderV2(queryBuilder, highlighter, from, size);
-  }
-
-  public OpenSearchRequestBuilder buildColumnSearchBuilderV2(String query, int from, int size) {
-    os.org.opensearch.client.opensearch._types.query_dsl.Query queryBuilder;
-    if (nullOrEmpty(query) || "*".equals(query.trim())) {
-      queryBuilder =
-          os.org.opensearch.client.opensearch._types.query_dsl.Query.of(q -> q.matchAll(m -> m));
-    } else {
-      Map<String, Float> fields = ColumnSearchIndex.getFields();
-      queryBuilder =
-          OpenSearchQueryBuilder.multiMatchQuery(
-              query,
-              fields,
-              os.org.opensearch.client.opensearch._types.query_dsl.TextQueryType.BestFields,
-              os.org.opensearch.client.opensearch._types.query_dsl.Operator.Or,
-              String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
-    }
-    os.org.opensearch.client.opensearch.core.search.Highlight highlighter =
-        buildHighlightsV2(List.of("name", "displayName", "description"));
     return searchBuilderV2(queryBuilder, highlighter, from, size);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
@@ -19,6 +19,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import es.co.elastic.clients.util.NamedValue;
+import jakarta.json.stream.JsonGenerator;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -38,6 +40,7 @@ import org.openmetadata.service.search.elasticsearch.ElasticSearchRequestBuilder
 import org.openmetadata.service.search.elasticsearch.ElasticSearchSourceBuilderFactory;
 import org.openmetadata.service.search.opensearch.OpenSearchRequestBuilder;
 import org.openmetadata.service.search.opensearch.OpenSearchSourceBuilderFactory;
+import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
 
 public class SearchSourceBuilderFactoryTest {
 
@@ -209,6 +212,40 @@ public class SearchSourceBuilderFactoryTest {
       assertEquals(0, tableBuilder.from());
       assertEquals(10, tableBuilder.size());
     }
+  }
+
+  @Test
+  public void testColumnIndexUsesStructuredDataAssetBuilder() {
+    // Regression for the Explore column count-vs-results mismatch: index=tableColumn must go
+    // through the structured data-asset builder (operator AND over fqnParts) so an FQN query
+    // matches the one column precisely. The old permissive OR multi_match had no fqnParts and
+    // matched every column that shared a parent-name token (returned the whole index).
+    OpenSearchSourceBuilderFactory osFactory = new OpenSearchSourceBuilderFactory(searchSettings);
+    ElasticSearchSourceBuilderFactory esFactory =
+        new ElasticSearchSourceBuilderFactory(searchSettings);
+
+    String osQuery =
+        serializeOpenSearchRequest(
+            osFactory.getSearchSourceBuilderV2("tableColumn", "customer orders", 0, 15));
+    String esQuery =
+        esFactory
+            .getSearchSourceBuilderV2("tableColumn", "customer orders", 0, 15)
+            .query()
+            .toString();
+
+    assertTrue(osQuery.contains("fqnParts"), osQuery);
+    assertTrue(osQuery.contains("\"operator\":\"and\""), osQuery);
+    assertTrue(esQuery.contains("fqnParts"), esQuery);
+    assertTrue(esQuery.contains("\"operator\":\"and\""), esQuery);
+  }
+
+  private static String serializeOpenSearchRequest(OpenSearchRequestBuilder requestBuilder) {
+    JacksonJsonpMapper mapper = new JacksonJsonpMapper();
+    StringWriter writer = new StringWriter();
+    JsonGenerator generator = mapper.jsonProvider().createGenerator(writer);
+    requestBuilder.build("table_search_index").serialize(generator, mapper);
+    generator.close();
+    return writer.toString();
   }
 
   @Test


### PR DESCRIPTION
Backport of #31106 to `1.13`.

### Describe your changes:

Fixes open-metadata/openmetadata-collate#3851 on the 1.13 line.

The Explore **Columns** tab shows a count of **1** but the results list shows **7,381**. Root cause: `index=tableColumn` results were built by `buildColumnSearchBuilderV2` — a permissive `multi_match` (`best_fields`, `operator: OR`) that does **not** search `fqnParts`. An FQN query therefore OR-matched every column that shares a parent-name token (service/db/schema/table) and returned the whole column index, while the `dataAsset` aggregation that backs the tab count uses the **structured** builder (`operator: AND` over `fqnParts`) and correctly returns 1.

**Fix:** route column indexes through `buildDataAssetSearchBuilderV2` (like `table` does) so they use the existing `tableColumn` `AssetTypeConfiguration`, which already has `fqnParts` + structured match types. An FQN search now matches the one column precisely (count == results), and column-name search still works via the config's `name`/`name.ngram` fields. The now-unused `buildColumnSearchBuilderV2` is removed from both engine factories.

### Backport notes (differences from the `main` commit):

- The `main` commit applied verbatim to both `SourceBuilderFactory` files (the V2 builder architecture is identical on 1.13).
- The integration test `ColumnSearchIndexIT#testColumnFqnSearchIsPrecise` was adapted to 1.13's existing IT conventions (fixed `TimeUnit.SECONDS.sleep(2)` wait + `"column_search_index"` string literal) because the `Awaitility` polling helpers and `COLUMN_SEARCH_INDEX` constant used on `main` are from later, un-backported IT refactors. Assertions are unchanged (total == 1, single hit is the searched column).
- The unit test `SearchSourceBuilderFactoryTest#testColumnIndexUsesStructuredDataAssetBuilder` applied as-is (its `serializeOpenSearchRequest` helper + imports were brought along, since they were pre-existing on `main` but absent on 1.13).

### Type of change:

- [x] Bug fix

### Tests:

- `SearchSourceBuilderFactoryTest#testColumnIndexUsesStructuredDataAssetBuilder` — `index=tableColumn` now emits a query carrying `fqnParts` + `"operator":"and"` (OpenSearch **and** Elasticsearch). Verified locally: `Tests run: 13, Failures: 0, Errors: 0`.
- `ColumnSearchIndexIT#testColumnFqnSearchIsPrecise` — against real OpenSearch, searching a column's full FQN returns exactly that column (total == 1). Compile-verified locally; runs in CI against the Docker/OpenSearch stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)