### PR TITLE
fix(mssql): foreign keys, temporal period columns and query-log truncation visibility (#31135)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/lineage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/lineage_source.py
@@ -335,13 +335,7 @@ class LineageSource(QueryParserSource, ABC):
                         logger.debug(traceback.format_exc())
                         logger.warning(f"Error processing query_dict {query_dict}: {exc}")
                 logger.info(f"Processed {row_count} query log entries for lineage")
-                result_limit = getattr(self.source_config, "resultLimit", None)
-                if isinstance(result_limit, int) and row_count >= result_limit:
-                    logger.debug(
-                        f"Reached the configured resultLimit of {result_limit} query log entries; "
-                        f"if more queries exist they were truncated and lineage may be incomplete. "
-                        f"Consider increasing resultLimit."
-                    )
+                self.warn_if_query_log_truncated(row_count, "lineage")
 
     def get_table_query(self) -> Iterator[TableQuery]:
         """

--- a/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/queries.py
@@ -297,7 +297,8 @@ index_info AS (
         constraint_info.column_name AS referred_column,
         fk_info.match_option,
         fk_info.update_rule,
-        fk_info.delete_rule
+        fk_info.delete_rule,
+        DB_NAME() AS referred_database
     FROM
         fk_info INNER JOIN constraint_info ON
             constraint_info.constraint_schema =
@@ -316,7 +317,8 @@ index_info AS (
         index_info.column_name AS referred_column,
         fk_info.match_option,
         fk_info.update_rule,
-        fk_info.delete_rule
+        fk_info.delete_rule,
+        DB_NAME() AS referred_database
     FROM
         fk_info INNER JOIN index_info ON
             index_info.index_schema = fk_info.unique_constraint_schema

--- a/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/mssql/utils.py
@@ -147,7 +147,6 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
             Column("object_id", Integer, primary_key=True),
             Column("name", String, primary_key=True),
             Column("column_id", Integer, primary_key=True),
-            Column("generated_always_type", Integer),
             schema="sys",
         )
     )
@@ -216,7 +215,6 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
             identity_cols.c.seed_value,
             identity_cols.c.increment_value,
             sql.cast(extended_properties.c.value, NVARCHAR(4000)).label("comment"),
-            sys_columns.c.generated_always_type,
         )
         .where(whereclause)
         .select_from(join)
@@ -228,9 +226,6 @@ def get_columns(self, connection, tablename, dbname, owner, schema, **kw):  # py
     cols = []
     for row in cursr.mappings():
         name = row[columns.c.column_name]
-        generated_always_type = row[sys_columns.c.generated_always_type]
-        if generated_always_type in (1, 2):
-            continue
         type_ = row[columns.c.data_type]
         nullable = row[columns.c.is_nullable] == "YES"
         charlen = row[columns.c.character_maximum_length]
@@ -379,6 +374,7 @@ def get_foreign_keys(self, connection, tablename, dbname, owner=None, schema=Non
             referred_table_schema=sqltypes.Unicode(),
             referred_table_name=sqltypes.Unicode(),
             referred_column=sqltypes.Unicode(),
+            referred_database=sqltypes.Unicode(),
         )
     )
 
@@ -389,6 +385,7 @@ def get_foreign_keys(self, connection, tablename, dbname, owner=None, schema=Non
         return {
             "name": None,
             "constrained_columns": [],
+            "referred_database": None,
             "referred_schema": None,
             "referred_table": None,
             "referred_columns": [],
@@ -412,10 +409,12 @@ def get_foreign_keys(self, connection, tablename, dbname, owner=None, schema=Non
             _,  # match rule
             fkuprule,
             fkdelrule,
+            rdbname,
         ) = row_
 
         rec = fkeys[rfknm]
         rec["name"] = rfknm
+        rec["referred_database"] = rdbname
 
         if fkuprule != "NO ACTION":
             rec["options"]["onupdate"] = fkuprule

--- a/ingestion/src/metadata/ingestion/source/database/query_parser_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/query_parser_source.py
@@ -52,6 +52,8 @@ class QueryParserSource(Source, ABC):
 
     progress_mode = ProgressMode.MANUAL
 
+    _result_limit_warned = False
+
     @property
     def progress_tracking(self) -> ProgressTracking:
         """Composed per-source progress state; these query sources are MANUAL,
@@ -106,6 +108,26 @@ class QueryParserSource(Source, ABC):
     @staticmethod
     def get_schema_name(data: dict) -> str:
         return data.get("schema_name")
+
+    def warn_if_query_log_truncated(self, row_count: int, subject: str) -> None:
+        """Warn at most once per run that a query log batch filled resultLimit.
+
+        Args:
+            row_count: rows read from the batch just processed
+            subject: what the truncation degrades, e.g. "lineage" or "usage"
+        """
+        result_limit = getattr(self.source_config, "resultLimit", None)
+        if not isinstance(result_limit, int) or row_count < result_limit:
+            return
+        # Batches run per day per engine, so an unguarded warning fires hundreds of times
+        if self._result_limit_warned:
+            return
+        self._result_limit_warned = True
+        logger.warning(
+            f"Reached the configured resultLimit of {result_limit} query log entries; "
+            f"the query log may have been truncated and {subject} may be incomplete. "
+            f"Consider increasing resultLimit."
+        )
 
     @staticmethod
     def get_aborted_status(data: dict) -> bool:

--- a/ingestion/src/metadata/ingestion/source/database/usage_source.py
+++ b/ingestion/src/metadata/ingestion/source/database/usage_source.py
@@ -150,13 +150,7 @@ class UsageSource(QueryParserSource, ABC):
                                 logger.debug(traceback.format_exc())
                                 logger.warning(f"Unexpected exception processing row [{row}]: {exc}")
                     logger.info(f"Processed {row_count} query log entries for usage")
-                    result_limit = getattr(self.source_config, "resultLimit", None)
-                    if isinstance(result_limit, int) and row_count >= result_limit:
-                        logger.debug(
-                            f"Reached the configured resultLimit of {result_limit} query log entries; "
-                            f"if more queries exist they were truncated and usage may be incomplete. "
-                            f"Consider increasing resultLimit."
-                        )
+                    self.warn_if_query_log_truncated(row_count, "usage")
                     yield TableQueries(queries=queries)
             except Exception as exc:
                 if query:

--- a/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/azuresql/sampler.py
@@ -18,13 +18,13 @@ from typing import List, Optional  # noqa: UP035
 from sqlalchemy import Column, Table, text
 from sqlalchemy.sql.selectable import CTE
 
-from metadata.generated.schema.entity.data.table import Table as TableEntity
 from metadata.generated.schema.entity.data.table import TableData, TableType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 from metadata.sampler.sqlalchemy.sampler import (
     ProfileSampleType,
     SQASampler,
 )
+from metadata.sampler.sqlalchemy.tsql import get_temporal_column_names
 
 
 class AzureSQLSampler(SQASampler):
@@ -37,27 +37,6 @@ class AzureSQLSampler(SQASampler):
     # an error when trying to fetch data from these columns
     # pyodbc.ProgrammingError: ('ODBC SQL type -151 is not yet supported.  column-index=x  type=-151', 'HY106')
     NOT_COMPUTE_PYODBC = {"SQASGeography", "UndeterminedType"}  # noqa: RUF012
-
-    def _get_temporal_column_names(self) -> frozenset:
-        schema_name = (
-            self.entity.databaseSchema.name
-            if isinstance(self.entity, TableEntity) and self.entity.databaseSchema
-            else "dbo"
-        )
-        query = text(
-            "SELECT c.name FROM sys.columns c"
-            " JOIN sys.tables t ON c.object_id = t.object_id"
-            " JOIN sys.schemas s ON t.schema_id = s.schema_id"
-            " WHERE t.name = :table_name"
-            " AND s.name = :schema_name"
-            " AND c.generated_always_type IN (1, 2)"
-        )
-        with self.session_factory() as session:
-            rows = session.execute(
-                query,
-                {"table_name": self.entity.name.root, "schema_name": schema_name},
-            ).fetchall()
-        return frozenset(row[0] for row in rows)
 
     def set_tablesample(self, static: StaticSamplingConfig, selectable: Table):
         """Set the TABLESAMPLE clause for MSSQL
@@ -80,13 +59,15 @@ class AzureSQLSampler(SQASampler):
         return query.cte(f"{self.get_sampler_table_name()}_sample")
 
     def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:  # noqa: UP006, UP045
-        sqa_columns = []
-        if columns:
-            temporal_cols = self._get_temporal_column_names()
-            for col in columns:
-                if col.type.__class__.__name__ in self.NOT_COMPUTE_PYODBC:
-                    continue
-                if col.name in temporal_cols:
-                    continue
-                sqa_columns.append(col)
-        return super().fetch_sample_data(sqa_columns if columns is not None else None)
+        if not columns:
+            return super().fetch_sample_data(columns)
+        temporal_cols = get_temporal_column_names(self)
+        sqa_columns = [
+            col
+            for col in columns
+            if col.type.__class__.__name__ not in self.NOT_COMPUTE_PYODBC and col.name not in temporal_cols
+        ]
+        if not sqa_columns:
+            # The base method reads an empty list as "caller gave me nothing, use them all"
+            return TableData(columns=[], rows=[])
+        return super().fetch_sample_data(sqa_columns)

--- a/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/mssql/sampler.py
@@ -13,13 +13,16 @@ Helper module to handle data sampling
 for the profiler
 """
 
-from sqlalchemy import Table, text
+from typing import List, Optional  # noqa: UP035
+
+from sqlalchemy import Column, Table, text
 from sqlalchemy.sql.selectable import CTE
 
-from metadata.generated.schema.entity.data.table import TableType
+from metadata.generated.schema.entity.data.table import TableData, TableType
 from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.generated.schema.type.staticSamplingConfig import StaticSamplingConfig
 from metadata.sampler.sqlalchemy.sampler import SQASampler
+from metadata.sampler.sqlalchemy.tsql import get_temporal_column_names
 
 
 class MssqlSampler(SQASampler):
@@ -47,3 +50,16 @@ class MssqlSampler(SQASampler):
         rnd = self._base_sample_query(selectable, column).cte(f"{self.get_sampler_table_name()}_rnd")
         query = self.get_client().query(rnd)
         return query.cte(f"{self.get_sampler_table_name()}_sample")
+
+    def fetch_sample_data(self, columns: Optional[List[Column]] = None) -> TableData:  # noqa: UP006, UP045
+        """Period columns are catalogued but kept out of the sample: they are row-validity
+        bookkeeping, not user data, and classifying them adds noise (issue #21329).
+        """
+        if not columns:
+            return super().fetch_sample_data(columns)
+        temporal_cols = get_temporal_column_names(self)
+        sampled = [col for col in columns if col.name not in temporal_cols]
+        if not sampled:
+            # The base method reads an empty list as "caller gave me nothing, use them all"
+            return TableData(columns=[], rows=[])
+        return super().fetch_sample_data(sampled)

--- a/ingestion/src/metadata/sampler/sqlalchemy/tsql.py
+++ b/ingestion/src/metadata/sampler/sqlalchemy/tsql.py
@@ -1,0 +1,38 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Sampling helpers shared by the T-SQL engines (MSSQL, AzureSQL)
+"""
+
+from sqlalchemy import text
+
+from metadata.generated.schema.entity.data.table import Table as TableEntity
+
+TEMPORAL_PERIOD_COLUMNS_QUERY = text(
+    "SELECT c.name FROM sys.columns c"
+    " JOIN sys.tables t ON c.object_id = t.object_id"
+    " JOIN sys.schemas s ON t.schema_id = s.schema_id"
+    " WHERE t.name = :table_name"
+    " AND s.name = :schema_name"
+    " AND c.generated_always_type IN (1, 2)"
+)
+
+
+def get_temporal_column_names(sampler) -> frozenset:
+    """Return the SYSTEM_TIME period column names of the sampled table, empty if it has none."""
+    entity = sampler.entity
+    schema_name = entity.databaseSchema.name if isinstance(entity, TableEntity) and entity.databaseSchema else "dbo"
+    with sampler.session_factory() as session:
+        rows = session.execute(
+            TEMPORAL_PERIOD_COLUMNS_QUERY,
+            {"table_name": entity.name.root, "schema_name": schema_name},
+        ).fetchall()
+    return frozenset(row[0] for row in rows)

--- a/ingestion/tests/unit/lineage/test_lineage_source.py
+++ b/ingestion/tests/unit/lineage/test_lineage_source.py
@@ -180,7 +180,7 @@ class TestQueryLineage(unittest.TestCase):
         return mock_engine
 
     def test_result_limit_truncation_logged_when_reached(self):
-        """A debug truncation notice is logged when the query log fills resultLimit"""
+        """A truncation warning is logged when the query log fills resultLimit"""
         self.lineage_source.source_config.resultLimit = 2
         rows = [
             {"query_text": "SELECT * FROM t1", "database_name": "db1", "schema_name": "s1"},
@@ -190,11 +190,11 @@ class TestQueryLineage(unittest.TestCase):
 
         with (
             patch.object(self.lineage_source, "get_engine", return_value=[mock_engine]),
-            patch("metadata.ingestion.source.database.lineage_source.logger") as mock_logger,
+            patch("metadata.ingestion.source.database.query_parser_source.logger") as mock_logger,
         ):
             list(self.lineage_source.yield_table_query())
 
-        assert any("resultLimit" in str(call.args[0]) for call in mock_logger.debug.call_args_list)
+        assert any("resultLimit" in str(call.args[0]) for call in mock_logger.warning.call_args_list)
 
     def test_result_limit_non_int_does_not_raise(self):
         """A non-int resultLimit (e.g. absent/mocked) skips the check without TypeError"""
@@ -206,13 +206,13 @@ class TestQueryLineage(unittest.TestCase):
 
         with (
             patch.object(self.lineage_source, "get_engine", return_value=[mock_engine]),
-            patch("metadata.ingestion.source.database.lineage_source.logger") as mock_logger,
+            patch("metadata.ingestion.source.database.query_parser_source.logger") as mock_logger,
         ):
             queries = list(self.lineage_source.yield_table_query())
 
         # Processing completes and no truncation notice is emitted
         self.assertEqual(len(queries), 1)
-        assert not any("resultLimit" in str(call.args[0]) for call in mock_logger.debug.call_args_list)
+        assert not any("resultLimit" in str(call.args[0]) for call in mock_logger.warning.call_args_list)
 
     def test_yield_table_queries_from_logs(self):
         """Test yielding table queries from CSV log files"""

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/azuresql/test_azuresql_sampling.py
@@ -185,9 +185,8 @@ class SampleTest(TestCase):
             return TableData(columns=[], rows=[])
 
         with (
-            patch.object(
-                sampler,
-                "_get_temporal_column_names",
+            patch(
+                "metadata.sampler.sqlalchemy.azuresql.sampler.get_temporal_column_names",
                 return_value=frozenset({"ValidFrom", "ValidTo"}),
             ),
             patch.object(
@@ -203,11 +202,11 @@ class SampleTest(TestCase):
         assert "ValidTo" not in passed_names
         assert "id" in passed_names
 
-    def test_all_columns_filtered_passes_empty_list_not_original(self, sampler_mock):
+    def test_all_columns_filtered_returns_no_sample(self, sampler_mock):
         """
-        When every column is a temporal period column, sqa_columns is [].
-        The empty list must be passed to super(), not the original column list —
-        otherwise the filter is bypassed entirely (falsy empty list bug).
+        When the filter empties the column list there is nothing left to sample.
+        Handing [] to super() reads as "caller gave me nothing, use them all", which
+        puts the filtered columns straight back into the query.
         """
         from unittest.mock import MagicMock, patch
 
@@ -227,29 +226,46 @@ class SampleTest(TestCase):
         valid_to_col.name = "ValidTo"
         valid_to_col.type = DateTime()
 
-        received = {}
-
-        def capture_fetch(cols=None):
-            received["columns"] = cols
-            from metadata.generated.schema.entity.data.table import TableData
-
-            return TableData(columns=[], rows=[])
-
         with (
-            patch.object(
-                sampler,
-                "_get_temporal_column_names",
+            patch(
+                "metadata.sampler.sqlalchemy.azuresql.sampler.get_temporal_column_names",
                 return_value=frozenset({"ValidFrom", "ValidTo"}),
             ),
-            patch.object(
-                SQASampler,
-                "fetch_sample_data",
-                side_effect=capture_fetch,
-            ),
+            patch.object(SQASampler, "fetch_sample_data") as super_fetch,
         ):
-            sampler.fetch_sample_data(columns=[valid_from_col, valid_to_col])
+            table_data = sampler.fetch_sample_data(columns=[valid_from_col, valid_to_col])
 
-        assert received["columns"] == [], "Expected empty list when all columns are filtered, not the original list"
+        assert table_data.columns == []
+        assert table_data.rows == []
+        super_fetch.assert_not_called()
+
+    def test_all_columns_unsupported_by_pyodbc_returns_no_sample(self, sampler_mock):
+        """A table of only geography columns must not un-filter back into the pyodbc
+        'ODBC SQL type -151 is not yet supported' crash NOT_COMPUTE_PYODBC guards against.
+        """
+        from unittest.mock import MagicMock, patch
+
+        geography_col = MagicMock()
+        geography_col.name = "shape"
+        geography_col.type.__class__.__name__ = "SQASGeography"
+
+        sampler = AzureSQLSampler(
+            service_connection_config=self.azuresql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+        )
+
+        with (
+            patch(
+                "metadata.sampler.sqlalchemy.azuresql.sampler.get_temporal_column_names",
+                return_value=frozenset(),
+            ),
+            patch.object(SQASampler, "fetch_sample_data") as super_fetch,
+        ):
+            table_data = sampler.fetch_sample_data(columns=[geography_col])
+
+        assert table_data.columns == []
+        super_fetch.assert_not_called()
 
     def test_sampling_with_partition(self, sampler_mock):
         """

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/mssql/test_mssql_sampling.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/mssql/test_mssql_sampling.py
@@ -13,6 +13,7 @@ from metadata.generated.schema.entity.data.table import (
     PartitionIntervalTypes,
     PartitionProfilerConfig,
     Table,
+    TableData,
 )
 from metadata.generated.schema.entity.services.connections.database.mssqlConnection import (
     MssqlConnection,
@@ -171,3 +172,118 @@ class SampleTest(TestCase):
             '\nFROM "9bc65c2abec141778ffaa729489f3e87_rnd"'
         )
         assert expected_query.casefold() == str(query.compile(compile_kwargs={"literal_binds": True})).casefold()
+
+    def test_temporal_columns_excluded_from_fetch_sample_data(self, sampler_mock):
+        """
+        Period columns are catalogued but must stay out of the sample: they are row
+        validity bookkeeping rather than user data (issue #21329).
+        """
+        from unittest.mock import MagicMock
+
+        from sqlalchemy.types import DateTime
+
+        sampler = MssqlSampler(
+            service_connection_config=self.mssql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+        )
+
+        valid_from_col = MagicMock()
+        valid_from_col.name = "valid_from"
+        valid_from_col.type = DateTime()
+
+        valid_to_col = MagicMock()
+        valid_to_col.name = "valid_to"
+        valid_to_col.type = DateTime()
+
+        id_col = MagicMock()
+        id_col.name = "id"
+
+        columns_passed_to_super = []
+
+        def capture_fetch(*args, **kwargs):
+            cols = args[0] if args else kwargs.get("columns")
+            if cols:
+                columns_passed_to_super.extend(cols)
+
+            return TableData(columns=[], rows=[])
+
+        with (
+            patch(
+                "metadata.sampler.sqlalchemy.mssql.sampler.get_temporal_column_names",
+                return_value=frozenset({"valid_from", "valid_to"}),
+            ),
+            patch.object(SQASampler, "fetch_sample_data", side_effect=capture_fetch),
+        ):
+            sampler.fetch_sample_data(columns=[id_col, valid_from_col, valid_to_col])
+
+        passed_names = {col.name for col in columns_passed_to_super}
+
+        assert passed_names == {"id"}
+
+    def test_non_temporal_table_keeps_every_column(self, sampler_mock):
+        """A table with no period columns must reach the sampler untouched."""
+        from unittest.mock import MagicMock
+
+        sampler = MssqlSampler(
+            service_connection_config=self.mssql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+        )
+
+        id_col = MagicMock()
+        id_col.name = "id"
+        name_col = MagicMock()
+        name_col.name = "name"
+
+        columns_passed_to_super = []
+
+        def capture_fetch(*args, **kwargs):
+            cols = args[0] if args else kwargs.get("columns")
+            if cols:
+                columns_passed_to_super.extend(cols)
+
+            return TableData(columns=[], rows=[])
+
+        with (
+            patch(
+                "metadata.sampler.sqlalchemy.mssql.sampler.get_temporal_column_names",
+                return_value=frozenset(),
+            ),
+            patch.object(SQASampler, "fetch_sample_data", side_effect=capture_fetch),
+        ):
+            sampler.fetch_sample_data(columns=[id_col, name_col])
+
+        passed_names = {col.name for col in columns_passed_to_super}
+
+        assert passed_names == {"id", "name"}
+
+    def test_all_columns_filtered_returns_no_sample(self, sampler_mock):
+        """
+        When the filter empties the column list there is nothing left to sample.
+        Handing [] to super() reads as "caller gave me nothing, use them all", which
+        puts the period columns straight back into the query.
+        """
+        from unittest.mock import MagicMock
+
+        sampler = MssqlSampler(
+            service_connection_config=self.mssql_conn,
+            ometa_client=None,
+            entity=self.table_entity,
+        )
+
+        valid_from_col = MagicMock()
+        valid_from_col.name = "valid_from"
+
+        with (
+            patch(
+                "metadata.sampler.sqlalchemy.mssql.sampler.get_temporal_column_names",
+                return_value=frozenset({"valid_from"}),
+            ),
+            patch.object(SQASampler, "fetch_sample_data") as super_fetch,
+        ):
+            table_data = sampler.fetch_sample_data(columns=[valid_from_col])
+
+        assert table_data.columns == []
+        assert table_data.rows == []
+        super_fetch.assert_not_called()

--- a/ingestion/tests/unit/topology/database/test_mssql.py
+++ b/ingestion/tests/unit/topology/database/test_mssql.py
@@ -53,6 +53,7 @@ from metadata.ingestion.source.database.mssql.lineage import MssqlLineageSource
 from metadata.ingestion.source.database.mssql.metadata import MssqlSource
 from metadata.ingestion.source.database.mssql.models import MssqlStoredProcedure
 from metadata.ingestion.source.database.mssql.queries import (
+    MSSQL_GET_FOREIGN_KEY,
     MSSQL_SQL_STATEMENT,
     MSSQL_SQL_STATEMENT_CURRENT_DB,
     MSSQL_SQL_STATEMENT_FROM_QUERY_STORE,
@@ -546,6 +547,113 @@ class MssqlIdentityColumnTest(TestCase):
     def test_missing_seed_returns_empty_dict(self):
         assert mssql_dialet.get_identity_values(BigInteger(), None, Decimal("1")) == {}
         assert mssql_dialet.get_identity_values(BigInteger(), Decimal("1"), None) == {}
+
+
+class TestMssqlForeignKeyReferredDatabase:
+    """``get_foreign_keys`` must report the database holding the referred table.
+
+    Without it the caller builds the referred FQN with a ``None`` database and the
+    constraint is dropped.
+    """
+
+    @staticmethod
+    def _fk_row(constraint_name, constrained_column, referred_column):
+        return (
+            "sales",  # constraint schema
+            constraint_name,
+            1,  # ordinal position
+            constrained_column,
+            "sales",  # referred schema
+            "customers",
+            referred_column,
+            None,  # match rule
+            "NO ACTION",
+            "NO ACTION",
+            "my_catalog",  # DB_NAME()
+        )
+
+    def _foreign_keys(self, rows):
+        from sqlalchemy.dialects.mssql.base import MSDialect
+
+        connection = MagicMock()
+        connection.execute.return_value.fetchall.return_value = rows
+
+        return mssql_dialet.get_foreign_keys(MSDialect(), connection, "orders", schema="sales")
+
+    def test_referred_database_comes_from_the_query(self):
+        keys = self._foreign_keys([self._fk_row("fk_orders_customer", "customer_id", "id")])
+
+        assert [key["referred_database"] for key in keys] == ["my_catalog"]
+
+    def test_query_selects_the_database_name(self):
+        assert "DB_NAME() AS referred_database" in MSSQL_GET_FOREIGN_KEY
+
+    def test_multi_column_key_is_still_grouped(self):
+        (key,) = self._foreign_keys(
+            [
+                self._fk_row("fk_orders_customer", "customer_id", "id"),
+                self._fk_row("fk_orders_customer", "customer_region", "region"),
+            ]
+        )
+
+        assert key["name"] == "fk_orders_customer"
+        assert key["referred_table"] == "customers"
+        assert key["constrained_columns"] == ["customer_id", "customer_region"]
+        assert key["referred_columns"] == ["id", "region"]
+
+
+class TestMssqlTemporalPeriodColumns:
+    """``get_columns`` must reflect SYSTEM_TIME period columns.
+
+    Skipping them left system-versioned tables missing their SysStartTime/SysEndTime
+    pair from the catalogue entirely.
+    """
+
+    @staticmethod
+    def _row(name, data_type="datetime2", generated_always_type=0):
+        values = {
+            "column_name": name,
+            "data_type": data_type,
+            "is_nullable": "NO",
+            "character_maximum_length": None,
+            "numeric_precision": None,
+            "numeric_scale": None,
+            "column_default": None,
+            "collation_name": None,
+            "generated_always_type": generated_always_type,
+        }
+
+        class _Mapping:
+            """Rows come back keyed by the column expression, as cursor.mappings() gives them."""
+
+            def __getitem__(self, key):
+                return values.get(getattr(key, "key", key))
+
+        return _Mapping()
+
+    def _get_columns(self, rows):
+        from sqlalchemy.dialects.mssql.base import MSDialect
+
+        connection = MagicMock()
+        connection.execution_options.return_value.execute.return_value.mappings.return_value = rows
+
+        return mssql_dialet.get_columns(MSDialect(), connection, "orders", schema="sales")
+
+    def test_period_columns_are_reflected(self):
+        cols = self._get_columns(
+            [
+                self._row("id", data_type="int"),
+                self._row("SysStartTime", generated_always_type=1),
+                self._row("SysEndTime", generated_always_type=2),
+            ]
+        )
+
+        assert [col["name"] for col in cols] == ["id", "SysStartTime", "SysEndTime"]
+
+    def test_a_table_without_period_columns_is_unaffected(self):
+        cols = self._get_columns([self._row("id", data_type="int"), self._row("name", data_type="varchar")])
+
+        assert [col["name"] for col in cols] == ["id", "name"]
 
 
 class TestMssqlQueryStoreSelection:

--- a/ingestion/tests/unit/topology/database/test_query_log_truncation.py
+++ b/ingestion/tests/unit/topology/database/test_query_log_truncation.py
@@ -1,0 +1,124 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests that a query log capped by resultLimit is reported to the user
+"""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.database.lineage_source import LineageSource
+from metadata.ingestion.source.database.query_parser_source import QueryParserSource
+from metadata.ingestion.source.database.usage_source import UsageSource
+
+WARN_LOGGER = "metadata.ingestion.source.database.query_parser_source.logger"
+
+ROW_FIELDS = {
+    "query_text": "SELECT 1",
+    "query_type": "SELECT",
+    "user_name": "ingestion",
+    "start_time": datetime(2026, 8, 1, 10, 0, 0),
+    "end_time": datetime(2026, 8, 1, 10, 0, 1),
+    "duration": 1.0,
+    "cost": None,
+    "schema_name": "my_schema",
+    "database_name": "my_database",
+    "aborted": False,
+}
+
+
+class _Row:
+    """Stands in for a SQLAlchemy Row, which the sources read via _asdict()."""
+
+    def _asdict(self):
+        return dict(ROW_FIELDS)
+
+
+def _engine_yielding(row_count: int):
+    connection = MagicMock()
+    connection.execute.return_value = [_Row() for _ in range(row_count)]
+
+    @contextmanager
+    def connect():
+        yield connection
+
+    engine = MagicMock()
+    engine.connect = connect
+    return engine
+
+
+def _source(cls, method_name: str, row_count: int, result_limit: int, engines: int = 1, days: int = 1):
+    source = MagicMock()
+    source.get_engine.return_value = [_engine_yielding(row_count) for _ in range(engines)]
+    source.get_sql_statement.return_value = "SELECT 1"
+    source.source_config.resultLimit = result_limit
+    source.config.serviceName = "my_service"
+    source.dialect.value = "mssql"
+    source.get_database_name.return_value = "my_database"
+    source.get_schema_name.return_value = "my_schema"
+    source.get_aborted_status.return_value = False
+    source.format_query.side_effect = lambda query: query
+    source.start = datetime(2026, 8, 1)
+    source.end = datetime(2026, 8, 1) + timedelta(days=days)
+
+    source._result_limit_warned = False
+    source.warn_if_query_log_truncated = QueryParserSource.warn_if_query_log_truncated.__get__(source)
+
+    method = getattr(cls, method_name)
+    return method.__get__(source)
+
+
+CASES = [
+    (UsageSource, "yield_table_queries", "usage may be incomplete"),
+    (LineageSource, "yield_table_query", "lineage may be incomplete"),
+]
+
+
+@pytest.mark.parametrize("source_class, method_name, expected_message", CASES)
+def test_hitting_the_result_limit_warns(source_class, method_name, expected_message):
+    """A capped query log silently drops the oldest queries, so the run has to say so
+    at a level the user actually sees.
+    """
+    bound = _source(source_class, method_name, row_count=5, result_limit=5)
+
+    with patch(WARN_LOGGER) as mock_logger:
+        list(bound())
+
+    warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+    assert any("Reached the configured resultLimit of 5" in message for message in warnings)
+    assert any(expected_message in message for message in warnings)
+
+
+@pytest.mark.parametrize("source_class, method_name, expected_message", CASES)
+def test_staying_under_the_result_limit_does_not_warn(source_class, method_name, expected_message):
+    bound = _source(source_class, method_name, row_count=2, result_limit=5)
+
+    with patch(WARN_LOGGER) as mock_logger:
+        list(bound())
+
+    warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+    assert not any("resultLimit" in message for message in warnings)
+
+
+@pytest.mark.parametrize("source_class, method_name, expected_message", CASES)
+def test_the_notice_fires_once_per_run(source_class, method_name, expected_message):
+    """Batches run per day per engine, so a per-batch notice would flood the log."""
+    bound = _source(source_class, method_name, row_count=5, result_limit=5, engines=3, days=4)
+
+    with patch(WARN_LOGGER) as mock_logger:
+        list(bound())
+
+    warnings = [call.args[0] for call in mock_logger.warning.call_args_list]
+    assert len([message for message in warnings if "resultLimit" in message]) == 1


### PR DESCRIPTION
Cherry-pick of #31135 onto `2.0`. Picked clean from `f2789b6` (squash merge), no conflicts.

### Foreign keys were silently dropped

MSSQL's `get_foreign_keys` never returned `referred_database`, so `common_db_source` built the referred table FQN with a `None` database, failed to look the table up and discarded the constraint. No FK ever reached the catalogue.

`MSSQL_GET_FOREIGN_KEY` now selects `DB_NAME() AS referred_database`, mirroring how `POSTGRES_FETCH_FK` returns `con_db_name`.

### Temporal tables lost their period columns

The dialect skipped every column with `generated_always_type in (1, 2)`, so the `SysStartTime`/`SysEndTime` pair of a system-versioned table was missing from the catalogue entirely. The columns are now reflected; the sampler excludes them from sample-data queries instead.

`get_temporal_column_names` is shared by the MSSQL and AzureSQL samplers.

### Column filter could invert

An empty column list reads as "caller gave me nothing, use them all" in `SQASampler.fetch_sample_data`, so a filter that removed every column un-filtered instead. Both samplers now return empty `TableData`, which also keeps an all-geography table out of the pyodbc type -151 crash.

### Query-log truncation was invisible

`usage_source` and `lineage_source` logged the `resultLimit` truncation notice at `debug`, so a run that silently processed a fraction of the queries looked complete. Raised to `warning` and moved to `QueryParserSource` behind a run-scoped flag — it sat inside the per-day and per-engine loops, so a 30-day window over 20 databases emitted it up to 600 times.