### PR TITLE
fix(tests): stop namespace cleanup paying a 5s poll delay per root (#31244) [1.13 backport]

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/util/NamespaceCleanup.java
@@ -31,12 +31,16 @@ public final class NamespaceCleanup {
   private static final Logger LOG = LoggerFactory.getLogger(NamespaceCleanup.class);
 
   // How long to wait for a recursive hard delete to finish cascading. Sized for the scale suite's
-  // 100k-table service, whose cascade ran ~6 minutes on an unloaded cluster; small tests fall
-  // through on the first poll, so a generous cap costs them nothing. Override with
+  // 100k-table service, whose cascade ran ~6 minutes on an unloaded cluster. Override with
   // -Djpw.cleanup.cascadeTimeoutMin.
   private static final Duration CASCADE_TIMEOUT =
       Duration.ofMinutes(Integer.getInteger("jpw.cleanup.cascadeTimeoutMin", 15));
-  private static final Duration CASCADE_POLL = Duration.ofSeconds(5);
+  // Awaitility defaults its poll delay to the poll interval, so a 5s interval meant every root -
+  // including the overwhelming majority whose cascade is already finished - blocked 5s before its
+  // first check. Across a lane's namespaces that dominated the integration budget. The delay is
+  // pinned to zero below; this interval only paces genuinely in-flight cascades, and each poll is
+  // a single cheap 404 probe.
+  private static final Duration CASCADE_POLL = Duration.ofMillis(500);
 
   // OM entity type -> REST collection path. Only top-level (root) types need entries.
   private static final Map<String, String> COLLECTION_PATHS =
@@ -105,6 +109,7 @@ public final class NamespaceCleanup {
     try {
       Awaitility.await("cleanup cascade for " + root.entityType() + " " + root.id())
           .atMost(CASCADE_TIMEOUT)
+          .pollDelay(Duration.ZERO)
           .pollInterval(CASCADE_POLL)
           .until(() -> isGone(http, path));
     } catch (final ConditionTimeoutException stillRunning) {


### PR DESCRIPTION
### Describe your changes:

Backport of #31244 to `1.13`.

`1.13` carries #31193 through its own cherry-pick, so it has the same regression `main` did — but #31244 only landed on `main`. This applies the identical fix.

#### The bug

`NamespaceCleanup` blocks until a recursive hard delete finishes cascading (#31193), polling every 5s. **Awaitility derives its poll delay from the poll interval** when that interval is a `FixedPollInterval` and no delay is set explicitly, so the first check only happened 5 seconds in. Measured against the awaitility 4.2.2 jar this branch resolves:

```
default pollDelay (as on 1.13) -> first success after 5028 ms
pollDelay(ZERO)              -> first success after    1 ms
```

Every tracked root paid at least 5s of sleeping — and `TestNamespaceExtension.afterEach` fires per test *method*, then loops over every tracked root, so a test tracking three services paid 15s. On `main`'s lane that measured as 5265 cleanups × ~5s = 26,200s of pure sleep, which is what pushed the parallel lane past its 65m budget (exit 124) with zero failing tests.

#### The change

```java
Awaitility.await(...)
    .atMost(CASCADE_TIMEOUT)
    .pollDelay(Duration.ZERO)      // finished cascade returns immediately
    .pollInterval(CASCADE_POLL)    // 5s -> 500ms
    .until(() -> isGone(http, path));
```

**#31193's semantics are unchanged** — the cascade cap and the wait-for-completion behaviour stay exactly as they are. This only changes *how often it checks*, not *whether it waits*.

#
### Type of change:
- [x] Bug fix

#
### Tests:

#### Backend integration tests
- [x] Not applicable — this *is* integration-test infrastructure. The real signal is this PR's own parallel lane duration.

#### Unit tests
- [x] Not applicable — no product code changed; carried over from #31244 unchanged.

#### Manual testing performed
1. Verified the diff is **byte-identical** to the merged `main` fix (9ab47dcf39): `git diff` bodies compare equal.
2. Confirmed `1.13` still carried the regression before this change — `CASCADE_POLL = Duration.ofSeconds(5)`, zero occurrences of `pollDelay`.
3. Re-measured the poll-delay behaviour against awaitility 4.2.2 (numbers above).

**Not run locally:** the integration lane itself — it needs Docker/testcontainers. Watch this PR's `Integration Test Lane (parallel)` duration; it should return to roughly its pre-#31193 time instead of hitting the 65m timeout.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
