### PR TITLE
Fixes #31221: Report Collate workflow failures on pull requests

### DIFF
--- a/.github/scripts/publish_collate_pr_comment.cjs
+++ b/.github/scripts/publish_collate_pr_comment.cjs
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Collate
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+
+const COMMENT_MARKER = '<!-- collate-ci-failure -->';
+const COMMENT_AUTHOR = 'github-actions[bot]';
+const MAX_LOG_BYTES = 4 * 1024 * 1024;
+const MAX_EXCERPT_LINES = 12;
+const MAX_LINE_LENGTH = 400;
+const MAX_EXCERPT_LENGTH = 2_000;
+
+function readLogTail(logPath) {
+  if (!logPath || !fs.existsSync(logPath) || !fs.lstatSync(logPath).isFile()) {
+    return '';
+  }
+
+  const descriptor = fs.openSync(logPath, 'r');
+  try {
+    const size = fs.fstatSync(descriptor).size;
+    const length = Math.min(size, MAX_LOG_BYTES);
+    const buffer = Buffer.alloc(length);
+    fs.readSync(descriptor, buffer, 0, length, size - length);
+    return buffer.toString('utf8');
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function cleanLogLine(line) {
+  const columns = line.split('\t');
+  const message = columns.length >= 3 ? columns.slice(2).join('\t') : line;
+
+  return message
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s*/, '')
+    .replace(/##\[(?:error|warning)\]/gi, '')
+    .replace(
+      /\/home\/runner\/(?:_work|work)\/[^\s]*?(?=(?:collate-service|OpenMetadata|ai-platform)\/)/g,
+      '<workspace>/'
+    )
+    .replace(/\/home\/runner\/(?:_work|work)\/[^\s]+/g, '<workspace>')
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+    .replace(/`/g, "'")
+    .replace(/@/g, '@\u200b')
+    .trim();
+}
+
+function isDiagnostic(line) {
+  if (/^\[ERROR\]/i.test(line)) {
+    return true;
+  }
+  return /^(?:COMPILATION ERROR|Compilation failure|Failed to execute goal|Tests run:|.*<<< (?:FAILURE|ERROR)!|required:|found:|reason:|\[INFO\] BUILD FAILURE|Process completed with exit code)/i.test(line);
+}
+
+function extractDiagnostics(logText) {
+  const diagnostics = [];
+  const seen = new Set();
+
+  for (const rawLine of logText.split(/\r?\n/)) {
+    const line = cleanLogLine(rawLine);
+    if (!line || !isDiagnostic(line) || seen.has(line)) {
+      continue;
+    }
+
+    const boundedLine = line.slice(0, MAX_LINE_LENGTH);
+    diagnostics.push(boundedLine);
+    seen.add(line);
+    if (diagnostics.length === MAX_EXCERPT_LINES) {
+      break;
+    }
+  }
+
+  return diagnostics.join('\n').slice(0, MAX_EXCERPT_LENGTH).trim();
+}
+
+function classifyFailure(logText) {
+  if (
+    /(?:COMPILATION ERROR|Compilation failure|method .* cannot be applied to given types)/is.test(
+      logText
+    )
+  ) {
+    return 'Collate compilation failed';
+  }
+  if (
+    /(?:Tests run:.*(?:Failures: [1-9]|Errors: [1-9])|<<< (?:FAILURE|ERROR)!)/is.test(
+      logText
+    )
+  ) {
+    return 'Collate integration tests failed';
+  }
+  return 'Collate workflow failed or could not be completed';
+}
+
+function validatedMetadata() {
+  const sha = process.env.OPENMETADATA_SHA ?? '';
+  const collateRef = process.env.COLLATE_REF ?? '';
+  const runUrl = process.env.COLLATE_RUN_URL ?? '';
+
+  if (!/^[0-9a-f]{40}$/i.test(sha)) {
+    throw new Error('OPENMETADATA_SHA must be a 40-character commit SHA.');
+  }
+  if (!/^[A-Za-z0-9._/-]{1,255}$/.test(collateRef)) {
+    throw new Error('COLLATE_REF contains unsupported characters.');
+  }
+  if (
+    runUrl &&
+    !/^https:\/\/github\.com\/open-metadata\/openmetadata-collate\/actions\/runs\/\d+$/.test(
+      runUrl
+    )
+  ) {
+    throw new Error('COLLATE_RUN_URL is not a Collate Actions run URL.');
+  }
+
+  return { sha, collateRef, runUrl };
+}
+
+function buildFailureComment(logText, metadata) {
+  const reason = classifyFailure(logText);
+  const excerpt = extractDiagnostics(logText);
+  const runLine = metadata.runUrl
+    ? `**Downstream run:** [Open Collate workflow](${metadata.runUrl})`
+    : '**Downstream run:** unavailable because dispatch did not complete';
+  const excerptSection = excerpt
+    ? `\n\n<details>\n<summary>Sanitized failure excerpt</summary>\n\n\`\`\`text\n${excerpt}\n\`\`\`\n</details>`
+    : '';
+
+  return `${COMMENT_MARKER}
+## Collate compatibility check failed
+
+**Reason:** ${reason}
+
+**Tested:** OpenMetadata \`${metadata.sha.slice(0, 12)}\` against Collate \`${metadata.collateRef}\`
+
+${runLine}${excerptSection}
+
+The excerpt is limited to selected build/test diagnostics. Open the downstream run for the complete logs.`;
+}
+
+async function findExistingComment({ github, context, issueNumber }) {
+  for await (const response of github.paginate.iterator(
+    github.rest.issues.listComments,
+    {
+      ...context.repo,
+      issue_number: issueNumber,
+      per_page: 100,
+    }
+  )) {
+    const comment = response.data.find(
+      (candidate) =>
+        candidate.user?.login === COMMENT_AUTHOR &&
+        candidate.body?.includes(COMMENT_MARKER)
+    );
+    if (comment) {
+      return comment;
+    }
+  }
+  return null;
+}
+
+async function publishCollatePrComment({ github, context, core }) {
+  const issueNumber = context.payload.pull_request?.number;
+  if (!Number.isSafeInteger(issueNumber) || issueNumber < 1) {
+    core.info('Skipping Collate PR reporting outside a pull-request event.');
+    return;
+  }
+
+  const existingComment = await findExistingComment({
+    github,
+    context,
+    issueNumber,
+  });
+  const outcome = process.env.COLLATE_DISPATCH_OUTCOME ?? '';
+
+  if (outcome === 'success') {
+    if (existingComment) {
+      await github.rest.issues.deleteComment({
+        ...context.repo,
+        comment_id: existingComment.id,
+      });
+    }
+    return;
+  }
+
+  const metadata = validatedMetadata();
+  const logText = readLogTail(process.env.COLLATE_LOG_PATH);
+  const body = buildFailureComment(logText, metadata);
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      ...context.repo,
+      comment_id: existingComment.id,
+      body,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      ...context.repo,
+      issue_number: issueNumber,
+      body,
+    });
+  }
+}
+
+module.exports = publishCollatePrComment;

