### PR TITLE
Fixes #31265: Fivetran lineage fallback for unset service names and Table -> Topic support

### DIFF
--- a/ingestion/src/metadata/ingestion/lineage/topic_lineage.py
+++ b/ingestion/src/metadata/ingestion/lineage/topic_lineage.py
@@ -1,0 +1,80 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Helpers to resolve fields inside a Topic's message schema.
+
+Topic-side counterpart to get_column_fqn: Topics expose their fields under
+messageSchema.schemaFields rather than a flat `columns` list, and Debezium
+wraps the real record under an after/before envelope.
+"""
+
+from typing import Optional
+
+from metadata.generated.schema.entity.data.topic import Topic
+from metadata.ingestion.ometa.utils import model_str
+from metadata.utils.logger import ingestion_logger
+
+logger = ingestion_logger()
+
+CDC_ENVELOPE_FIELDS = {"after", "before", "op"}
+
+
+def get_topic_field_fqn(topic_entity: Topic, field_name: str) -> Optional[str]:  # noqa: C901, UP045
+    """
+    Get the fully qualified name for a field in a Topic's schema.
+    Handles nested structures where fields may be children of a parent RECORD.
+    For Debezium CDC topics, searches for fields inside after/before envelope children.
+    """
+    if not topic_entity.messageSchema or not topic_entity.messageSchema.schemaFields:
+        logger.debug(f"Topic {model_str(topic_entity.name)} has no message schema")
+        return None
+
+    for field in topic_entity.messageSchema.schemaFields:
+        field_name_str = model_str(field.name)
+
+        if field_name_str == field_name:
+            return field.fullyQualifiedName.root if field.fullyQualifiedName else None
+
+        if field.children:
+            after_child = None
+            before_child = None
+
+            for child in field.children:
+                child_name = model_str(child.name)
+                if child_name == "after":
+                    after_child = child
+                elif child_name == "before":
+                    before_child = child
+                if child_name == field_name:
+                    return child.fullyQualifiedName.root if child.fullyQualifiedName else None
+
+            # Debezium: 'after' holds post-change state, prefer it over 'before'
+            for cdc_child in [after_child, before_child]:
+                if cdc_child and cdc_child.children:
+                    for grandchild in cdc_child.children:
+                        if model_str(grandchild.name) == field_name:
+                            return grandchild.fullyQualifiedName.root if grandchild.fullyQualifiedName else None
+
+            for child in field.children:
+                if child not in [after_child, before_child] and child.children:
+                    for grandchild in child.children:
+                        if model_str(grandchild.name) == field_name:
+                            return grandchild.fullyQualifiedName.root if grandchild.fullyQualifiedName else None
+
+    # CDC columns may exist only in schemaText, not as field objects
+    for field in topic_entity.messageSchema.schemaFields:
+        field_name_str = model_str(field.name)
+        if "Envelope" in field_name_str and field.fullyQualifiedName:
+            envelope_fqn = field.fullyQualifiedName.root
+            return f"{envelope_fqn}.{field_name}"
+
+    logger.debug(f"Field {field_name} not found in topic {model_str(topic_entity.name)} schema")
+    return None

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -68,6 +68,7 @@ from metadata.ingestion.source.pipeline.fivetran.fivetran_log import (
 from metadata.ingestion.source.pipeline.fivetran.models import FivetranPipelineDetails
 from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
 from metadata.utils import fqn
+from metadata.utils.constants import ENTITY_REFERENCE_TYPE_MAP
 from metadata.utils.helpers import datetime_to_ts
 from metadata.utils.logger import ingestion_logger
 
@@ -336,6 +337,7 @@ class FivetranSource(PipelineServiceSource):
 
         source_connector_type = pipeline_details.source.get("service")
         is_messaging_source = source_connector_type in MESSAGING_CONNECTOR_TYPES
+        is_messaging_destination = pipeline_details.destination.get("service") in MESSAGING_CONNECTOR_TYPES
 
         source_database_name = self._get_database_name(pipeline_details.source)
         destination_database_name = self._get_database_name(pipeline_details.destination)
@@ -364,12 +366,14 @@ class FivetranSource(PipelineServiceSource):
 
                 destination_table_name = table_data.get("name_in_destination")
 
-                from_entity = self._resolve_source_entity(
-                    is_messaging_source=is_messaging_source,
-                    table_name=table_name,
-                    schema_name=schema_name,
-                    database_name=source_database_name,
-                )
+                if is_messaging_source:
+                    from_entity = self._resolve_topic(topic_name=table_name)
+                else:
+                    from_entity = self._resolve_table(
+                        table_name=table_name,
+                        schema_name=schema_name,
+                        database_name=source_database_name,
+                    )
                 if not from_entity:
                     logger.debug(
                         f"Lineage skipped for pipeline [{pipeline_name}]"
@@ -377,15 +381,18 @@ class FivetranSource(PipelineServiceSource):
                     )
                     continue
 
-                to_entity = self._resolve_destination_table(
-                    table_name=destination_table_name,
-                    schema_name=destination_schema_name,
-                    database_name=destination_database_name,
-                )
+                if is_messaging_destination:
+                    to_entity = self._resolve_topic(topic_name=f"{destination_schema_name}.{destination_table_name}")
+                else:
+                    to_entity = self._resolve_table(
+                        table_name=destination_table_name,
+                        schema_name=destination_schema_name,
+                        database_name=destination_database_name,
+                    )
                 if not to_entity:
                     logger.debug(
                         f"Lineage skipped for pipeline [{pipeline_name}]"
-                        f" since destination table [{destination_schema_name}."
+                        f" since destination entity [{destination_schema_name}."
                         f"{destination_table_name}] not found."
                     )
                     continue
@@ -413,12 +420,17 @@ class FivetranSource(PipelineServiceSource):
                         logger.warning(f"Pipeline entity not found for [{pipeline_name}], skipping lineage.")
                         return
 
-                from_entity_type = "topic" if is_messaging_source else "table"
                 yield Either(
                     right=AddLineageRequest(
                         edge=EntitiesEdge(
-                            fromEntity=EntityReference(id=from_entity.id, type=from_entity_type),  # type: ignore
-                            toEntity=EntityReference(id=to_entity.id, type="table"),  # type: ignore
+                            fromEntity=EntityReference(  # type: ignore
+                                id=from_entity.id,
+                                type=ENTITY_REFERENCE_TYPE_MAP[from_entity.__class__.__name__],
+                            ),
+                            toEntity=EntityReference(  # type: ignore
+                                id=to_entity.id,
+                                type=ENTITY_REFERENCE_TYPE_MAP[to_entity.__class__.__name__],
+                            ),
                             lineageDetails=LineageDetails(
                                 pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),  # type: ignore
                                 source=LineageSource.PipelineLineage,

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -53,6 +53,7 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.lineage.topic_lineage import get_topic_field_fqn
 from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.pipeline.fivetran.client import FivetranClient
@@ -89,6 +90,12 @@ HISTORICAL_SYNC_FIELDS = [
     ("succeeded_at", StatusType.Successful),
     ("failed_at", StatusType.Failed),
 ]
+
+
+def _resolve_field_fqn(entity: Union[Table, Topic], name: str) -> Optional[str]:  # noqa: UP007, UP045
+    if isinstance(entity, Topic):
+        return get_topic_field_fqn(entity, name)
+    return get_column_fqn(table_entity=entity, column=name)
 
 
 class FivetranSource(PipelineServiceSource):
@@ -403,16 +410,14 @@ class FivetranSource(PipelineServiceSource):
                     )
                     continue
 
-                col_lineage = []
-                if not is_messaging_source:
-                    col_lineage = self._fetch_column_lineage(
-                        pipeline_details=pipeline_details,
-                        pipeline_name=pipeline_name,
-                        schema_name=schema_name,
-                        table_name=table_name,
-                        from_table_entity=from_entity,
-                        to_table_entity=to_entity,
-                    )
+                col_lineage = self._fetch_column_lineage(
+                    pipeline_details=pipeline_details,
+                    pipeline_name=pipeline_name,
+                    schema_name=schema_name,
+                    table_name=table_name,
+                    from_entity=from_entity,
+                    to_entity=to_entity,
+                )
 
                 if pipeline_entity is None:
                     pipeline_entity = self._get_pipeline_entity()
@@ -516,8 +521,8 @@ class FivetranSource(PipelineServiceSource):
         pipeline_name: str,
         schema_name: str,
         table_name: str,
-        from_table_entity: Table,
-        to_table_entity: Table,
+        from_entity: Union[Table, Topic],  # noqa: UP007
+        to_entity: Union[Table, Topic],  # noqa: UP007
     ) -> List[ColumnLineage]:  # noqa: UP006
         col_lineage = []
         for (
@@ -539,8 +544,8 @@ class FivetranSource(PipelineServiceSource):
                 )
                 continue
 
-            from_col = get_column_fqn(table_entity=from_table_entity, column=column_name)
-            to_col = get_column_fqn(table_entity=to_table_entity, column=dest_column_name)
+            from_col = _resolve_field_fqn(from_entity, column_name)
+            to_col = _resolve_field_fqn(to_entity, dest_column_name)
             if not from_col or not to_col:
                 logger.debug(
                     f"Skipping column [{column_name}] -> [{dest_column_name}]"

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -13,6 +13,7 @@ Fivetran source to extract metadata
 """
 
 import traceback
