### PR TITLE
fix(search): route column search through the structured builder so counts match results (#31106) [2.0 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ColumnSearchIndexIT.java
@@ -80,6 +80,51 @@ public class ColumnSearchIndexIT {
     }
 
     @Test
+    @DisplayName("FQN search on tableColumn matches only that column, not its siblings")
+    void testColumnFqnSearchIsPrecise(TestNamespace ns) {
+      OpenMetadataClient client = SdkClients.adminClient();
+      Table table = createTableWithColumns(ns, "col_fqn_precise");
+      String userIdFqn =
+          table.getColumns().stream()
+              .filter(c -> c.getName().equals(ns.prefix("user_id")))
+              .findFirst()
+              .orElseThrow()
+              .getFullyQualifiedName();
+
+      // Searching a column's full FQN must return only that column. The permissive OR builder
+      // also matched sibling columns (user_email, created_at) that share the service/db/schema/
+      // table tokens, inflating the count (the "count 1 vs results 7381" bug); the structured
+      // builder (operator AND over fqnParts) matches just the one column.
+      Awaitility.await("precise FQN column search")
+          .pollInterval(POLL_INTERVAL)
+          .atMost(POLL_AT_MOST)
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                String response =
+                    client
+                        .search()
+                        .query(userIdFqn)
+                        .index(COLUMN_SEARCH_INDEX)
+                        .size(50)
+                        .deleted(false)
+                        .execute();
+                JsonNode root = OBJECT_MAPPER.readTree(response);
+                int total = root.path("hits").path("total").path("value").asInt();
+                assertEquals(1, total, "FQN search should match one column, response: " + response);
+                assertEquals(
+                    userIdFqn,
+                    root.path("hits")
+                        .path("hits")
+                        .get(0)
+                        .path("_source")
+                        .path("fullyQualifiedName")
+                        .asText(),
+                    "The single hit should be the searched column");
+              });
+    }
+
+    @Test
     @DisplayName("Should return columns with parent table reference")
     void testColumnHasTableReference(TestNamespace ns) {
       OpenMetadataClient client = SdkClients.adminClient();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchSourceBuilderFactory.java
@@ -39,7 +39,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.CustomPropertySearchFields;
 import org.openmetadata.service.search.SearchRankingHelper;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 import org.openmetadata.service.search.indexes.ContextMemoryIndex;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.indexes.TestCaseIndex;
@@ -330,7 +329,12 @@ public class ElasticSearchSourceBuilderFactory
     }
 
     if (isColumnIndex(indexName)) {
-      return buildColumnSearchBuilderV2(searchQuery, fromOffset, size);
+      // Column docs carry fqnParts and structured search fields (the "tableColumn"
+      // AssetTypeConfiguration). Route through the data-asset builder so an FQN query
+      // matches precisely (operator AND over fqnParts) instead of OR-matching every
+      // column that merely shares a parent-name token.
+      return buildDataAssetSearchBuilderV2(
+          indexName, searchQuery, fromOffset, size, includeExplain, includeAggregations);
     }
 
     if (isServiceIndex(indexName)) {
@@ -373,25 +377,6 @@ public class ElasticSearchSourceBuilderFactory
           query, from, size);
       default -> buildAggregateSearchBuilderV2(query, from, size);
     };
