### PR TITLE
fix(tests): wire ServiceDeleteSearchCleanupScaleIT's knobs and size its budget to measured throughput

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/search/scale/ServiceDeleteSearchCleanupScaleIT.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Scale regression for the bulk service-delete search cascade. Seeds a {@code databaseService} with
- * {@value #DEFAULT_TABLES} tables (override with {@code -Dscale.tables=N}), each carrying
+ * {@value #DEFAULT_TABLES} tables (override with {@code -Djpw.scale.tables=N}), each carrying
  * {@value #COLUMNS_PER_TABLE} columns, recursively hard-deletes the service, and asserts the search
  * index is fully clean — both the {@code table_search_index} docs AND the {@code column_search_index}
  * docs scoped to that service drop to zero.
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  *
  * <pre>{@code
  * mvn test -pl openmetadata-integration-tests \
- *   -Dtest=ServiceDeleteSearchCleanupScaleIT -Dscale.tables=100000 -Dgroups=scale
+ *   -Dtest=ServiceDeleteSearchCleanupScaleIT -Djpw.scale.tables=100000 -Dgroups=scale
  * }</pre>
  */
 @Tag("scale")
@@ -80,9 +80,19 @@ class ServiceDeleteSearchCleanupScaleIT {
   private static final int COLUMNS_PER_TABLE = 5;
   // Concurrency is intentionally modest: each create blocks on a synchronous table-doc index, and
   // too many in flight saturates a single-node search engine's write queue. Tune with
-  // -Dscale.workers.
-  private static final int LOAD_WORKERS = Integer.getInteger("scale.workers", 8);
+  // -Djpw.scale.workers.
+  private static final int LOAD_WORKERS = Integer.getInteger("jpw.scale.workers", 8);
   private static final int CREATE_TIMEOUT_SECONDS = 300;
+  // How long the search cascade gets to drop this service's docs to zero after the async delete is
+  // accepted. On an unloaded cluster this ran in 116s, which is what the original 5 minutes was
+  // sized against. It no longer holds: POST /v1/tables now spends ~1.3s server-side per table
+  // (db 23ms, search 101ms — the rest is unaccounted resourceCreate time, with a governance
+  // workflow firing per table-entityCreated), so by the time this test runs last the cluster is
+  // slow enough that the same delete took between 5 and 14 minutes on run 31286594784. Sized to
+  // cover that with headroom rather than to hide it — the throughput regression is tracked
+  // separately. Override with -Djpw.scale.searchCleanupTimeoutMin.
+  private static final Duration SEARCH_CLEANUP_TIMEOUT =
+      Duration.ofMinutes(Integer.getInteger("jpw.scale.searchCleanupTimeoutMin", 20));
 
   private static ServerHandle server;
   private static SearchClient search;
@@ -98,7 +108,7 @@ class ServiceDeleteSearchCleanupScaleIT {
   @Test
   void recursiveServiceHardDelete_clearsTableAndColumnDocsAtScale(final TestNamespace ns)
       throws Exception {
-    final int tableCount = Integer.getInteger("scale.tables", DEFAULT_TABLES);
+    final int tableCount = Integer.getInteger("jpw.scale.tables", DEFAULT_TABLES);
 
     final DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
     final DatabaseSchema schema = DatabaseSchemaTestFactory.createSimple(ns, service);
@@ -200,7 +210,7 @@ class ServiceDeleteSearchCleanupScaleIT {
 
   private void awaitCount(final String index, final String serviceId, final long expected) {
     Awaitility.await("count(" + index + ") for service " + serviceId + " == " + expected)
-        .atMost(Duration.ofSeconds(300))
+        .atMost(SEARCH_CLEANUP_TIMEOUT)
         .pollInterval(Duration.ofSeconds(2))
         .ignoreExceptions()
         .untilAsserted(


### PR DESCRIPTION
Two fixes for `ServiceDeleteSearchCleanupScaleIT`, which is the only remaining red test in the nightly scale job on **main, 2.0 and 1.13**.

## 1. The tuning knobs were dead

Every sibling scale test reads `jpw.scale.tables`, and the workflow passes `-Djpw.scale.tables` / `-Djpw.loader.maxWorkers`. This test read **`scale.tables`** and **`scale.workers`** — no prefix — so neither ever reached it. It always seeded 100k regardless of the matrix seed, and its concurrency couldn't be tuned at all.

Renamed to `jpw.scale.tables` / `jpw.scale.workers`, so this test can now be dialled down from the workflow without a code change.

## 2. The 5-minute budget no longer matches reality

**The delete is not broken.** On [run 31286594784](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31286594784) the service *was* deleted — `NamespaceCleanup` confirmed the root gone at 05:20:23, after the test gave up at ~05:11. It just took between 5 and 14 minutes. The original 5 minutes was sized against a **116-second** delete on an unloaded cluster.

### Why the cluster is slow

The server log for that exact window shows every `POST /v1/tables` costing ~1.4s:

```
total: 1440ms, db: 23ms, search: 101ms, auth: 0ms, rdf: 0ms, server: 1316ms
phaseExclusive: {resourceCreate: 1309ms, lifecycleDispatch: 101ms, <all others ≤7ms>}
```

Every measured sub-phase sums to under 20ms. **~1.3s per table is unaccounted time inside `resourceCreate`**, with `WorkflowEventConsumer — Triggering with signal: table-entityCreated` firing once per create (2673 times in an 18-minute window) and Quartz `JobStoreTX` active.

That is what drags this test's seed out while `EntityLoader` does the identical 100k in a flat ~28 min in the same runs:

| run | EntityLoader 100k | this test's seed | ratio |
|---|---|---|---|
| 2.0 Aug 3 (green) | 28.0 min | 31.4 min | 1.1× |
| 2.0 Aug 9 | 28.0 min | 96.6 min | 3.5× |
| 1.13 Aug 8 | 27.1 min | 285.4 min | 10.5× |

Budget raised to 20 min (`jpw.scale.searchCleanupTimeoutMin`) to cover the measured 5–14 min with headroom.

## What this is and isn't

This makes the suite report the **delete-cascade correctness it exists to test**, instead of failing on a throughput timeout that has nothing to do with the cascade. It is explicitly **not** a fix for the ~1.3s-per-create regression — that's a separate defect, and the constant's comment says so, so a future reader doesn't mistake a bigger number for a solution.

## Verification

`mvn test-compile -pl openmetadata-integration-tests` — BUILD SUCCESS. Behaviour needs the nightly scale run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
