### PR TITLE
fix(ui): declare @tanstack/react-query dependency on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/package.json
+++ b/openmetadata-ui/src/main/resources/ui/package.json
@@ -85,6 +85,7 @@
     "@rjsf/core": "5.24.13",
     "@rjsf/utils": "5.24.13",
     "@rjsf/validator-ajv8": "5.24.13",
+    "@tanstack/react-query": "^5.62.0",
     "@tiptap/core": "^2.3.0",
     "@tiptap/extension-link": "^2.10.4",
     "@tiptap/extension-placeholder": "^2.3.0",

--- a/openmetadata-ui/src/main/resources/ui/yarn.lock
+++ b/openmetadata-ui/src/main/resources/ui/yarn.lock
@@ -4846,6 +4846,18 @@
     "@tailwindcss/oxide" "4.2.1"
     tailwindcss "4.2.1"
 
+"@tanstack/query-core@5.100.11":
+  version "5.100.11"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.100.11.tgz#fdf273bec49277600311a4c552e2c2d95f4df73b"
+  integrity sha512-lmE0994apShXPj8CUxgx4ch5yUJhE9k/+tVwihBvPOyerACWdBocfFg24t8+0RhtlTd7tEgchDkhlCxNssvDxw==
+
+"@tanstack/react-query@^5.62.0":
+  version "5.100.11"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.100.11.tgz#096005bf2868be2f5798c9a48e8f3f7f08c77f20"
+  integrity sha512-J0f9s5x3LE1450nNNfYx+e/n0DMa0uOBdFJUy5r0RvmsXd4nB/n0rbHtHI1vYXhikNFan+wf51p6Tmp4c8ucrg==
+  dependencies:
+    "@tanstack/query-core" "5.100.11"
+
 "@testing-library/dom@^9.0.0":
   version "9.3.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"


### PR DESCRIPTION
## TL;DR
The UI build (`yarn build`) is red on **1.13**: `@tanstack/react-query` is imported but never declared.

```
[vite]: Rollup failed to resolve import "@tanstack/react-query" from
".../src/hooks/popover/useEntityPopoverData.ts"
```

## Root cause
#31108 (team quick info popover) added `src/hooks/popover/useEntityPopoverData.ts`, which imports `@tanstack/react-query`. It's consumed by the live `PopOverCard` components (`PopoverContent`, `PopoverTitle`, `TeamPopoverContent`, `TeamPopoverTitle`), so it's in the build graph. But the dependency was never added to `package.json` / `yarn.lock` on the 1.13 branch.

## Fix
Add `@tanstack/react-query` `^5.62.0` to `package.json` + `yarn.lock`. Version and resolution (`query-core`/`react-query` 5.100.11) match what is already declared on the `2.0` branch.

## Scope
- **Only** `package.json` + `yarn.lock`. No source changes.
- `2.0` already declares this dep and is unaffected.