+from collections import Counter
 from datetime import datetime
 from typing import Iterable, List, Optional, Union, cast  # noqa: UP035
 
@@ -350,6 +351,8 @@ class FivetranSource(PipelineServiceSource):
         destination_database_name = self._get_database_name(pipeline_details.destination)
 
         pipeline_entity = None
+        edge_count = 0
+        skip_reasons: Counter = Counter()
 
         for (
             schema_name,
@@ -359,6 +362,7 @@ class FivetranSource(PipelineServiceSource):
                 logger.debug(
                     f"Skipping schema [{schema_name}] for pipeline [{pipeline_name}] lineage - schema is disabled"
                 )
+                skip_reasons["schema disabled in Fivetran"] += 1
                 continue
 
             destination_schema_name = schema_data.get("name_in_destination")
@@ -369,6 +373,7 @@ class FivetranSource(PipelineServiceSource):
                         f"Skipping table [{schema_name}].[{table_name}] for pipeline"
                         f" [{pipeline_name}] lineage - table is disabled"
                     )
+                    skip_reasons["table disabled in Fivetran"] += 1
                     continue
 
                 destination_table_name = table_data.get("name_in_destination")
@@ -386,6 +391,7 @@ class FivetranSource(PipelineServiceSource):
                         f"Lineage skipped for pipeline [{pipeline_name}]"
                         f" since source entity [{schema_name}.{table_name}] not found."
                     )
+                    skip_reasons["source entity not found"] += 1
                     continue
 
                 if is_messaging_destination:
@@ -402,12 +408,14 @@ class FivetranSource(PipelineServiceSource):
                         f" since destination entity [{destination_schema_name}."
                         f"{destination_table_name}] not found."
                     )
+                    skip_reasons["destination entity not found"] += 1
                     continue
 
                 if from_entity.id == to_entity.id:
                     logger.debug(
                         f"Lineage skipped for pipeline [{pipeline_name}] - self-referencing lineage is not allowed."
                     )
+                    skip_reasons["self-referencing edge"] += 1
                     continue
 
                 col_lineage = self._fetch_column_lineage(
@@ -425,6 +433,7 @@ class FivetranSource(PipelineServiceSource):
                         logger.warning(f"Pipeline entity not found for [{pipeline_name}], skipping lineage.")
                         return
 
+                edge_count += 1
                 yield Either(
                     right=AddLineageRequest(
                         edge=EntitiesEdge(
@@ -444,6 +453,15 @@ class FivetranSource(PipelineServiceSource):
                         )
                     )
                 )  # type: ignore
+
+        if not edge_count and skip_reasons:
+            reason, count = skip_reasons.most_common(1)[0]
+            logger.warning(
+                f"Pipeline [{pipeline_name}] produced no lineage."
+                f" Most common reason: {reason} ({count} of {sum(skip_reasons.values())} candidates)."
+                " If dbServiceNames/messagingServiceNames are unset, entities are matched across all"
+                " services; if they are set, verify the names match the services holding these entities."
+            )
 
     def _resolve_table(
         self,

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -15,6 +15,7 @@ Fivetran source to extract metadata
 import traceback
 from collections import Counter
 from datetime import datetime
+from itertools import dropwhile
 from typing import Iterable, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
@@ -91,6 +92,20 @@ HISTORICAL_SYNC_FIELDS = [
     ("succeeded_at", StatusType.Successful),
     ("failed_at", StatusType.Failed),
 ]
+
+# Fivetran-side disables ("schema/table disabled in Fivetran") are deliberate
+# configuration, not defects - warning on them trains operators to ignore the
+# warning. Only resolution failures mean the connector is misconfigured on the
+# OpenMetadata side; "self-referencing edge" belongs here too, since under the
+# empty-service-name fallback it usually means first-match-wins resolved both
+# ends to the same entity, a real resolution problem.
+ACTIONABLE_SKIP_REASONS = frozenset(
+    {
+        "source entity not found",
+        "destination entity not found",
+        "self-referencing edge",
+    }
+)
 
 
 # Constrained (not just bound) so isinstance(x, entity_type) narrows `x` to the concrete
@@ -400,7 +415,19 @@ class FivetranSource(PipelineServiceSource):
                     continue
 
                 if is_messaging_destination:
-                    to_entity = self._resolve_topic(topic_name=f"{destination_schema_name}.{destination_table_name}")
+                    # Guard against fabricating a "None.table" / "schema.None" search string
+                    # when name_in_destination is absent - fall through to the not-found skip below.
+                    to_entity = (
+                        self._resolve_topic(
+                            topic_name=(
+                                f"{destination_schema_name}.{destination_table_name}"
+                                if destination_schema_name
+                                else destination_table_name
+                            )
+                        )
+                        if destination_table_name
+                        else None
+                    )
                 else:
                     to_entity = self._resolve_table(
                         table_name=destination_table_name,
@@ -423,14 +450,23 @@ class FivetranSource(PipelineServiceSource):
                     skip_reasons["self-referencing edge"] += 1
                     continue
 
-                col_lineage = self._fetch_column_lineage(
-                    pipeline_details=pipeline_details,
-                    pipeline_name=pipeline_name,
-                    schema_name=schema_name,
-                    table_name=table_name,
-                    from_entity=from_entity,
-                    to_entity=to_entity,
-                )
+                try:
+                    col_lineage = self._fetch_column_lineage(
+                        pipeline_details=pipeline_details,
+                        pipeline_name=pipeline_name,
+                        schema_name=schema_name,
+                        table_name=table_name,
+                        from_entity=from_entity,
+                        to_entity=to_entity,
+                    )
+                except Exception as exc:
+                    # Column-config endpoint isn't supported for every connector type
+                    # (e.g. messaging sources); best-effort - keep the entity-level edge.
+                    logger.warning(
+                        f"Column lineage skipped for [{schema_name}].[{table_name}] in [{pipeline_name}]: {exc}"
+                    )
+                    logger.debug(traceback.format_exc())
+                    col_lineage = []
 
                 if pipeline_entity is None:
                     pipeline_entity = self._get_pipeline_entity()
@@ -459,11 +495,14 @@ class FivetranSource(PipelineServiceSource):
                     )
                 )  # type: ignore
 
-        if not edge_count and skip_reasons:
-            reason, count = skip_reasons.most_common(1)[0]
+        actionable_reasons = Counter(
+            {reason: count for reason, count in skip_reasons.items() if reason in ACTIONABLE_SKIP_REASONS}
+        )
+        if not edge_count and actionable_reasons:
+            reason, count = actionable_reasons.most_common(1)[0]
             logger.warning(
                 f"Pipeline [{pipeline_name}] produced no lineage."
-                f" Most common reason: {reason} ({count} of {sum(skip_reasons.values())} candidates)."
+                f" Most common actionable reason: {reason} ({count} of {sum(skip_reasons.values())} candidates)."
                 " If dbServiceNames/messagingServiceNames are unset, entities are matched across all"
                 " services; if they are set, verify the names match the services holding these entities."
             )
@@ -516,11 +555,16 @@ class FivetranSource(PipelineServiceSource):
         self,
         entity_type: type[EntityT],
         parts: List[Optional[str]],  # noqa: UP006, UP045
-    ) -> EntityT | None:
-        # search_in_any_service pads missing parent levels with `*`, so pass only
-        # known parts. Quoting matters: a dotted topic name would otherwise be
-        # split into service.topic instead of being treated as one FQN part.
-        search_string = fqn.FQN_SEPARATOR.join(fqn.quote_name(part) for part in parts if part)
+    ) -> Optional[EntityT]:  # noqa: UP045
+        # search_in_any_service pads missing parent levels with `*` at the front only
+        # (prefix_entity_for_wildcard_search), so leading unknown parts can be dropped -
+        # padding fills them back in. An interior gap must NOT be dropped: doing so
+        # shifts a later, known part into the missing slot (e.g. database landing in the
+        # schema slot). A missing leaf can't be searched for at all.
+        if not parts or not parts[-1]:
+            return None
+        known_parts = list(dropwhile(lambda part: not part, parts))
+        search_string = fqn.FQN_SEPARATOR.join(fqn.quote_name(part) if part else "*" for part in known_parts)
         result = self.metadata.search_in_any_service(
             entity_type=entity_type,
             fqn_search_string=search_string,

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -428,58 +428,66 @@ class FivetranSource(PipelineServiceSource):
                     )
                 )  # type: ignore
 
