### PR TITLE
fix(security): bump reactor-netty-http to 1.2.18 (CVE-2026-41715)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.16</version>
+        <version>1.2.18</version>
       </dependency>
       <!-- CVE-2026-45292: opentelemetry-api 1.37.0 (transitive of
            co.elastic.clients:elasticsearch-java, shaded into elasticsearch-deps)


### PR DESCRIPTION
## Advisory

**CVE-2026-41715** — Cleartext Transmission of Sensitive Information in `io.projectreactor.netty:reactor-netty-http`. CVSS 4.9 (medium). Affects 1.2.16; fixed in **1.2.18** on the 1.2 line (and 1.3.6 on the 1.3 line).

## Change

Root `pom.xml` `dependencyManagement` already pins `reactor-netty-http` to **1.2.16**. Bump that pin to **1.2.18**.

```diff
-        <version>1.2.16</version>
+        <version>1.2.18</version>
```

## Why upstream

This is the upstream half of a security-scan triage. `reactor-netty-http` is reached via `com.azure:azure-core-http-netty` (both the `azure-storage-blob` and `azure-security-keyvault-secrets` paths). The pin lives here in OpenMetadata's `dependencyManagement`, so bumping it here fixes every consumer — including the downstream Collate build, which currently has to restate the same pin (openmetadata-collate#5614) precisely because OM's `dependencyManagement` does not propagate to a repo with no OM parent POM. Fixing it here lets that restatement be dropped.

## Verified

- Artifact exists: `repo1.maven.org/.../reactor-netty-http/1.2.18/reactor-netty-http-1.2.18.pom` → HTTP 200.
- Stayed on the 1.2 line (patch move) rather than jumping to 1.3.6 under a pinned Azure SDK.
- `pom.xml` parses as well-formed XML after the edit.
- Existing `netty-transport-native-epoll` / `netty-resolver-dns-native-macos` exclusions are unaffected — a version pin does not alter exclusions.

## Not tested

- No `mvn` build / `dependency:tree` run. Reviewer should confirm resolution with `mvn dependency:tree -Dincludes=io.projectreactor.netty`.
- No runtime exercise of the Azure blob/keyvault paths; `azure-core-http-netty@1.16.4` compatibility with 1.2.18 assumed on the strength of a patch-line move.