### PR TITLE
fix(tests): eliminate flacky race in OntologyExplorerCardinality setup

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/OntologyExplorerCardinality.spec.ts
@@ -15,7 +15,7 @@ import { expect, test } from '@playwright/test';
 import { Glossary } from '../../support/glossary/Glossary';
 import { GlossaryTerm } from '../../support/glossary/GlossaryTerm';
 import {
-  addRelationTypeWithCardinality,
+  addRelationTypesWithCardinality,
   addTermRelation,
   applyGlossaryFilter,
   createApiContext,
@@ -74,33 +74,47 @@ test.describe('Ontology Explorer - Cardinality Labels', () => {
     await relSrc.create(apiContext);
     await relDst.create(apiContext);
 
-    await addRelationTypeWithCardinality(apiContext, {
-      name: CUSTOM_RELATION_NAMES.ONE_TO_ONE,
-      displayName: 'PW One To One',
-      cardinality: 'ONE_TO_ONE',
-    });
-    await addRelationTypeWithCardinality(apiContext, {
-      name: CUSTOM_RELATION_NAMES.ONE_TO_MANY,
-      displayName: 'PW One To Many',
-      cardinality: 'ONE_TO_MANY',
-    });
-    await addRelationTypeWithCardinality(apiContext, {
-      name: CUSTOM_RELATION_NAMES.MANY_TO_ONE,
-      displayName: 'PW Many To One',
-      cardinality: 'MANY_TO_ONE',
-    });
-    await addRelationTypeWithCardinality(apiContext, {
-      name: CUSTOM_RELATION_NAMES.MANY_TO_MANY,
-      displayName: 'PW Many To Many',
-      cardinality: 'MANY_TO_MANY',
-    });
-    await addRelationTypeWithCardinality(apiContext, {
-      name: CUSTOM_RELATION_NAMES.CUSTOM_1_M,
-      displayName: 'PW Custom 1:M',
-      cardinality: 'CUSTOM',
-      sourceMax: 1,
-      targetMax: null,
-    });
+    // Add all custom relation types in a single batch RMW to minimise the
+    // conflict window with concurrent parallel workers. Five sequential
+    // read-modify-writes previously meant five windows where a peer with a
+    // stale snapshot could silently overwrite our types; one batched write
+    // reduces that to a single window.
+    const ALL_CUSTOM_TYPES = [
+      {
+        name: CUSTOM_RELATION_NAMES.ONE_TO_ONE,
+        displayName: 'PW One To One',
+        cardinality: 'ONE_TO_ONE',
+      },
+      {
+        name: CUSTOM_RELATION_NAMES.ONE_TO_MANY,
+        displayName: 'PW One To Many',
+        cardinality: 'ONE_TO_MANY',
+      },
+      {
+        name: CUSTOM_RELATION_NAMES.MANY_TO_ONE,
+        displayName: 'PW Many To One',
+        cardinality: 'MANY_TO_ONE',
+      },
+      {
+        name: CUSTOM_RELATION_NAMES.MANY_TO_MANY,
+        displayName: 'PW Many To Many',
+        cardinality: 'MANY_TO_MANY',
+      },
+      {
+        name: CUSTOM_RELATION_NAMES.CUSTOM_1_M,
+        displayName: 'PW Custom 1:M',
+        cardinality: 'CUSTOM',
+        sourceMax: 1,
+        targetMax: null,
+      },
+    ];
+    await addRelationTypesWithCardinality(apiContext, ALL_CUSTOM_TYPES);
+
+    // Guard: a concurrent worker that had a stale snapshot can overwrite our
+    // types between the add above and the term patches below. This second
+    // (idempotent) call verifies all types are still present and re-adds any
+    // that were lost. Cost when all present: one GET → early return.
+    await addRelationTypesWithCardinality(apiContext, ALL_CUSTOM_TYPES);
 
     await addTermRelation(
       apiContext,

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ontologyExplorer.ts
@@ -407,6 +407,53 @@ export async function addRelationTypeWithCardinality(
   );
 }
 
+// Batch variant: adds ALL supplied relation types in a single read-modify-write.
+// Use this instead of multiple sequential addRelationTypeWithCardinality calls so
+// that parallel workers only have ONE conflict window to race on rather than N.
+// The retry loop re-reads fresh each time, so a concurrent writer that removes
+// one of our types will cause the verification to fail and the loop to re-add it.
+export async function addRelationTypesWithCardinality(
+  apiContext: APIRequestContext,
+  relationTypes: Array<{
+    name: string;
+    displayName: string;
+    cardinality: string;
+    sourceMax?: number | null;
+    targetMax?: number | null;
+  }>
+): Promise<void> {
+  const names = relationTypes.map((rt) => rt.name);
+
+  for (let attempt = 0; attempt < MAX_RELATION_SETTINGS_ATTEMPTS; attempt++) {
+    const existing = await getRelationTypes(apiContext);
+    const existingNames = new Set(existing.map((rt) => rt.name));
+    const toAdd = relationTypes.filter((rt) => !existingNames.has(rt.name));
+
+    if (toAdd.length === 0) {
+      return;
+    }
+
+    const res = await putRelationTypes(apiContext, [
+      ...existing,
+      ...toAdd.map(buildRelationTypeEntry),
+    ]);
+
+    if (res.ok()) {
+      const updated = await getRelationTypes(apiContext);
+      const updatedNames = new Set(updated.map((rt) => rt.name));
+      if (names.every((n) => updatedNames.has(n))) {
+        return;
+      }
+    }
+
+    await backoffBeforeRetry(attempt);
+  }
+
+  throw new Error(
+    `addRelationTypesWithCardinality: failed to confirm all types after ${MAX_RELATION_SETTINGS_ATTEMPTS} attempts`
+  );
+}
+
 export async function waitForMoreNodesThan(
   page: Page,
   count: number


### PR DESCRIPTION
## Summary

- **Root cause**: `glossaryTermRelationSettings` only supports a full-document PUT. Parallel Playwright workers called `addRelationTypeWithCardinality` 5 times sequentially, creating 5 read-modify-write windows where a concurrent worker with a stale snapshot could silently erase freshly written types, causing `addTermRelation` to fail with HTTP 400 `Invalid relation type`.
- **Add `addRelationTypesWithCardinality` (batch)** to `ontologyExplorer.ts`: reads once, appends all missing types in a single PUT, verifies all N are present, retries on conflict. Reduces 5 concurrent-write windows to 1.
- **Update `OntologyExplorerCardinality.spec.ts`**: replace 5 sequential calls with one batch call, then call it again immediately before `addTermRelation` as an idempotent TOCTOU guard — no-op if all types are still present, repairs if a concurrent worker's stale PUT erased any.

## Test plan

- [ ] Run `OntologyExplorerCardinality.spec.ts` with multiple parallel workers to confirm no more 400 "Invalid relation type" failures
- [ ] Confirm `addRelationTypesWithCardinality` early-returns (one GET) when all types are already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)