-    def _resolve_source_entity(
+    def _resolve_table(
         self,
-        is_messaging_source: bool,
-        table_name: str,
-        schema_name: str,
-        database_name: Optional[str],  # noqa: UP045
-    ) -> Optional[Union[Table, Topic]]:  # noqa: UP007, UP045
-        if is_messaging_source:
-            for svc_name in self.get_messaging_service_names() or []:
-                entity_fqn = fqn.build(
-                    metadata=self.metadata,
-                    entity_type=Topic,
-                    service_name=svc_name,
-                    topic_name=table_name,
-                )
-                entity = self.metadata.get_by_name(entity=Topic, fqn=entity_fqn)
-                if entity:
-                    return entity
-        else:
-            for db_service_name in self.get_db_service_names() or []:
-                entity_fqn = fqn.build(
-                    metadata=self.metadata,
-                    entity_type=Table,
-                    table_name=table_name,
-                    database_name=database_name,
-                    schema_name=schema_name,
-                    service_name=db_service_name,
-                )
-                entity = self.metadata.get_by_name(entity=Table, fqn=entity_fqn)
-                if entity:
-                    return entity
-        return None
-
-    def _resolve_destination_table(
-        self,
+        *,
         table_name: str,
         schema_name: Optional[str],  # noqa: UP045
         database_name: Optional[str],  # noqa: UP045
     ) -> Optional[Table]:  # noqa: UP045
-        for db_service_name in self.get_db_service_names() or []:
+        service_names = self.get_db_service_names()
+        for service_name in service_names or []:
             entity_fqn = fqn.build(
-                self.metadata,
-                Table,
-                table_name=table_name,
+                metadata=self.metadata,
+                entity_type=Table,
+                service_name=service_name,
                 database_name=database_name,
                 schema_name=schema_name,
-                service_name=db_service_name,
+                table_name=table_name,
             )
             entity = self.metadata.get_by_name(entity=Table, fqn=entity_fqn)
             if entity:
                 return entity
-        return None
+        if service_names:
+            return None
+        return self._search_any_service(Table, [database_name, schema_name, table_name])
+
+    def _resolve_topic(self, *, topic_name: str) -> Optional[Topic]:  # noqa: UP045
+        service_names = self.get_messaging_service_names()
+        for service_name in service_names or []:
+            entity_fqn = fqn.build(
+                metadata=self.metadata,
+                entity_type=Topic,
+                service_name=service_name,
+                topic_name=topic_name,
+            )
+            entity = self.metadata.get_by_name(entity=Topic, fqn=entity_fqn)
+            if entity:
+                return entity
+        if service_names:
+            return None
+        return self._search_any_service(Topic, [topic_name])
+
+    def _search_any_service(
+        self,
+        entity_type: type,
+        parts: List[Optional[str]],  # noqa: UP006, UP045
+    ) -> Optional[Union[Table, Topic]]:  # noqa: UP007, UP045
+        # search_in_any_service pads missing parent levels with `*`, so pass only
+        # known parts. Quoting matters: a dotted topic name would otherwise be
+        # split into service.topic instead of being treated as one FQN part.
+        search_string = fqn.FQN_SEPARATOR.join(fqn.quote_name(part) for part in parts if part)
+        entity = self.metadata.search_in_any_service(
+            entity_type=entity_type,
+            fqn_search_string=search_string,
+        )
+        if entity:
+            service_name = entity.service.name if getattr(entity, "service", None) else "unknown"
+            logger.debug(
+                f"Resolved {entity_type.__name__} [{search_string}] via cross-service search"
+                f" in service [{service_name}]"
+            )
+        return entity
 
     def _get_pipeline_entity(self) -> Optional[Pipeline]:  # noqa: UP045
         pipeline_fqn = fqn.build(

--- a/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py
@@ -15,7 +15,7 @@ Fivetran source to extract metadata
 import traceback
 from collections import Counter
 from datetime import datetime
-from typing import Iterable, List, Optional, Union, cast  # noqa: UP035
+from typing import Iterable, List, Optional, TypeVar, Union, cast  # noqa: UP035
 
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
@@ -91,6 +91,11 @@ HISTORICAL_SYNC_FIELDS = [
     ("succeeded_at", StatusType.Successful),
     ("failed_at", StatusType.Failed),
 ]
+
+
+# Constrained (not just bound) so isinstance(x, entity_type) narrows `x` to the concrete
+# member type instead of the union - see _search_any_service.
+EntityT = TypeVar("EntityT", Table, Topic)
 
 
 def _resolve_field_fqn(entity: Union[Table, Topic], name: str) -> Optional[str]:  # noqa: UP007, UP045
@@ -480,6 +485,8 @@ class FivetranSource(PipelineServiceSource):
                 schema_name=schema_name,
                 table_name=table_name,
             )
+            if not entity_fqn:
+                continue
             entity = self.metadata.get_by_name(entity=Table, fqn=entity_fqn)
             if entity:
                 return entity
@@ -496,6 +503,8 @@ class FivetranSource(PipelineServiceSource):
                 service_name=service_name,
                 topic_name=topic_name,
             )
+            if not entity_fqn:
+                continue
             entity = self.metadata.get_by_name(entity=Topic, fqn=entity_fqn)
             if entity:
                 return entity
@@ -505,24 +514,26 @@ class FivetranSource(PipelineServiceSource):
 
     def _search_any_service(
         self,
-        entity_type: type,
+        entity_type: type[EntityT],
         parts: List[Optional[str]],  # noqa: UP006, UP045
-    ) -> Optional[Union[Table, Topic]]:  # noqa: UP007, UP045
+    ) -> EntityT | None:
         # search_in_any_service pads missing parent levels with `*`, so pass only
         # known parts. Quoting matters: a dotted topic name would otherwise be
         # split into service.topic instead of being treated as one FQN part.
         search_string = fqn.FQN_SEPARATOR.join(fqn.quote_name(part) for part in parts if part)
