### PR TITLE
fix(ui): activity feed and announcement bodies stuck on loading spinner

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ActivityFeed/ActivityFeedCard/FeedCardBody/FeedCardBody.tsx
@@ -14,27 +14,17 @@
 import { Button, Space, Typography } from 'antd';
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
-import { FC, lazy, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatDateTime } from '../../../../utils/date-time/DateTimeUtils';
 import {
   getFrontEndFormat,
   MarkdownToHTMLConverter,
 } from '../../../../utils/FeedUtilsPure';
-import withSuspenseFallback from '../../../AppRouter/withSuspenseFallback';
+import RichTextEditorPreviewerV1 from '../../../common/RichTextEditor/RichTextEditorPreviewerV1';
+import ActivityFeedEditor from '../../ActivityFeedEditor/ActivityFeedEditor';
+import Reactions from '../../Reactions/Reactions';
 import { FeedBodyProp } from '../ActivityFeedCard.interface';
-
-const RichTextEditorPreviewerV1 = withSuspenseFallback(
-  lazy(() => import('../../../common/RichTextEditor/RichTextEditorPreviewerV1'))
-);
-
-const Reactions = withSuspenseFallback(
-  lazy(() => import('../../Reactions/Reactions'))
-);
-
-const ActivityFeedEditor = withSuspenseFallback(
-  lazy(() => import('../../ActivityFeedEditor/ActivityFeedEditor'))
-);
 
 const FeedCardBody: FC<FeedBodyProp> = ({
   message,

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/RichTextEditor/RichTextEditorPreviewerV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/RichTextEditor/RichTextEditorPreviewerV1.tsx
@@ -12,7 +12,7 @@
  */
 import { Button } from 'antd';
 import classNames from 'classnames';
-import { FC, lazy, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { DESCRIPTION_MAX_PREVIEW_CHARACTERS } from '../../../constants/constants';
 import {
@@ -20,13 +20,9 @@ import {
   isDescriptionContentEmpty,
 } from '../../../utils/BlockEditorPureUtils';
 import { getTrimmedContent } from '../../../utils/StringUtils';
-import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
+import BlockEditor from '../../BlockEditor/BlockEditor';
 import './rich-text-editor-previewerV1.less';
 import { PreviewerProp } from './RichTextEditor.interface';
-
-const BlockEditor = withSuspenseFallback(
-  lazy(() => import('../../BlockEditor/BlockEditor'))
-);
 
 const RichTextEditorPreviewerV1: FC<PreviewerProp> = ({
   markdown = '',


### PR DESCRIPTION
## Symptom

Activity feed cards render their header but never their message — the body sits on a loading spinner indefinitely. Same for announcement bodies.

Caught by nightly E2E: `KnowledgeCenter.spec.ts` ("Activity feed functionality", "User Mentions in article") and `ServiceEntity.spec.ts` ("Announcement create, edit & delete"). Identical failures on **both MySQL and PostgreSQL**, on all 3 retries — deterministic, not flake. Because the KC file is serial, one failure cascaded into 21 skipped tests.

```
expect(locator).toBeVisible() failed
Locator: locator('text=Test Conversation Message e90798aa')
Error: element(s) not found
```

## Root cause

#29062 (backported to 1.13 as #31042) wrapped four components in `withSuspenseFallback(lazy(...))`:

- in `FeedCardBody` — `RichTextEditorPreviewerV1`, `Reactions`, `ActivityFeedEditor`
- in `RichTextEditorPreviewerV1` — `BlockEditor`

Those dynamic-import boundaries never settle, so the Suspense fallback is the only thing that ever renders. The DOM at failure is exactly `withSuspenseFallback`'s fallback:

```html
<div class="feed-message">
  <div class="ant-layout-content flex-center"><div class="loader" data-testid="loader"></div></div>
</div>
```

Note `viewer-container` is absent — React replaces the entire boundary subtree with the fallback, so the previewer never mounts at all.

### What it is not

- **Not the backend.** `POST /api/v1/feed` → 201 with `"message":"Test Conversation Message 386818de"`; the follow-up `GET /api/v1/feed?entityLink=…` → 200 returning the thread.
- **Not a chunk-loading failure.** Of 236 JS requests on the failing page, none are zero-byte and none are pending. No console exceptions.
- **Not a code-splitting artifact.** It reproduces on the Vite dev server, where there is no production chunking.
- **Not a test bug.** The assertion fails because the message genuinely never renders.

### Why the boundaries hang

The same series split utils into `*Pure` modules. `RichTextEditorPreviewerV1` now sits in 6 static import cycles, and the first hop out of it is precisely what that split introduced:

```
RichTextEditorPreviewerV1
  -> utils/BlockEditorPureUtils      (was BlockEditorUtils before the series)
  -> utils/FeedUtilsPure             (swapped into FeedCardBody in the same diff)
  -> utils/EntityUtilClassBase
  -> ... 15 more hops ...
  -> RichTextEditorPreviewerV1
```

As **static** imports these cycles are harmless — hoisting and live bindings cover them, which is why this code worked before. Making the previewer a **dynamic** boundary turns the cycle load-bearing: the module is still evaluating when the boundary awaits it, so the promise never resolves. That matches every observation — permanent fallback, no failed request, no error.

## Fix

Revert the four wrappers to direct imports.

Both files are required. Fixing `FeedCardBody` alone only moved the spinner one level down — `viewer-container` then rendered, with the loader relocated inside `markdown-parser`, i.e. the `BlockEditor` boundary. Verified stepwise:

| Stage | `viewer-container` | loader | message text |
|---|---|---|---|
| Before | ✗ | stuck | ✗ |
| `FeedCardBody` only | ✓ | stuck (one level deeper) | ✗ |
| Both files | ✓ | gone | **renders** |

These are small leaves rendered once per feed card and already in the bundle for nearly every page, so lazy-loading them bought almost no bundle win in exchange for a Suspense boundary per card.

## Verification

- **Reproduced** on a local 1.13.1 instance (`rev c7de720`): posted a conversation on a Knowledge Center article, body stuck on the spinner, still spinning after 24s, message text absent from the page.
- **Fix validated** on the same instance — message renders, no loader.
- **Production build**: `yarn build` clean, exit 0 in 64.71s.

## Note for reviewers

`main` carries the identical pattern in both files, so it needs the same change. I have not verified the cycle reproduces there, only that the code is the same — worth confirming before porting.

Not run here: the Playwright suites themselves. CI is the check on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)