### PR TITLE
fix(test): de-flake announcement reply edit by scoping the editor

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/entity.ts
@@ -1492,12 +1492,33 @@ export const replyAnnouncement = async (page: Page) => {
   await page.locator('.ant-popover').first().waitFor({ state: 'visible' });
   await page.click('[data-testid="edit-message"]');
 
-  await page.fill(
-    '[data-testid="editor-wrapper"] .ql-editor',
-    'Reply message edited'
+  // With the edit box open there are two Quill editors on the page: the reply's
+  // edit box and the drawer's reply composer. A page-level
+  // `[data-testid="editor-wrapper"] .ql-editor` binds to whichever mounted
+  // first, so the text can land in the composer instead. The edit box then
+  // saves unchanged content, the client sends no PATCH at all, and the final
+  // assertion times out on stale text. `.is_edit_post` is set only on the edit
+  // box (FeedCardBody passes it as `editorClass`), so scope to it — and no
+  // `.first()`, so strict mode fails loudly if it ever stops being unique.
+  const replyEditor = page.locator(
+    '[data-testid="editor-wrapper"] .is_edit_post .ql-editor'
+  );
+
+  // Pre-populated with the current reply, which proves the editor is mounted
+  // and that we are addressing the edit box rather than the empty composer.
+  await expect(replyEditor).toHaveText('Reply message');
+
+  await replyEditor.fill('Reply message edited');
+  await expect(replyEditor).toHaveText('Reply message edited');
+
+  const updatedPostResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes('/api/v1/feed/') &&
+      response.request().method() === 'PATCH'
   );
 
   await page.click('[data-testid="save-button"]');
+  await updatedPostResponse;
 
   await expect(
     page.locator('[data-testid="replies"] [data-testid="viewer-container"]')


### PR DESCRIPTION
## Symptom

`Announcement create, edit & delete` fails intermittently across `Entity.spec.ts`, `ServiceEntity.spec.ts` and `Domains.spec.ts`:

```
Locator:  locator('[data-testid="replies"] [data-testid="viewer-container"]')
Expected: "Reply message edited"
Received: "Reply message"
```

**This is the largest single failure source in recent nightlies** — 8–13 occurrences per run, mostly absorbed by retries, occasionally exhausting all three and going red. It hits a different random subset of entity types each run (Dashboard, Container, Chart, Topic, Ml Model, Search Index, Domains…), which is the signature of one race rather than per-entity bugs.

| Nightly run | occurrences | hard failures |
|---|---|---|
| postgres/172 | 8 | 0 (all absorbed) |
| mysql/173 | 13 | 2 |

## Root cause

`replyAnnouncement` fills at page level:

```ts
await page.fill('[data-testid="editor-wrapper"] .ql-editor', 'Reply message edited');
```

Once the edit box opens there are **two** Quill editors on the page — the reply's edit box and the drawer's reply composer — both matching `[data-testid="editor-wrapper"] .ql-editor`. The selector binds to whichever mounted first.

When the composer wins:
1. the edited text lands in the composer
2. the edit box still holds the original `"Reply message"`
3. Save submits unchanged content, the client computes an empty diff and **sends no PATCH at all**
4. the reply text never changes and the assertion times out 15s later

The missing request is what made this hard to read — the failure surfaces as a text mismatch, far from the cause.

## Reproduced by hand

Driving the flow manually on a local 1.13.1 instance, with a recorder on `fetch`/`XHR`:

**Page-level selector** — text went into the composer, and after Save:

```json
{ "requestsAfterSave": [], "patchSent": false, "replyTextNow": ["Reply message"] }
```

**Scoped selector** — same flow:

```json
{ "requestsAfterSave": ["PATCH /api/v1/feed/<id>/posts/<id>", "GET ..."],
  "patchSent": true,  "replyTextNow": ["Reply message edited"] }
```

With the edit box open, the DOM confirms the ambiguity and that the scope resolves it:

```json
{ "totalQlEditors": 2, "scopedMatches": 1, "scopedText": ["Reply message"] }
```

## Fix

Scope to the edit box. `.is_edit_post` is set only there — `FeedCardBody` passes it as `editorClass`, and `FeedEditor` applies it to `.editor-container`. No product change needed.

```ts
const replyEditor = page.locator(
  '[data-testid="editor-wrapper"] .is_edit_post .ql-editor'
);

await expect(replyEditor).toHaveText('Reply message');
await replyEditor.fill('Reply message edited');
await expect(replyEditor).toHaveText('Reply message edited');

const updatedPostResponse = page.waitForResponse(
  (response) =>
    response.url().includes('/api/v1/feed/') &&
    response.request().method() === 'PATCH'
);

await page.click('[data-testid="save-button"]');
await updatedPostResponse;
```

Each part earns its place:

- **No `.first()`** — if two elements ever match again, strict mode fails loudly naming both, instead of silently picking one. That silent selection is what caused this.
- **`toHaveText('Reply message')` before filling** — proves the editor is mounted *and* that it is the edit box rather than the empty composer. A specific readiness signal, not a sleep.
- **`waitForResponse` on the PATCH** — a save that submits nothing now fails immediately and points at the cause.

## Verification

Controlled A/B against a local 1.13.1 instance, same machine, 6 repeats each:

| | Result |
|---|---|
| Before | **1 failed**, 5 passed — failure identical to CI, same line |
| After | **6 passed** |

The control failure reproduced the CI message and location exactly (`at ../utils/entity.ts:1504`).

`prettier --check` and `tsc --noEmit --strict` both clean.

## Notes for reviewers

- Six repeats against a ~1-in-6 base rate is meaningful but not conclusive on its own; the mechanistic evidence above (2 editors → 1 match, no PATCH → PATCH) is the stronger part.
- `main` and `2.0` carry a byte-identical `replyAnnouncement` and need the same change. Happy to follow up once this is agreed.
- The same unscoped pattern exists at `entity.ts:1677` (reply *creation*). It is not currently failing — only one editor exists at that point — but it is the same hazard one step earlier. Left out to keep this diff focused.
- Underlying product smell, not addressed here: a save with unchanged content sends nothing and gives the user no feedback. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)