-        entity = self.metadata.search_in_any_service(
+        result = self.metadata.search_in_any_service(
             entity_type=entity_type,
             fqn_search_string=search_string,
         )
-        if entity:
-            service_name = entity.service.name if getattr(entity, "service", None) else "unknown"
-            logger.debug(
-                f"Resolved {entity_type.__name__} [{search_string}] via cross-service search"
-                f" in service [{service_name}]"
-            )
-        return entity
+        # search_in_any_service is annotated to allow a list (fetch_multiple_entities=True),
+        # which we never request; reject that shape explicitly rather than assume it away.
+        if not isinstance(result, entity_type):
+            return None
+        service_name = result.service.name if result.service else "unknown"
+        logger.debug(
+            f"Resolved {entity_type.__name__} [{search_string}] via cross-service search in service [{service_name}]"
+        )
+        return result
 
     def _get_pipeline_entity(self) -> Optional[Pipeline]:  # noqa: UP045
         pipeline_fqn = fqn.build(

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/constants.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/constants.py
@@ -12,6 +12,9 @@
 Constants for Kafka Connect connector configuration keys and mappings
 """
 
+# Re-exported so existing kafkaconnect imports keep working
+from metadata.ingestion.lineage.topic_lineage import CDC_ENVELOPE_FIELDS  # noqa: F401
+
 
 class ConnectorConfigKeys:
     """Configuration keys for various Kafka Connect connectors"""
@@ -147,6 +150,3 @@ STORAGE_ENDPOINT_KEYS = {
     "gcs": ["gcs.credentials.path"],
     "azure": ["azure.storage.account.name", "azblob.account.name"],
 }
-
-# CDC envelope field names used for Debezium detection and parsing
-CDC_ENVELOPE_FIELDS = {"after", "before", "op"}

--- a/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/kafkaconnect/metadata.py
@@ -56,6 +56,7 @@ from metadata.generated.schema.type.entityReference import EntityReference
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn
+from metadata.ingestion.lineage.topic_lineage import get_topic_field_fqn
 from metadata.ingestion.models.pipeline_status import OMetaPipelineStatus
 from metadata.ingestion.ometa.ometa_api import OpenMetadata, T
 from metadata.ingestion.ometa.utils import model_str
@@ -743,66 +744,8 @@ class KafkaconnectSource(PipelineServiceSource):
 
         return []
 
-    def _get_topic_field_fqn(self, topic_entity: Topic, field_name: str) -> Optional[str]:  # noqa: C901, UP045
-        """
-        Get the fully qualified name for a field in a Topic's schema.
-        Handles nested structures where fields may be children of a parent RECORD.
-        For Debezium CDC topics, searches for fields inside after/before envelope children.
-        """
-        if not topic_entity.messageSchema or not topic_entity.messageSchema.schemaFields:
-            logger.debug(f"Topic {model_str(topic_entity.name)} has no message schema")
-            return None
-
-        # Search for the field in the schema (including nested fields)
-        for field in topic_entity.messageSchema.schemaFields:
-            field_name_str = model_str(field.name)
-
-            # Check if it's a direct field
-            if field_name_str == field_name:
-                return field.fullyQualifiedName.root if field.fullyQualifiedName else None
-
-            # Check if it's a child field (nested - one level deep)
-            if field.children:
-                # For Debezium CDC, prioritize 'after' over 'before' when searching for grandchildren
-                after_child = None
-                before_child = None
-
-                for child in field.children:
-                    child_name = model_str(child.name)
-                    if child_name == "after":
-                        after_child = child
-                    elif child_name == "before":
-                        before_child = child
-                    # Check direct child match
-                    if child_name == field_name:
-                        return child.fullyQualifiedName.root if child.fullyQualifiedName else None
-
-                # Search grandchildren - prefer 'after' over 'before' for CDC topics
-                for cdc_child in [after_child, before_child]:
-                    if cdc_child and cdc_child.children:
-                        for grandchild in cdc_child.children:
-                            if model_str(grandchild.name) == field_name:
-                                return grandchild.fullyQualifiedName.root if grandchild.fullyQualifiedName else None
-
-                # Search other grandchildren (non-CDC fields)
-                for child in field.children:
-                    if child not in [after_child, before_child] and child.children:
-                        for grandchild in child.children:
-                            if model_str(grandchild.name) == field_name:
-                                return grandchild.fullyQualifiedName.root if grandchild.fullyQualifiedName else None
-
-        # For Debezium CDC topics, columns might only exist in schemaText (not as field objects)
-        # Manually construct FQN: topicFQN.Envelope.columnName
-        for field in topic_entity.messageSchema.schemaFields:
-            field_name_str = model_str(field.name)
-            # Check if this is a CDC envelope field
-            if "Envelope" in field_name_str and field.fullyQualifiedName:
-                # Construct FQN manually for CDC column
-                envelope_fqn = field.fullyQualifiedName.root
-                return f"{envelope_fqn}.{field_name}"
-
-        logger.debug(f"Field {field_name} not found in topic {model_str(topic_entity.name)} schema")
-        return None
+    def _get_topic_field_fqn(self, topic_entity: Topic, field_name: str) -> Optional[str]:  # noqa: UP045
+        return get_topic_field_fqn(topic_entity, field_name)
 
     def build_column_lineage(
         self,

--- a/ingestion/tests/unit/lineage/test_topic_lineage.py
+++ b/ingestion/tests/unit/lineage/test_topic_lineage.py
@@ -1,0 +1,65 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Test the shared topic field FQN resolver
+"""
+
+from unittest.mock import Mock
+
+from metadata.ingestion.lineage.topic_lineage import (
+    CDC_ENVELOPE_FIELDS,
+    get_topic_field_fqn,
+)
+
+
+def _field(name, fqn=None, children=None):
+    field = Mock()
+    field.name = name
+    field.fullyQualifiedName = Mock(root=fqn) if fqn else None
+    field.children = children
+    return field
+
+
+def _topic(name, schema_fields):
+    topic = Mock()
+    topic.name = name
+    topic.messageSchema = Mock(schemaFields=schema_fields, schemaText=None)
+    return topic
+
+
+class TestGetTopicFieldFqn:
+    def test_cdc_envelope_fields_constant(self):
+        assert {"after", "before", "op"} == CDC_ENVELOPE_FIELDS
+
+    def test_no_message_schema_returns_none(self):
+        topic = Mock()
+        topic.name = "t"
+        topic.messageSchema = None
+        assert get_topic_field_fqn(topic, "col") is None
+
+    def test_direct_field_match(self):
+        topic = _topic("t", [_field("col", "svc.t.col")])
+        assert get_topic_field_fqn(topic, "col") == "svc.t.col"
+
+    def test_nested_child_match(self):
+        child = _field("col", "svc.t.rec.col")
+        topic = _topic("t", [_field("rec", "svc.t.rec", children=[child])])
+        assert get_topic_field_fqn(topic, "col") == "svc.t.rec.col"
+
+    def test_cdc_prefers_after_over_before(self):
+        after = _field("after", "svc.t.env.after", children=[_field("id", "svc.t.env.after.id")])
+        before = _field("before", "svc.t.env.before", children=[_field("id", "svc.t.env.before.id")])
+        topic = _topic("t", [_field("env", "svc.t.env", children=[after, before])])
+        assert get_topic_field_fqn(topic, "id") == "svc.t.env.after.id"
+
+    def test_unknown_field_returns_none(self):
+        topic = _topic("t", [_field("col", "svc.t.col")])
+        assert get_topic_field_fqn(topic, "missing") is None

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -680,6 +680,64 @@ class TestFivetranLineage:
             assert len(result) == 1
             assert result[0].right.edge.fromEntity.type == "topic"
 
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_falls_back_to_cross_service_search_when_unconfigured(self, mock_get_services, fivetran_source):
+        source, _ = fivetran_source
+        mock_get_services.return_value = []
+        found = Mock()
+        found.service = Mock(name="svc")
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.search_in_any_service = Mock(return_value=found)
+            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name=None)
+
+        assert result is found
+        assert mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"] == "cxcases.action"
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_configured_services_do_not_use_fallback(self, mock_get_services, fivetran_source):
+        source, _ = fivetran_source
+        mock_get_services.return_value = ["pg"]
+        found = Mock()
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(return_value=found)
+            mock_metadata.search_in_any_service = Mock()
+            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name="db")
+
+        assert result is found
+        mock_metadata.search_in_any_service.assert_not_called()
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_configured_but_not_found_still_skips(self, mock_get_services, fivetran_source):
+        source, _ = fivetran_source
+        mock_get_services.return_value = ["pg"]
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(return_value=None)
+            mock_metadata.search_in_any_service = Mock()
+            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name="db")
+
+        assert result is None
+        mock_metadata.search_in_any_service.assert_not_called()
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")
+    def test_topic_search_string_quotes_dotted_name(self, mock_get_services, fivetran_source):
+        source, _ = fivetran_source
+        mock_get_services.return_value = []
+        found = Mock()
+        found.service = Mock(name="kafka")
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.search_in_any_service = Mock(return_value=found)
+            source._resolve_topic(topic_name="fivetran_dex.employee_paystub")
+
+        # Topic FQNs have 2 slots; an unquoted dotted name would be read as service.topic
+        assert (
+            mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"]
+            == '"fivetran_dex.employee_paystub"'
+        )
+
 
 class TestFivetranColumnLineage:
     @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_column_fqn")

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -13,6 +13,7 @@ Test fivetran using the topology
 """
 
 import json
+import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -791,6 +792,26 @@ class TestFivetranLineage:
         assert len(result) == 1
         assert result[0].right.edge.fromEntity.type == "table"
         assert result[0].right.edge.toEntity.type == "topic"
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_warns_when_lineage_enabled_but_no_edges(self, mock_get_services, fivetran_source, caplog):
+        source, client = fivetran_source
+        mock_get_services.return_value = ["pg"]
+        client.get_connector_schema_details.return_value = {
+            "public": {
+                "enabled": True,
+                "name_in_destination": "pub",
+                "tables": {"users": {"enabled": True, "name_in_destination": "users"}},
+            }
+        }
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(return_value=None)
+            with caplog.at_level(logging.WARNING):
+                result = list(source.yield_pipeline_lineage_details(EXPECTED_FIVETRAN_DETAILS))
+
+        assert result == []
+        assert "produced no lineage" in caplog.text
+        assert "source entity not found" in caplog.text
 
 
 class TestFivetranColumnLineage:

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -739,8 +739,7 @@ class TestFivetranLineage:
 
         # Topic FQNs have 2 slots; an unquoted dotted name would be read as service.topic
         assert (
-            mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"]
-            == '"hr_stream.employee_events"'
+            mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"] == '"hr_stream.employee_events"'
         )
 
     @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -54,6 +54,7 @@ from metadata.ingestion.source.pipeline.fivetran.fivetran_log import (
 )
 from metadata.ingestion.source.pipeline.fivetran.metadata import FivetranSource
 from metadata.ingestion.source.pipeline.fivetran.models import FivetranPipelineDetails
+from metadata.utils.fqn import prefix_entity_for_wildcard_search
 
 mock_file_path = Path(__file__).parent.parent.parent / "resources/datasets/fivetran_dataset.json"
 with open(mock_file_path) as file:  # noqa: PTH123
@@ -812,6 +813,347 @@ class TestFivetranLineage:
         assert result == []
         assert "produced no lineage" in caplog.text
         assert "source entity not found" in caplog.text
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_no_warning_when_only_fivetran_side_disables_skipped(self, mock_get_services, fivetran_source, caplog):
+        """Finding 4: every schema disabled is deliberate Fivetran-side configuration,
+        not a defect - it must stay silent so the warning isn't trained to be ignored."""
+        source, client = fivetran_source
+        mock_get_services.return_value = ["pg"]
+        client.get_connector_schema_details.return_value = {
+            "s": {
+                "enabled": False,
+                "name_in_destination": "s",
+                "tables": {"t": {"enabled": True}},
+            }
+        }
+        with caplog.at_level(logging.WARNING):
+            result = list(source.yield_pipeline_lineage_details(EXPECTED_FIVETRAN_DETAILS))
+
+        assert result == []
+        assert "produced no lineage" not in caplog.text
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    def test_warning_names_actionable_reason_over_disabled(self, mock_get_services, fivetran_source, caplog):
+        """When both Fivetran-side disables and a real resolution failure are present,
+        the warning must name the actionable reason, not whichever is more common."""
+        source, client = fivetran_source
+        mock_get_services.return_value = ["pg"]
+        client.get_connector_schema_details.return_value = {
+            "disabled_one": {
+                "enabled": False,
+                "name_in_destination": "d1",
+                "tables": {"t": {"enabled": True}},
+            },
+            "disabled_two": {
+                "enabled": False,
+                "name_in_destination": "d2",
+                "tables": {"t": {"enabled": True}},
+            },
+            "public": {
+                "enabled": True,
+                "name_in_destination": "pub",
+                "tables": {"users": {"enabled": True, "name_in_destination": "users"}},
+            },
+        }
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(return_value=None)
+            with caplog.at_level(logging.WARNING):
+                result = list(source.yield_pipeline_lineage_details(EXPECTED_FIVETRAN_DETAILS))
+
+        assert result == []
+        assert "produced no lineage" in caplog.text
+        assert "source entity not found" in caplog.text
+        assert "schema disabled in Fivetran" not in caplog.text
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    @patch("metadata.utils.fqn.build")
+    def test_no_warning_when_edges_produced_despite_skips(self, mock_build, mock_get_services, fivetran_source, caplog):
+        """A healthy connector that produced at least one edge must stay silent even
+        though some other candidates were skipped."""
+        source, client = fivetran_source
+        mock_get_services.return_value = ["pg"]
+        mock_src = Mock(spec=Table)
+        mock_src.id = str(uuid4())
+        mock_dst = Mock(spec=Table)
+        mock_dst.id = str(uuid4())
+        mock_pipe = Mock()
+        mock_pipe.id.root = str(uuid4())
+
+        mock_build.side_effect = lambda *a, **kw: ".".join(
+            str(v)
+            for v in [
+                kw.get("service_name", ""),
+                kw.get("database_name", ""),
+                kw.get("schema_name", ""),
+                kw.get("table_name", ""),
+            ]
+            if v
+        )
+
+        def side_effect(entity, fqn):
+            s = str(fqn)
+            if "orders_dest" in s:
+                return mock_dst
+            if "orders" in s:
+                return mock_src
+            if "pipeline" in s or "fivetran" in s:
+                return mock_pipe
+            return None
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(side_effect=side_effect)
+            client.get_connector_schema_details.return_value = {
+                "disabled": {
+                    "enabled": False,
+                    "name_in_destination": "d",
+                    "tables": {"t": {"enabled": True}},
+                },
+                "public": {
+                    "enabled": True,
+                    "name_in_destination": "pub",
+                    "tables": {"orders": {"enabled": True, "name_in_destination": "orders_dest"}},
+                },
+            }
+            client.get_connector_column_lineage.return_value = {}
+            with caplog.at_level(logging.WARNING):
+                result = list(source.yield_pipeline_lineage_details(EXPECTED_FIVETRAN_DETAILS))
+
+        assert len(result) == 1
+        assert "produced no lineage" not in caplog.text
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_topic_field_fqn")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_column_fqn")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    @patch("metadata.utils.fqn.build")
+    def test_messaging_source_column_lineage_happy_path(
+        self, mock_build, mock_db, mock_msg, mock_col_fqn, mock_topic_fqn, fivetran_source
+    ):
+        """Column lineage is now attempted when the *source* side is a Topic - this was
+        never exercised end-to-end before the messaging gate was removed."""
+        source, client = fivetran_source
+        mock_db.return_value = ["sf"]
+        mock_msg.return_value = ["kafka"]
+        mock_topic = Mock(spec=Topic)
+        mock_topic.id = str(uuid4())
+        mock_table = Mock(spec=Table)
+        mock_table.id = str(uuid4())
+        mock_pipe = Mock()
+        mock_pipe.id.root = str(uuid4())
+
+        def build_se(*a, **kw):
+            if kw.get("topic_name"):
+                return f"{kw['service_name']}.{kw['topic_name']}"
+            return ".".join(str(v) for v in [kw.get("service_name", ""), kw.get("table_name", "")] if v)
+
+        mock_build.side_effect = build_se
+        mock_topic_fqn.return_value = "kafka.TRADES.symbol"
+        mock_col_fqn.return_value = "sf.db.sch.tbl.symbol"
+
+        def side_effect(entity, fqn):
+            s = str(fqn)
+            if "kafka" in s:
+                return mock_topic
+            if "sf" in s:
+                return mock_table
+            if "pipeline" in s or "fivetran" in s:
+                return mock_pipe
+            return None
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(side_effect=side_effect)
+            client.get_connector_schema_details.return_value = {
+                "topics": {
+                    "enabled": True,
+                    "name_in_destination": "cc",
+                    "tables": {"TRADES": {"enabled": True, "name_in_destination": "TRADES"}},
+                }
+            }
+            client.get_connector_column_lineage.return_value = {
+                "symbol": {"enabled": True, "name_in_destination": "symbol"}
+            }
+            details = FivetranPipelineDetails(
+                source={
+                    "id": "cc",
+                    "service": "confluent_cloud",
+                    "schema": "cc",
+                    "config": {},
+                },
+                destination=mock_data["destination"],
+                group=mock_data["group"],
+                connector_id="cc",
+            )
+            result = list(source.yield_pipeline_lineage_details(details))
+
+        assert len(result) == 1
+        columns_lineage = result[0].right.edge.lineageDetails.columnsLineage
+        assert columns_lineage is not None
+        assert len(columns_lineage) == 1
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    @patch("metadata.utils.fqn.build")
+    def test_messaging_source_column_lineage_raises_still_emits_edge(
+        self, mock_build, mock_db, mock_msg, fivetran_source, caplog
+    ):
+        """Regression test for Finding 1: Fivetran's column-config endpoint 404s /
+        raises for connector types it doesn't support (messaging sources are the
+        newly-reachable case). That must not abort the whole entity-level edge."""
+        source, client = fivetran_source
+        mock_db.return_value = ["sf"]
+        mock_msg.return_value = ["kafka"]
+        mock_topic = Mock(spec=Topic)
+        mock_topic.id = str(uuid4())
+        mock_table = Mock(spec=Table)
+        mock_table.id = str(uuid4())
+        mock_pipe = Mock()
+        mock_pipe.id.root = str(uuid4())
+
+        def build_se(*a, **kw):
+            if kw.get("topic_name"):
+                return f"{kw['service_name']}.{kw['topic_name']}"
+            return ".".join(str(v) for v in [kw.get("service_name", ""), kw.get("table_name", "")] if v)
+
+        mock_build.side_effect = build_se
+
+        def side_effect(entity, fqn):
+            s = str(fqn)
+            if "kafka" in s:
+                return mock_topic
+            if "sf" in s:
+                return mock_table
+            if "pipeline" in s or "fivetran" in s:
+                return mock_pipe
+            return None
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(side_effect=side_effect)
+            client.get_connector_schema_details.return_value = {
+                "topics": {
+                    "enabled": True,
+                    "name_in_destination": "cc",
+                    "tables": {"TRADES": {"enabled": True, "name_in_destination": "TRADES"}},
+                }
+            }
+            client.get_connector_column_lineage.side_effect = RuntimeError(
+                "Fivetran API request failed for /connectors/cc/schemas/topics/tables/TRADES/columns"
+                " — received None response"
+            )
+            details = FivetranPipelineDetails(
+                source={
+                    "id": "cc",
+                    "service": "confluent_cloud",
+                    "schema": "cc",
+                    "config": {},
+                },
+                destination=mock_data["destination"],
+                group=mock_data["group"],
+                connector_id="cc",
+            )
+            with caplog.at_level(logging.WARNING):
+                result = list(source.yield_pipeline_lineage_details(details))
+
+        assert len(result) == 1
+        assert result[0].right.edge.lineageDetails.columnsLineage is None
+        assert "Column lineage skipped" in caplog.text
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_column_fqn")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    @patch("metadata.utils.fqn.build")
+    def test_entity_edge_survives_unresolvable_column(
+        self, mock_build, mock_get_services, mock_col_fqn, fivetran_source
+    ):
+        """At the yield_pipeline_lineage_details level (not just _fetch_column_lineage):
+        when column FQN resolution yields nothing, the entity-level edge must still land."""
+        source, client = fivetran_source
+        mock_get_services.return_value = ["pg_svc"]
+        mock_src = Mock(spec=Table)
+        mock_src.id = str(uuid4())
+        mock_dst = Mock(spec=Table)
+        mock_dst.id = str(uuid4())
+        mock_pipe = Mock()
+        mock_pipe.id.root = str(uuid4())
+
+        mock_build.side_effect = lambda *a, **kw: ".".join(
+            str(v)
+            for v in [
+                kw.get("service_name", ""),
+                kw.get("database_name", ""),
+                kw.get("schema_name", ""),
+                kw.get("table_name", ""),
+            ]
+            if v
+        )
+        mock_col_fqn.return_value = None  # unresolvable -> _fetch_column_lineage yields []
+
+        def side_effect(entity, fqn):
+            s = str(fqn)
+            if "users_dest" in s:
+                return mock_dst
+            if "users" in s:
+                return mock_src
+            if "pipeline" in s or "fivetran" in s:
+                return mock_pipe
+            return None
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(side_effect=side_effect)
+            client.get_connector_schema_details.return_value = {
+                "public": {
+                    "enabled": True,
+                    "name_in_destination": "pub",
+                    "tables": {"users": {"enabled": True, "name_in_destination": "users_dest"}},
+                }
+            }
+            client.get_connector_column_lineage.return_value = {"id": {"enabled": True, "name_in_destination": "id"}}
+            result = list(source.yield_pipeline_lineage_details(EXPECTED_FIVETRAN_DETAILS))
+
+        assert len(result) == 1
+        assert result[0].right.edge.lineageDetails.columnsLineage is None
+
+
+class TestSearchAnyService:
+    """Pins the FQN slot-padding contract that the cross-service fallback rests on
+    (Finding 2/4): leading gaps are dropped for prefix_entity_for_wildcard_search to
+    pad back with `*`, interior gaps must stay as explicit `*`, and a missing leaf
+    can't be searched for at all."""
+
+    @staticmethod
+    def _capture_search_string(source, entity_type, parts):
+        captured = {}
+
+        def fake_search(entity_type, fqn_search_string):
+            captured["search_string"] = fqn_search_string
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.search_in_any_service = Mock(side_effect=fake_search)
+            source._search_any_service(entity_type, parts)
+        return captured.get("search_string")
+
+    def test_padding_contract_matches_real_helper(self, fivetran_source):
+        source, _ = fivetran_source
+        search_string = self._capture_search_string(source, Table, [None, "cxcases", "action"])
+        assert prefix_entity_for_wildcard_search(Table, search_string) == "*.*.cxcases.action"
+
+    def test_leading_gap_is_dropped(self, fivetran_source):
+        source, _ = fivetran_source
+        search_string = self._capture_search_string(source, Table, [None, "cxcases", "action"])
+        assert search_string == "cxcases.action"
+
+    def test_interior_gap_is_kept_as_wildcard(self, fivetran_source):
+        source, _ = fivetran_source
+        search_string = self._capture_search_string(source, Table, ["dev", None, "users"])
+        assert search_string == "dev.*.users"
+
+    def test_missing_leaf_performs_no_search(self, fivetran_source):
+        source, _ = fivetran_source
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.search_in_any_service = Mock()
+            result = source._search_any_service(Table, ["dev", "pub", None])
+
+        assert result is None
+        mock_metadata.search_in_any_service.assert_not_called()
 
 
 class TestFivetranColumnLineage:

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -27,6 +27,8 @@ from metadata.generated.schema.entity.data.pipeline import (
     StatusType,
     Task,
 )