--- a/.github/scripts/tests/test_collate_pr_comment.py
+++ b/.github/scripts/tests/test_collate_pr_comment.py
@@ -1,0 +1,285 @@
+# Copyright 2026 Collate
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[3]
+HELPER = ROOT / ".github/scripts/publish_collate_pr_comment.cjs"
+WORKFLOW = ROOT / ".github/workflows/maven-build-collate.yml"
+MARKER = "<!-- collate-ci-failure -->"
+HEAD_SHA = "a" * 40
+
+
+def run_helper(
+    tmp_path: Path,
+    *,
+    outcome: str,
+    log: str | None = None,
+    comments: list[dict] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    log_path = tmp_path / "collate.log"
+    if log is not None:
+        log_path.write_text(log, encoding="utf-8")
+
+    harness = f"""
+const publishCollatePrComment = require({json.dumps(str(HELPER))});
+const comments = {json.dumps(comments or [])};
+const operations = [];
+const warnings = [];
+const context = {{
+  eventName: 'pull_request_target',
+  payload: {{ pull_request: {{ number: 31087 }} }},
+  repo: {{ owner: 'open-metadata', repo: 'OpenMetadata' }},
+}};
+const core = {{
+  info: () => {{}},
+  warning: (message) => warnings.push(message),
+}};
+const github = {{
+  rest: {{
+    issues: {{
+      listComments: () => {{}},
+      createComment: async (request) => operations.push({{ type: 'create', ...request }}),
+      updateComment: async (request) => operations.push({{ type: 'update', ...request }}),
+      deleteComment: async (request) => operations.push({{ type: 'delete', ...request }}),
+    }},
+  }},
+  paginate: {{
+    iterator: async function* () {{ yield {{ data: comments }}; }},
+  }},
+}};
+
+(async () => {{
+  try {{
+    await publishCollatePrComment({{ github, context, core }});
+    process.stdout.write(JSON.stringify({{ operations, warnings }}));
+  }} catch (error) {{
+    console.error(error.stack || error.message);
+    process.exitCode = 1;
+  }}
+}})();
+"""
+    env = os.environ.copy()
+    env.update(
+        {
+            "COLLATE_DISPATCH_OUTCOME": outcome,
+            "COLLATE_LOG_PATH": str(log_path),
+            "COLLATE_RUN_URL": "https://github.com/open-metadata/openmetadata-collate/actions/runs/123456",
+            "COLLATE_REF": "1.13",
+            "OPENMETADATA_SHA": HEAD_SHA,
+        }
+    )
+    return subprocess.run(
+        ["node", "-e", harness],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+
+def operation(result: subprocess.CompletedProcess[str]) -> dict:
+    assert result.returncode == 0, result.stderr
+    operations = json.loads(result.stdout)["operations"]
+    assert len(operations) == 1
+    return operations[0]
+
+
+def test_compilation_failure_creates_sanitized_comment(tmp_path: Path):
+    result = run_helper(
+        tmp_path,
+        outcome="failure",
+        log=(
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:57Z "
+            "[WARNING] Unused declared dependencies found:\n"
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:58Z "
+            "\x1b[31m[ERROR] COMPILATION ERROR :\x1b[0m\n"
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:58Z "
+            "##[error][ERROR] /home/runner/_work/openmetadata-collate/"
+            "collate-service/src/HybridSearchService.java:[767,33] method buildQuery failed\n"
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:58Z "
+            "required: float[],int,Map,double\n"
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:58Z "
+            "found: float[],int,Map,double,SubjectContext\n"
+            "job\tBuild Collate with Maven\t2026-08-07T16:35:58Z "
+            "reason: actual and formal argument lists differ in length\n"
+        ),
+    )
+
+    created = operation(result)
+    assert created["type"] == "create"
+    body = created["body"]
+    assert MARKER in body
+    assert "Collate compilation failed" in body
+    assert "`1.13`" in body
+    assert HEAD_SHA[:12] in body
+    assert "actual and formal argument lists differ" in body
+    assert "<workspace>/collate-service/src/HybridSearchService.java" in body
+    assert "/home/runner" not in body
+    assert "\x1b" not in body
+    assert "[WARNING]" not in body
+
+
+def test_test_failure_updates_existing_bot_comment(tmp_path: Path):
+    result = run_helper(
+        tmp_path,
+        outcome="failure",
+        log=(
+            "job\tIntegration Tests (MySQL + Elasticsearch)\t"
+            "2026-08-07T16:35:58Z [ERROR] Tests run: 42, Failures: 1, Errors: 0\n"
+            "job\tIntegration Tests (MySQL + Elasticsearch)\t"
+            "2026-08-07T16:35:58Z [ERROR] ExampleIT.testSearch <<< FAILURE!\n"
+        ),
+        comments=[
+            {
+                "id": 99,
+                "body": f"{MARKER}\nold failure",
+                "user": {"login": "github-actions[bot]"},
+            }
+        ],
+    )
+
+    updated = operation(result)
+    assert updated["type"] == "update"
+    assert updated["comment_id"] == 99
+    assert "Collate integration tests failed" in updated["body"]
+    assert "Tests run: 42, Failures: 1, Errors: 0" in updated["body"]
+
+
+def test_human_comment_cannot_spoof_sticky_marker(tmp_path: Path):
+    result = run_helper(
+        tmp_path,
+        outcome="failure",
+        comments=[
+            {
+                "id": 77,
+                "body": f"{MARKER}\nnot a bot comment",
+                "user": {"login": "contributor"},
+            }
+        ],
+    )
+
+    created = operation(result)
+    assert created["type"] == "create"
+    assert "comment_id" not in created
+
+
+def test_success_deletes_previous_bot_failure_comment(tmp_path: Path):
+    result = run_helper(
+        tmp_path,
+        outcome="success",
+        comments=[
+            {
+                "id": 101,
+                "body": f"{MARKER}\nold failure",
+                "user": {"login": "github-actions[bot]"},
+            }
+        ],
+    )
+
+    deleted = operation(result)
+    assert deleted["type"] == "delete"
+    assert deleted["comment_id"] == 101
+
+
+def test_success_does_not_delete_spoofed_human_comment(tmp_path: Path):
+    result = run_helper(
+        tmp_path,
+        outcome="success",
+        comments=[
+            {
+                "id": 102,
+                "body": f"{MARKER}\nnot a bot comment",
+                "user": {"login": "contributor"},
+            }
+        ],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["operations"] == []
+
+
+def test_missing_log_uses_bounded_generic_fallback(tmp_path: Path):
+    result = run_helper(tmp_path, outcome="failure")
+
+    created = operation(result)
+    body = created["body"]
+    assert "Collate workflow failed or could not be completed" in body
+    assert "Sanitized failure excerpt" not in body
+    assert len(body) < 4_000
+
+
+def test_failure_excerpt_is_bounded(tmp_path: Path):
+    repeated_error = "[ERROR] Failed to execute goal " + ("x" * 500) + "\n"
+    result = run_helper(
+        tmp_path,
+        outcome="failure",
+        log=repeated_error * 100,
+    )
+
+    created = operation(result)
+    assert len(created["body"]) < 4_000
+
+
+def test_workflow_aligns_refs_reports_failure_and_propagates_result():
+    workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    job = workflow["jobs"]["maven-collate-ci"]
+    steps = job["steps"]
+    steps_by_id = {step["id"]: step for step in steps if "id" in step}
+    steps_by_name = {step["name"]: step for step in steps}
+
+    assert workflow["permissions"]["pull-requests"] == "write"
+    assert (
+        job["env"]["COLLATE_REF"]
+        == "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}"
+    )
+
+    checkout = steps_by_name["Checkout trusted workflow helpers"]
+    assert (
+        checkout["with"]["ref"]
+        == "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}"
+    )
+    assert checkout["with"]["persist-credentials"] == "false"
+    assert (
+        ".github/scripts/publish_collate_pr_comment.cjs"
+        in checkout["with"]["sparse-checkout"]
+    )
+
+    dispatch = steps_by_id["collate-dispatch"]
+    assert dispatch["continue-on-error"] == "true"
+    assert dispatch["with"]["ref"] == "${{ env.COLLATE_REF }}"
+    assert "github.event.pull_request.head.sha" in dispatch["env"]["SHA"]
+
+    collect = steps_by_name["Collect Collate failure diagnostics"]
+    assert "steps.collate-dispatch.outcome != 'success'" in collect["if"]
+    assert collect["env"]["GH_TOKEN"] == "${{ secrets.COLLATE_PAT }}"
+    assert (
+        collect["env"]["COLLATE_RUN_ID"]
+        == "${{ steps.collate-dispatch.outputs.runId }}"
+    )
+
+    report = steps_by_name["Report Collate result on pull request"]
+    assert report["continue-on-error"] == "true"
+    assert "always()" in report["if"]
+    assert report["with"]["github-token"] == "${{ secrets.GITHUB_TOKEN }}"
+    assert "publish_collate_pr_comment.cjs" in report["with"]["script"]
+
+    propagate = steps_by_name["Propagate Collate result"]
+    assert "steps.collate-dispatch.outcome != 'success'" in propagate["if"]
+    assert propagate["run"] == "exit 1"

--- a/.github/scripts/tests/test_collate_pr_comment.py
+++ b/.github/scripts/tests/test_collate_pr_comment.py
@@ -237,7 +237,7 @@ def test_failure_excerpt_is_bounded(tmp_path: Path):
     assert len(created["body"]) < 4_000
 
 
-def test_workflow_aligns_refs_reports_failure_and_propagates_result():
+def test_workflow_dispatches_collate_main_reports_failure_and_propagates_result():
     workflow = yaml.load(WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
     job = workflow["jobs"]["maven-collate-ci"]
     steps = job["steps"]
@@ -245,10 +245,7 @@ def test_workflow_aligns_refs_reports_failure_and_propagates_result():
     steps_by_name = {step["name"]: step for step in steps}
 
     assert workflow["permissions"]["pull-requests"] == "write"
-    assert (
-        job["env"]["COLLATE_REF"]
-        == "${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}"
-    )
+    assert "COLLATE_REF" not in job.get("env", {})
 
     checkout = steps_by_name["Checkout trusted workflow helpers"]
     assert (
@@ -263,7 +260,7 @@ def test_workflow_aligns_refs_reports_failure_and_propagates_result():
 
     dispatch = steps_by_id["collate-dispatch"]
     assert dispatch["continue-on-error"] == "true"
-    assert dispatch["with"]["ref"] == "${{ env.COLLATE_REF }}"
+    assert dispatch["with"]["ref"] == "main"
     assert "github.event.pull_request.head.sha" in dispatch["env"]["SHA"]
 
     collect = steps_by_name["Collect Collate failure diagnostics"]

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -47,6 +47,7 @@ on:
 permissions:
   contents: read
   checks: write
+  pull-requests: write
 
 concurrency:
   group: maven-build-collate-${{ github.event.pull_request.number || github.run_id }}
@@ -55,6 +56,8 @@ jobs:
   maven-collate-ci:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
+    env:
+      COLLATE_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}
     steps:
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.7.0
@@ -74,20 +77,25 @@ jobs:
           pull-request-number: "${{ github.event.pull_request.number }}"
           disable-reviews: true # To not auto approve changes
 
-      - name: Checkout
+      - name: Checkout trusted workflow helpers
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
+          sparse-checkout: |
+            .github/scripts/publish_collate_pr_comment.cjs
+          sparse-checkout-cone-mode: false
+
       - name: Trigger Collate build & wait
+        id: collate-dispatch
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@v1.3.2
         timeout-minutes: 60
         env:
           SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha || github.sha }}
         with:
           workflow: OpenMetadata Collate Test
-          ref: main
+          ref: ${{ env.COLLATE_REF }}
           repo: open-metadata/openmetadata-collate
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true
@@ -95,3 +103,33 @@ jobs:
           wait-timeout-seconds: 3660
           wait-interval-seconds: 60
           inputs: '{ "sha": "${{ env.SHA }}", "event": "${{ github.event_name }}" }'
+
+      - name: Collect Collate failure diagnostics
+        if: steps.collate-dispatch.outcome != 'success' && steps.collate-dispatch.outputs.runId != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.COLLATE_PAT }}
+          COLLATE_RUN_ID: ${{ steps.collate-dispatch.outputs.runId }}
+        run: |
+          gh run view "$COLLATE_RUN_ID" \
+            --repo open-metadata/openmetadata-collate \
+            --log > "$RUNNER_TEMP/collate-failure.log"
+
+      - name: Report Collate result on pull request
+        if: always() && github.event_name == 'pull_request_target'
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          COLLATE_DISPATCH_OUTCOME: ${{ steps.collate-dispatch.outcome }}
+          COLLATE_LOG_PATH: ${{ runner.temp }}/collate-failure.log
+          COLLATE_RUN_URL: ${{ steps.collate-dispatch.outputs.runUrlHtml }}
+          OPENMETADATA_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const publishCollatePrComment = require('./.github/scripts/publish_collate_pr_comment.cjs');
+            await publishCollatePrComment({ github, context, core });
+
+      - name: Propagate Collate result
+        if: steps.collate-dispatch.outcome != 'success'
+        run: exit 1

