### PR TITLE
ci: add Workflow Builder UI paths to Collate E2E trigger filter

### DIFF
--- a/.github/workflows/data-access-request-e2e.yml
+++ b/.github/workflows/data-access-request-e2e.yml
@@ -40,6 +40,12 @@ jobs:
               - 'openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TaskRepository.java'
               - 'openmetadata-service/src/main/java/org/openmetadata/service/resources/feeds/FeedResource.java'
               - 'openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/**'
+              - 'openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/**'
+              - 'openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/**'
+              - 'openmetadata-ui/src/main/resources/ui/src/constants/WorkflowBuilder.constants.ts'
+              - 'openmetadata-ui/src/main/resources/ui/src/interface/WorkflowBuilder.interface.ts'
+              - 'openmetadata-ui/src/main/resources/ui/src/utils/WorkflowBuilderUtils.ts'
+              - 'openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/**'
 
   data-access-request-e2e:
     needs: check-changes


### PR DESCRIPTION
### Describe your changes:

Extends the `data-access-request-e2e` CI workflow to also trigger the Collate Governance Workflow Playwright suite when an OpenMetadata PR touches **Workflow Builder / WorkflowDefinitions UI files**, in addition to the existing backend governance workflow paths.

Previously, changes to the UI components, pages, constants, interfaces, utils, or generated types for the Workflow Builder could silently break Collate's workflow features without triggering the Collate E2E check. This adds the missing path filters to catch those cases.

**New paths added to the `dar` filter:**
- `openmetadata-ui/src/main/resources/ui/src/components/WorkflowDefinitions/**`
- `openmetadata-ui/src/main/resources/ui/src/pages/WorkflowDefinitions/**`
- `openmetadata-ui/src/main/resources/ui/src/constants/WorkflowBuilder.constants.ts`
- `openmetadata-ui/src/main/resources/ui/src/interface/WorkflowBuilder.interface.ts`
- `openmetadata-ui/src/main/resources/ui/src/utils/WorkflowBuilderUtils.ts`
- `openmetadata-ui/src/main/resources/ui/src/generated/governance/workflows/**`

### Type of change:
- [ ] Bug fix
- [x] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

### High-level design:

N/A — small change. Adds six path filter entries to the existing `dorny/paths-filter` step.

### Tests:

#### Use cases covered
- OSS PR touching any file under `WorkflowDefinitions/` components or pages will now trigger the Collate Workflow Playwright suite
- OSS PR touching generated governance workflow types will trigger the check
- PRs with no workflow-related changes continue to skip the check (no regression)

#### Playwright (UI) tests
- [x] Not applicable (CI configuration change only)

### UI screen recording / screenshots:

Not applicable.

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `ci: add Workflow Builder UI paths to Collate E2E trigger filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)