+from metadata.generated.schema.entity.data.table import Table
+from metadata.generated.schema.entity.data.topic import Topic
 from metadata.generated.schema.entity.services.pipelineService import (
     PipelineConnection,
     PipelineService,
@@ -558,9 +560,9 @@ class TestFivetranLineage:
     def test_cross_service(self, mock_build, mock_get_services, fivetran_source):
         source, client = fivetran_source
         mock_get_services.return_value = ["pg_svc", "sf_svc"]
-        mock_src = Mock()
+        mock_src = Mock(spec=Table)
         mock_src.id = str(uuid4())
-        mock_dst = Mock()
+        mock_dst = Mock(spec=Table)
         mock_dst.id = str(uuid4())
         mock_pipe = Mock()
         mock_pipe.id.root = str(uuid4())
@@ -606,7 +608,7 @@ class TestFivetranLineage:
         source, client = fivetran_source
         mock_get_services.return_value = ["pg"]
         same_id = str(uuid4())
-        mock_table = Mock()
+        mock_table = Mock(spec=Table)
         mock_table.id = same_id
 
         mock_build.side_effect = lambda *a, **kw: "pg.db.public.orders"
@@ -632,9 +634,9 @@ class TestFivetranLineage:
         source, client = fivetran_source
         mock_db.return_value = ["sf"]
         mock_msg.return_value = ["kafka"]
-        mock_topic = Mock()
+        mock_topic = Mock(spec=Topic)
         mock_topic.id = str(uuid4())
-        mock_table = Mock()
+        mock_table = Mock(spec=Table)
         mock_table.id = str(uuid4())
         mock_pipe = Mock()
         mock_pipe.id.root = str(uuid4())
@@ -737,6 +739,57 @@ class TestFivetranLineage:
             mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"]
             == '"fivetran_dex.employee_paystub"'
         )
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
+    @patch("metadata.utils.fqn.build")
+    def test_table_to_topic_lineage(self, mock_build, mock_db, mock_msg, fivetran_source):
+        source, client = fivetran_source
+        mock_db.return_value = ["pg"]
+        mock_msg.return_value = ["kafka"]
+        mock_table = Mock(spec=Table)
+        mock_table.id = str(uuid4())
+        mock_topic = Mock(spec=Topic)
+        mock_topic.id = str(uuid4())
+        mock_pipe = Mock()
+        mock_pipe.id.root = str(uuid4())
+
+        def build_se(*a, **kw):
+            if kw.get("topic_name"):
+                return f"{kw['service_name']}.{kw['topic_name']}"
+            return ".".join(str(v) for v in [kw.get("service_name", ""), kw.get("table_name", "")] if v)
+
+        mock_build.side_effect = build_se
+
+        def get_by_name(entity, fqn):
+            s = str(fqn)
+            if "kafka" in s:
+                return mock_topic
+            if "pg" in s:
+                return mock_table
+            return mock_pipe
+
+        with patch.object(source, "metadata") as mock_metadata:
+            mock_metadata.get_by_name = Mock(side_effect=get_by_name)
+            client.get_connector_schema_details.return_value = {
+                "hr": {
+                    "enabled": True,
+                    "name_in_destination": "fivetran_dex",
+                    "tables": {"paystub": {"enabled": True, "name_in_destination": "employee_paystub"}},
+                }
+            }
+            client.get_connector_column_lineage.return_value = {}
+            details = FivetranPipelineDetails(
+                source={"id": "pg", "service": "postgres", "schema": "hr", "config": {"database": "db"}},
+                destination={"id": "cc", "service": "confluent_cloud", "config": {}},
+                group=mock_data["group"],
+                connector_id="pg",
+            )
+            result = list(source.yield_pipeline_lineage_details(details))
+
+        assert len(result) == 1
+        assert result[0].right.edge.fromEntity.type == "table"
+        assert result[0].right.edge.toEntity.type == "topic"
 
 
 class TestFivetranColumnLineage:

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -694,10 +694,10 @@ class TestFivetranLineage:
 
         with patch.object(source, "metadata") as mock_metadata:
             mock_metadata.search_in_any_service = Mock(return_value=found)