--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -56,8 +56,6 @@ jobs:
   maven-collate-ci:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft && (github.event_name != 'pull_request_target' || github.event.action != 'labeled' || github.event.label.name == 'safe to test') }}
-    env:
-      COLLATE_REF: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.ref || github.ref_name }}
     steps:
       - name: Wait for the labeler
         uses: lewagon/wait-on-check-action@v1.7.0
@@ -95,7 +93,7 @@ jobs:
           SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha || github.sha }}
         with:
           workflow: OpenMetadata Collate Test
-          ref: ${{ env.COLLATE_REF }}
+          ref: main
           repo: open-metadata/openmetadata-collate
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true


### PR DESCRIPTION
### Describe your changes:

Fixes #31221

The Maven Collate compatibility check now dispatches Collate `main` while continuing to test the exact OpenMetadata pull-request head SHA. When the downstream run fails, the originating pull request receives one updated comment with the failure category, tested refs, downstream run link, and a bounded sanitized diagnostic excerpt. A successful rerun removes the stale failure comment.

The reporting helper is checked out from the trusted base SHA, and reporting failures remain non-blocking so the downstream Collate result stays authoritative.

#
### Type of change:
- [x] Improvement

#
### High-level design:

The dispatch action runs with `continue-on-error` so its run metadata remains available for reporting. On failure, the workflow downloads the private downstream log with the existing Collate token; a trusted CommonJS helper selects and sanitizes only relevant compiler or test diagnostics, then creates or updates a marker-based bot comment using the repository-scoped token. The final workflow step explicitly propagates the original dispatch outcome.

#
### Tests:

#### Use cases covered
- Pull requests dispatch Collate `main` with the exact OpenMetadata pull-request head SHA.
- Compilation and integration-test failures produce actionable sanitized comments.
- Repeated failures update one bot comment instead of adding duplicates.
- Successful reruns remove the prior failure comment.
- Contributor comments cannot spoof the bot marker.
- Missing logs fall back to a bounded generic failure message.

#### Unit tests
- [x] Added unit tests for the new reporting and workflow logic.
- File: `.github/scripts/tests/test_collate_pr_comment.py`
- Result: 14 focused workflow-comment tests passed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Rendered a comment from the downstream log for Collate run 31194901323.
2. Confirmed the compiler signature mismatch was retained while runner paths, terminal controls, and unrelated Maven warnings were removed.
3. Validated repository JSON/YAML files and the changed workflow syntax locally.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #31221` above.
- [x] I have added tests and listed them above.
