### PR TITLE
fix(tests): stop namespace cleanup paying a 5s poll delay per root

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
@@ -31,12 +31,16 @@ public final class NamespaceCleanup {
   private static final Logger LOG = LoggerFactory.getLogger(NamespaceCleanup.class);
 
   // How long to wait for a recursive hard delete to finish cascading. Sized for the scale suite's
-  // 100k-table service, whose cascade ran ~6 minutes on an unloaded cluster; small tests fall
-  // through on the first poll, so a generous cap costs them nothing. Override with
+  // 100k-table service, whose cascade ran ~6 minutes on an unloaded cluster. Override with
   // -Djpw.cleanup.cascadeTimeoutMin.
   private static final Duration CASCADE_TIMEOUT =
       Duration.ofMinutes(Integer.getInteger("jpw.cleanup.cascadeTimeoutMin", 15));
-  private static final Duration CASCADE_POLL = Duration.ofSeconds(5);
+  // Awaitility defaults its poll delay to the poll interval, so a 5s interval meant every root -
+  // including the overwhelming majority whose cascade is already finished - blocked 5s before its
+  // first check. Across a lane's namespaces that dominated the integration budget. The delay is
+  // pinned to zero below; this interval only paces genuinely in-flight cascades, and each poll is
+  // a single cheap 404 probe.
+  private static final Duration CASCADE_POLL = Duration.ofMillis(500);
 
   // OM entity type -> REST collection path. Only top-level (root) types need entries.
   private static final Map<String, String> COLLECTION_PATHS =
@@ -105,6 +109,7 @@ public final class NamespaceCleanup {
     try {
       Awaitility.await("cleanup cascade for " + root.entityType() + " " + root.id())
           .atMost(CASCADE_TIMEOUT)
+          .pollDelay(Duration.ZERO)
           .pollInterval(CASCADE_POLL)
           .until(() -> isGone(http, path));
     } catch (final ConditionTimeoutException stillRunning) {


### PR DESCRIPTION
## What

`NamespaceCleanup` blocks until a recursive hard delete finishes cascading (#31193). It polls every 5s — but **Awaitility defaults its poll delay to the poll interval**, so the first check only happens 5 seconds in. Measured on Awaitility 4.2.2:

```
default pollDelay  -> first success after 5034 ms
pollDelay(ZERO)    -> first success after 2 ms
```

Every tracked root therefore paid **at least 5 seconds of sleeping**, including the overwhelming majority whose cascade was already complete. #31193's own comment assumed the opposite — *"small tests fall through on the first poll, so a generous cap costs them nothing"* — which is the intent, but the first poll is 5s away.

## Why it matters

This is what has been timing out the `parallel` integration lane (`timeout ... 65m`, exit 124) on **every PR** since #31193 landed, with zero failing tests.

From a full lane log:

| metric | value |
|---|---|
| API requests | 58,771 |
| **total server time** | **21.1 min** |
| mean latency | 21.6 ms |
| requests > 1s | 35 |

21 minutes of backend work cannot fill a 65-minute lane — the wall clock was cleanup sleeping. It shows up as a per-test cost, not a per-request one:

| class | time | tests | per test |
|---|---|---|---|
| `DatabaseSchemaResourceIT` | 2010 s | 1 | 2010 s |
| `TableResourceIT` | 2234 s | 15 | 149 s |
| `APIEndpointResourceIT` | 1860 s | 14 | 133 s |
| `PipelineResourceIT` | 1999 s | 470 | 4.3 s |

The split tracks how much teardown each class does, not how much work.

## The change

```java
Awaitility.await(...)
    .atMost(CASCADE_TIMEOUT)
    .pollDelay(Duration.ZERO)      // finished cascade returns immediately
    .pollInterval(CASCADE_POLL)    // 5s -> 500ms
    .until(() -> isGone(http, path));
```

A finished cascade now returns immediately; an in-flight one is paced by cheap 404 probes instead of 5s sleeps.

**#31193's semantics are unchanged** — the cascade cap and the wait-for-completion behaviour stay exactly as they are. A cleanup that returns early doesn't save time, it hands the cost to the next test's seed. This only changes *how often it checks*, not *whether it waits*.

## Testing

- Poll-delay behaviour verified empirically against Awaitility 4.2.2 (numbers above)
- `openmetadata-integration-tests` test-compiles; spotless clean

The real signal will be the `parallel` lane duration on this PR — it should return to roughly its pre-#31193 time (~25 min) instead of blowing the 65m budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)