-            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name=None)
+            result = source._resolve_table(table_name="orders", schema_name="crm", database_name=None)
 
         assert result is found
-        assert mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"] == "cxcases.action"
+        assert mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"] == "crm.orders"
 
     @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_db_service_names")
     def test_configured_services_do_not_use_fallback(self, mock_get_services, fivetran_source):
@@ -708,7 +708,7 @@ class TestFivetranLineage:
         with patch.object(source, "metadata") as mock_metadata:
             mock_metadata.get_by_name = Mock(return_value=found)
             mock_metadata.search_in_any_service = Mock()
-            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name="db")
+            result = source._resolve_table(table_name="orders", schema_name="crm", database_name="db")
 
         assert result is found
         mock_metadata.search_in_any_service.assert_not_called()
@@ -721,7 +721,7 @@ class TestFivetranLineage:
         with patch.object(source, "metadata") as mock_metadata:
             mock_metadata.get_by_name = Mock(return_value=None)
             mock_metadata.search_in_any_service = Mock()
-            result = source._resolve_table(table_name="action", schema_name="cxcases", database_name="db")
+            result = source._resolve_table(table_name="orders", schema_name="crm", database_name="db")
 
         assert result is None
         mock_metadata.search_in_any_service.assert_not_called()
@@ -735,12 +735,12 @@ class TestFivetranLineage:
 
         with patch.object(source, "metadata") as mock_metadata:
             mock_metadata.search_in_any_service = Mock(return_value=found)
