### PR TITLE
fix(ui): fix version drawer overlap and article diff in ContextCenter

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNode.ts
@@ -45,6 +45,13 @@ const FileNode = Node.create<FileNodeOptions>({
       tempFile: { default: null },
       isImage: { default: false },
       alt: { default: null },
+      diffState: {
+        default: null,
+        parseHTML: (el) =>
+          el instanceof HTMLElement ? el.getAttribute('data-diff-state') : null,
+        renderHTML: (attrs) =>
+          attrs.diffState ? { 'data-diff-state': attrs.diffState } : {},
+      },
     };
   },
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNodeView.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/BlockEditor/Extensions/File/FileNodeView.tsx
@@ -71,8 +71,16 @@ const FileNodeView: FC<NodeViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const { setPopoverOpen } = useEntityAttachment();
-  const { url, fileName, fileSize, mimeType, isUploading, tempFile, isImage } =
-    node.attrs;
+  const {
+    url,
+    fileName,
+    fileSize,
+    mimeType,
+    isUploading,
+    tempFile,
+    isImage,
+    diffState,
+  } = node.attrs;
   const isValidSource = !isEmpty(url) || isUploading;
   const isVideo = mimeType?.startsWith(FileType.VIDEO);
   const isAudio = mimeType?.startsWith(FileType.AUDIO);
@@ -166,6 +174,9 @@ const FileNodeView: FC<NodeViewProps> = ({
         'file-type-video': isVideo,
         'file-type-audio': isAudio,
         uploading: isUploading,
+        'tw:outline tw:outline-2 tw:outline-offset-2': Boolean(diffState),
+        'tw:outline-green-600': diffState === 'added',
+        'tw:outline-red-500 tw:opacity-60': diffState === 'removed',
       })}
       data-filename={fileName || tempFile?.name}
       data-filesize={(fileSize || tempFile?.size)?.toString()}

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgePageVersion/KnowledgePageVersion.tsx
@@ -13,8 +13,7 @@
 import Icon from '@ant-design/icons';
 import { Button, Col, Row, Space, Typography } from 'antd';
 import classNames from 'classnames';
-import { diffWordsWithSpace } from 'diff';
-import { isEmpty, map, toString } from 'lodash';
+import { toString } from 'lodash';
 import { useMemo, type FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ReactComponent as VersionIcon } from '../../../assets/svg/ic-version.svg';
@@ -33,6 +32,7 @@ import {
   getChangedEntityOldValue,
   getDiffByFieldName,
 } from '../../../utils/EntityDiffPureUtils';
