### PR TITLE
fix(security): bump tomcat-jdbc/tomcat-juli to 11.0.11 (CVE-2025-55754)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <postgres.connector.version>42.7.12</postgres.connector.version>
     <jsonschema2pojo.version>1.3.1</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
-    <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
+    <tomcat-jdbc.version>11.0.11</tomcat-jdbc.version>
     <hikaricp.version>7.0.2</hikaricp.version>
     <elasticsearch.version>7.17.25</elasticsearch.version>
     <opensearch.version>2.6.0</opensearch.version>


### PR DESCRIPTION
## Advisory

**CVE-2025-55754** — Improper Output Neutralization for Logs (ANSI escape-sequence injection into log output) in `org.apache.tomcat:tomcat-juli`. CVSS 6.3 (medium). Affects 11.0.5; fixed in **11.0.11** on the 11.0 line (also 9.0.109 / 10.1.45 on older lines).

## Change

Bump the `tomcat-jdbc.version` property in root `pom.xml`:

```diff
-    <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
+    <tomcat-jdbc.version>11.0.11</tomcat-jdbc.version>
```

`tomcat-juli` is not pinned separately — it comes in transitively via `tomcat-jdbc`. The `tomcat-jdbc:11.0.11` POM declares exactly one dependency, `tomcat-juli:11.0.11` (verified against Maven Central), so moving the property moves both to the patched release.

## Why upstream

This is the upstream half of a security-scan triage. The dependency is declared entirely here — `tomcat-jdbc` in `openmetadata-service/pom.xml`, version driven by this root property. There is no downstream-owned path to it, so the clean fix is here. The downstream Collate PR (openmetadata-collate#5615) restates the pin only because OM's `dependencyManagement` does not propagate to a repo with no OM parent POM; fixing it here lets that restatement be dropped and keeps Collate on the same Tomcat release the OSS server is tested against.

## Verified

- Both artifacts exist: `.../tomcat-jdbc/11.0.11/...pom` → 200, `.../tomcat-juli/11.0.11/...pom` → 200.
- Read `tomcat-jdbc:11.0.11` POM — its only dependency is `tomcat-juli:11.0.11`.
- Stayed on the 11.0 line; 9.0.109 / 10.1.45 would be a major-line downgrade.
- `pom.xml` parses as well-formed XML after the edit.

## Not tested

- No `mvn` build / `dependency:tree` run. Reviewer should confirm resolution with `mvn dependency:tree -Dincludes=org.apache.tomcat`.
- No diff of 11.0.5 → 11.0.11 connection-pool behaviour (`PoolProperties`), and no runtime exercise of the JDBC pool.