-            source._resolve_topic(topic_name="fivetran_dex.employee_paystub")
+            source._resolve_topic(topic_name="hr_stream.employee_events")
 
         # Topic FQNs have 2 slots; an unquoted dotted name would be read as service.topic
         assert (
             mock_metadata.search_in_any_service.call_args.kwargs["fqn_search_string"]
-            == '"fivetran_dex.employee_paystub"'
+            == '"hr_stream.employee_events"'
         )
 
     @patch("metadata.ingestion.source.pipeline.fivetran.metadata.FivetranSource.get_messaging_service_names")
@@ -777,8 +777,8 @@ class TestFivetranLineage:
             client.get_connector_schema_details.return_value = {
                 "hr": {
                     "enabled": True,
-                    "name_in_destination": "fivetran_dex",
-                    "tables": {"paystub": {"enabled": True, "name_in_destination": "employee_paystub"}},
+                    "name_in_destination": "hr_stream",
+                    "tables": {"employees": {"enabled": True, "name_in_destination": "employee_events"}},
                 }
             }
             client.get_connector_column_lineage.return_value = {}
@@ -1133,13 +1133,13 @@ class TestSearchAnyService:
 
     def test_padding_contract_matches_real_helper(self, fivetran_source):
         source, _ = fivetran_source
-        search_string = self._capture_search_string(source, Table, [None, "cxcases", "action"])
-        assert prefix_entity_for_wildcard_search(Table, search_string) == "*.*.cxcases.action"
+        search_string = self._capture_search_string(source, Table, [None, "crm", "orders"])
+        assert prefix_entity_for_wildcard_search(Table, search_string) == "*.*.crm.orders"
 
     def test_leading_gap_is_dropped(self, fivetran_source):
         source, _ = fivetran_source
-        search_string = self._capture_search_string(source, Table, [None, "cxcases", "action"])
-        assert search_string == "cxcases.action"
+        search_string = self._capture_search_string(source, Table, [None, "crm", "orders"])
+        assert search_string == "crm.orders"
 
     def test_interior_gap_is_kept_as_wildcard(self, fivetran_source):
         source, _ = fivetran_source

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -688,7 +688,7 @@ class TestFivetranLineage:
     def test_falls_back_to_cross_service_search_when_unconfigured(self, mock_get_services, fivetran_source):
         source, _ = fivetran_source
         mock_get_services.return_value = []
-        found = Mock()
+        found = Mock(spec=Table)
         found.service = Mock(name="svc")
 
         with patch.object(source, "metadata") as mock_metadata:
@@ -729,7 +729,7 @@ class TestFivetranLineage:
     def test_topic_search_string_quotes_dotted_name(self, mock_get_services, fivetran_source):
         source, _ = fivetran_source
         mock_get_services.return_value = []
-        found = Mock()
+        found = Mock(spec=Topic)
         found.service = Mock(name="kafka")
 
         with patch.object(source, "metadata") as mock_metadata:

--- a/ingestion/tests/unit/topology/pipeline/test_fivetran.py
+++ b/ingestion/tests/unit/topology/pipeline/test_fivetran.py
@@ -40,6 +40,7 @@ from metadata.generated.schema.metadataIngestion.workflow import (
 from metadata.generated.schema.type.basic import FullyQualifiedEntityName, SourceUrl
 from metadata.generated.schema.type.entityLineage import ColumnLineage
 from metadata.generated.schema.type.entityReference import EntityReference
+from metadata.ingestion.ometa.utils import model_str
 from metadata.ingestion.source.pipeline.fivetran.client import FivetranClient
 from metadata.ingestion.source.pipeline.fivetran.fivetran_log import (
     FIVETRAN_TASK_EXTRACT,
@@ -820,3 +821,31 @@ class TestFivetranColumnLineage:
         result = source._fetch_column_lineage(EXPECTED_FIVETRAN_DETAILS, "test", "public", "users", Mock(), Mock())
         assert result == []
         mock_fqn.assert_not_called()
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_topic_field_fqn")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_column_fqn")
+    def test_table_to_topic_uses_topic_field_resolver(self, mock_col_fqn, mock_topic_fqn, fivetran_source):
+        source, client = fivetran_source
+        client.get_connector_column_lineage.return_value = {"src": {"enabled": True, "name_in_destination": "dst"}}
+        mock_col_fqn.return_value = "svc.db.sch.tbl.src"
+        mock_topic_fqn.return_value = "kafka.topic.dst"
+
+        topic = Topic.model_construct(id=uuid4(), name="topic")
+        result = source._fetch_column_lineage(EXPECTED_FIVETRAN_DETAILS, "test", "public", "users", Mock(), topic)
+
+        assert len(result) == 1
+        mock_topic_fqn.assert_called_once_with(topic, "dst")
+        assert model_str(result[0].toColumn) == "kafka.topic.dst"
+
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_topic_field_fqn")
+    @patch("metadata.ingestion.source.pipeline.fivetran.metadata.get_column_fqn")
+    def test_unresolvable_topic_field_is_skipped(self, mock_col_fqn, mock_topic_fqn, fivetran_source):
+        source, client = fivetran_source
+        client.get_connector_column_lineage.return_value = {"src": {"enabled": True, "name_in_destination": "dst"}}
+        mock_col_fqn.return_value = "svc.db.sch.tbl.src"
+        mock_topic_fqn.return_value = None
+
+        topic = Topic.model_construct(id=uuid4(), name="topic")
+        result = source._fetch_column_lineage(EXPECTED_FIVETRAN_DETAILS, "test", "public", "users", Mock(), topic)
+
+        assert result == []


### PR DESCRIPTION
### Describe your changes:

Fixes #31265

I made the Fivetran connector resolve lineage endpoints across all services when `lineageInformation.dbServiceNames` / `messagingServiceNames` are left unset, and taught it to emit `Table -> Topic` lineage (including column level) for messaging destinations. Previously both ends of every edge were resolved by looping over those lists, so an empty list meant the loop body never ran, **zero** lineage edges were produced, and the run still reported `Errors: 0, Warnings: 0, Success %: 100.0` with every skip reason logged only at DEBUG — a silent failure that is hard to diagnose from the outside. Fivetran connectors writing into Kafka/Confluent Cloud could never produce lineage at all, because the destination was unconditionally resolved as a `Table`. A misconfigured or unresolvable connector now also logs one actionable summary warning naming the dominant skip reason.

#
### Type of change:
- [x] Bug fix
- [x] New feature

#
### High-level design:

**Approach.** Adopt the pattern kafkaconnect already uses rather than inventing a Fivetran-specific one: `search_in_any_service` for the empty-service-name fallback, and `ENTITY_REFERENCE_TYPE_MAP` plus entity-derived edge endpoint types for topic edges.

**Components.**

- **`ingestion/src/metadata/ingestion/lineage/topic_lineage.py` (new, shared).** `get_topic_field_fqn(topic_entity, field_name)` — the topic-side twin of `get_column_fqn`, resolving a field inside a Topic's `messageSchema.schemaFields`, including nested records and Debezium `after`/`before` envelopes. Moved verbatim out of kafkaconnect, whose private `_get_topic_field_fqn` is now a one-line delegate; `CDC_ENVELOPE_FIELDS` is re-exported from `kafkaconnect/constants.py` so existing imports keep working. This sits next to `get_column_fqn` in `lineage/sql_lineage.py` because it is `Topic` entity traversal, not connector-specific logic.
- **Resolution (`fivetran/metadata.py`).** `_resolve_source_entity` / `_resolve_destination_table` collapse into `_resolve_table` / `_resolve_topic`, both keeping the exact `get_by_name` loop when their service-name list is non-empty and falling through to a shared `_search_any_service` cross-service search only when it is empty. Fallback hits log which service the match resolved in.
- **Topic destinations.** `is_messaging_destination` mirrors the existing `is_messaging_source` check. A messaging destination resolves as a `Topic` named `{destination_schema_name}.{destination_table_name}`, passed through `fqn.quote_name()` — required because `FQN_ENTITY_SLOTS[Topic] == 2`, so an unquoted dotted name would be misread as `service.topic`. Edge endpoint types now come from `ENTITY_REFERENCE_TYPE_MAP[entity.__class__.__name__]` instead of a hardcoded ternary, which makes the direction combinations fall out for free.
- **Column lineage.** A module-level `_resolve_field_fqn` dispatches on entity type (`get_column_fqn` for a `Table`, `get_topic_field_fqn` for a `Topic`). This is a required correctness fix, not only a feature: `Topic` has no `.columns`, so the previous unconditional `get_column_fqn` would `AttributeError` on the first `Table -> Topic` edge. The call is wrapped best-effort — Fivetran's column-config endpoint is not supported for every connector type, and an error there must not discard the entity-level edge.

**Accepted trade-off.** On an ambiguous cross-service match, `search_in_any_service` returns the first hit. This is deliberate: it is the existing convention across ~15 connectors (kafkaconnect, dbtcloud, and every dashboard source), and a Fivetran-only disambiguation rule would be a maintenance trap. The mitigation is logging the resolved service so an ambiguous pick stays diagnosable. Explicit service names remain the recommended configuration and take the deterministic exact-lookup path.

**Rejected alternatives.** (1) Disambiguating candidates by `serviceType` before falling back — resolves more cases automatically but diverges from every sibling connector. (2) Duplicating the topic-field resolver into the Fivetran package, or importing kafkaconnect's private method — both rejected in favour of the shared `lineage/` helper.

**Backward compatibility.** No behaviour change for deployments that already configure service names: the exact-lookup loop is unchanged and "configured but not found" still skips without falling back. Two unit tests guard that promise specifically. One behaviour widening is intentional: messaging **sources** previously skipped column lineage entirely and now attempt it, which is why that call is exception-guarded.

**Out of scope.** `Topic -> Topic` edges (Fivetran has no messaging-to-messaging connectors) and surfacing the zero-lineage signal in the workflow `Status.warnings` count.

#
### Tests:

#### Use cases covered

- A Fivetran agent with `includeLineage: true` and empty `dbServiceNames` now produces table-level lineage by matching entities across all services, instead of silently producing none.
- A deployment that already sets `dbServiceNames` keeps its exact-lookup behaviour, and a configured-but-missing table still skips rather than falling back.
- A Fivetran connector whose destination is Kafka/Confluent Cloud produces `Table -> Topic` lineage, with the dotted topic name correctly quoted as a single FQN part.
- Column-level lineage resolves per end by entity type, so a `Table -> Topic` edge maps source columns to topic schema fields; an unresolvable field degrades to an entity-level edge instead of failing.
- A Fivetran column-config API error leaves the entity-level edge intact rather than discarding all lineage for the connector.
- An agent that resolves nothing logs one warning naming the dominant actionable skip reason; a connector whose schemas/tables are simply disabled in Fivetran stays quiet.

#### Unit tests

- [x] I added unit tests for the new/changed logic.
- Files added/updated:
  - `ingestion/tests/unit/lineage/test_topic_lineage.py` (new, 6 tests)
  - `ingestion/tests/unit/topology/pipeline/test_fivetran.py` (+24 tests)
- Command: `python -m pytest tests/unit/topology/pipeline/test_fivetran.py tests/unit/topology/pipeline/test_kafkaconnect.py tests/unit/topology/pipeline/test_kafkaconnect_service_discovery.py tests/unit/source/pipeline/test_kafkaconnect.py tests/unit/lineage/test_topic_lineage.py`
- Result: **180 passed**. kafkaconnect's 100 pre-existing tests pass unchanged after the delegation refactor.
- Coverage on changed modules (`pytest --cov`, whole-file figures including pre-existing untouched code):
  - `ingestion/src/metadata/ingestion/source/pipeline/fivetran/metadata.py` — **86%**
  - `ingestion/src/metadata/ingestion/lineage/topic_lineage.py` — **74%**
- Below the 90% target. The residual misses are pre-existing paths this PR does not touch (client pagination, `get_pipelines_list` error handling) plus the moved resolver's `schemaText`/Envelope fallback, which is verbatim-moved code already live in kafkaconnect.
- Type checks: `basedpyright -p pyproject.toml --baselinefile .basedpyright/baseline.json --baselinemode=discard` on both changed source files — **0 errors**, baseline unmodified. `make py_format_check` clean.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

No new ingestion integration test. The changed logic is entity resolution against OpenMetadata plus Fivetran API response shaping, both covered at the unit level; exercising it end to end needs a live Fivetran account with both a database and a Kafka destination, which this repo's ingestion ITs do not provision.

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

Not yet performed against a live deployment — flagging honestly rather than claiming it. The intended verification, which needs a real Fivetran account:

1. On a Fivetran ingestion pipeline with `includeLineage: true`, set `lineageInformation.dbServiceNames: []` and `loggerLevel: DEBUG`, then run the metadata agent.
2. Expect lineage edges created via the fallback, each logging `Resolved Table [...] via cross-service search in service [...]`.
3. Set `dbServiceNames` to a wrong service name and re-run. Expect zero edges plus one `produced no lineage` warning naming `source entity not found`.
4. For a connector with a Confluent Cloud destination, confirm `Table -> Topic` edges appear with `toEntity.type == "topic"`.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema changes.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
- [x] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