+import { getRichTextDiff } from '../../../utils/EntityDiffUtils';
 import { getEntityName } from '../../../utils/EntityNameUtils';
 import type { VersionEntityTypes } from '../../../utils/EntityVersionUtils.interface';
 import {
@@ -63,14 +63,10 @@ const KnowledgePageVersion: FC<KnowledgePageVersionProps> = ({
   );
 
   const descriptionDiff = useMemo(() => {
-    const changeDescription = knowledgePage.changeDescription ?? {};
-    const currentDescription = knowledgePage.description;
-
     const fieldDiff = getDiffByFieldName(
       EntityField.DESCRIPTION,
-      changeDescription
+      knowledgePage.changeDescription ?? {}
     );
-
     const oldField = getFrontEndFormat(
       toString(getChangedEntityOldValue(fieldDiff))
     );
@@ -78,30 +74,7 @@ const KnowledgePageVersion: FC<KnowledgePageVersionProps> = ({
       toString(getChangedEntityNewValue(fieldDiff))
     );
 
-    if (isEmpty(newField) && isEmpty(oldField)) {
-      return currentDescription;
-    }
-
-    const diffArr = diffWordsWithSpace(oldField, newField);
-
-    const result = map(diffArr, (diff) => {
-      const value = diff.value.trim().replaceAll('\n', '<br>');
-
-      if (diff.added && value) {
-        return `<diff-view class="diff-added">${value}</diff-view>`;
-      }
-      if (diff.removed && value) {
-        return `<diff-view class="diff-removed">${value}</diff-view>`;
-      }
-
-      if (value) {
-        return `<diff-view>${value}</diff-view>`;
-      }
-
-      return '';
-    });
-
-    return result.join('');
+    return getRichTextDiff(oldField, newField, knowledgePage.description);
   }, [knowledgePage]);
 
   const tags = useMemo(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
@@ -314,11 +314,11 @@ const ContextCenterArticlesPage = () => {
   );
 
   const rightSidebar = useMemo(() => {
-    if (isActivityFeedTab) {
+    if (isActivityFeedTab || version) {
       return null;
     }
 
-    if (version || isRightPanelOpen) {
+    if (isRightPanelOpen) {
       return page.rightPanel;
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KnowledgePageVersionPage/KnowledgePageVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KnowledgePageVersionPage/KnowledgePageVersionPage.tsx
@@ -135,7 +135,7 @@ const KnowledgePageVersionPage: FC<KnowledgePageVersionPageProps> = ({
 
   useEffect(() => {
     onPageChange({
-      rightPanel: getVersionTimeLineElement(),
+      rightPanel: null,
       title: getKnowledgePageName(selectedData, t),
       data: knowledgePage,
     });
@@ -143,25 +143,30 @@ const KnowledgePageVersionPage: FC<KnowledgePageVersionPageProps> = ({
 
   if (loading) {
     return (
-      <div className="knowledge-version-page-container">
-        <Space direction="vertical" style={{ width: '650px' }}>
-          <Skeleton active avatar paragraph={{ rows: 2 }} title={false} />
-          <Skeleton
-            active
-            className="m-t-sm"
-            paragraph={{ rows: 8 }}
-            title={false}
-          />
-        </Space>
-      </div>
+      <>
+        <div className="version-data">
+          <Space direction="vertical" style={{ width: '650px' }}>
+            <Skeleton active avatar paragraph={{ rows: 2 }} title={false} />
+            <Skeleton
+              active
+              className="m-t-sm"
+              paragraph={{ rows: 8 }}
+              title={false}
+            />
+          </Space>
+        </div>
+      </>
     );
   }
 
   return (
     <>
-      {selectedData && (
-        <KnowledgePageVersion knowledgePage={selectedData} loading={loading} />
-      )}
+      <div className="version-data">
+        {selectedData && (
+          <KnowledgePageVersion knowledgePage={selectedData} loading={loading} />
+        )}
+      </div>
+      {getVersionTimeLineElement()}
     </>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/pages/KnowledgePageVersionPage/KnowledgePageVersionPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/KnowledgePageVersionPage/KnowledgePageVersionPage.tsx
@@ -163,7 +163,10 @@ const KnowledgePageVersionPage: FC<KnowledgePageVersionPageProps> = ({
     <>
       <div className="version-data">
         {selectedData && (
-          <KnowledgePageVersion knowledgePage={selectedData} loading={loading} />
+          <KnowledgePageVersion
+            knowledgePage={selectedData}
+            loading={loading}
+          />
         )}
       </div>
       {getVersionTimeLineElement()}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.test.ts
@@ -1,0 +1,141 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { getRichTextDiff } from './EntityDiffUtils';
+
+const IMAGE_A =
+  '<div data-type="file-attachment" data-url="/api/v1/files/abc" data-filename="a.png" data-mimetype="image/png" data-is-image="true"></div>';
+
+const IMAGE_B =
+  '<div data-type="file-attachment" data-url="/api/v1/files/xyz" data-filename="b.png" data-mimetype="image/png" data-is-image="true"></div>';
+
+describe('getRichTextDiff', () => {
+
+  describe('empty / fallback', () => {
+
+    it('returns empty string when both inputs are empty', () => {
+      expect(getRichTextDiff('', '')).toBe('');
+    });
+
+    it('returns provided fallback when both inputs are empty', () => {
+      expect(getRichTextDiff('', '', 'fallback content')).toBe('fallback content');
+    });
+
+    it('returns empty string when fallback is not provided and both inputs are empty', () => {
+      expect(getRichTextDiff('', '', undefined)).toBe('');
+    });
+
+  });
+
+  describe('text-only diffs', () => {
+
+    it('wraps unchanged text in diff-normal spans', () => {
+      const result = getRichTextDiff('<p>hello</p>', '<p>hello</p>');
+
+      expect(result).toContain('data-testid="diff-normal"');
+      expect(result).not.toContain('data-testid="diff-added"');
+      expect(result).not.toContain('data-testid="diff-removed"');
+    });
+
+    it('marks added words with diff-added class and testid', () => {
+      const result = getRichTextDiff('hello world', 'hello world earth');
+
+      expect(result).toContain('data-testid="diff-added"');
+      expect(result).toContain('class="diff-added text-underline');
+      expect(result).toContain('earth');
+    });
+
+    it('marks removed words with diff-removed class and testid', () => {
+      const result = getRichTextDiff('hello world', 'hello');
+
+      expect(result).toContain('data-testid="diff-removed"');
+      expect(result).toContain('class="text-grey-muted text-line-through');
+      expect(result).toContain('world');
+    });
+
+    it('marks replaced word: removed old word and added new word', () => {
+      const result = getRichTextDiff('hello world', 'hello earth');
+
+      expect(result).toContain('data-testid="diff-removed"');
+      expect(result).toContain('data-testid="diff-added"');
+      expect(result).toContain('world');
+      expect(result).toContain('earth');
+    });
+
+    it('converts newlines to <br> tags', () => {
+      const result = getRichTextDiff('line one\nline two', 'line one\nline three');
+
+      expect(result).toContain('<br>');
+    });
+
+  });
+
+  describe('whitespace preservation', () => {
+
+    it('preserves spaces between diff chunks so words do not merge', () => {
+      const result = getRichTextDiff('one two three', 'one changed three');
+
+      expect(result).not.toContain('changedthree');
+      expect(result).toContain(' three');
+    });
+
+  });
+
+  describe('file-attachment image diffs', () => {
+
+    it('renders unchanged image without a data-diff-state attribute', () => {
+      const result = getRichTextDiff(IMAGE_A, IMAGE_A);
+
+      expect(result).toContain('data-url="/api/v1/files/abc"');
+      expect(result).not.toContain('data-diff-state');
+    });
+
+    it('marks an added image with data-diff-state="added"', () => {
+      const result = getRichTextDiff('<p>text</p>', `<p>text</p>${IMAGE_A}`);
+
+      expect(result).toContain('data-diff-state="added"');
+      expect(result).toContain('data-url="/api/v1/files/abc"');
+    });
+
+    it('marks a removed image with data-diff-state="removed"', () => {
+      const result = getRichTextDiff(`<p>text</p>${IMAGE_A}`, '<p>text</p>');
+
+      expect(result).toContain('data-diff-state="removed"');
+      expect(result).toContain('data-url="/api/v1/files/abc"');
+    });
+
+    it('marks replaced image: old as removed and new as added', () => {
+      const result = getRichTextDiff(IMAGE_A, IMAGE_B);
+
+      expect(result).toContain('data-diff-state="removed"');
+      expect(result).toContain('data-url="/api/v1/files/abc"');
+      expect(result).toContain('data-diff-state="added"');
+      expect(result).toContain('data-url="/api/v1/files/xyz"');
+    });
+
+    it('leaves unchanged image unaffected when only surrounding text changes', () => {
+      const result = getRichTextDiff(
+        `${IMAGE_A}<p>hello</p>`,
+        `${IMAGE_A}<p>world</p>`
+      );
+
+      expect(result).toContain('data-url="/api/v1/files/abc"');
+      expect(result).not.toContain('data-diff-state="added"');
+      expect(result).not.toContain('data-diff-state="removed"');
+      expect(result).toContain('data-testid="diff-removed"');
+      expect(result).toContain('data-testid="diff-added"');
+    });
+
+  });
+
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.test.ts
@@ -20,25 +20,23 @@ const IMAGE_B =
   '<div data-type="file-attachment" data-url="/api/v1/files/xyz" data-filename="b.png" data-mimetype="image/png" data-is-image="true"></div>';
 
 describe('getRichTextDiff', () => {
-
   describe('empty / fallback', () => {
-
     it('returns empty string when both inputs are empty', () => {
       expect(getRichTextDiff('', '')).toBe('');
     });
 
     it('returns provided fallback when both inputs are empty', () => {
-      expect(getRichTextDiff('', '', 'fallback content')).toBe('fallback content');
+      expect(getRichTextDiff('', '', 'fallback content')).toBe(
+        'fallback content'
+      );
     });
 
     it('returns empty string when fallback is not provided and both inputs are empty', () => {
       expect(getRichTextDiff('', '', undefined)).toBe('');
     });
-
   });
 
   describe('text-only diffs', () => {
-
     it('wraps unchanged text in diff-normal spans', () => {
       const result = getRichTextDiff('<p>hello</p>', '<p>hello</p>');
 
@@ -73,26 +71,25 @@ describe('getRichTextDiff', () => {
     });
 
     it('converts newlines to <br> tags', () => {
-      const result = getRichTextDiff('line one\nline two', 'line one\nline three');
+      const result = getRichTextDiff(
+        'line one\nline two',
+        'line one\nline three'
+      );
 
       expect(result).toContain('<br>');
     });
-
   });
 
   describe('whitespace preservation', () => {
-
     it('preserves spaces between diff chunks so words do not merge', () => {
       const result = getRichTextDiff('one two three', 'one changed three');
 
       expect(result).not.toContain('changedthree');
       expect(result).toContain(' three');
     });
-
   });
 
   describe('file-attachment image diffs', () => {
-
     it('renders unchanged image without a data-diff-state attribute', () => {
       const result = getRichTextDiff(IMAGE_A, IMAGE_A);
 
@@ -135,7 +132,5 @@ describe('getRichTextDiff', () => {
       expect(result).toContain('data-testid="diff-removed"');
       expect(result).toContain('data-testid="diff-added"');
     });
-
   });
-
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
@@ -206,48 +206,50 @@ export const getRichTextDiff = (
 
   const FILE_BLOCK_RE =
     /<div[^>]*data-type="file-attachment"[^>]*>[\s\S]*?<\/div>/g;
-  const oldBlocks: string[] = [];
-  const newBlocks: string[] = [];
 
-  const oldTokenized = oldHtml.replace(FILE_BLOCK_RE, (match) => {
-    oldBlocks.push(match);
+  // Shared content-keyed registry: identical blocks share a token so diffWords
+  // correctly marks them unchanged; genuinely different blocks get distinct tokens.
+  const blockToToken = new Map<string, string>();
+  const tokenToBlock = new Map<string, string>();
 
-    return `FILEBLOCK${oldBlocks.length - 1}`;
-  });
+  const tokenize = (html: string) =>
+    html.replace(FILE_BLOCK_RE, (match) => {
+      let token = blockToToken.get(match);
 
-  const newTokenized = newHtml.replace(FILE_BLOCK_RE, (match) => {
-    newBlocks.push(match);
+      if (!token) {
+        token = `FILEBLOCK${blockToToken.size}`;
+        blockToToken.set(match, token);
+        tokenToBlock.set(token, match);
+      }
 
-    return `FILEBLOCK${newBlocks.length - 1}`;
-  });
+      return token;
+    });
+
+  const oldTokenized = tokenize(oldHtml);
+  const newTokenized = tokenize(newHtml);
 
   const diffArr = diffWords(oldTokenized, newTokenized);
 
   return diffArr
     .flatMap((chunk) =>
       chunk.value.split(/(FILEBLOCK\d+)/).map((part) => {
-        const tokenMatch = part.match(/^FILEBLOCK(\d+)$/);
+        const tokenMatch = part.match(/^FILEBLOCK\d+$/);
 
         if (tokenMatch) {
-          const idx = parseInt(tokenMatch[1]);
+          const block = tokenToBlock.get(part) ?? '';
 
           if (chunk.added) {
-            return (newBlocks[idx] ?? '').replace(
-              /<div/,
-              '<div data-diff-state="added"'
-            );
+            return block.replace(/<div/, '<div data-diff-state="added"');
           }
           if (chunk.removed) {
-            return (oldBlocks[idx] ?? '').replace(
-              /<div/,
-              '<div data-diff-state="removed"'
-            );
+            return block.replace(/<div/, '<div data-diff-state="removed"');
           }
 
-          return newBlocks[idx] ?? oldBlocks[idx] ?? '';
+          return block;
         }
 
-        const value = part.trim().replaceAll('\n', '<br>');
+        // Preserve spaces — only skip the empty strings emitted by split at boundaries.
+        const value = part.replaceAll('\n', '<br>');
         if (!value) {
           return '';
         }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/EntityDiffUtils.tsx
@@ -189,6 +189,81 @@ export const getDiffDisplayValue = (diff: {
   }
 };
 
+/**
+ * Like getTextDiff but safe for TipTap HTML content: extracts block-level
+ * file-attachment nodes before word-diffing so their attribute strings are
+ * never split across diff chunks. Restored blocks carry a data-diff-state
+ * attribute ("added" | "removed") so FileNodeView can style them visually.
+ */
+export const getRichTextDiff = (
+  oldHtml: string,
+  newHtml: string,
+  fallback?: string
+): string => {
+  if (isEmpty(oldHtml) && isEmpty(newHtml)) {
+    return fallback ?? '';
+  }
+
+  const FILE_BLOCK_RE =
+    /<div[^>]*data-type="file-attachment"[^>]*>[\s\S]*?<\/div>/g;
+  const oldBlocks: string[] = [];
+  const newBlocks: string[] = [];
+
+  const oldTokenized = oldHtml.replace(FILE_BLOCK_RE, (match) => {
+    oldBlocks.push(match);
+
+    return `FILEBLOCK${oldBlocks.length - 1}`;
+  });
+
+  const newTokenized = newHtml.replace(FILE_BLOCK_RE, (match) => {
+    newBlocks.push(match);
+
+    return `FILEBLOCK${newBlocks.length - 1}`;
+  });
+
+  const diffArr = diffWords(oldTokenized, newTokenized);
+
+  return diffArr
+    .flatMap((chunk) =>
+      chunk.value.split(/(FILEBLOCK\d+)/).map((part) => {
+        const tokenMatch = part.match(/^FILEBLOCK(\d+)$/);
+
+        if (tokenMatch) {
+          const idx = parseInt(tokenMatch[1]);
+
+          if (chunk.added) {
+            return (newBlocks[idx] ?? '').replace(
+              /<div/,
+              '<div data-diff-state="added"'
+            );
+          }
+          if (chunk.removed) {
+            return (oldBlocks[idx] ?? '').replace(
+              /<div/,
+              '<div data-diff-state="removed"'
+            );
+          }
+
+          return newBlocks[idx] ?? oldBlocks[idx] ?? '';
+        }
+
+        const value = part.trim().replaceAll('\n', '<br>');
+        if (!value) {
+          return '';
+        }
+        if (chunk.added) {
+          return `<span data-diff="true" class="diff-added text-underline tw:bg-success-primary" data-testid="diff-added">${value}</span>`;
+        }
+        if (chunk.removed) {
+          return `<span data-diff="true" class="text-grey-muted text-line-through tw:bg-error-primary" data-testid="diff-removed">${value}</span>`;
+        }
+
+        return `<span data-diff="true" data-testid="diff-normal">${value}</span>`;
+      })
+    )
+    .join('');
+};
+
 export const getUpdatedExtensionDiffFields = (
   entityDetails: ExtentionEntities[ExtentionEntitiesKeys],
   extensionDiff: EntityDiffProps


### PR DESCRIPTION
### Describe your changes:

<!-- Fixes #<issue-number> -->

I fixed two bugs on the ContextCenter article version page (`context-center/articles/:fqn/versions/:version`):

1. **Drawer overlap** — `EntityVersionTimeLine` was rendered inside a `ReflexElement` right panel, causing the Ant Design Drawer (which is `position: fixed`) to bleed over the article content. Fixed by adopting the existing `.version-data { width: calc(100% - 330px) }` pattern used by all other entity version pages, rendering the timeline as a sibling of the content div.

2. **Article diff rendering** — `KnowledgePageVersion` hand-rolled a diff loop using `diffWordsWithSpace` that emitted `<diff-view>` tags (not parsed by the Tiptap `diffView` extension) and also failed to protect `<div data-type="file-attachment">` blocks from word-splitting, causing images to render as raw HTML text. Fixed by extracting `getRichTextDiff()` into `EntityDiffUtils.tsx` that tokenises file-attachment blocks before diffing and emits standard `<span data-diff>` markup reusing the existing CSS classes.

3. **Image diff state** — Added `diffState` attribute to `FileNode` / `FileNodeView` so images added or removed in a version show a Tailwind outline (green = added, red = removed).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Layout fix:** Adopted the existing OpenMetadata pattern — content in `<div className="version-data">` (app.less gives it `width: calc(100% - 330px)`) with `EntityVersionTimeLine` as a sibling. The drawer's `position: fixed` anchors it to the viewport right edge, leaving the article content unobscured.

**Diff fix:** `getRichTextDiff(oldHtml, newHtml, fallback?)` in `EntityDiffUtils.tsx` replaces each `<div data-type="file-attachment">` with a `FILEBLOCK{n}` token before calling `diffWords`, then restores the blocks post-diff with `data-diff-state="added|removed"` injected into the div attributes. Text chunks are wrapped in `<span data-diff="true" class="diff-added …">` template literals (not ReactDOMServer — that would escape the inner HTML).

#
### Tests:

#### Use cases covered
- Article version page layout: drawer visible at right edge, article scrollable without overlap
- Text changes between versions highlighted green (added) / grey strikethrough (removed)
- Images added/removed in a version render as actual images with coloured outline, not as raw HTML

#### Unit tests
- [ ] Not added — UI-only layout and visual diff change

#### Backend integration tests
- [x] Not applicable (no backend API changes)

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes)

#### Playwright (UI) tests
- [ ] Not added in this PR

#### Manual testing performed
1. Navigated to `context-center/articles/Article_3INcLFMV/versions/0.2`
2. Verified drawer appears on the right without overlapping article content
3. Verified changed text words are highlighted with diff colours
4. Verified existing Table / Dashboard version pages are unaffected

#
### UI screen recording / screenshots:
<!-- Attach recording showing before/after -->

https://github.com/user-attachments/assets/6431f7bf-f037-49f0-b7a0-b44db88c1dda


#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: Not applicable.
- [x] For UI changes: Manual testing performed; screen recording to be attached.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.