-  }
-
-  public ElasticSearchRequestBuilder buildColumnSearchBuilderV2(String query, int from, int size) {
-    Query queryBuilder;
-    if (nullOrEmpty(query) || "*".equals(query.trim())) {
-      queryBuilder = Query.of(q -> q.matchAll(m -> m));
-    } else {
-      Map<String, Float> fields = ColumnSearchIndex.getFields();
-      queryBuilder =
-          ElasticQueryBuilder.multiMatchQuery(
-              query,
-              fields,
-              TextQueryType.BestFields,
-              Operator.Or,
-              String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
-    }
-    Highlight hb = buildHighlightsV2(List.of("name", "displayName", "description"));
-    return searchBuilderV2(queryBuilder, hb, from, size);
   }
 
   public ElasticSearchRequestBuilder buildServiceSearchBuilderV2(String query, int from, int size) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchSourceBuilderFactory.java
@@ -31,7 +31,6 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.search.CustomPropertySearchFields;
 import org.openmetadata.service.search.SearchRankingHelper;
 import org.openmetadata.service.search.SearchSourceBuilderFactory;
-import org.openmetadata.service.search.indexes.ColumnSearchIndex;
 import org.openmetadata.service.search.indexes.ContextMemoryIndex;
 import org.openmetadata.service.search.indexes.SearchIndex;
 import org.openmetadata.service.search.indexes.TestCaseIndex;
@@ -318,7 +317,12 @@ public class OpenSearchSourceBuilderFactory
     }
 
     if (isColumnIndex(indexName)) {
-      return buildColumnSearchBuilderV2(searchQuery, fromOffset, size);
+      // Column docs carry fqnParts and structured search fields (the "tableColumn"
+      // AssetTypeConfiguration). Route through the data-asset builder so an FQN query
+      // matches precisely (operator AND over fqnParts) instead of OR-matching every
+      // column that merely shares a parent-name token.
+      return buildDataAssetSearchBuilderV2(
+          indexName, searchQuery, fromOffset, size, includeExplain, includeAggregations);
     }
 
     if (isServiceIndex(indexName)) {
@@ -373,25 +377,6 @@ public class OpenSearchSourceBuilderFactory
   public OpenSearchRequestBuilder buildTestCaseResultSearchV2(String query, int from, int size) {
     Query queryBuilder = buildSearchQueryBuilderV2(query, TestCaseResultIndex.getFields());
     Highlight highlighter = buildHighlightsV2(new ArrayList<>());
-    return searchBuilderV2(queryBuilder, highlighter, from, size);
-  }
-
-  public OpenSearchRequestBuilder buildColumnSearchBuilderV2(String query, int from, int size) {
-    Query queryBuilder;
-    if (nullOrEmpty(query) || "*".equals(query.trim())) {
-      queryBuilder = Query.of(q -> q.matchAll(m -> m));
-    } else {
-      Map<String, Float> fields = ColumnSearchIndex.getFields();
-      queryBuilder =
-          OpenSearchQueryBuilder.multiMatchQuery(
-              query,
-              fields,
-              TextQueryType.BestFields,
-              Operator.Or,
-              String.valueOf(DEFAULT_TIE_BREAKER),
-              "0");
-    }
-    Highlight highlighter = buildHighlightsV2(List.of("name", "displayName", "description"));
     return searchBuilderV2(queryBuilder, highlighter, from, size);
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/search/SearchSourceBuilderFactoryTest.java
@@ -347,6 +347,31 @@ public class SearchSourceBuilderFactoryTest {
     assertTrue(esQuery.contains("\"operator\":\"and\""), esQuery);
   }
 
+  @Test
+  public void testColumnIndexUsesStructuredDataAssetBuilder() {
+    // Regression for the Explore column count-vs-results mismatch: index=tableColumn must go
+    // through the structured data-asset builder (operator AND over fqnParts) so an FQN query
+    // matches the one column precisely. The old permissive OR multi_match had no fqnParts and
+    // matched every column that shared a parent-name token (returned the whole index).
+    OpenSearchSourceBuilderFactory osFactory = new OpenSearchSourceBuilderFactory(searchSettings);
+    ElasticSearchSourceBuilderFactory esFactory =
+        new ElasticSearchSourceBuilderFactory(searchSettings);
+
+    String osQuery =
+        serializeOpenSearchRequest(
+            osFactory.getSearchSourceBuilderV2("tableColumn", "customer orders", 0, 15));
+    String esQuery =
+        esFactory
+            .getSearchSourceBuilderV2("tableColumn", "customer orders", 0, 15)
+            .query()
+            .toString();
+
+    assertTrue(osQuery.contains("fqnParts"), osQuery);
+    assertTrue(osQuery.contains("\"operator\":\"and\""), osQuery);
+    assertTrue(esQuery.contains("fqnParts"), esQuery);
+    assertTrue(esQuery.contains("\"operator\":\"and\""), esQuery);
+  }
+
   private static String serializeOpenSearchRequest(OpenSearchRequestBuilder requestBuilder) {
     JacksonJsonpMapper mapper = new JacksonJsonpMapper();
     StringWriter writer = new StringWriter();


### PR DESCRIPTION
Backport of #31106 to `2.0`.

### Describe your changes:

Fixes open-metadata/openmetadata-collate#3851 on the 2.0 line.

The Explore **Columns** tab shows a count of **1** but the results list shows **7,381**. Root cause: `index=tableColumn` results were built by `buildColumnSearchBuilderV2` — a permissive `multi_match` (`best_fields`, `operator: OR`) that does **not** search `fqnParts`. An FQN query therefore OR-matched every column that shares a parent-name token (service/db/schema/table) and returned the whole column index, while the `dataAsset` aggregation that backs the tab count uses the **structured** builder (`operator: AND` over `fqnParts`) and correctly returns 1.

**Fix:** route column indexes through `buildDataAssetSearchBuilderV2` (like `table` does) so they use the existing `tableColumn` `AssetTypeConfiguration`, which already has `fqnParts` + structured match types. An FQN search now matches the one column precisely (count == results), and column-name search still works via the config's `name`/`name.ngram` fields. The now-unused `buildColumnSearchBuilderV2` is removed from both engine factories.

### Backport notes:

- Clean cherry-pick (`-x`) — all four files were byte-identical to the parent of the `main` commit, so the patch applied verbatim with **no** conflicts and no adaptation (unlike the 1.13 backport).

### Type of change:

- [x] Bug fix

### Tests:

- `SearchSourceBuilderFactoryTest#testColumnIndexUsesStructuredDataAssetBuilder` — `index=tableColumn` now emits a query carrying `fqnParts` + `"operator":"and"` (OpenSearch **and** Elasticsearch). Verified locally: `Tests run: 18, Failures: 0, Errors: 0`.
- `ColumnSearchIndexIT#testColumnFqnSearchIsPrecise` — against real OpenSearch, searching a column's full FQN returns exactly that column (total == 1). Compile-verified locally; runs in CI against the Docker/OpenSearch stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)