### PR TITLE
fix(ui): stop a superseded Test Connection run's poll error from clobbering a newer run

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.test.tsx
@@ -1296,6 +1296,84 @@ describe('Test Connection Component', () => {
     );
   });
 
+  it('Should ignore a superseded run whose poll rejects after a newer run started', async () => {
+    jest.useFakeTimers();
+
+    let rejectStalePoll: (reason?: unknown) => void = () => undefined;
+    const stalePoll = new Promise((_resolve, reject) => {
+      rejectStalePoll = reject;
+    });
+
+    (getWorkflowById as jest.Mock)
+      .mockImplementationOnce(() => stalePoll)
+      .mockImplementation(() =>
+        Promise.resolve({
+          ...WORKFLOW_DETAILS,
+          status: 'Running',
+          response: { ...WORKFLOW_DETAILS.response, status: 'Running' },
+        })
+      );
+
+    const onTestConnectionStatusChange = jest.fn();
+
+    await act(async () => {
+      render(
+        <TestConnection
+          {...mockProps}
+          onTestConnectionStatusChange={onTestConnectionStatusChange}
+        />
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-connection-btn'));
+    });
+
+    // the first run's poll is now in flight and will not settle yet
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    // its expiry re-enables the button while that request is still pending
+    await act(async () => {
+      jest.advanceTimersByTime(180000);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('test-connection-btn'));
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    const callsBeforeStaleRejects = (getWorkflowById as jest.Mock).mock.calls
+      .length;
+    const statusChangeCallsBeforeStaleRejects =
+      onTestConnectionStatusChange.mock.calls.length;
+
+    await act(async () => {
+      rejectStalePoll(new Error('stale run failed'));
+    });
+
+    // the stale run's rejection must not clobber the newer run's status
+    expect(onTestConnectionStatusChange.mock.calls.length).toBe(
+      statusChangeCallsBeforeStaleRejects
+    );
+    expect(
+      screen.queryByText('message.connection-test-failed')
+    ).not.toBeInTheDocument();
+
+    // the newer run must still own its timers and keep polling
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect((getWorkflowById as jest.Mock).mock.calls.length).toBeGreaterThan(
+      callsBeforeStaleRejects
+    );
+  });
+
   it('Should stop polling the workflow after unmount', async () => {
     jest.useFakeTimers();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.tsx
@@ -399,6 +399,13 @@ const TestConnection: FC<TestConnectionProps> = ({
 
             resolve();
           } catch (error) {
+            // a newer run may have started while this request was in flight;
+            // its rejection must not clear the newer run's timers/state
+            if (runId !== runIdRef.current) {
+              resolve();
+
+              return;
+            }
             reject(error as AxiosError);
           }
         }, FETCH_INTERVAL)


### PR DESCRIPTION
## Summary

`handleWorkflowPolling`'s interval callback (added in #31136) guards the success path with a
`runId` check — once at the top of the tick, and again after the awaited `getWorkflowData` call
— but not the error path. If a superseded run's `getWorkflowData` request is in flight when a
newer run starts, and that request later rejects, the callback calls `reject(error)`
unconditionally. That propagates to `testConnection()`'s outer `catch`, which unconditionally
calls `clearTimers()` and marks the connection `Failed`, wiping out a newer run that is still
actively polling — the exact stale-clobber #31136 set out to prevent, just reached through the
error path instead of the success path.

- Guard the `catch` in `handleWorkflowPolling` the same way the two success-path checks already
  are: if the run has been superseded, resolve and bail out instead of rejecting.
- Add a Jest test mirroring the existing superseded-run coverage, using a deferred promise that
  rejects after a newer run has started, asserting the stale rejection doesn't touch
  `onTestConnectionStatusChange` and that the newer run keeps polling afterward.

## Context

This was flagged by `gitar-bot` on #31253 (the 2.0 backport of #31136) — a review comment posted
minutes before merge that never got addressed:
https://github.com/open-metadata/OpenMetadata/pull/31253#discussion_r3747048145

The same gap exists in #31136's original fix on `main`, since the backport was a clean
cherry-pick. This PR fixes it on `main`.

## Test plan

- [x] `yarn test src/components/common/TestConnection/TestConnection.test.tsx` — 45/45 pass
- [x] Verified the new test fails without the fix (reverted the fix locally, confirmed the test
      catches the clobber, restored the fix)
- [x] `ui-checkstyle` (organize-imports + eslint --fix + prettier) run on changed files — no
      errors, no diff (only pre-existing warnings unrelated to this change)
- [x] No new user-visible behavior — internal polling race fix, no new Playwright coverage needed
      (existing impact-map mapping from #31136/#31253 already routes changes here to the relevant
      specs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)