### PR TITLE
fix(security): move ingestion images to Python 3.12, upgrade datamode…

### DIFF
--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -2,18 +2,10 @@
     "files": {
         "./src/_openmetadata_testutils/factories/base/polymorphic_subfactory.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 12,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 25,
+                    "startColumn": 20,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -44,18 +36,18 @@
         ],
         "./src/_openmetadata_testutils/factories/base/root_model.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 14,
+                    "startColumn": 31,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportIncompatibleVariableOverride",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
+                    "startColumn": 10,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -71,6 +63,22 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 33,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
                     "endColumn": 39,
                     "lineCount": 1
                 }
@@ -118,20 +126,10 @@
         ],
         "./src/_openmetadata_testutils/factories/base/test_polymorphic_subfactory.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/base/test_root_model.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 25,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -140,6 +138,144 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/base/test_root_model.py": [
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -154,50 +290,10 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_classification.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_tag.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/classification.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/tag.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/data/table.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 46,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -206,6 +302,262 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_tag.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/classification.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/tag.py": [
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/data/table.py": [
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -220,10 +572,10 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/basic.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 19,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -262,20 +614,100 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/entity_reference.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 28,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/recognizer.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 29,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -284,16 +716,288 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/tag_label.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 19,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -304,14 +1008,134 @@
                     "endColumn": 14,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/pii/models.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 20,
+                    "startColumn": 31,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleVariableOverride",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             }
@@ -362,14 +1186,6 @@
         ],
         "./src/_openmetadata_testutils/helpers/login_user.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 23,
@@ -405,38 +1221,6 @@
             }
         ],
         "./src/_openmetadata_testutils/kafka/load_csv_data.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -505,6 +1289,14 @@
             }
         ],
         "./src/_openmetadata_testutils/ometa.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 5,
+                    "lineCount": 5
+                }
+            },
             {
                 "code": "reportCallIssue",
                 "range": {
@@ -780,18 +1572,50 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportGeneralTypeIssues",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 73,
+                    "startColumn": 15,
+                    "endColumn": 24,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 32,
+                    "startColumn": 64,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             }
@@ -954,11 +1778,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 56,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 9,
+                    "lineCount": 16
                 }
             },
             {
@@ -968,14 +1792,6 @@
                     "endColumn": 17,
                     "lineCount": 5
                 }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/airflow_provider_openmetadata/lineage/operator.py": [
@@ -984,6 +1800,14 @@
                 "range": {
                     "startColumn": 5,
                     "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -1054,11 +1878,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 49,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 9
                 }
             },
             {
@@ -1078,11 +1902,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 82,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 10
                 }
             },
             {
@@ -1090,14 +1914,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -1118,43 +1934,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 60,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 7
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 46,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -1182,43 +1974,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 93,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 83,
-                    "lineCount": 1
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             },
             {
@@ -1227,6 +1995,38 @@
                     "startColumn": 78,
                     "endColumn": 82,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 9,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 103,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 33,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 4
                 }
             },
             {
@@ -1302,10 +2102,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 57,
+                    "startColumn": 33,
+                    "endColumn": 17,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 106,
                     "lineCount": 1
                 }
             },
@@ -1315,6 +2123,14 @@
                     "startColumn": 55,
                     "endColumn": 57,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 21,
+                    "lineCount": 4
                 }
             },
             {
@@ -1334,10 +2150,26 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 55,
+                    "startColumn": 33,
+                    "endColumn": 17,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -1376,11 +2208,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             },
             {
@@ -1394,33 +2226,25 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 62,
+                    "startColumn": 37,
+                    "endColumn": 61,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 58,
+                    "startColumn": 35,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 32,
-                    "lineCount": 1
+                    "startColumn": 21,
+                    "endColumn": 5,
+                    "lineCount": 8
                 }
             },
             {
@@ -2846,25 +3670,9 @@
                     "endColumn": 80,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/clients/domo_client.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportCallIssue",
                 "range": {
@@ -2902,6 +3710,138 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/clients/microsoftfabric/fabric_client.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/clients/microsoftfabric/models.py": [
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
@@ -3016,6 +3956,14 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 34,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 16,
                     "endColumn": 59,
                     "lineCount": 1
@@ -3062,6 +4010,14 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 100,
+                    "endColumn": 110,
                     "lineCount": 1
                 }
             }
@@ -3124,18 +4080,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 53,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 18
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAssignmentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 67,
+                    "startColumn": 46,
+                    "endColumn": 114,
                     "lineCount": 1
                 }
             },
@@ -3161,6 +4117,14 @@
                     "startColumn": 15,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             }
         ],
@@ -3242,6 +4206,22 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -3378,11 +4358,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 13,
+                    "lineCount": 11
                 }
             },
             {
@@ -3398,22 +4378,6 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -3458,11 +4422,27 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 21,
+                    "lineCount": 4
                 }
             },
             {
@@ -3511,6 +4491,14 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             },
             {
@@ -3764,6 +4752,22 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueLengthsToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3777,6 +4781,22 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -3822,6 +4842,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMaxToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3835,6 +4863,14 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -3848,6 +4884,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMeanToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3861,6 +4905,14 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -3874,6 +4926,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMedianToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3887,6 +4947,14 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -3900,6 +4968,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMinToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3913,6 +4989,14 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -3926,6 +5010,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueStdDevToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -3942,6 +5034,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -3951,6 +5051,14 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesMissingCount.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -3968,6 +5076,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -3978,10 +5094,26 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesSumToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -3991,6 +5123,14 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -4030,6 +5170,22 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeBetween.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4042,6 +5198,22 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 81,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -4096,6 +5268,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeInSet.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4136,6 +5316,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -4153,6 +5341,14 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotInSet.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -4186,6 +5382,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -4195,6 +5399,14 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotNull.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -4234,9 +5446,49 @@
                     "endColumn": 31,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeUnique.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -4272,6 +5524,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4309,6 +5569,14 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -4322,6 +5590,14 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToNotMatchRegex.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4359,6 +5635,14 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -6972,8 +8256,40 @@
             {
                 "code": "reportAssignmentType",
                 "range": {
+                    "startColumn": 36,
+                    "endColumn": 9,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
                     "startColumn": 24,
                     "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 115,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 96,
+                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -7074,7 +8390,33 @@
                 }
             }
         ],
+        "./src/metadata/data_quality/validations/table/base/tableColumnCountToBeBetween.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/data_quality/validations/table/base/tableColumnCountToEqual.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -7082,14 +8424,38 @@
                     "endColumn": 42,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/data_quality/validations/table/base/tableColumnNameToExist.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             }
@@ -7112,10 +8478,26 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             }
@@ -7126,6 +8508,76 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/data_quality/validations/table/base/tableRowCountToBeBetween.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/data_quality/validations/table/base/tableRowCountToEqual.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/data_quality/validations/table/base/tableRowInsertedCountToBeBetween.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -7390,6 +8842,22 @@
                     "endColumn": 69,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py": [
@@ -7538,6 +9006,78 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 91,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
@@ -7630,6 +9170,30 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -7822,70 +9386,6 @@
         ],
         "./src/metadata/great_expectations/action.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
@@ -7902,18 +9402,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 105,
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 68,
+                    "startColumn": 64,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -7926,18 +9426,74 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 33,
+                    "startColumn": 65,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 69,
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -8000,34 +9556,10 @@
         ],
         "./src/metadata/great_expectations/action1xx.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportIncompatibleMethodOverride",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 43,
+                    "startColumn": 8,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
             },
@@ -8080,26 +9612,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -8116,6 +9632,70 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -8218,6 +9798,32 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/api/delete.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 106,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            }
+        ],
         "./src/metadata/ingestion/api/parser.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -8259,6 +9865,14 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 21,
+                    "endColumn": 81,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
                     "endColumn": 68,
                     "lineCount": 1
                 }
@@ -8282,14 +9896,6 @@
                 }
             },
             {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 73,
@@ -8302,6 +9908,14 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -8334,6 +9948,14 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -8520,6 +10142,14 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -8814,6 +10444,38 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 19,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 18,
                     "endColumn": 22,
                     "lineCount": 1
@@ -8862,14 +10524,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 37,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 21,
                     "endColumn": 25,
                     "lineCount": 1
@@ -8894,6 +10548,22 @@
         ],
         "./src/metadata/ingestion/connections/test_connections.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 5,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -8902,11 +10572,27 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 51,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 5,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -9340,10 +11026,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 53,
+                    "startColumn": 17,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -9388,27 +11074,43 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 77,
+                    "startColumn": 38,
+                    "endColumn": 100,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 89,
-                    "endColumn": 99,
+                    "startColumn": 26,
+                    "endColumn": 106,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 62,
-                    "lineCount": 1
+                    "startColumn": 17,
+                    "endColumn": 13,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             },
             {
@@ -9633,6 +11335,30 @@
                     "startColumn": 32,
                     "endColumn": 42,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             }
         ],
@@ -10012,14 +11738,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 8,
@@ -10252,14 +11970,6 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 44,
                     "lineCount": 1
                 }
             },
@@ -10672,6 +12382,14 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -11612,6 +13330,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 19,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 36,
                     "endColumn": 40,
                     "lineCount": 1
@@ -11676,6 +13402,38 @@
         ],
         "./src/metadata/ingestion/ometa/mixins/lineage_mixin.py": [
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 49,
@@ -11692,6 +13450,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 62,
@@ -11704,6 +13470,22 @@
                 "range": {
                     "startColumn": 53,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -11752,6 +13534,14 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -11888,11 +13678,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 47,
-                    "lineCount": 1
+                    "startColumn": 25,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             },
             {
@@ -11928,6 +13718,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 23,
@@ -11936,27 +13742,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 21,
-                    "lineCount": 1
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 14
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
-                    "endColumn": 35,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 59,
+                    "startColumn": 82,
+                    "endColumn": 99,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             }
         ],
@@ -12202,6 +14016,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 25,
@@ -12214,6 +14036,22 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -12366,11 +14204,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 55,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 14
                 }
             },
             {
@@ -12382,11 +14220,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 55,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 14
                 }
             },
             {
@@ -12522,10 +14360,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 51,
-                    "endColumn": 65,
+                    "startColumn": 32,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -12634,10 +14472,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
+                    "startColumn": 27,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -13462,6 +15300,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 15,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 37,
                     "endColumn": 41,
                     "lineCount": 1
@@ -13602,19 +15448,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 50,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -13634,35 +15472,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 44,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -13678,38 +15492,6 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -13734,14 +15516,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -13900,6 +15674,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 23,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 35,
                     "endColumn": 39,
                     "lineCount": 1
@@ -13998,35 +15780,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 45,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 49,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -14038,11 +15804,27 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 49,
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 6
                 }
             },
             {
@@ -14215,6 +15997,14 @@
                     "startColumn": 28,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -14450,18 +16240,26 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 39,
-                    "lineCount": 1
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 12
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 48,
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
@@ -14474,19 +16272,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 36,
-                    "lineCount": 1
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -14498,11 +16288,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 103,
-                    "lineCount": 1
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 15
                 }
             },
             {
@@ -14510,14 +16300,6 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -14624,6 +16406,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 5,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 18,
@@ -14710,16 +16500,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/progress/runner_tracker.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -14888,6 +16668,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 19,
@@ -14962,6 +16750,30 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 31,
+                    "endColumn": 109,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 96,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
@@ -15005,6 +16817,30 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -15200,11 +17036,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
                     "endColumn": 63,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
                 }
             },
             {
@@ -15514,6 +17366,64 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/api/rest/connection.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/api/rest/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -15561,6 +17471,14 @@
                     "startColumn": 43,
                     "endColumn": 49,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -15612,19 +17530,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 83,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 17
                 }
             },
             {
@@ -15748,19 +17658,107 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 54,
+                    "startColumn": 23,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 58,
+                    "startColumn": 31,
+                    "endColumn": 93,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 81,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 7
                 }
             }
         ],
@@ -15782,20 +17780,22 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/api/rest/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/connections.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 57,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -16180,11 +18180,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 37,
-                    "endColumn": 40,
-                    "lineCount": 1
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 19
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 25,
+                    "lineCount": 5
                 }
             },
             {
@@ -16268,6 +18292,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 37,
@@ -16281,6 +18313,14 @@
                     "startColumn": 48,
                     "endColumn": 58,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -16300,28 +18340,28 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 69,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 92,
-                    "endColumn": 101,
+                    "startColumn": 42,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/dashboard/domodashboard/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
+                    "startColumn": 21,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -16413,6 +18453,14 @@
                     "startColumn": 15,
                     "endColumn": 24,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 19
                 }
             },
             {
@@ -16552,6 +18600,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 21,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
@@ -16624,6 +18680,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/domodashboard/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/grafana/client.py": [
             {
                 "code": "reportMissingParameterType",
@@ -16646,6 +18712,24 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/grafana/connection.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -16705,6 +18789,14 @@
                     "startColumn": 55,
                     "endColumn": 58,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 29
                 }
             },
             {
@@ -16772,11 +18864,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 40,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 11
                 }
             },
             {
@@ -16876,6 +18968,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/grafana/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/hex/client.py": [
             {
                 "code": "reportArgumentType",
@@ -16898,6 +19000,16 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 48,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/hex/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -16941,6 +19053,14 @@
                     "startColumn": 34,
                     "endColumn": 51,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -16996,6 +19116,30 @@
                 "range": {
                     "startColumn": 72,
                     "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -17102,6 +19246,16 @@
                 "range": {
                     "startColumn": 55,
                     "endColumn": 59,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/hex/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -17238,6 +19392,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/lightdash/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/lightdash/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -17277,6 +19441,14 @@
                     "startColumn": 56,
                     "endColumn": 80,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -17328,18 +19500,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -17360,15 +19532,17 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/looker/bulk_parser.py": [
+        "./src/metadata/ingestion/source/dashboard/lightdash/service_spec.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
+                    "startColumn": 45,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/looker/bulk_parser.py": [
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -17412,11 +19586,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 53,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 9
                 }
             },
             {
@@ -17424,14 +19598,6 @@
                 "range": {
                     "startColumn": 42,
                     "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -17492,31 +19658,25 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/looker/connection.py": [
+            {
+                "code": "reportOptionalIterable",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 100,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/looker/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportUnreachable",
                 "range": {
@@ -17702,6 +19862,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 17,
+                    "lineCount": 22
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -17714,30 +19882,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -17854,6 +19998,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 17,
+                    "lineCount": 21
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -17874,30 +20026,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -18054,6 +20182,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 17,
+                    "lineCount": 23
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -18066,30 +20202,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -18230,18 +20342,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 79,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 102,
-                    "endColumn": 111,
+                    "startColumn": 52,
+                    "endColumn": 112,
                     "lineCount": 1
                 }
             },
@@ -18470,6 +20574,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 22
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -18646,19 +20758,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 50,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 29,
+                    "lineCount": 4
                 }
             },
             {
@@ -18758,11 +20862,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 71,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -18986,14 +21090,6 @@
         ],
         "./src/metadata/ingestion/source/dashboard/looker/parser.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 30,
@@ -19058,15 +21154,17 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/looker/utils.py": [
+        "./src/metadata/ingestion/source/dashboard/looker/service_spec.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 8,
+                    "startColumn": 45,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/looker/utils.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -19198,6 +21296,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/metabase/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/metabase/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -19245,6 +21353,14 @@
                     "startColumn": 67,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -19312,11 +21428,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 82,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -19414,6 +21530,16 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/metabase/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -19596,6 +21722,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/microstrategy/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/microstrategy/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -19619,6 +21755,14 @@
                     "startColumn": 12,
                     "endColumn": 99,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 17,
+                    "lineCount": 19
                 }
             },
             {
@@ -19758,10 +21902,34 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -19798,19 +21966,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 84,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -19846,34 +22006,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 21,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -19930,6 +22074,16 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/microstrategy/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             }
@@ -20008,6 +22162,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/mode/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/mode/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -20079,6 +22243,14 @@
                     "startColumn": 15,
                     "endColumn": 41,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 23
                 }
             },
             {
@@ -20186,6 +22358,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 21,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 51,
@@ -20207,6 +22387,16 @@
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/mode/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             }
         ],
@@ -20238,11 +22428,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 61,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
@@ -20262,18 +22452,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 10
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -20315,6 +22505,14 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 19
                 }
             },
             {
@@ -20371,6 +22569,14 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -20508,14 +22714,6 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -20908,6 +23106,24 @@
                 "range": {
                     "startColumn": 48,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/powerbi/connection.py": [
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -21190,6 +23406,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 20,
@@ -21230,6 +23454,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 21,
+                    "lineCount": 25
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -21251,6 +23483,14 @@
                     "startColumn": 95,
                     "endColumn": 106,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 21,
+                    "lineCount": 15
                 }
             },
             {
@@ -21294,11 +23534,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 40,
+                    "endColumn": 25,
+                    "lineCount": 13
                 }
             },
             {
@@ -21355,30 +23595,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 45,
-                    "lineCount": 1
                 }
             },
             {
@@ -21742,18 +23958,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 98,
-                    "endColumn": 111,
+                    "startColumn": 46,
+                    "endColumn": 112,
                     "lineCount": 1
                 }
             },
@@ -21798,18 +24006,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 69,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 92,
-                    "endColumn": 101,
+                    "startColumn": 42,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
@@ -21916,6 +24116,16 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 37,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/powerbi/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -22162,6 +24372,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/qlikcloud/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/qlikcloud/metadata.py": [
             {
                 "code": "reportIncompatibleVariableOverride",
@@ -22305,6 +24525,14 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -22484,6 +24712,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 44,
@@ -22546,6 +24782,16 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 46,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/qlikcloud/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -22744,6 +24990,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/qliksense/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/qliksense/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -22791,6 +25047,14 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 21
                 }
             },
             {
@@ -22895,6 +25159,14 @@
                     "startColumn": 51,
                     "endColumn": 56,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -23010,6 +25282,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 21,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 40,
@@ -23030,22 +25310,6 @@
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -23306,6 +25570,42 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/qliksense/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/quicksight/connection.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 84,
+                    "endColumn": 96,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/quicksight/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -23388,6 +25688,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 23
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -23452,18 +25760,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
-                    "lineCount": 1
+                    "startColumn": 36,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 55,
+                    "startColumn": 40,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -23540,10 +25848,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 93,
-                    "endColumn": 102,
+                    "startColumn": 30,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -23572,11 +25880,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 41,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 41,
+                    "lineCount": 4
                 }
             },
             {
@@ -23598,9 +25922,33 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 45,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 34,
                     "endColumn": 29,
                     "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 37,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 41,
+                    "lineCount": 4
                 }
             },
             {
@@ -23828,18 +26176,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -23857,6 +26205,16 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/quicksight/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 61,
+                    "lineCount": 1
                 }
             }
         ],
@@ -23918,6 +26276,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/redash/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/redash/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -23965,6 +26333,14 @@
                     "startColumn": 28,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 25
                 }
             },
             {
@@ -24104,6 +26480,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
@@ -24125,6 +26509,16 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/redash/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 57,
+                    "lineCount": 1
                 }
             }
         ],
@@ -24218,6 +26612,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/sigma/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/sigma/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -24257,6 +26661,14 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 19
                 }
             },
             {
@@ -24313,6 +26725,14 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -24444,11 +26864,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 54,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -24468,26 +26888,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 21,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -24508,20 +26920,32 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
+        "./src/metadata/ingestion/source/dashboard/sigma/service_spec.py": [
             {
-                "code": "reportMissingModuleSource",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 18,
+                    "startColumn": 45,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 52,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/dashboard/ssrs/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -24557,6 +26981,14 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -24616,11 +27048,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 47,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -24672,6 +27104,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -24680,19 +27120,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 44,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -24776,6 +27208,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/ssrs/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/superset/api_source.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -24783,6 +27225,14 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 18
                 }
             },
             {
@@ -24855,6 +27305,14 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -24940,6 +27398,22 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 94,
+                    "endColumn": 109,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 34,
                     "endColumn": 71,
                     "lineCount": 1
@@ -24962,18 +27436,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 21,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -25220,6 +27694,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/superset/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/superset/db_source.py": [
             {
                 "code": "reportReturnType",
@@ -25235,6 +27719,14 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -25299,6 +27791,14 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 10
                 }
             },
             {
@@ -25422,6 +27922,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 21,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
@@ -25432,24 +27940,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 53,
                     "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -25602,19 +28094,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 47,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -25682,10 +28166,58 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 41,
+                    "startColumn": 20,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 21,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -25694,22 +28226,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -25730,9 +28246,9 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 36,
+                    "startColumn": 42,
                     "endColumn": 53,
                     "lineCount": 1
                 }
@@ -25772,6 +28288,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/superset/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/dashboard/superset/utils.py": [
             {
                 "code": "reportUnreachable",
@@ -25800,18 +28326,18 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/client.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 17,
+                    "startColumn": 4,
+                    "endColumn": 9,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 24,
+                    "startColumn": 4,
+                    "endColumn": 10,
                     "lineCount": 1
                 }
             },
@@ -25820,6 +28346,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -25898,50 +28432,10 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
+                    "startColumn": 32,
                     "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -25990,6 +28484,22 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             }
@@ -26076,6 +28586,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 13,
+                    "lineCount": 18
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -26086,40 +28604,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 33,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
@@ -26145,6 +28631,14 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 37
                 }
             },
             {
@@ -26300,18 +28794,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 77,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 100,
-                    "endColumn": 109,
+                    "startColumn": 50,
+                    "endColumn": 110,
                     "lineCount": 1
                 }
             },
@@ -26444,19 +28930,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 56,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 29,
+                    "lineCount": 4
                 }
             },
             {
@@ -26476,18 +28954,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 83,
-                    "endColumn": 94,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 106,
-                    "endColumn": 115,
+                    "startColumn": 56,
+                    "endColumn": 116,
                     "lineCount": 1
                 }
             },
@@ -26585,6 +29055,14 @@
                     "startColumn": 47,
                     "endColumn": 63,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 13
                 }
             },
             {
@@ -27526,6 +30004,34 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/dashboard/tableau/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/athena/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/athena/lineage.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -27584,28 +30090,20 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/athena/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
+                    "startColumn": 36,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -27968,6 +30466,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 12
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 41,
@@ -27996,22 +30502,6 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -28049,14 +30539,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/athena/utils.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -28468,14 +30950,6 @@
         ],
         "./src/metadata/ingestion/source/database/bigquery/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 43,
@@ -28552,6 +31026,46 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -28654,24 +31168,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/bigquery/incremental_table_processor.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/bigquery/lineage.py": [
             {
                 "code": "reportArgumentType",
@@ -28683,14 +31179,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/bigquery/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -29036,10 +31524,42 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -29068,6 +31588,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 9,
+                    "lineCount": 16
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -29089,22 +31617,6 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -29184,6 +31696,22 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 105,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -29284,11 +31812,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 80,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 7
                 }
             },
             {
@@ -29316,11 +31860,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 24
                 }
             },
             {
@@ -29490,14 +32034,6 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 10,
@@ -29556,10 +32092,10 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
+                    "startColumn": 60,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -29610,33 +32146,17 @@
                     "endColumn": 111,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/bigtable/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -29694,6 +32214,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 40,
@@ -29710,12 +32238,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/bigtable/models.py": [
+        "./src/metadata/ingestion/source/database/bigtable/service_spec.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 30,
+                    "startColumn": 56,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             }
@@ -29726,6 +32254,24 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/burstiq/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -29780,34 +32326,34 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 97,
-                    "endColumn": 107,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 46,
-                    "endColumn": 64,
+                    "endColumn": 108,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 60,
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -29910,6 +32456,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -29923,6 +32477,14 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -30022,6 +32584,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 52,
@@ -30067,6 +32645,14 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 16
                 }
             },
             {
@@ -30146,26 +32732,122 @@
         ],
         "./src/metadata/ingestion/source/database/cassandra/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
+                    "startColumn": 43,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
+                    "startColumn": 43,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
+                    "startColumn": 44,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -30248,31 +32930,33 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/clickhouse/connection.py": [
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/clickhouse/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -30300,8 +32984,48 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 38,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 10,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -30463,22 +33187,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/clickhouse/utils.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -30946,15 +33654,17 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/column_type_parser.py": [
+        "./src/metadata/ingestion/source/database/cockroach/service_spec.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 31,
+                    "startColumn": 56,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/database/column_type_parser.py": [
             {
                 "code": "reportReturnType",
                 "range": {
@@ -31112,6 +33822,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -31133,6 +33851,14 @@
                     "startColumn": 83,
                     "endColumn": 91,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 15
                 }
             },
             {
@@ -31352,19 +34078,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 50,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 27
                 }
             },
             {
@@ -31389,14 +34107,6 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             },
             {
@@ -31682,18 +34392,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -31738,6 +34448,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 15
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -31759,14 +34477,6 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -31858,6 +34568,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 25
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -31887,14 +34605,6 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             },
             {
@@ -31956,34 +34666,34 @@
         ],
         "./src/metadata/ingestion/source/database/couchbase/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 27,
+                    "startColumn": 31,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 30,
+                    "startColumn": 45,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 30,
+                    "startColumn": 33,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 30,
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -32062,14 +34772,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -32082,6 +34784,16 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 62,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/couchbase/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             }
@@ -32706,10 +35418,18 @@
         ],
         "./src/metadata/ingestion/source/database/databricks/auth.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportPrivateImportUsage",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 24,
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportPrivateImportUsage",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 88,
                     "lineCount": 1
                 }
             },
@@ -32811,6 +35531,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/databricks/client.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -33068,15 +35796,33 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/databricks/metadata.py": [
+        "./src/metadata/ingestion/source/database/databricks/connection.py": [
             {
-                "code": "reportMissingModuleSource",
+                "code": "reportOptionalSubscript",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
+                    "startColumn": 8,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/databricks/metadata.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -34060,6 +36806,14 @@
                     "endColumn": 72,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/databricks/query_parser.py": [
@@ -34179,14 +36933,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/datalake/clients/azure_blob.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -34462,6 +37208,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -34523,6 +37277,30 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -34606,11 +37384,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 17
                 }
             },
             {
@@ -34634,14 +37412,6 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -34793,6 +37563,22 @@
             }
         ],
         "./src/metadata/ingestion/source/database/db2/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -35222,6 +38008,110 @@
         ],
         "./src/metadata/ingestion/source/database/dbt/dbt_service.py": [
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 14,
@@ -35246,10 +38136,114 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 48,
+                    "startColumn": 35,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 80,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 84,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 93,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -35276,14 +38270,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -35334,33 +38320,17 @@
                     "endColumn": 37,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/dbt/metadata.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -35434,11 +38404,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 21,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 36,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -35474,6 +38460,30 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 41,
@@ -35486,6 +38496,22 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -35510,6 +38536,30 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -35542,6 +38592,62 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -35594,6 +38700,38 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 21,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -35642,11 +38780,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 25,
-                    "lineCount": 3
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 11
                 }
             },
             {
@@ -35687,6 +38825,46 @@
                     "startColumn": 29,
                     "endColumn": 63,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 29,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 10
                 }
             },
             {
@@ -35754,6 +38932,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -35762,211 +38956,51 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 10
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 33,
                     "lineCount": 4
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
                 }
             },
             {
@@ -36050,6 +39084,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
@@ -36074,19 +39124,27 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 53,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 21,
+                    "lineCount": 11
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 101,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -36106,19 +39164,51 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 58,
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 29,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 91,
+                    "startColumn": 55,
+                    "endColumn": 80,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 17,
+                    "lineCount": 12
                 }
             },
             {
@@ -36127,6 +39217,14 @@
                     "startColumn": 62,
                     "endColumn": 75,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -36220,14 +39318,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
@@ -36440,31 +39530,15 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 33,
-                    "lineCount": 1
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/deltalake/clients/s3.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -36626,6 +39700,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 58,
@@ -36698,6 +39788,14 @@
                     "endColumn": 30,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/deltalake/metadata.py": [
@@ -36750,11 +39848,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 30,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
                 }
             },
             {
@@ -36819,6 +39917,14 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -36974,6 +40080,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 18
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -37062,12 +40176,30 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/deltalake/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/domodatabase/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 11,
+                    "startColumn": 21,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -37114,6 +40246,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
@@ -37127,6 +40267,14 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -37242,11 +40390,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 52,
-                    "lineCount": 1
+                    "endColumn": 13,
+                    "lineCount": 21
                 }
             },
             {
@@ -37282,14 +40430,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -37314,19 +40454,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 44,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -37380,6 +40512,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/domodatabase/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/doris/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -37416,18 +40558,18 @@
         ],
         "./src/metadata/ingestion/source/database/doris/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 23,
+                    "startColumn": 13,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
+                    "startColumn": 33,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -37500,6 +40642,30 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -37584,19 +40750,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 72,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 11
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 11
                 }
             }
         ],
@@ -37802,6 +40968,14 @@
                     "endColumn": 28,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/dynamodb/metadata.py": [
@@ -37872,15 +41046,65 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/exasol/metadata.py": [
+        "./src/metadata/ingestion/source/database/exasol/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
+                    "startColumn": 31,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/exasol/metadata.py": [
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -37958,6 +41182,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/exasol/sqla_utils.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 8,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/external_table_lineage_mixin.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -38016,6 +41250,30 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 33,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 33,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportUnreachable",
                 "range": {
                     "startColumn": 12,
@@ -38048,18 +41306,44 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 69,
-                    "endColumn": 80,
+                    "startColumn": 42,
+                    "endColumn": 102,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/glue/connection.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 92,
-                    "endColumn": 101,
+                    "startColumn": 27,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -38186,11 +41470,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 30,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
                 }
             },
             {
@@ -38274,6 +41558,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 16
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -38295,14 +41587,6 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -38442,6 +41726,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 23
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 29,
@@ -38463,14 +41755,6 @@
                     "startColumn": 56,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 5
                 }
             },
             {
@@ -38646,6 +41930,16 @@
                 "range": {
                     "startColumn": 46,
                     "endColumn": 72,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/glue/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             }
@@ -39188,18 +42482,66 @@
         ],
         "./src/metadata/ingestion/source/database/hive/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 18,
+                    "startColumn": 31,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
                 "range": {
                     "startColumn": 8,
-                    "endColumn": 14,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -39216,14 +42558,6 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -39245,54 +42579,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/hive/custom_hive_connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -39446,18 +42732,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 36,
+                    "startColumn": 48,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 34,
+                    "startColumn": 54,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -39498,10 +42784,10 @@
         ],
         "./src/metadata/ingestion/source/database/hive/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -39542,6 +42828,14 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -40092,14 +43386,6 @@
         ],
         "./src/metadata/ingestion/source/database/hive/utils.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
@@ -40388,6 +43674,56 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/impala/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/impala/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -40423,14 +43759,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/impala/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -40678,6 +44006,22 @@
                     "endColumn": 92,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/impala/service_spec.py": [
@@ -40846,6 +44190,38 @@
         ],
         "./src/metadata/ingestion/source/database/life_cycle_query_mixin.py": [
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 76,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 99,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -40934,6 +44310,30 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -40984,6 +44384,38 @@
                 }
             },
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -41008,6 +44440,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 9,
+                    "lineCount": 12
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 59,
@@ -41016,11 +44456,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 32,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -41072,6 +44512,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -41080,10 +44528,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 51,
+                    "startColumn": 34,
+                    "endColumn": 29,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -41194,11 +44650,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 6
                 }
             },
             {
@@ -41210,11 +44666,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 7
                 }
             },
             {
@@ -41394,18 +44850,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 69,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 92,
-                    "endColumn": 101,
+                    "startColumn": 42,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
@@ -41423,6 +44871,30 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 12
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 94,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -41622,11 +45094,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 15
                 }
             },
             {
@@ -41696,25 +45168,355 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/microsoftfabric/connection.py": [
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/microsoftfabric/lineage.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/microsoftfabric/metadata.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 70,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 91,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 14
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/microsoftfabric/query_parser.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 77,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/microsoftfabric/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/mongodb/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 12,
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/mongodb/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -42052,19 +45854,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 15
                 }
             },
             {
@@ -42352,30 +46146,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -42434,6 +46204,22 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -42801,7 +46587,151 @@
                 "code": "reportMissingImports",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 43,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 90,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 90,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 90,
+                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -42814,26 +46744,10 @@
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
+                    "startColumn": 65,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             }
@@ -42872,11 +46786,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 82,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 16
                 }
             },
             {
@@ -43236,22 +47158,6 @@
         ],
         "./src/metadata/ingestion/source/database/oracle/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 28,
@@ -43264,6 +47170,22 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -43496,11 +47418,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -43796,86 +47718,6 @@
                 "range": {
                     "startColumn": 47,
                     "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 62,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -44408,6 +48250,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/pinotdb/connection.py": [
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/pinotdb/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -44443,14 +48295,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/pinotdb/metadata.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -44594,11 +48438,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 11
                 }
             }
         ],
@@ -44852,11 +48696,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 16
                 }
             },
             {
@@ -45034,6 +48878,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 16,
@@ -45070,6 +48922,30 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 21,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 91,
                     "lineCount": 1
                 }
             }
@@ -45274,18 +49150,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 29,
+                    "lineCount": 11
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -45780,15 +49656,41 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/presto/metadata.py": [
+        "./src/metadata/ingestion/source/database/presto/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 29,
+                    "startColumn": 31,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/presto/metadata.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -45874,6 +49776,14 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -46128,34 +50038,26 @@
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 32,
+                    "startColumn": 35,
                     "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 59,
+                    "startColumn": 23,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 40,
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -46170,11 +50072,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 7
                 }
             },
             {
@@ -46188,18 +50090,18 @@
         ],
         "./src/metadata/ingestion/source/database/redshift/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
+                    "startColumn": 10,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 26,
+                    "startColumn": 16,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -46396,6 +50298,22 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
@@ -46404,19 +50322,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 47,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 47,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             },
             {
@@ -46428,11 +50346,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 14
                 }
             },
             {
@@ -46594,6 +50512,38 @@
                     "endColumn": 24,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/redshift/query_parser.py": [
@@ -46731,14 +50681,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/redshift/utils.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -46880,6 +50822,14 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 6,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -47358,10 +51308,34 @@
         ],
         "./src/metadata/ingestion/source/database/salesforce/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
+                    "startColumn": 17,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -47440,11 +51414,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 30,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
                 }
             },
             {
@@ -47461,6 +51435,14 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -47576,11 +51558,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -47616,14 +51598,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -47640,11 +51614,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 10
                 }
             },
             {
@@ -47680,12 +51654,22 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/sample_data.py": [
+        "./src/metadata/ingestion/source/database/salesforce/service_spec.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 36,
+                    "startColumn": 56,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/sample_data.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -47694,6 +51678,38 @@
                 "range": {
                     "startColumn": 27,
                     "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -48156,6 +52172,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 29,
+                    "endColumn": 21,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 26,
                     "endColumn": 46,
                     "lineCount": 1
@@ -48196,6 +52220,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 29,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 18,
                     "endColumn": 46,
                     "lineCount": 1
@@ -48210,11 +52242,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 14
                 }
             },
             {
@@ -48282,11 +52314,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -48330,11 +52362,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 9,
+                    "lineCount": 5
                 }
             },
             {
@@ -48359,6 +52399,14 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 9,
+                    "lineCount": 5
                 }
             },
             {
@@ -48394,6 +52442,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 10
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -48410,11 +52466,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 13,
+                    "endColumn": 9,
+                    "lineCount": 5
                 }
             },
             {
@@ -48439,6 +52495,14 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 9,
+                    "lineCount": 5
                 }
             },
             {
@@ -48474,6 +52538,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -48487,6 +52559,14 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 17,
+                    "lineCount": 11
                 }
             },
             {
@@ -48506,11 +52586,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 65,
-                    "lineCount": 1
+                    "startColumn": 13,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             },
             {
@@ -48535,6 +52615,14 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             },
             {
@@ -48567,6 +52655,14 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 9
                 }
             },
             {
@@ -48602,6 +52698,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -48615,6 +52719,14 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 9,
+                    "lineCount": 5
                 }
             },
             {
@@ -48642,6 +52754,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 37,
@@ -48663,6 +52783,14 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 12
                 }
             },
             {
@@ -48818,6 +52946,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 9,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 86,
@@ -48839,6 +52975,14 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             },
             {
@@ -48866,6 +53010,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -48890,10 +53042,26 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -48906,6 +53074,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -48914,11 +53098,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 61,
+                    "startColumn": 31,
+                    "endColumn": 97,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 11
                 }
             },
             {
@@ -48954,11 +53146,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 62,
+                    "startColumn": 38,
+                    "endColumn": 102,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -48970,11 +53170,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 10
                 }
             },
             {
@@ -48986,11 +53186,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 9
                 }
             },
             {
@@ -49002,11 +53202,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 9
                 }
             },
             {
@@ -49026,10 +53226,34 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 62,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -49047,6 +53271,22 @@
                     "startColumn": 14,
                     "endColumn": 9,
                     "lineCount": 8
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 101,
+                    "lineCount": 1
                 }
             },
             {
@@ -49058,6 +53298,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 63,
@@ -49074,10 +53322,18 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 67,
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 100,
                     "lineCount": 1
                 }
             },
@@ -49090,11 +53346,27 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 69,
+                    "startColumn": 29,
+                    "endColumn": 91,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -49114,11 +53386,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 10
                 }
             },
             {
@@ -49130,11 +53402,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 65,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 10
                 }
             },
             {
@@ -49146,11 +53418,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 35,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 13,
+                    "lineCount": 10
                 }
             },
             {
@@ -49159,6 +53431,14 @@
                     "startColumn": 18,
                     "endColumn": 43,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             },
             {
@@ -49188,16 +53468,56 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 43,
+                    "endColumn": 29,
+                    "lineCount": 16
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 65,
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 23
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 82,
                     "lineCount": 1
                 }
             },
@@ -49210,11 +53530,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 14
                 }
             },
             {
@@ -49250,10 +53570,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 67,
+                    "startColumn": 36,
+                    "endColumn": 17,
+                    "lineCount": 14
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -49290,35 +53618,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 37,
+                    "startColumn": 30,
+                    "endColumn": 25,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 75,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 70,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 5
                 }
             },
             {
@@ -49327,6 +53655,14 @@
                     "startColumn": 38,
                     "endColumn": 47,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -49348,6 +53684,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 41,
+                    "endColumn": 29,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 26,
                     "endColumn": 53,
                     "lineCount": 1
@@ -49359,6 +53703,14 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             },
             {
@@ -49378,11 +53730,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 54,
+                    "endColumn": 25,
+                    "lineCount": 5
                 }
             },
             {
@@ -49402,11 +53754,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
-                    "lineCount": 1
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 6
                 }
             },
             {
@@ -49426,11 +53778,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
-                    "lineCount": 1
+                    "startColumn": 43,
+                    "endColumn": 33,
+                    "lineCount": 6
                 }
             },
             {
@@ -49447,6 +53799,14 @@
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 3
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 25,
+                    "lineCount": 10
                 }
             },
             {
@@ -49471,6 +53831,38 @@
                     "startColumn": 20,
                     "endColumn": 24,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 13,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 13,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 11
                 }
             },
             {
@@ -49538,11 +53930,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 36,
-                    "lineCount": 1
+                    "startColumn": 23,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -49562,11 +53954,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 37,
-                    "lineCount": 1
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -49674,11 +54066,43 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 70,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 25,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 33,
+                    "lineCount": 6
                 }
             },
             {
@@ -49706,18 +54130,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 82,
-                    "endColumn": 94,
+                    "startColumn": 38,
+                    "endColumn": 95,
                     "lineCount": 1
                 }
             },
@@ -49770,18 +54186,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 97,
-                    "endColumn": 109,
+                    "startColumn": 42,
+                    "endColumn": 110,
                     "lineCount": 1
                 }
             },
@@ -49834,26 +54242,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 39,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 21,
+                    "lineCount": 16
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 95,
+                    "startColumn": 57,
+                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -49916,19 +54316,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 40,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 10
                 }
             }
         ],
@@ -50002,6 +54394,16 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/saperp/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -50120,6 +54522,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -50136,11 +54546,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 40,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 18
                 }
             },
             {
@@ -50157,6 +54567,14 @@
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 16
                 }
             },
             {
@@ -50180,14 +54598,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -50228,6 +54638,16 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 114,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/saperp/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             }
@@ -50287,6 +54707,30 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 18
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 29,
+                    "lineCount": 4
                 }
             },
             {
@@ -50634,6 +55078,56 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/saphana/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/saphana/lineage.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -50790,19 +55284,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 15
                 }
             },
             {
@@ -50853,6 +55339,24 @@
                     "startColumn": 15,
                     "endColumn": 9,
                     "lineCount": 8
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/saphana/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 112,
+                    "lineCount": 1
                 }
             }
         ],
@@ -51274,6 +55778,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/sas/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/sas/metadata.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -51460,6 +55974,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 9,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 17,
@@ -51488,14 +56010,6 @@
                 "range": {
                     "startColumn": 24,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -51508,26 +56022,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 37,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 80,
+                    "endColumn": 119,
                     "lineCount": 1
                 }
             },
@@ -51552,6 +56058,14 @@
                 "range": {
                     "startColumn": 30,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 110,
                     "lineCount": 1
                 }
             },
@@ -51828,19 +56342,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 32,
-                    "endColumn": 49,
-                    "lineCount": 1
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -51848,14 +56354,6 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -51881,6 +56379,22 @@
                     "startColumn": 76,
                     "endColumn": 79,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 17,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
@@ -52006,6 +56520,22 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 40,
+                    "endColumn": 13,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 21,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 18,
                     "endColumn": 57,
                     "lineCount": 1
@@ -52108,6 +56638,30 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -52116,19 +56670,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 51,
-                    "lineCount": 1
+                    "startColumn": 29,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -52180,11 +56726,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 51,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -52217,6 +56763,14 @@
                     "startColumn": 24,
                     "endColumn": 38,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 4
                 }
             },
             {
@@ -52260,19 +56814,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 9
                 }
             },
             {
@@ -52336,6 +56882,16 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 109,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/sas/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -52442,6 +56998,46 @@
                     "endColumn": 40,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py": [
@@ -52536,87 +57132,15 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 74,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 29,
+                    "lineCount": 7
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/snowflake/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -52629,6 +57153,70 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 42,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
                     "endColumn": 58,
                     "lineCount": 1
                 }
@@ -52670,14 +57258,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -52814,6 +57394,30 @@
                 "range": {
                     "startColumn": 66,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -52978,27 +57582,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 25
                 }
             },
             {
@@ -53388,18 +57976,26 @@
         ],
         "./src/metadata/ingestion/source/database/snowflake/utils.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -53774,30 +58370,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 23,
                     "endColumn": 27,
                     "lineCount": 1
@@ -54022,38 +58594,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -54206,6 +58746,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 20,
@@ -54214,11 +58770,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 37,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 18
                 }
             },
             {
@@ -54380,6 +58936,16 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 24,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/sqlite/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             }
@@ -54624,19 +59190,27 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 66,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 10
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -54916,6 +59490,14 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 52,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 84,
                     "endColumn": 96,
                     "lineCount": 1
@@ -54986,6 +59568,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/teradata/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/teradata/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -55022,18 +59614,26 @@
         ],
         "./src/metadata/ingestion/source/database/teradata/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportFunctionMemberAccess",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -55070,11 +59670,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 39,
+                    "endColumn": 13,
+                    "lineCount": 15
                 }
             },
             {
@@ -55232,6 +59832,16 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/timescale/connection.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -56090,10 +60700,26 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 99,
+                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -56156,11 +60782,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 29,
+                    "lineCount": 7
                 }
             },
             {
@@ -56774,28 +61400,62 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/unitycatalog/client.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 82,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/unitycatalog/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 19,
+                    "startColumn": 31,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalSubscript",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
+                    "startColumn": 8,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
+                    "startColumn": 40,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -56882,19 +61542,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 69,
-                    "endColumn": 80,
+                    "startColumn": 42,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 92,
-                    "endColumn": 101,
-                    "lineCount": 1
+                    "startColumn": 23,
+                    "endColumn": 17,
+                    "lineCount": 4
                 }
             },
             {
@@ -56906,17 +61566,17 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 66,
-                    "endColumn": 78,
+                    "startColumn": 39,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 90,
+                    "startColumn": 23,
                     "endColumn": 100,
                     "lineCount": 1
                 }
@@ -56927,6 +61587,22 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 15
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
                 }
             },
             {
@@ -56943,6 +61619,22 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 87,
+                    "lineCount": 1
                 }
             },
             {
@@ -56988,22 +61680,6 @@
         ],
         "./src/metadata/ingestion/source/database/unitycatalog/metadata.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 6,
@@ -57032,6 +61708,14 @@
                 "range": {
                     "startColumn": 88,
                     "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -57116,11 +61800,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 30,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             },
             {
@@ -57193,6 +61877,14 @@
                     "startColumn": 39,
                     "endColumn": 49,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 9,
+                    "lineCount": 14
                 }
             },
             {
@@ -57284,11 +61976,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 50,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 20
                 }
             },
             {
@@ -57329,6 +62021,14 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 4
                 }
             },
             {
@@ -57412,6 +62112,14 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 16,
@@ -57464,6 +62172,14 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -57536,6 +62252,206 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportRedeclaration",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportRedeclaration",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportRedeclaration",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportIndexIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             }
@@ -57724,34 +62640,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 29,
+                    "lineCount": 14
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -57847,14 +62747,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/vertica/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -58044,6 +62936,30 @@
                 "range": {
                     "startColumn": 6,
                     "endColumn": 8,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
@@ -58570,8 +63486,64 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 19,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 41,
                     "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 106,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -58722,43 +63694,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 54,
-                    "lineCount": 1
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 11
                 }
             },
             {
@@ -58842,35 +63782,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 69,
-                    "lineCount": 1
+                    "startColumn": 42,
+                    "endColumn": 33,
+                    "lineCount": 10
                 }
             },
             {
@@ -58890,43 +63806,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 61,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 25,
+                    "lineCount": 10
                 }
             },
             {
@@ -58962,19 +63846,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 10
                 }
             },
             {
@@ -58982,38 +63858,6 @@
                 "range": {
                     "startColumn": 43,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -59074,11 +63918,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 63,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 18
                 }
             },
             {
@@ -59087,22 +63931,6 @@
                     "startColumn": 47,
                     "endColumn": 60,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 21,
-                    "lineCount": 7
                 }
             },
             {
@@ -59150,18 +63978,10 @@
         ],
         "./src/metadata/ingestion/source/drive/sftp/connection.py": [
             {
-                "code": "reportMissingModuleSource",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 15,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 13,
+                    "startColumn": 31,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
@@ -59170,6 +63990,14 @@
                 "range": {
                     "startColumn": 17,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -59312,27 +64140,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 39,
-                    "lineCount": 1
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -59400,19 +64212,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 55,
-                    "lineCount": 1
+                    "startColumn": 42,
+                    "endColumn": 33,
+                    "lineCount": 10
                 }
             },
             {
@@ -59432,27 +64236,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 57,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 25,
+                    "lineCount": 10
                 }
             },
             {
@@ -59520,11 +64308,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 42,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -59532,6 +64320,16 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 60,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/drive/sftp/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -59568,6 +64366,16 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/mcp/mcp/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -59670,71 +64478,81 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 49,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 35,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 15
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 13,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 20,
-                    "endColumn": 43,
+                    "endColumn": 21,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/mcp/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/messaging/common_broker_source.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 7,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -59748,6 +64566,14 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
@@ -59776,10 +64602,26 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -59864,6 +64706,14 @@
                 }
             },
             {
+                "code": "reportUnusedExcept",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -59881,30 +64731,6 @@
             }
         ],
         "./src/metadata/ingestion/source/messaging/kafka/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -59925,7 +64751,7 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 61,
-                    "endColumn": 77,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -60004,6 +64830,34 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/messaging/kafka/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/messaging/kinesis/connection.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/messaging/kinesis/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -60059,6 +64913,14 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -60182,6 +65044,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/messaging/kinesis/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/messaging/messaging_service.py": [
             {
                 "code": "reportCallIssue",
@@ -60290,39 +65162,15 @@
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/connection.py": [
             {
-                "code": "reportMissingModuleSource",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 45,
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/metadata.py": [
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -60369,6 +65217,14 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -60458,6 +65314,40 @@
                     "endColumn": 17,
                     "lineCount": 21
                 }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 29,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 29,
+                    "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/messaging/pubsub/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/messaging/redpanda/metadata.py": [
@@ -60490,6 +65380,16 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 94,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/messaging/redpanda/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -60680,6 +65580,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/metadata/alationsink/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/metadata/alationsink/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -60836,20 +65746,56 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/metadata/alationsink/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/metadata/amundsen/client.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 7,
-                    "endColumn": 12,
+                    "startColumn": 17,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/metadata/amundsen/connection.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 10,
+                    "startColumn": 28,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -60952,11 +65898,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 55,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -61016,6 +65970,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 21,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 64,
@@ -61072,11 +66034,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 113,
-                    "lineCount": 1
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -61084,14 +66046,6 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -61125,6 +66079,14 @@
                     "startColumn": 44,
                     "endColumn": 49,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -61240,11 +66202,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 35,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 13
                 }
             },
             {
@@ -61296,11 +66258,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 65,
-                    "lineCount": 1
+                    "startColumn": 32,
+                    "endColumn": 13,
+                    "lineCount": 11
                 }
             },
             {
@@ -61328,19 +66290,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 65,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -61360,11 +66314,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 33,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 10
                 }
             },
             {
@@ -61388,6 +66342,16 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 19,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/metadata/amundsen/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -61510,6 +66474,16 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 48,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/metadata/atlas/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -61780,11 +66754,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 89,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 8
                 }
             },
             {
@@ -62036,6 +67010,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportOptionalSubscript",
                 "range": {
                     "startColumn": 21,
@@ -62049,6 +67031,14 @@
                     "startColumn": 28,
                     "endColumn": 59,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -62094,6 +67084,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 45,
+                    "endColumn": 109,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 18,
                     "endColumn": 39,
                     "lineCount": 1
@@ -62108,10 +67106,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 55,
+                    "startColumn": 23,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -62124,41 +67122,35 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/metadata/atlas/service_spec.py": [
+            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 58,
+                    "startColumn": 45,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/mlmodel/mlflow/connection.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/mlmodel/mlflow/metadata.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -62194,8 +67186,80 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 47,
+                    "startColumn": 93,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 93,
+                    "endColumn": 115,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 121,
+                    "endColumn": 136,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 9,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -62216,10 +67280,44 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/mlmodel/mlflow/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -62426,6 +67524,24 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/mlmodel/sagemaker/connection.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/mlmodel/sagemaker/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -62460,6 +67576,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -62480,6 +67604,14 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
                     "lineCount": 7
                 }
             },
@@ -62512,6 +67644,16 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 46,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/mlmodel/sagemaker/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -62702,6 +67844,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/airbyte/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/airbyte/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -62752,6 +67904,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -62768,51 +67936,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 104,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 100,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 87,
-                    "lineCount": 1
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -62848,51 +67984,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 96,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 30,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 71,
-                    "lineCount": 1
+                    "endColumn": 13,
+                    "lineCount": 5
                 }
             },
             {
@@ -62952,6 +68056,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -62968,6 +68088,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 83,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -62980,6 +68116,16 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/airbyte/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -63041,6 +68187,78 @@
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 34,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
                     "endColumn": 44,
                     "lineCount": 1
                 }
@@ -63174,64 +68392,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/airflow/api/diagnostics.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py": [
             {
                 "code": "reportArgumentType",
@@ -63284,11 +68444,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 108,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 9
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 19
                 }
             },
             {
@@ -63348,27 +68516,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 59,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -63380,11 +68532,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 91,
-                    "lineCount": 1
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -63482,6 +68634,46 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -63602,6 +68794,46 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 53,
@@ -63618,6 +68850,70 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -63626,35 +68922,59 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportGeneralTypeIssues",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 102,
+                    "startColumn": 68,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
+                    "startColumn": 32,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 65,
+                    "startColumn": 28,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 95,
+                    "startColumn": 48,
+                    "endColumn": 62,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -63706,11 +69026,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 13,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 32,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -63754,6 +69090,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 17
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -63762,11 +69106,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 108,
-                    "lineCount": 1
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 19
                 }
             },
             {
@@ -63890,6 +69234,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 27,
@@ -63924,6 +69284,22 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 47,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 34,
                     "endColumn": 55,
                     "lineCount": 1
@@ -63938,11 +69314,35 @@
                 }
             },
             {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 107,
+                    "startColumn": 16,
+                    "endColumn": 51,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 16
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 9
                 }
             },
             {
@@ -63964,8 +69364,40 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 48,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 72,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 31,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -63980,8 +69412,16 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 81,
+                    "startColumn": 50,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 70,
+                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -64050,23 +69490,17 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/airflow/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/dagster/client.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -64080,6 +69514,16 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 36,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/dagster/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -64142,6 +69586,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 21,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 14
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -64198,11 +69658,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 92,
-                    "lineCount": 1
+                    "startColumn": 26,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -64214,27 +69674,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 92,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 5
                 }
             },
             {
@@ -64242,14 +69686,6 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -64392,9 +69828,33 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 15
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 33,
+                    "lineCount": 4
                 }
             },
             {
@@ -64403,6 +69863,14 @@
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 4
                 }
             },
             {
@@ -64458,6 +69926,34 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 84,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/dagster/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py": [
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -64554,6 +70050,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -64594,11 +70098,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 95,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -64607,6 +70111,14 @@
                     "startColumn": 8,
                     "endColumn": 29,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
@@ -64642,11 +70154,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 48,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 8
                 }
             },
             {
@@ -64722,19 +70234,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 50,
-                    "lineCount": 1
+                    "startColumn": 28,
+                    "endColumn": 29,
+                    "lineCount": 4
                 }
             },
             {
@@ -64794,19 +70298,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 63,
-                    "endColumn": 61,
-                    "lineCount": 8
+                    "startColumn": 67,
+                    "endColumn": 57,
+                    "lineCount": 4
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 67,
-                    "endColumn": 90,
-                    "lineCount": 1
+                    "startColumn": 65,
+                    "endColumn": 57,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 57,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 61,
+                    "lineCount": 4
                 }
             },
             {
@@ -64834,19 +70354,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 71,
-                    "endColumn": 69,
-                    "lineCount": 8
+                    "startColumn": 75,
+                    "endColumn": 65,
+                    "lineCount": 4
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 75,
-                    "endColumn": 98,
-                    "lineCount": 1
+                    "startColumn": 73,
+                    "endColumn": 65,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 79,
+                    "endColumn": 65,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 77,
+                    "endColumn": 69,
+                    "lineCount": 4
                 }
             },
             {
@@ -64874,27 +70410,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 57,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 57,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 63,
-                    "endColumn": 86,
-                    "lineCount": 1
+                    "endColumn": 53,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 53,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 53,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 65,
+                    "endColumn": 57,
+                    "lineCount": 4
                 }
             },
             {
@@ -64946,6 +70490,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 25,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
@@ -64964,9 +70524,35 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 47,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/databrickspipeline/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             }
         ],
@@ -65024,6 +70610,14 @@
                 "range": {
                     "startColumn": 44,
                     "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -65088,6 +70682,16 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/dbtcloud/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -65158,6 +70762,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 17,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 35,
@@ -65179,6 +70791,14 @@
                     "startColumn": 35,
                     "endColumn": 47,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 8
                 }
             },
             {
@@ -65344,9 +70964,41 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 42,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 15
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 37,
+                    "lineCount": 4
                 }
             },
             {
@@ -65398,11 +71050,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 105,
-                    "lineCount": 1
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 14
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 7
                 }
             },
             {
@@ -65410,14 +71070,6 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -65488,6 +71140,38 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
+                    "startColumn": 20,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
                     "startColumn": 23,
                     "endColumn": 35,
                     "lineCount": 1
@@ -65502,11 +71186,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 82,
-                    "lineCount": 1
+                    "startColumn": 30,
+                    "endColumn": 17,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -65531,6 +71223,42 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/dbtcloud/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/domopipeline/connection.py": [
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             }
         ],
@@ -65608,6 +71336,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -65672,27 +71416,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 30,
-                    "endColumn": 38,
-                    "lineCount": 1
+                    "endColumn": 17,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -65752,12 +71488,32 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/domopipeline/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/fivetran/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/fivetran/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -65785,6 +71541,54 @@
                     "startColumn": 44,
                     "endColumn": 54,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 9,
+                    "lineCount": 6
                 }
             }
         ],
@@ -65862,6 +71666,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 21,
+                    "lineCount": 5
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 44,
@@ -65875,6 +71687,14 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 25,
+                    "lineCount": 5
                 }
             },
             {
@@ -65907,6 +71727,14 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 25,
+                    "lineCount": 5
                 }
             },
             {
@@ -65998,18 +71826,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 58,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 78,
-                    "endColumn": 84,
+                    "startColumn": 31,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -66018,6 +71838,16 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 26,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/fivetran/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -66072,6 +71902,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/flink/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/flink/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -66103,6 +71943,22 @@
                     "startColumn": 12,
                     "endColumn": 91,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -66154,11 +72010,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 72,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 5
                 }
             },
             {
@@ -66210,6 +72074,34 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/flink/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/gluepipeline/connection.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/gluepipeline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -66252,6 +72144,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -66265,6 +72165,14 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -66300,11 +72208,27 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 29,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 83,
                     "endColumn": 87,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 21,
+                    "lineCount": 6
                 }
             },
             {
@@ -66348,19 +72272,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 116,
-                    "lineCount": 1
+                    "startColumn": 24,
+                    "endColumn": 25,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 112,
-                    "lineCount": 1
+                    "startColumn": 38,
+                    "endColumn": 21,
+                    "lineCount": 5
                 }
             },
             {
@@ -66416,6 +72340,22 @@
                 "range": {
                     "startColumn": 77,
                     "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -66476,15 +72416,17 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/client.py": [
+        "./src/metadata/ingestion/source/pipeline/gluepipeline/service_spec.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 18,
+                    "startColumn": 45,
+                    "endColumn": 63,
                     "lineCount": 1
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/kafkaconnect/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -66506,6 +72448,14 @@
                 "range": {
                     "startColumn": 94,
                     "endColumn": 110,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -66542,6 +72492,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 22,
@@ -66562,6 +72520,16 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/kafkaconnect/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -66992,6 +72960,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 12
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 3
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 43,
@@ -67288,118 +73272,6 @@
                 }
             },
             {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 86,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 78,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -67424,11 +73296,43 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 25,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 74,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 33,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 33,
+                    "lineCount": 4
                 }
             },
             {
@@ -67456,11 +73360,43 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 25,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -67498,6 +73434,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 36,
                     "endColumn": 82,
                     "lineCount": 1
@@ -67509,6 +73453,14 @@
                     "startColumn": 51,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -67582,6 +73534,246 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 10,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/kafkaconnect/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/metadata.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 81,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 84,
+                    "endColumn": 94,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 33,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 6
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             }
@@ -67660,6 +73852,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/nifi/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/nifi/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -67691,6 +73893,22 @@
                     "startColumn": 12,
                     "endColumn": 90,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             },
             {
@@ -67728,6 +73946,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 30,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 36,
                     "endColumn": 87,
                     "lineCount": 1
@@ -67742,11 +73968,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 21,
-                    "lineCount": 3
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -67854,6 +74080,30 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 42,
@@ -67878,6 +74128,30 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 91,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 15,
@@ -67886,23 +74160,17 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/nifi/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/openlineage/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -67990,6 +74258,30 @@
                     "endColumn": 67,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/pipeline/openlineage/metadata.py": [
@@ -68074,18 +74366,74 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 73,
-                    "endColumn": 86,
+                    "startColumn": 15,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 7
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 100,
-                    "endColumn": 113,
+                    "startColumn": 24,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 114,
                     "lineCount": 1
                 }
             },
@@ -68098,6 +74446,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 38,
@@ -68106,27 +74462,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 39,
-                    "lineCount": 1
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -68170,34 +74510,42 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 57,
+                    "startColumn": 28,
+                    "endColumn": 93,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 58,
+                    "startColumn": 28,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 58,
+                    "startColumn": 28,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 57,
+                    "startColumn": 28,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -68206,6 +74554,14 @@
                 "range": {
                     "startColumn": 99,
                     "endColumn": 103,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -68250,10 +74606,42 @@
                 }
             },
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -68266,19 +74654,35 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 54,
-                    "endColumn": 73,
+                    "startColumn": 35,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 69,
+                    "startColumn": 33,
+                    "endColumn": 99,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 25,
+                    "lineCount": 15
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 33,
+                    "lineCount": 4
                 }
             },
             {
@@ -68330,6 +74734,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportPossiblyUnboundVariable",
                 "range": {
                     "startColumn": 12,
@@ -68370,6 +74782,14 @@
                 }
             },
             {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 31,
@@ -68394,20 +74814,22 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/ownership_resolver.py": [
+        "./src/metadata/ingestion/source/pipeline/openlineage/service_resolver.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 49,
-                    "lineCount": 1
+                    "startColumn": 14,
+                    "endColumn": 5,
+                    "lineCount": 4
                 }
-            },
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/openlineage/service_spec.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 49,
+                    "startColumn": 45,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             }
@@ -68710,56 +75132,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/prefect/metadata.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/spline/client.py": [
             {
                 "code": "reportOperatorIssue",
@@ -68850,6 +75222,16 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/spline/connection.py": [
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/spline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -68884,35 +75266,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 54,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 36,
-                    "lineCount": 1
+                    "startColumn": 27,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             },
             {
@@ -69012,6 +75378,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 33,
+                    "lineCount": 16
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 37,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -69020,18 +75402,26 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 45,
-                    "lineCount": 3
+                    "startColumn": 40,
+                    "endColumn": 41,
+                    "lineCount": 6
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 53,
-                    "endColumn": 92,
+                    "startColumn": 43,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
@@ -69048,6 +75438,16 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/pipeline/spline/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -69376,10 +75776,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 33,
+                    "startColumn": 10,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -69458,18 +75866,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 13,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -69578,18 +75986,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 21,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -69626,17 +76034,27 @@
                     "endColumn": 18,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/search/elasticsearch/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/connection.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -69892,17 +76310,33 @@
                     "endColumn": 56,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/search/opensearch/metadata.py": [
+            },
             {
-                "code": "reportMissingImports",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 17,
+                    "startColumn": 10,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/search/opensearch/metadata.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -69960,6 +76394,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -69968,18 +76410,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 13,
+                    "lineCount": 8
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -70012,6 +76454,30 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -70080,18 +76546,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 21,
+                    "lineCount": 9
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -70126,6 +76592,24 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 7
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/search/opensearch/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 61,
                     "lineCount": 1
                 }
             }
@@ -70334,6 +76818,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 14,
@@ -70402,18 +76894,18 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/client.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 10,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -70468,14 +76960,6 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -70490,14 +76974,62 @@
                     "endColumn": 25,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/storage/gcs/metadata.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 5,
-                    "endColumn": 37,
+                    "startColumn": 49,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -70566,11 +77098,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 62,
-                    "lineCount": 1
+                    "startColumn": 49,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 12
                 }
             },
             {
@@ -70654,10 +77194,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 57,
+                    "startColumn": 29,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -70674,6 +77214,14 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -70718,10 +77266,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
+                    "startColumn": 27,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -70746,6 +77294,24 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 41,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/storage/gcs/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 70,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             }
@@ -70798,9 +77364,49 @@
                     "endColumn": 76,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/ingestion/source/storage/s3/metadata.py": [
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -70866,11 +77472,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 62,
-                    "lineCount": 1
+                    "startColumn": 49,
+                    "endColumn": 17,
+                    "lineCount": 3
                 }
             },
             {
@@ -70887,6 +77493,22 @@
                     "startColumn": 55,
                     "endColumn": 59,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 9,
+                    "lineCount": 13
                 }
             },
             {
@@ -70946,10 +77568,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 57,
+                    "startColumn": 29,
+                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -70994,6 +77616,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 87,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 61,
@@ -71034,10 +77664,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
+                    "startColumn": 27,
+                    "endColumn": 74,
                     "lineCount": 1
                 }
             },
@@ -71055,6 +77685,14 @@
                     "startColumn": 24,
                     "endColumn": 58,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 9,
+                    "lineCount": 11
                 }
             },
             {
@@ -71078,6 +77716,24 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 27,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/storage/s3/service_spec.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             }
@@ -71156,6 +77812,14 @@
                 }
             },
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 93,
+                    "endColumn": 111,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -71204,11 +77868,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 42,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -71217,6 +77881,22 @@
                     "startColumn": 15,
                     "endColumn": 54,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 17,
+                    "lineCount": 10
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 13,
+                    "lineCount": 10
                 }
             }
         ],
@@ -71238,19 +77918,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 31,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 11
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 31,
-                    "lineCount": 1
+                    "startColumn": 16,
+                    "endColumn": 17,
+                    "lineCount": 11
                 }
             },
             {
@@ -71262,11 +77942,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 41,
-                    "lineCount": 1
+                    "startColumn": 36,
+                    "endColumn": 17,
+                    "lineCount": 9
                 }
             },
             {
@@ -72078,11 +78758,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 26,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 9,
+                    "lineCount": 7
                 }
             }
         ],
@@ -72278,11 +78958,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 52,
+                    "startColumn": 23,
+                    "endColumn": 82,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 9,
+                    "lineCount": 8
                 }
             },
             {
@@ -72398,26 +79086,10 @@
         ],
         "./src/metadata/profiler/adaptors/mongodb.py": [
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 9,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 23,
+                    "startColumn": 13,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -72604,16 +79276,6 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 12,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/profiler/api/models.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -73246,14 +79908,6 @@
         ],
         "./src/metadata/profiler/interface/sqlalchemy/athena/profiler_interface.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 38,
@@ -73570,14 +80224,6 @@
                 }
             },
             {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 48,
@@ -73656,24 +80302,6 @@
                 "range": {
                     "startColumn": 77,
                     "endColumn": 84,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/profiler/interface/sqlalchemy/exasol/profiler_interface.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 13,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
                     "lineCount": 1
                 }
             }
@@ -74030,6 +80658,14 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -77474,6 +84110,38 @@
                     "endColumn": 70,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 105,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 102,
+                    "endColumn": 104,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAssignmentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 86,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/profiler/orm/converter/bigquery/converter.py": [
@@ -77544,22 +84212,6 @@
                     "endColumn": 64,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/profiler/orm/converter/snowflake/converter.py": [
@@ -77580,18 +84232,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 33,
+                    "startColumn": 12,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             }
@@ -81326,6 +87970,14 @@
         ],
         "./src/metadata/profiler/source/database/base/profiler_source.py": [
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 85,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -81416,14 +88068,6 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingModuleSource",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
@@ -81636,14 +88280,6 @@
                     "endColumn": 67,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/profiler/source/database/pinotdb/profiler_source.py": [
@@ -81820,7 +88456,31 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
+                    "startColumn": 95,
+                    "endColumn": 99,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
                     "startColumn": 89,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 27,
                     "endColumn": 97,
                     "lineCount": 1
                 }
@@ -81976,6 +88636,14 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -82098,120 +88766,6 @@
                 }
             }
         ],
-        "./src/metadata/readers/archive.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/readers/dataframe/avro.py": [
             {
                 "code": "reportMissingParameterType",
@@ -82230,26 +88784,10 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -82286,14 +88824,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 15,
@@ -82302,18 +88832,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -82346,6 +88876,86 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -82574,14 +89184,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportUndefinedVariable",
                 "range": {
                     "startColumn": 26,
@@ -82630,26 +89232,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -82682,6 +89276,86 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -82704,14 +89378,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -82728,22 +89394,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
@@ -82752,26 +89402,18 @@
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 25,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -82808,18 +89450,90 @@
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 53,
+                    "startColumn": 14,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingImports",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 20,
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 14,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportReturnType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -82841,22 +89555,6 @@
             }
         ],
         "./src/metadata/readers/dataframe/parquet.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -83178,14 +89876,6 @@
                 }
             },
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 55,
@@ -83226,6 +89916,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -83254,6 +89952,86 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -83848,50 +90626,6 @@
                 }
             }
         ],
-        "./src/metadata/sampler/messaging/kafka/sampler.py": [
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 9,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/sampler/messaging/sampler.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/sampler/models.py": [
             {
                 "code": "reportArgumentType",
@@ -83936,10 +90670,26 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 96,
                     "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 109,
+                    "endColumn": 116,
                     "lineCount": 1
                 }
             },
@@ -83972,6 +90722,14 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 70,
+                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -84030,6 +90788,14 @@
                     "endColumn": 19,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 91,
+                    "endColumn": 98,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/sampler/pandas/burstiq/sampler.py": [
@@ -84074,18 +90840,18 @@
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 36,
+                    "startColumn": 39,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 25,
+                    "startColumn": 31,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -84224,6 +90990,14 @@
         ],
         "./src/metadata/sampler/processor.py": [
             {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 90,
+                    "endColumn": 100,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -84266,6 +91040,38 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -84292,6 +91098,14 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 80,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 31,
                     "endColumn": 42,
                     "lineCount": 1
@@ -84304,6 +91118,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -84342,18 +91164,58 @@
         ],
         "./src/metadata/sampler/sqlalchemy/bigquery/sampler.py": [
             {
-                "code": "reportMissingParameterType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
+                    "startColumn": 44,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
+                    "startColumn": 10,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 89,
+                    "endColumn": 97,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -84362,6 +91224,14 @@
                 "range": {
                     "startColumn": 85,
                     "endColumn": 110,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 97,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -84440,6 +91310,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 52,
+                    "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -84464,6 +91342,30 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 105,
+                    "endColumn": 112,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 105,
+                    "endColumn": 112,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 105,
+                    "endColumn": 112,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -84478,6 +91380,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -84516,18 +91426,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/postgres/sampler.py": [
             {
-                "code": "reportMissingParameterType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
+                    "startColumn": 44,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
+                    "startColumn": 10,
+                    "endColumn": 16,
                     "lineCount": 1
                 }
             },
@@ -84808,18 +91718,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/snowflake/sampler.py": [
             {
-                "code": "reportMissingParameterType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
+                    "startColumn": 44,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
+                    "startColumn": 10,
+                    "endColumn": 16,
                     "lineCount": 1
                 }
             },
@@ -85052,16 +91962,6 @@
                 }
             }
         ],
-        "./src/metadata/sampler/sqlalchemy/tsql.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py": [
             {
                 "code": "reportMissingParameterType",
@@ -85130,6 +92030,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
@@ -85152,6 +92060,14 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -85182,6 +92098,46 @@
                 }
             },
             {
+                "code": "reportIncompatibleMethodOverride",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -85198,10 +92154,34 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 58,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
                     "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -85234,64 +92214,6 @@
                 "range": {
                     "startColumn": 93,
                     "endColumn": 97,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/sdk/data_quality/dataframes/models.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 22,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             }
@@ -85794,11 +92716,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
                     "startColumn": 25,
-                    "endColumn": 58,
-                    "lineCount": 1
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -85888,16 +92810,6 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/utils/entity_reference.py": [
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -87086,11 +93998,11 @@
         ],
         "./src/metadata/utils/path_pattern.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 29,
-                    "lineCount": 1
+                    "startColumn": 12,
+                    "endColumn": 13,
+                    "lineCount": 5
                 }
             }
         ],
@@ -87142,6 +94054,14 @@
             {
                 "code": "reportCallIssue",
                 "range": {
+                    "startColumn": 22,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
@@ -87152,6 +94072,14 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -87210,11 +94138,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 34,
-                    "lineCount": 1
+                    "startColumn": 11,
+                    "endColumn": 5,
+                    "lineCount": 6
                 }
             },
             {
@@ -87222,6 +94150,14 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -87252,6 +94188,22 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUndefinedVariable",
                 "range": {
                     "startColumn": 21,
@@ -87260,10 +94212,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 58,
-                    "endColumn": 68,
+                    "startColumn": 17,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -87276,10 +94236,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 58,
-                    "endColumn": 68,
+                    "startColumn": 17,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -88558,8 +95526,8 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 36,
+                    "startColumn": 55,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
@@ -88576,6 +95544,22 @@
                 "range": {
                     "startColumn": 32,
                     "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -88620,10 +95604,42 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 81,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -88657,6 +95673,14 @@
                     "startColumn": 8,
                     "endColumn": 9,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 48,
+                    "lineCount": 1
                 }
             },
             {
@@ -88724,10 +95748,50 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalMemberAccess",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -88748,6 +95812,22 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -88756,10 +95836,66 @@
                 }
             },
             {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 12,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportOptionalSubscript",
+                "range": {
+                    "startColumn": 16,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -89062,8 +96198,16 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 32,
+                    "startColumn": 19,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
@@ -89071,23 +96215,15 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 37,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportMissingParameterType",
+                "code": "reportReturnType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
+                    "startColumn": 15,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             }
@@ -89110,11 +96246,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 106,
-                    "lineCount": 1
+                    "startColumn": 39,
+                    "endColumn": 17,
+                    "lineCount": 4
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -89142,34 +96286,18 @@
                 }
             },
             {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 13,
+                    "lineCount": 6
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 30,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             }
@@ -89666,11 +96794,19 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 42,
-                    "lineCount": 1
+                    "startColumn": 20,
+                    "endColumn": 21,
+                    "lineCount": 11
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 25,
+                    "lineCount": 4
                 }
             },
             {
@@ -89694,6 +96830,14 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -89744,6 +96888,30 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -90164,6 +97332,14 @@
                 }
             },
             {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 17,
@@ -90213,6 +97389,14 @@
             }
         ],
         "./src/metadata/workflow/usage.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportAssignmentType",
                 "range": {
@@ -90333,6 +97517,14 @@
                     "startColumn": 32,
                     "endColumn": 46,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportCallIssue",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             }
         ]

--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -2,10 +2,18 @@
     "files": {
         "./src/_openmetadata_testutils/factories/base/polymorphic_subfactory.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 30,
+                    "startColumn": 5,
+                    "endColumn": 12,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 25,
                     "lineCount": 1
                 }
             },
@@ -36,18 +44,18 @@
         ],
         "./src/_openmetadata_testutils/factories/base/root_model.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 38,
+                    "startColumn": 7,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportIncompatibleVariableOverride",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 5,
+                    "endColumn": 17,
                     "lineCount": 1
                 }
             },
@@ -63,22 +71,6 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 33,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 29,
                     "endColumn": 39,
                     "lineCount": 1
                 }
@@ -126,84 +118,20 @@
         ],
         "./src/_openmetadata_testutils/factories/base/test_polymorphic_subfactory.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/base/test_root_model.py": [
             {
-                "code": "reportIncompatibleVariableOverride",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -212,70 +140,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -290,226 +154,50 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_classification.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/api/classification/create_tag.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/classification.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/classification/tag.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 47,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/entity/data/table.py": [
             {
-                "code": "reportIncompatibleVariableOverride",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -518,46 +206,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -572,10 +220,10 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/basic.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 31,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -614,100 +262,20 @@
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/entity_reference.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/recognizer.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 36,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -716,288 +284,16 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/generated/schema/type/tag_label.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 32,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -1006,136 +302,16 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             }
         ],
         "./src/_openmetadata_testutils/factories/metadata/pii/models.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleVariableOverride",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 14,
+                    "startColumn": 7,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
@@ -1186,6 +362,14 @@
         ],
         "./src/_openmetadata_testutils/helpers/login_user.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 23,
@@ -1221,6 +405,38 @@
             }
         ],
         "./src/_openmetadata_testutils/kafka/load_csv_data.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -1289,14 +505,6 @@
             }
         ],
         "./src/_openmetadata_testutils/ometa.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 5,
-                    "lineCount": 5
-                }
-            },
             {
                 "code": "reportCallIssue",
                 "range": {
@@ -1572,50 +780,18 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 24,
+                    "startColumn": 64,
+                    "endColumn": 73,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 9,
-                    "lineCount": 7
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 73,
+                    "startColumn": 22,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             }
@@ -1778,11 +954,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 9,
-                    "lineCount": 16
+                    "startColumn": 25,
+                    "endColumn": 56,
+                    "lineCount": 1
                 }
             },
             {
@@ -1792,6 +968,14 @@
                     "endColumn": 17,
                     "lineCount": 5
                 }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/airflow_provider_openmetadata/lineage/operator.py": [
@@ -1800,14 +984,6 @@
                 "range": {
                     "startColumn": 5,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -1878,11 +1054,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
+                    "startColumn": 26,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -1902,11 +1078,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 10
+                    "startColumn": 22,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -1914,6 +1090,14 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -1934,19 +1118,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 60,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 38,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 46,
+                    "lineCount": 1
                 }
             },
             {
@@ -1974,19 +1182,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 32,
+                    "endColumn": 93,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 26,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 83,
+                    "lineCount": 1
                 }
             },
             {
@@ -1995,38 +1227,6 @@
                     "startColumn": 78,
                     "endColumn": 82,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 103,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -2102,18 +1302,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 106,
+                    "startColumn": 50,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -2123,14 +1315,6 @@
                     "startColumn": 55,
                     "endColumn": 57,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -2150,26 +1334,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 104,
+                    "startColumn": 48,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -2208,11 +1376,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 28,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -2226,25 +1394,33 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 37,
-                    "endColumn": 61,
+                    "startColumn": 22,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 57,
+                    "startColumn": 20,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 5,
-                    "lineCount": 8
+                    "startColumn": 20,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 32,
+                    "lineCount": 1
                 }
             },
             {
@@ -3670,9 +2846,25 @@
                     "endColumn": 80,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/clients/domo_client.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 11,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportCallIssue",
                 "range": {
@@ -3710,138 +2902,6 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 34,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/clients/microsoftfabric/fabric_client.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/clients/microsoftfabric/models.py": [
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
@@ -3956,14 +3016,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 16,
                     "endColumn": 59,
                     "lineCount": 1
@@ -4010,14 +3062,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 100,
-                    "endColumn": 110,
                     "lineCount": 1
                 }
             }
@@ -4080,18 +3124,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportAssignmentType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 114,
+                    "startColumn": 36,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -4117,14 +3161,6 @@
                     "startColumn": 15,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             }
         ],
@@ -4206,22 +3242,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -4358,11 +3378,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -4378,6 +3398,22 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -4422,27 +3458,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -4491,14 +3511,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             },
             {
@@ -4752,22 +3764,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueLengthsToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4781,22 +3777,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4842,14 +3822,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMaxToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4863,14 +3835,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4884,14 +3848,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMeanToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4905,14 +3861,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4926,14 +3874,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMedianToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4947,14 +3887,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4968,14 +3900,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMinToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4989,14 +3913,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5010,14 +3926,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueStdDevToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5034,14 +3942,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -5051,14 +3951,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesMissingCount.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5076,14 +3968,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -5094,26 +3978,10 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesSumToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -5123,14 +3991,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5170,22 +4030,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5198,22 +4042,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -5268,14 +4096,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeInSet.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5316,14 +4136,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -5341,14 +4153,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotInSet.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5382,14 +4186,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -5399,14 +4195,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotNull.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5446,49 +4234,9 @@
                     "endColumn": 31,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeUnique.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5524,14 +4272,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5569,14 +4309,6 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5590,14 +4322,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToNotMatchRegex.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5635,14 +4359,6 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -8256,40 +6972,8 @@
             {
                 "code": "reportAssignmentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
                     "startColumn": 24,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 115,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 96,
-                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -8390,72 +7074,22 @@
                 }
             }
         ],
-        "./src/metadata/data_quality/validations/table/base/tableColumnCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/data_quality/validations/table/base/tableColumnCountToEqual.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/data_quality/validations/table/base/tableColumnNameToExist.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             }
@@ -8478,26 +7112,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 72,
                     "lineCount": 1
                 }
             }
@@ -8508,76 +7126,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowCountToEqual.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowInsertedCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -8842,22 +7390,6 @@
                     "endColumn": 69,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py": [
@@ -9006,78 +7538,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
@@ -9170,30 +7630,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -9386,6 +7822,70 @@
         ],
         "./src/metadata/great_expectations/action.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
@@ -9402,18 +7902,18 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 49,
+                    "startColumn": 64,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 105,
+                    "startColumn": 17,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -9426,74 +7926,18 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 65,
+                    "startColumn": 33,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
+                    "startColumn": 65,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -9556,10 +8000,34 @@
         ],
         "./src/metadata/great_expectations/action1xx.py": [
             {
-                "code": "reportIncompatibleMethodOverride",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 11,
+                    "startColumn": 5,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -9612,10 +8080,26 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -9632,70 +8116,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -9798,32 +8218,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/api/delete.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 106,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            }
-        ],
         "./src/metadata/ingestion/api/parser.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -9865,14 +8259,6 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 21,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
                     "endColumn": 68,
                     "lineCount": 1
                 }
@@ -9896,6 +8282,14 @@
                 }
             },
             {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 73,
@@ -9908,14 +8302,6 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -9948,14 +8334,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -10142,14 +8520,6 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -10444,38 +8814,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 22,
                     "lineCount": 1
@@ -10524,6 +8862,14 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 21,
                     "endColumn": 25,
                     "lineCount": 1
@@ -10548,22 +8894,6 @@
         ],
         "./src/metadata/ingestion/connections/test_connections.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -10572,27 +8902,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -11026,10 +9340,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 78,
+                    "startColumn": 36,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -11074,43 +9388,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 100,
+                    "startColumn": 65,
+                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 106,
+                    "startColumn": 89,
+                    "endColumn": 99,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 50,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -11335,30 +9633,6 @@
                     "startColumn": 32,
                     "endColumn": 42,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             }
         ],
@@ -11738,6 +10012,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 8,
@@ -11970,6 +10252,14 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
                     "lineCount": 1
                 }
             },
@@ -12382,14 +10672,6 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -13330,14 +11612,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 40,
                     "lineCount": 1
@@ -13402,38 +11676,6 @@
         ],
         "./src/metadata/ingestion/ometa/mixins/lineage_mixin.py": [
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 49,
@@ -13450,14 +11692,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 62,
@@ -13470,22 +11704,6 @@
                 "range": {
                     "startColumn": 53,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -13534,14 +11752,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -13678,11 +11888,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -13718,22 +11928,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 23,
@@ -13742,35 +11936,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 17,
+                    "endColumn": 21,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 24,
-                    "endColumn": 60,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 82,
-                    "endColumn": 99,
+                    "startColumn": 39,
+                    "endColumn": 59,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             }
         ],
@@ -14016,14 +12202,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 25,
@@ -14036,22 +12214,6 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 74,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -14204,11 +12366,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 20,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -14220,11 +12382,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 20,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -14360,10 +12522,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 80,
+                    "startColumn": 51,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
@@ -14472,10 +12634,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
@@ -15300,14 +13462,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 37,
                     "endColumn": 41,
                     "lineCount": 1
@@ -15448,11 +13602,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 21,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -15472,11 +13634,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -15492,6 +13678,38 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -15516,6 +13734,14 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -15674,14 +13900,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 35,
                     "endColumn": 39,
                     "lineCount": 1
@@ -15780,19 +13998,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 27,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 27,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
@@ -15804,11 +14022,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -15820,11 +14038,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -15997,14 +14215,6 @@
                     "startColumn": 28,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -16240,26 +14450,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 12
+                    "startColumn": 38,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 42,
+                    "startColumn": 35,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -16272,11 +14474,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 38,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -16288,11 +14498,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 15
+                    "startColumn": 34,
+                    "endColumn": 103,
+                    "lineCount": 1
                 }
             },
             {
@@ -16300,6 +14510,14 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -16406,14 +14624,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 5,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 18,
@@ -16500,6 +14710,16 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/progress/runner_tracker.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -16668,14 +14888,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 19,
@@ -16750,30 +14962,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 74,
-                    "endColumn": 96,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
@@ -16817,30 +15005,6 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 35,
-                    "lineCount": 1
                 }
             },
             {
@@ -17036,27 +15200,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -17366,64 +15514,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/api/rest/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 71,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/api/rest/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -17471,14 +15561,6 @@
                     "startColumn": 43,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -17530,11 +15612,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 17
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 83,
+                    "lineCount": 1
                 }
             },
             {
@@ -17658,107 +15748,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
+                    "startColumn": 48,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 93,
+                    "startColumn": 52,
+                    "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
                 }
             }
         ],
@@ -17780,22 +15782,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/api/rest/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/connections.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
+                    "startColumn": 43,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -18180,35 +16180,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 19
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 37,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -18292,14 +16268,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 37,
@@ -18313,14 +16281,6 @@
                     "startColumn": 48,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -18340,28 +16300,28 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/dashboard/domodashboard/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
             }
@@ -18453,14 +16413,6 @@
                     "startColumn": 15,
                     "endColumn": 24,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -18600,14 +16552,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
@@ -18680,16 +16624,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/domodashboard/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/grafana/client.py": [
             {
                 "code": "reportMissingParameterType",
@@ -18712,24 +16646,6 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/grafana/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -18789,14 +16705,6 @@
                     "startColumn": 55,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 29
                 }
             },
             {
@@ -18864,11 +16772,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 30,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -18968,16 +16876,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/grafana/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/hex/client.py": [
             {
                 "code": "reportArgumentType",
@@ -19000,16 +16898,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 48,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/hex/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -19053,14 +16941,6 @@
                     "startColumn": 34,
                     "endColumn": 51,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -19116,30 +16996,6 @@
                 "range": {
                     "startColumn": 72,
                     "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -19246,16 +17102,6 @@
                 "range": {
                     "startColumn": 55,
                     "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/hex/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -19392,16 +17238,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/lightdash/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/lightdash/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -19441,14 +17277,6 @@
                     "startColumn": 56,
                     "endColumn": 80,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -19500,18 +17328,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -19532,17 +17360,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/lightdash/service_spec.py": [
+        "./src/metadata/ingestion/source/dashboard/looker/bulk_parser.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
+                    "startColumn": 7,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/looker/bulk_parser.py": [
+            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -19586,11 +17412,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
+                    "startColumn": 21,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
@@ -19598,6 +17424,14 @@
                 "range": {
                     "startColumn": 42,
                     "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -19658,25 +17492,31 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/looker/connection.py": [
+        "./src/metadata/ingestion/source/dashboard/looker/metadata.py": [
             {
-                "code": "reportOptionalIterable",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 100,
+                    "startColumn": 7,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 7,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/looker/metadata.py": [
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 11,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportUnreachable",
                 "range": {
@@ -19862,14 +17702,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 22
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -19882,6 +17714,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -19998,14 +17854,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 21
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -20026,6 +17874,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -20182,14 +18054,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -20202,6 +18066,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -20342,10 +18230,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 112,
+                    "startColumn": 79,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 102,
+                    "endColumn": 111,
                     "lineCount": 1
                 }
             },
@@ -20574,14 +18470,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 22
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -20758,11 +18646,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -20862,11 +18758,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 30,
+                    "endColumn": 71,
+                    "lineCount": 1
                 }
             },
             {
@@ -21090,6 +18986,14 @@
         ],
         "./src/metadata/ingestion/source/dashboard/looker/parser.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 11,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 30,
@@ -21154,17 +19058,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/looker/service_spec.py": [
+        "./src/metadata/ingestion/source/dashboard/looker/utils.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
+                    "startColumn": 5,
+                    "endColumn": 8,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/looker/utils.py": [
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -21296,16 +19198,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/metabase/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/metabase/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -21353,14 +19245,6 @@
                     "startColumn": 67,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -21428,11 +19312,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 30,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -21530,16 +19414,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 34,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/metabase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -21722,16 +19596,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/microstrategy/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/microstrategy/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -21755,14 +19619,6 @@
                     "startColumn": 12,
                     "endColumn": 99,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 19
                 }
             },
             {
@@ -21902,34 +19758,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -21966,11 +19798,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 25,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 84,
+                    "lineCount": 1
                 }
             },
             {
@@ -22006,18 +19846,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -22074,16 +19930,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/microstrategy/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             }
@@ -22162,16 +20008,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/mode/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/mode/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -22243,14 +20079,6 @@
                     "startColumn": 15,
                     "endColumn": 41,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 23
                 }
             },
             {
@@ -22358,14 +20186,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 51,
@@ -22387,16 +20207,6 @@
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/mode/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
                 }
             }
         ],
@@ -22428,11 +20238,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 29,
+                    "endColumn": 61,
+                    "lineCount": 1
                 }
             },
             {
@@ -22452,18 +20262,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -22505,14 +20315,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -22569,14 +20371,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 7
                 }
             },
             {
@@ -22714,6 +20508,14 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -23110,24 +20912,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/powerbi/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/powerbi/databricks_parser.py": [
             {
                 "code": "reportCallIssue",
@@ -23406,14 +21190,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 20,
@@ -23454,14 +21230,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 21,
-                    "lineCount": 25
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -23483,14 +21251,6 @@
                     "startColumn": 95,
                     "endColumn": 106,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 21,
-                    "lineCount": 15
                 }
             },
             {
@@ -23534,11 +21294,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 13
+                    "startColumn": 38,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -23595,6 +21355,30 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
@@ -23958,10 +21742,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 112,
+                    "startColumn": 73,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 98,
+                    "endColumn": 111,
                     "lineCount": 1
                 }
             },
@@ -24006,10 +21798,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
@@ -24116,16 +21916,6 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/powerbi/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -24372,16 +22162,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qlikcloud/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/qlikcloud/metadata.py": [
             {
                 "code": "reportIncompatibleVariableOverride",
@@ -24525,14 +22305,6 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -24712,14 +22484,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 44,
@@ -24782,16 +22546,6 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/qlikcloud/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -24990,16 +22744,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qliksense/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/qliksense/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -25047,14 +22791,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 21
                 }
             },
             {
@@ -25159,14 +22895,6 @@
                     "startColumn": 51,
                     "endColumn": 56,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -25282,14 +23010,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 40,
@@ -25310,6 +23030,22 @@
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -25570,42 +23306,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qliksense/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/quicksight/connection.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 96,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/quicksight/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -25688,14 +23388,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -25760,18 +23452,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
+                    "startColumn": 34,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -25848,10 +23540,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 103,
+                    "startColumn": 93,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
@@ -25880,27 +23572,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 41,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 41,
-                    "lineCount": 4
                 }
             },
             {
@@ -25922,33 +23598,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 29,
                     "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 37,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 41,
-                    "lineCount": 4
                 }
             },
             {
@@ -26176,18 +23828,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -26205,16 +23857,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/quicksight/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 61,
-                    "lineCount": 1
                 }
             }
         ],
@@ -26276,16 +23918,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/redash/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/redash/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -26333,14 +23965,6 @@
                     "startColumn": 28,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 25
                 }
             },
             {
@@ -26480,14 +24104,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
@@ -26509,16 +24125,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/redash/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
-                    "lineCount": 1
                 }
             }
         ],
@@ -26612,16 +24218,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/sigma/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/sigma/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -26661,14 +24257,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -26725,14 +24313,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -26864,11 +24444,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 29,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
@@ -26888,18 +24468,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -26920,32 +24508,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/sigma/service_spec.py": [
+        "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingModuleSource",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
+                    "startColumn": 5,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 52,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -26981,14 +24557,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -27048,11 +24616,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 26,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -27104,14 +24672,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -27120,11 +24680,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 26,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -27208,16 +24776,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/api_source.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -27225,14 +24783,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 18
                 }
             },
             {
@@ -27305,14 +24855,6 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -27398,22 +24940,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 94,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 71,
                     "lineCount": 1
@@ -27436,18 +24962,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -27694,16 +25220,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/superset/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/db_source.py": [
             {
                 "code": "reportReturnType",
@@ -27719,14 +25235,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -27791,14 +25299,6 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
                 }
             },
             {
@@ -27922,14 +25422,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
@@ -27940,8 +25432,24 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 32,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 53,
                     "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -28094,11 +25602,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 40,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -28166,58 +25682,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 50,
+                    "startColumn": 32,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -28226,6 +25694,22 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -28246,9 +25730,9 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
+                    "startColumn": 36,
                     "endColumn": 53,
                     "lineCount": 1
                 }
@@ -28288,16 +25772,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/superset/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/utils.py": [
             {
                 "code": "reportUnreachable",
@@ -28326,18 +25800,18 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/client.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
+                    "startColumn": 7,
+                    "endColumn": 17,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
+                    "startColumn": 5,
+                    "endColumn": 24,
                     "lineCount": 1
                 }
             },
@@ -28346,14 +25820,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -28432,10 +25898,50 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 32,
+                    "startColumn": 7,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
                     "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 56,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 69,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -28484,22 +25990,6 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 23,
                     "lineCount": 1
                 }
             }
@@ -28586,14 +26076,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 13,
-                    "lineCount": 18
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -28604,8 +26086,40 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 30,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 33,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
@@ -28631,14 +26145,6 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 37
                 }
             },
             {
@@ -28794,10 +26300,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 110,
+                    "startColumn": 77,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 100,
+                    "endColumn": 109,
                     "lineCount": 1
                 }
             },
@@ -28930,11 +26444,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 56,
+                    "lineCount": 1
                 }
             },
             {
@@ -28954,10 +26476,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 116,
+                    "startColumn": 83,
+                    "endColumn": 94,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 106,
+                    "endColumn": 115,
                     "lineCount": 1
                 }
             },
@@ -29055,14 +26585,6 @@
                     "startColumn": 47,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 13
                 }
             },
             {
@@ -30004,34 +27526,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/tableau/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/athena/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/athena/lineage.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -30090,20 +27584,28 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/athena/metadata.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 55,
+                    "startColumn": 5,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -30466,14 +27968,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 12
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 41,
@@ -30502,6 +27996,22 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -30539,6 +28049,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/athena/utils.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -30950,6 +28468,14 @@
         ],
         "./src/metadata/ingestion/source/database/bigquery/connection.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 43,
@@ -31026,46 +28552,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -31168,6 +28654,24 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/database/bigquery/incremental_table_processor.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/database/bigquery/lineage.py": [
             {
                 "code": "reportArgumentType",
@@ -31179,6 +28683,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/bigquery/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -31524,42 +29036,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -31588,14 +29068,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -31617,6 +29089,22 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -31696,22 +29184,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -31812,27 +29284,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 80,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
                 }
             },
             {
@@ -31860,11 +29316,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 24
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -32034,6 +29490,14 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/client.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 10,
@@ -32092,10 +29556,10 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 60,
-                    "endColumn": 64,
+                    "startColumn": 5,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
@@ -32146,17 +29610,33 @@
                     "endColumn": 111,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/bigtable/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -32214,14 +29694,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 40,
@@ -32238,12 +29710,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/bigtable/service_spec.py": [
+        "./src/metadata/ingestion/source/database/bigtable/models.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 70,
+                    "startColumn": 5,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             }
@@ -32254,24 +29726,6 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/burstiq/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -32326,34 +29780,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 97,
+                    "endColumn": 107,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 46,
-                    "endColumn": 108,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 75,
+                    "startColumn": 44,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -32456,14 +29910,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -32477,14 +29923,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -32584,22 +30022,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 52,
@@ -32645,14 +30067,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 16
                 }
             },
             {
@@ -32732,122 +30146,26 @@
         ],
         "./src/metadata/ingestion/source/database/cassandra/connection.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 54,
+                    "startColumn": 5,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 54,
+                    "startColumn": 5,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 64,
+                    "startColumn": 5,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -32930,33 +30248,31 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/clickhouse/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/clickhouse/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -32984,48 +30300,8 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 10,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -33187,6 +30463,22 @@
             }
         ],
         "./src/metadata/ingestion/source/database/clickhouse/utils.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -33654,17 +30946,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/cockroach/service_spec.py": [
+        "./src/metadata/ingestion/source/database/column_type_parser.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
+                    "startColumn": 13,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/column_type_parser.py": [
+            },
             {
                 "code": "reportReturnType",
                 "range": {
@@ -33822,14 +31112,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -33851,14 +31133,6 @@
                     "startColumn": 83,
                     "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 15
                 }
             },
             {
@@ -34078,11 +31352,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 27
+                    "startColumn": 24,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -34107,6 +31389,14 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -34392,18 +31682,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -34448,14 +31738,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 15
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -34477,6 +31759,14 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -34568,14 +31858,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 25
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -34605,6 +31887,14 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -34666,34 +31956,34 @@
         ],
         "./src/metadata/ingestion/source/database/couchbase/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
+                    "startColumn": 13,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 65,
+                    "startColumn": 13,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 48,
+                    "startColumn": 13,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 13,
+                    "endColumn": 30,
                     "lineCount": 1
                 }
             }
@@ -34772,6 +32062,14 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -34784,16 +32082,6 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 62,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/couchbase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
                     "lineCount": 1
                 }
             }
@@ -35418,18 +32706,10 @@
         ],
         "./src/metadata/ingestion/source/database/databricks/auth.py": [
             {
-                "code": "reportPrivateImportUsage",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 88,
+                    "startColumn": 5,
+                    "endColumn": 24,
                     "lineCount": 1
                 }
             },
@@ -35531,14 +32811,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/databricks/client.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -35796,33 +33068,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/databricks/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/databricks/metadata.py": [
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -36806,14 +34060,6 @@
                     "endColumn": 72,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/databricks/query_parser.py": [
@@ -36933,6 +34179,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/datalake/clients/azure_blob.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -37208,14 +34462,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -37277,30 +34523,6 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -37384,11 +34606,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 17
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -37412,6 +34634,14 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -37563,22 +34793,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/db2/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -38008,110 +35222,6 @@
         ],
         "./src/metadata/ingestion/source/database/dbt/dbt_service.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 14,
@@ -38136,114 +35246,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 80,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
+                    "startColumn": 13,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             }
@@ -38270,6 +35276,14 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -38320,17 +35334,33 @@
                     "endColumn": 37,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/dbt/metadata.py": [
+            },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 60,
+                    "startColumn": 36,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/dbt/metadata.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -38404,27 +35434,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 36,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 7
                 }
             },
             {
@@ -38460,30 +35474,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 41,
@@ -38496,22 +35486,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -38536,30 +35510,6 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -38592,62 +35542,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -38700,38 +35594,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -38780,11 +35642,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 25,
+                    "lineCount": 3
                 }
             },
             {
@@ -38825,46 +35687,6 @@
                     "startColumn": 29,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 10
                 }
             },
             {
@@ -38932,22 +35754,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -38956,51 +35762,211 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 33,
                     "lineCount": 4
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 62,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -39084,22 +36050,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
@@ -39124,27 +36074,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 48,
+                    "endColumn": 101,
+                    "lineCount": 1
                 }
             },
             {
@@ -39164,51 +36106,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 65,
+                    "startColumn": 43,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 80,
+                    "startColumn": 48,
+                    "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 17,
-                    "lineCount": 12
                 }
             },
             {
@@ -39217,14 +36127,6 @@
                     "startColumn": 62,
                     "endColumn": 75,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -39318,6 +36220,14 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
@@ -39530,15 +36440,31 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 25,
+                    "endColumn": 33,
+                    "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/deltalake/clients/s3.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 25,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -39700,22 +36626,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 58,
@@ -39788,14 +36698,6 @@
                     "endColumn": 30,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/deltalake/metadata.py": [
@@ -39848,11 +36750,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -39917,14 +36819,6 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -40080,14 +36974,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 18
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -40176,30 +37062,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/deltalake/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/domodatabase/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 11,
                     "lineCount": 1
                 }
             }
@@ -40246,14 +37114,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
@@ -40267,14 +37127,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -40390,11 +37242,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 21
+                    "endColumn": 52,
+                    "lineCount": 1
                 }
             },
             {
@@ -40430,6 +37282,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -40454,11 +37314,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -40512,16 +37380,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/domodatabase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 74,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/doris/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -40558,18 +37416,18 @@
         ],
         "./src/metadata/ingestion/source/database/doris/metadata.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 37,
+                    "startColumn": 5,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -40642,30 +37500,6 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -40750,19 +37584,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 72,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 25,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             }
         ],
@@ -40968,14 +37802,6 @@
                     "endColumn": 28,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/dynamodb/metadata.py": [
@@ -41046,65 +37872,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/exasol/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/exasol/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -41182,16 +37958,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/exasol/sqla_utils.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/external_table_lineage_mixin.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -41250,30 +38016,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportUnreachable",
                 "range": {
                     "startColumn": 12,
@@ -41306,44 +38048,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/glue/connection.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 40,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             }
@@ -41470,11 +38186,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -41558,14 +38274,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -41587,6 +38295,14 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -41726,14 +38442,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 29,
@@ -41755,6 +38463,14 @@
                     "startColumn": 56,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -41930,16 +38646,6 @@
                 "range": {
                     "startColumn": 46,
                     "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/glue/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             }
@@ -42482,66 +39188,18 @@
         ],
         "./src/metadata/ingestion/source/database/hive/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
+                    "startColumn": 7,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
+                "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -42558,6 +39216,14 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -42579,6 +39245,54 @@
             }
         ],
         "./src/metadata/ingestion/source/database/hive/custom_hive_connection.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -42732,18 +39446,18 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 59,
+                    "startColumn": 23,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 54,
-                    "endColumn": 58,
+                    "startColumn": 23,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             }
@@ -42784,10 +39498,10 @@
         ],
         "./src/metadata/ingestion/source/database/hive/metadata.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 49,
+                    "startColumn": 5,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -42828,14 +39542,6 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -43386,6 +40092,14 @@
         ],
         "./src/metadata/ingestion/source/database/hive/utils.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
@@ -43674,56 +40388,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/impala/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/impala/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -43759,6 +40423,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/impala/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -44006,22 +40678,6 @@
                     "endColumn": 92,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/impala/service_spec.py": [
@@ -44190,38 +40846,6 @@
         ],
         "./src/metadata/ingestion/source/database/life_cycle_query_mixin.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 76,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 99,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -44310,30 +40934,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -44384,38 +40984,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -44440,14 +41008,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 12
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 59,
@@ -44456,11 +41016,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 20,
+                    "endColumn": 32,
+                    "lineCount": 1
                 }
             },
             {
@@ -44512,14 +41072,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -44528,18 +41080,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 40,
+                    "startColumn": 40,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -44650,11 +41194,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -44666,11 +41210,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -44850,10 +41394,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
@@ -44871,30 +41423,6 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 12
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 94,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -45094,11 +41622,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -45168,355 +41696,25 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/lineage.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/metadata.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/query_parser.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/mongodb/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 12,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/mongodb/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -45854,11 +42052,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 28,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -46146,6 +42352,30 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 24,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -46204,22 +42434,6 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -46587,151 +42801,7 @@
                 "code": "reportMissingImports",
                 "range": {
                     "startColumn": 17,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -46744,10 +42814,26 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 70,
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             }
@@ -46786,19 +42872,11 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 82,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 16
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -47158,6 +43236,22 @@
         ],
         "./src/metadata/ingestion/source/database/oracle/connection.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 28,
@@ -47170,22 +43264,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -47418,11 +43496,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -47718,6 +43796,86 @@
                 "range": {
                     "startColumn": 47,
                     "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 62,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -48250,16 +44408,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/pinotdb/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/pinotdb/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -48295,6 +44443,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/pinotdb/metadata.py": [
+            {
+                "code": "reportAttributeAccessIssue",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -48438,11 +44594,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 11
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             }
         ],
@@ -48696,11 +44852,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 16
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -48878,14 +45034,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 16,
@@ -48922,30 +45070,6 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 91,
                     "lineCount": 1
                 }
             }
@@ -49150,18 +45274,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 11
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -49656,41 +45780,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/presto/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/presto/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 29,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -49776,14 +45874,6 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -50038,26 +46128,34 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 35,
+                    "startColumn": 32,
                     "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 26,
+                    "startColumn": 42,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 35,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             }
@@ -50072,11 +46170,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -50090,18 +46188,18 @@
         ],
         "./src/metadata/ingestion/source/database/redshift/metadata.py": [
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 26,
+                    "startColumn": 5,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 38,
+                    "startColumn": 10,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
@@ -50298,22 +46396,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
@@ -50322,19 +46404,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -50346,11 +46428,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 14
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -50512,38 +46594,6 @@
                     "endColumn": 24,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/redshift/query_parser.py": [
@@ -50681,6 +46731,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/redshift/utils.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -50822,14 +46880,6 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 6,
-                    "endColumn": 22,
                     "lineCount": 1
                 }
             },
@@ -51308,34 +47358,10 @@
         ],
         "./src/metadata/ingestion/source/database/salesforce/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             }
@@ -51414,11 +47440,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -51435,14 +47461,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -51558,11 +47576,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -51598,6 +47616,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -51614,11 +47640,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 29,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -51654,22 +47680,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/salesforce/service_spec.py": [
+        "./src/metadata/ingestion/source/database/sample_data.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sample_data.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 63,
+                    "startColumn": 23,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -51678,38 +47694,6 @@
                 "range": {
                     "startColumn": 27,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -52172,14 +48156,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 21,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 46,
                     "lineCount": 1
@@ -52220,14 +48196,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 46,
                     "lineCount": 1
@@ -52242,11 +48210,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 14
+                    "startColumn": 24,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52314,11 +48282,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 24,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52362,19 +48330,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
+                    "startColumn": 20,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52399,14 +48359,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52442,14 +48394,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52466,11 +48410,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
+                    "startColumn": 20,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -52495,14 +48439,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52538,14 +48474,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52559,14 +48487,6 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 17,
-                    "lineCount": 11
                 }
             },
             {
@@ -52586,11 +48506,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 20,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -52615,14 +48535,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             },
             {
@@ -52655,14 +48567,6 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 9
                 }
             },
             {
@@ -52698,14 +48602,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52719,14 +48615,6 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52754,14 +48642,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 37,
@@ -52783,14 +48663,6 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 12
                 }
             },
             {
@@ -52946,14 +48818,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 86,
@@ -52975,14 +48839,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             },
             {
@@ -53010,14 +48866,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -53042,26 +48890,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -53074,22 +48906,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -53098,19 +48914,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 97,
+                    "startColumn": 24,
+                    "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 11
                 }
             },
             {
@@ -53146,19 +48954,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 102,
+                    "startColumn": 24,
+                    "endColumn": 62,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -53170,11 +48970,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53186,11 +48986,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53202,11 +49002,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53226,34 +49026,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 62,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -53271,22 +49047,6 @@
                     "startColumn": 14,
                     "endColumn": 9,
                     "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 101,
-                    "lineCount": 1
                 }
             },
             {
@@ -53298,14 +49058,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 63,
@@ -53322,18 +49074,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 100,
+                    "startColumn": 65,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -53346,27 +49090,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 91,
+                    "startColumn": 28,
+                    "endColumn": 69,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -53386,11 +49114,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 28,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -53402,11 +49130,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -53418,11 +49146,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -53431,14 +49159,6 @@
                     "startColumn": 18,
                     "endColumn": 43,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             },
             {
@@ -53468,56 +49188,16 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 23
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 82,
+                    "startColumn": 28,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
@@ -53530,11 +49210,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 14
+                    "startColumn": 28,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -53570,18 +49250,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 81,
+                    "startColumn": 28,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -53618,35 +49290,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 89,
+                    "startColumn": 33,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 75,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 70,
+                    "lineCount": 1
                 }
             },
             {
@@ -53655,14 +49327,6 @@
                     "startColumn": 38,
                     "endColumn": 47,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 5
                 }
             },
             {
@@ -53684,14 +49348,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 29,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 53,
                     "lineCount": 1
@@ -53703,14 +49359,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             },
             {
@@ -53730,11 +49378,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 54,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -53754,11 +49402,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 6
+                    "startColumn": 39,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -53778,11 +49426,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 6
+                    "startColumn": 39,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -53799,14 +49447,6 @@
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 10
                 }
             },
             {
@@ -53831,38 +49471,6 @@
                     "startColumn": 20,
                     "endColumn": 24,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 11
                 }
             },
             {
@@ -53930,11 +49538,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 29,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -53954,11 +49562,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
@@ -54066,43 +49674,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 70,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 33,
-                    "lineCount": 6
                 }
             },
             {
@@ -54130,10 +49706,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 95,
+                    "startColumn": 65,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 82,
+                    "endColumn": 94,
                     "lineCount": 1
                 }
             },
@@ -54186,10 +49770,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 110,
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 97,
+                    "endColumn": 109,
                     "lineCount": 1
                 }
             },
@@ -54242,18 +49834,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 16
+                    "startColumn": 29,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 57,
-                    "endColumn": 98,
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 95,
                     "lineCount": 1
                 }
             },
@@ -54316,11 +49916,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 32,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             }
         ],
@@ -54394,16 +50002,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saperp/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -54522,14 +50120,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -54546,11 +50136,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -54567,14 +50157,6 @@
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 16
                 }
             },
             {
@@ -54598,6 +50180,14 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -54638,16 +50228,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 114,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saperp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 68,
                     "lineCount": 1
                 }
             }
@@ -54707,30 +50287,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 18
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 4
                 }
             },
             {
@@ -55078,56 +50634,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/saphana/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/saphana/lineage.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -55284,11 +50790,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 36,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -55339,24 +50853,6 @@
                     "startColumn": 15,
                     "endColumn": 9,
                     "lineCount": 8
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saphana/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 92,
-                    "endColumn": 112,
-                    "lineCount": 1
                 }
             }
         ],
@@ -55778,16 +51274,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/sas/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/sas/metadata.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -55974,14 +51460,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 17,
@@ -56010,6 +51488,14 @@
                 "range": {
                     "startColumn": 24,
                     "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -56022,18 +51508,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 119,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -56058,14 +51552,6 @@
                 "range": {
                     "startColumn": 30,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 110,
                     "lineCount": 1
                 }
             },
@@ -56342,11 +51828,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -56354,6 +51848,14 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -56379,22 +51881,6 @@
                     "startColumn": 76,
                     "endColumn": 79,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 21,
-                    "lineCount": 7
                 }
             },
             {
@@ -56520,22 +52006,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 57,
                     "lineCount": 1
@@ -56638,30 +52108,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -56670,11 +52116,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -56726,11 +52180,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -56763,14 +52217,6 @@
                     "startColumn": 24,
                     "endColumn": 38,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
                 }
             },
             {
@@ -56814,11 +52260,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 9
+                    "startColumn": 17,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -56882,16 +52336,6 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 109,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sas/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -56998,46 +52442,6 @@
                     "endColumn": 40,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py": [
@@ -57132,15 +52536,87 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/database/snowflake/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -57153,70 +52629,6 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 42,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
                     "endColumn": 58,
                     "lineCount": 1
                 }
@@ -57258,6 +52670,14 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -57394,30 +52814,6 @@
                 "range": {
                     "startColumn": 66,
                     "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -57582,11 +52978,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 25
+                    "startColumn": 28,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 112,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -57976,26 +53388,18 @@
         ],
         "./src/metadata/ingestion/source/database/snowflake/utils.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 29,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -58370,6 +53774,30 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 23,
                     "endColumn": 27,
                     "lineCount": 1
@@ -58594,6 +54022,38 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 35,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -58746,22 +54206,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 20,
@@ -58770,11 +54214,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
@@ -58936,16 +54380,6 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 24,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sqlite/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
                     "lineCount": 1
                 }
             }
@@ -59190,27 +54624,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 25,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -59490,14 +54916,6 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 84,
                     "endColumn": 96,
                     "lineCount": 1
@@ -59568,16 +54986,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/teradata/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/teradata/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -59614,26 +55022,18 @@
         ],
         "./src/metadata/ingestion/source/database/teradata/metadata.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportFunctionMemberAccess",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -59670,11 +55070,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -59832,16 +55232,6 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/timescale/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -60700,26 +56090,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 99,
-                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -60782,11 +56156,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 67,
+                    "lineCount": 1
                 }
             },
             {
@@ -61400,62 +56774,28 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/unitycatalog/client.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 82,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/unitycatalog/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
+                    "startColumn": 5,
+                    "endColumn": 19,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalSubscript",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
+                    "startColumn": 5,
+                    "endColumn": 26,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             }
@@ -61542,19 +56882,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 92,
+                    "endColumn": 101,
+                    "lineCount": 1
                 }
             },
             {
@@ -61566,17 +56906,17 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 101,
+                    "startColumn": 66,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
+                    "startColumn": 90,
                     "endColumn": 100,
                     "lineCount": 1
                 }
@@ -61587,22 +56927,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
                 }
             },
             {
@@ -61619,22 +56943,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 87,
-                    "lineCount": 1
                 }
             },
             {
@@ -61680,6 +56988,22 @@
         ],
         "./src/metadata/ingestion/source/database/unitycatalog/metadata.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 6,
@@ -61708,14 +57032,6 @@
                 "range": {
                     "startColumn": 88,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -61800,11 +57116,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -61877,14 +57193,6 @@
                     "startColumn": 39,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 14
                 }
             },
             {
@@ -61976,11 +57284,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 33,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -62021,14 +57329,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -62112,14 +57412,6 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 16,
@@ -62172,14 +57464,6 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -62252,206 +57536,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             }
@@ -62640,18 +57724,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 14
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -62747,6 +57847,14 @@
             }
         ],
         "./src/metadata/ingestion/source/database/vertica/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -62936,30 +58044,6 @@
                 "range": {
                     "startColumn": 6,
                     "endColumn": 8,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
@@ -63486,64 +58570,8 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 41,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 106,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -63694,11 +58722,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 105,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
@@ -63782,11 +58842,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 33,
-                    "lineCount": 10
+                    "startColumn": 41,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -63806,11 +58890,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 61,
+                    "lineCount": 1
                 }
             },
             {
@@ -63846,11 +58962,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 21,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -63858,6 +58982,38 @@
                 "range": {
                     "startColumn": 43,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -63918,11 +59074,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 25,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -63931,6 +59087,22 @@
                     "startColumn": 47,
                     "endColumn": 60,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
@@ -63978,10 +59150,18 @@
         ],
         "./src/metadata/ingestion/source/drive/sftp/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingModuleSource",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
+                    "startColumn": 7,
+                    "endColumn": 15,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 13,
                     "lineCount": 1
                 }
             },
@@ -63990,14 +59170,6 @@
                 "range": {
                     "startColumn": 17,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -64140,11 +59312,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
@@ -64212,11 +59400,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 33,
-                    "lineCount": 10
+                    "startColumn": 41,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -64236,11 +59432,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 57,
+                    "lineCount": 1
                 }
             },
             {
@@ -64308,11 +59520,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -64320,16 +59532,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/drive/sftp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -64366,16 +59568,6 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mcp/mcp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -64478,81 +59670,71 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 17,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mcp/service_spec.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/messaging/common_broker_source.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 7,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -64566,14 +59748,6 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
@@ -64602,26 +59776,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -64706,14 +59864,6 @@
                 }
             },
             {
-                "code": "reportUnusedExcept",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -64731,6 +59881,30 @@
             }
         ],
         "./src/metadata/ingestion/source/messaging/kafka/connection.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -64751,7 +59925,7 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 61,
-                    "endColumn": 76,
+                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -64830,34 +60004,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/messaging/kafka/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/kinesis/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/messaging/kinesis/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -64913,14 +60059,6 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -65044,16 +60182,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/messaging/kinesis/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/messaging/messaging_service.py": [
             {
                 "code": "reportCallIssue",
@@ -65162,15 +60290,39 @@
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingModuleSource",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 25,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/messaging/pubsub/metadata.py": [
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -65217,14 +60369,6 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -65314,40 +60458,6 @@
                     "endColumn": 17,
                     "lineCount": 21
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/pubsub/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/messaging/redpanda/metadata.py": [
@@ -65380,16 +60490,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 94,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/redpanda/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -65580,16 +60680,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/metadata/alationsink/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/metadata/alationsink/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -65746,56 +60836,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/metadata/alationsink/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/metadata/amundsen/client.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/amundsen/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 69,
+                    "startColumn": 7,
+                    "endColumn": 12,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 10,
                     "lineCount": 1
                 }
             }
@@ -65898,19 +60952,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 25,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -65970,14 +61016,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 64,
@@ -66034,11 +61072,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 21,
+                    "endColumn": 113,
+                    "lineCount": 1
                 }
             },
             {
@@ -66046,6 +61084,14 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -66079,14 +61125,6 @@
                     "startColumn": 44,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -66202,11 +61240,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 13
+                    "startColumn": 26,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -66258,11 +61296,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -66290,11 +61328,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 26,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -66314,11 +61360,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 21,
+                    "endColumn": 33,
+                    "lineCount": 1
                 }
             },
             {
@@ -66342,16 +61388,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 19,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/amundsen/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -66474,16 +61510,6 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 48,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/atlas/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -66754,11 +61780,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 29,
+                    "endColumn": 89,
+                    "lineCount": 1
                 }
             },
             {
@@ -67010,14 +62036,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalSubscript",
                 "range": {
                     "startColumn": 21,
@@ -67031,14 +62049,6 @@
                     "startColumn": 28,
                     "endColumn": 59,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -67084,14 +62094,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 39,
                     "lineCount": 1
@@ -67106,10 +62108,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 70,
+                    "startColumn": 42,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -67122,35 +62124,41 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/atlas/service_spec.py": [
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
+                    "startColumn": 42,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/mlmodel/mlflow/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 5,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/ingestion/source/mlmodel/mlflow/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -67186,80 +62194,8 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 93,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 115,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 121,
-                    "endColumn": 136,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 76,
+                    "startColumn": 40,
+                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -67280,44 +62216,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mlmodel/mlflow/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -67524,24 +62426,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/mlmodel/sagemaker/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/mlmodel/sagemaker/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -67576,14 +62460,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -67604,14 +62480,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
                     "lineCount": 7
                 }
             },
@@ -67644,16 +62512,6 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mlmodel/sagemaker/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -67844,16 +62702,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/airbyte/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/airbyte/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -67904,22 +62752,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -67936,19 +62768,51 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 104,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 100,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 87,
+                    "lineCount": 1
                 }
             },
             {
@@ -67984,19 +62848,51 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 36,
+                    "endColumn": 96,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 71,
+                    "lineCount": 1
                 }
             },
             {
@@ -68056,22 +62952,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -68088,22 +62968,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -68116,16 +62980,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/airbyte/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -68187,78 +63041,6 @@
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
                     "endColumn": 44,
                     "lineCount": 1
                 }
@@ -68392,6 +63174,64 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/airflow/api/diagnostics.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py": [
             {
                 "code": "reportArgumentType",
@@ -68444,19 +63284,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 19
+                    "startColumn": 26,
+                    "endColumn": 108,
+                    "lineCount": 1
                 }
             },
             {
@@ -68516,11 +63348,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 40,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -68532,11 +63380,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 91,
+                    "lineCount": 1
                 }
             },
             {
@@ -68634,46 +63482,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -68794,46 +63602,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 53,
@@ -68850,70 +63618,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -68922,59 +63626,35 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 68,
-                    "endColumn": 97,
+                    "startColumn": 44,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
+                    "startColumn": 38,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 67,
+                    "startColumn": 36,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 62,
+                    "startColumn": 40,
+                    "endColumn": 95,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 6
                 }
             },
             {
@@ -69026,27 +63706,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
                 }
             },
             {
@@ -69090,14 +63754,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 17
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -69106,11 +63762,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 19
+                    "startColumn": 26,
+                    "endColumn": 108,
+                    "lineCount": 1
                 }
             },
             {
@@ -69234,22 +63890,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 27,
@@ -69284,22 +63924,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 55,
                     "lineCount": 1
@@ -69314,35 +63938,11 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
+                    "startColumn": 19,
+                    "endColumn": 107,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 9
                 }
             },
             {
@@ -69364,40 +63964,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 72,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 31,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -69412,16 +63980,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 84,
+                    "startColumn": 26,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -69490,17 +64050,23 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/airflow/service_spec.py": [
+        "./src/metadata/ingestion/source/pipeline/dagster/client.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
+                    "startColumn": 5,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dagster/client.py": [
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 27,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -69514,16 +64080,6 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dagster/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -69586,22 +64142,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 14
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -69658,11 +64198,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
                 }
             },
             {
@@ -69674,11 +64214,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 26,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
                 }
             },
             {
@@ -69686,6 +64242,14 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -69828,33 +64392,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -69863,14 +64403,6 @@
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -69926,34 +64458,6 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 84,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dagster/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -70050,14 +64554,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -70098,11 +64594,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
                 }
             },
             {
@@ -70111,14 +64607,6 @@
                     "startColumn": 8,
                     "endColumn": 29,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
                 }
             },
             {
@@ -70154,11 +64642,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 8
+                    "startColumn": 32,
+                    "endColumn": 48,
+                    "lineCount": 1
                 }
             },
             {
@@ -70234,11 +64722,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -70298,35 +64794,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 61,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 67,
-                    "endColumn": 57,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 57,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 71,
-                    "endColumn": 57,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 61,
-                    "lineCount": 4
+                    "endColumn": 90,
+                    "lineCount": 1
                 }
             },
             {
@@ -70354,35 +64834,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 69,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 75,
-                    "endColumn": 65,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 65,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 79,
-                    "endColumn": 65,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 77,
-                    "endColumn": 69,
-                    "lineCount": 4
+                    "endColumn": 98,
+                    "lineCount": 1
                 }
             },
             {
@@ -70410,35 +64874,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 57,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 57,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 63,
-                    "endColumn": 53,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 53,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 53,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 57,
-                    "lineCount": 4
+                    "endColumn": 86,
+                    "lineCount": 1
                 }
             },
             {
@@ -70490,22 +64946,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
@@ -70524,35 +64964,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/databrickspipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 69,
-                    "lineCount": 1
                 }
             }
         ],
@@ -70610,14 +65024,6 @@
                 "range": {
                     "startColumn": 44,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -70682,16 +65088,6 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dbtcloud/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -70762,14 +65158,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 35,
@@ -70791,14 +65179,6 @@
                     "startColumn": 35,
                     "endColumn": 47,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -70964,41 +65344,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
                 }
             },
             {
@@ -71050,19 +65398,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 19,
+                    "endColumn": 105,
+                    "lineCount": 1
                 }
             },
             {
@@ -71070,6 +65410,14 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -71140,38 +65488,6 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 23,
                     "endColumn": 35,
                     "lineCount": 1
@@ -71186,19 +65502,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -71223,42 +65531,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dbtcloud/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/domopipeline/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
                 }
             }
         ],
@@ -71336,22 +65608,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -71416,19 +65672,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 38,
+                    "lineCount": 1
                 }
             },
             {
@@ -71488,32 +65752,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/domopipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/fivetran/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/fivetran/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -71541,54 +65785,6 @@
                     "startColumn": 44,
                     "endColumn": 54,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             }
         ],
@@ -71666,14 +65862,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 44,
@@ -71687,14 +65875,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 5
                 }
             },
             {
@@ -71727,14 +65907,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 5
                 }
             },
             {
@@ -71826,10 +65998,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 85,
+                    "startColumn": 58,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 78,
+                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -71838,16 +66018,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/fivetran/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -71902,16 +66072,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/flink/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/flink/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -71943,22 +66103,6 @@
                     "startColumn": 12,
                     "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -72010,19 +66154,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 40,
+                    "endColumn": 72,
+                    "lineCount": 1
                 }
             },
             {
@@ -72074,34 +66210,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/flink/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/gluepipeline/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/gluepipeline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -72144,14 +66252,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -72165,14 +66265,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             },
             {
@@ -72208,27 +66300,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 29,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 83,
                     "endColumn": 87,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 21,
-                    "lineCount": 6
                 }
             },
             {
@@ -72272,19 +66348,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 44,
+                    "endColumn": 116,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 40,
+                    "endColumn": 112,
+                    "lineCount": 1
                 }
             },
             {
@@ -72340,22 +66416,6 @@
                 "range": {
                     "startColumn": 77,
                     "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -72416,17 +66476,15 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/gluepipeline/service_spec.py": [
+        "./src/metadata/ingestion/source/pipeline/kafkaconnect/client.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
+                    "startColumn": 5,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/client.py": [
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -72448,14 +66506,6 @@
                 "range": {
                     "startColumn": 94,
                     "endColumn": 110,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 76,
                     "lineCount": 1
                 }
             },
@@ -72492,14 +66542,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 22,
@@ -72520,16 +66562,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -72960,22 +66992,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 12
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 3
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 43,
@@ -73272,6 +67288,118 @@
                 }
             },
             {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 86,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 78,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -73296,43 +67424,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 74,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -73360,43 +67456,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -73434,14 +67498,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 82,
                     "lineCount": 1
@@ -73453,14 +67509,6 @@
                     "startColumn": 51,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -73534,246 +67582,6 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 10,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/metadata.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 81,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 94,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 33,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 74,
                     "lineCount": 1
                 }
             }
@@ -73852,16 +67660,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/nifi/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/nifi/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -73893,22 +67691,6 @@
                     "startColumn": 12,
                     "endColumn": 90,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
                 }
             },
             {
@@ -73946,14 +67728,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 87,
                     "lineCount": 1
@@ -73968,11 +67742,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 30,
+                    "endColumn": 21,
+                    "lineCount": 3
                 }
             },
             {
@@ -74080,30 +67854,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 42,
@@ -74128,30 +67878,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 15,
@@ -74160,17 +67886,23 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/nifi/service_spec.py": [
+        "./src/metadata/ingestion/source/pipeline/openlineage/connection.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
+                    "startColumn": 5,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/connection.py": [
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
@@ -74258,30 +67990,6 @@
                     "endColumn": 67,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/pipeline/openlineage/metadata.py": [
@@ -74366,74 +68074,18 @@
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 68,
+                    "startColumn": 73,
+                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 114,
+                    "startColumn": 100,
+                    "endColumn": 113,
                     "lineCount": 1
                 }
             },
@@ -74446,14 +68098,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 38,
@@ -74462,11 +68106,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
@@ -74510,42 +68170,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 93,
+                    "startColumn": 47,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 76,
+                    "startColumn": 47,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 76,
+                    "startColumn": 47,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 104,
+                    "startColumn": 47,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -74554,14 +68206,6 @@
                 "range": {
                     "startColumn": 99,
                     "endColumn": 103,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -74606,42 +68250,10 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -74654,35 +68266,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 105,
+                    "startColumn": 54,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 99,
+                    "startColumn": 52,
+                    "endColumn": 69,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -74734,14 +68330,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportPossiblyUnboundVariable",
                 "range": {
                     "startColumn": 12,
@@ -74782,14 +68370,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 31,
@@ -74814,22 +68394,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/service_resolver.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/service_spec.py": [
+        "./src/metadata/ingestion/source/pipeline/openlineage/ownership_resolver.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 62,
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             }
@@ -75132,6 +68710,56 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/prefect/metadata.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/spline/client.py": [
             {
                 "code": "reportOperatorIssue",
@@ -75222,16 +68850,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/spline/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/spline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -75266,19 +68884,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 21,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 26,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -75378,22 +69012,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 33,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -75402,26 +69020,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 41,
-                    "lineCount": 6
+                    "startColumn": 56,
+                    "endColumn": 45,
+                    "lineCount": 3
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 86,
+                    "startColumn": 53,
+                    "endColumn": 92,
                     "lineCount": 1
                 }
             },
@@ -75438,16 +69048,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/spline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -75776,18 +69376,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 23,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             }
@@ -75866,18 +69458,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -75986,18 +69578,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -76034,27 +69626,17 @@
                     "endColumn": 18,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/search/elasticsearch/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/connection.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -76310,33 +69892,17 @@
                     "endColumn": 56,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/metadata.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportArgumentType",
                 "range": {
@@ -76394,14 +69960,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -76410,18 +69968,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -76454,30 +70012,6 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
@@ -76546,18 +70080,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -76592,24 +70126,6 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/search/opensearch/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 61,
                     "lineCount": 1
                 }
             }
@@ -76818,14 +70334,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 14,
@@ -76894,18 +70402,18 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/client.py": [
             {
-                "code": "reportMissingParameterType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 23,
+                    "startColumn": 5,
+                    "endColumn": 31,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 53,
-                    "endColumn": 60,
+                    "startColumn": 10,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -76960,6 +70468,14 @@
         ],
         "./src/metadata/ingestion/source/storage/gcs/connection.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -76974,62 +70490,14 @@
                     "endColumn": 25,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/storage/gcs/metadata.py": [
             {
-                "code": "reportCallIssue",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 60,
+                    "startColumn": 5,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
@@ -77098,19 +70566,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 12
+                    "startColumn": 23,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -77194,10 +70654,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 76,
+                    "startColumn": 48,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -77214,14 +70674,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -77266,10 +70718,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -77294,24 +70746,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/storage/gcs/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 80,
                     "lineCount": 1
                 }
             }
@@ -77364,49 +70798,9 @@
                     "endColumn": 76,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/storage/s3/metadata.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -77472,11 +70866,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 17,
-                    "lineCount": 3
+                    "startColumn": 23,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -77493,22 +70887,6 @@
                     "startColumn": 55,
                     "endColumn": 59,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 13
                 }
             },
             {
@@ -77568,10 +70946,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 76,
+                    "startColumn": 48,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -77616,14 +70994,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 61,
@@ -77664,10 +71034,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -77685,14 +71055,6 @@
                     "startColumn": 24,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -77716,24 +71078,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/storage/s3/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             }
@@ -77812,14 +71156,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 111,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -77868,11 +71204,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 28,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -77881,22 +71217,6 @@
                     "startColumn": 15,
                     "endColumn": 54,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 10
                 }
             }
         ],
@@ -77918,19 +71238,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
                 }
             },
             {
@@ -77942,11 +71262,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 25,
+                    "endColumn": 41,
+                    "lineCount": 1
                 }
             },
             {
@@ -78758,11 +72078,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 19,
+                    "endColumn": 26,
+                    "lineCount": 1
                 }
             }
         ],
@@ -78958,19 +72278,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 82,
+                    "startColumn": 19,
+                    "endColumn": 52,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 9,
-                    "lineCount": 8
                 }
             },
             {
@@ -79086,10 +72398,26 @@
         ],
         "./src/metadata/profiler/adaptors/mongodb.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 51,
+                    "startColumn": 9,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -79276,6 +72604,16 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 12,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/profiler/api/models.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -79908,6 +73246,14 @@
         ],
         "./src/metadata/profiler/interface/sqlalchemy/athena/profiler_interface.py": [
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 5,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 38,
@@ -80224,6 +73570,14 @@
                 }
             },
             {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 48,
@@ -80302,6 +73656,24 @@
                 "range": {
                     "startColumn": 77,
                     "endColumn": 84,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/profiler/interface/sqlalchemy/exasol/profiler_interface.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 13,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 16,
                     "lineCount": 1
                 }
             }
@@ -80658,14 +74030,6 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -84110,38 +77474,6 @@
                     "endColumn": 70,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 102,
-                    "endColumn": 104,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 86,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/profiler/orm/converter/bigquery/converter.py": [
@@ -84212,6 +77544,22 @@
                     "endColumn": 64,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/profiler/orm/converter/snowflake/converter.py": [
@@ -84232,10 +77580,18 @@
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 19,
+                    "startColumn": 17,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             }
@@ -87970,14 +81326,6 @@
         ],
         "./src/metadata/profiler/source/database/base/profiler_source.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 85,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -88068,6 +81416,14 @@
                 "range": {
                     "startColumn": 39,
                     "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingModuleSource",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             }
@@ -88280,6 +81636,14 @@
                     "endColumn": 67,
                     "lineCount": 1
                 }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/metadata/profiler/source/database/pinotdb/profiler_source.py": [
@@ -88456,31 +81820,7 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 95,
-                    "endColumn": 99,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 89,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
                     "endColumn": 97,
                     "lineCount": 1
                 }
@@ -88636,14 +81976,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -88766,6 +82098,120 @@
                 }
             }
         ],
+        "./src/metadata/readers/archive.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/readers/dataframe/avro.py": [
             {
                 "code": "reportMissingParameterType",
@@ -88784,10 +82230,26 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 26,
                     "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -88824,6 +82286,14 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 15,
@@ -88832,18 +82302,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 13,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 70,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -88876,86 +82346,6 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -89184,6 +82574,14 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportUndefinedVariable",
                 "range": {
                     "startColumn": 26,
@@ -89232,18 +82630,26 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 70,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -89276,86 +82682,6 @@
                 "range": {
                     "startColumn": 59,
                     "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -89378,6 +82704,14 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -89394,6 +82728,22 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 20,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
@@ -89402,18 +82752,26 @@
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingImports",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 73,
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 70,
+                    "startColumn": 55,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -89450,90 +82808,18 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 19,
                     "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -89555,6 +82841,22 @@
             }
         ],
         "./src/metadata/readers/dataframe/parquet.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 17,
+                    "lineCount": 1
+                }
+            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -89876,6 +83178,14 @@
                 }
             },
             {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 55,
@@ -89916,14 +83226,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -89952,86 +83254,6 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 33,
                     "lineCount": 1
                 }
             },
@@ -90626,6 +83848,50 @@
                 }
             }
         ],
+        "./src/metadata/sampler/messaging/kafka/sampler.py": [
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingImports",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/sampler/messaging/sampler.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/sampler/models.py": [
             {
                 "code": "reportArgumentType",
@@ -90670,26 +83936,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 96,
                     "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 109,
-                    "endColumn": 116,
                     "lineCount": 1
                 }
             },
@@ -90722,14 +83972,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -90788,14 +84030,6 @@
                     "endColumn": 19,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 91,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/sampler/pandas/burstiq/sampler.py": [
@@ -90840,18 +84074,18 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 46,
+                    "startColumn": 26,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 38,
+                    "startColumn": 20,
+                    "endColumn": 25,
                     "lineCount": 1
                 }
             }
@@ -90990,14 +84224,6 @@
         ],
         "./src/metadata/sampler/processor.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 100,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -91040,38 +84266,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -91098,14 +84292,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 80,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 31,
                     "endColumn": 42,
                     "lineCount": 1
@@ -91118,14 +84304,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -91164,58 +84342,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/bigquery/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 89,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91224,14 +84362,6 @@
                 "range": {
                     "startColumn": 85,
                     "endColumn": 110,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 97,
-                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -91310,14 +84440,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -91342,30 +84464,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -91380,14 +84478,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -91426,18 +84516,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/postgres/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91718,18 +84808,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/snowflake/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91962,6 +85052,16 @@
                 }
             }
         ],
+        "./src/metadata/sampler/sqlalchemy/tsql.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py": [
             {
                 "code": "reportMissingParameterType",
@@ -92030,14 +85130,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
@@ -92060,14 +85152,6 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -92098,46 +85182,6 @@
                 }
             },
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -92154,34 +85198,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -92214,6 +85234,64 @@
                 "range": {
                     "startColumn": 93,
                     "endColumn": 97,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/sdk/data_quality/dataframes/models.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             }
@@ -92716,11 +85794,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 25,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "endColumn": 58,
+                    "lineCount": 1
                 }
             },
             {
@@ -92810,6 +85888,16 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/utils/entity_reference.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -93998,11 +87086,11 @@
         ],
         "./src/metadata/utils/path_pattern.py": [
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
                 }
             }
         ],
@@ -94054,14 +87142,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
@@ -94072,14 +87152,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -94138,11 +87210,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 11,
-                    "endColumn": 5,
-                    "lineCount": 6
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
                 }
             },
             {
@@ -94150,14 +87222,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -94188,18 +87252,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportUndefinedVariable",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
+                    "startColumn": 21,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -94212,42 +87276,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUndefinedVariable",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -95526,14 +88558,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 32,
                     "endColumn": 36,
                     "lineCount": 1
@@ -95552,14 +88576,6 @@
                 "range": {
                     "startColumn": 32,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -95604,42 +88620,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -95673,14 +88657,6 @@
                     "startColumn": 8,
                     "endColumn": 9,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 48,
-                    "lineCount": 1
                 }
             },
             {
@@ -95748,50 +88724,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -95812,22 +88748,6 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -95836,66 +88756,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -96198,16 +89062,8 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
+                    "startColumn": 24,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -96215,15 +89071,23 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 40,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 103,
+                    "startColumn": 39,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             }
@@ -96246,19 +89110,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 32,
+                    "endColumn": 106,
+                    "lineCount": 1
                 }
             },
             {
@@ -96286,18 +89142,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
+                    "startColumn": 26,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             }
@@ -96794,19 +89666,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -96830,14 +89694,6 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -96888,30 +89744,6 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -97332,14 +90164,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 17,
@@ -97389,14 +90213,6 @@
             }
         ],
         "./src/metadata/workflow/usage.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAssignmentType",
                 "range": {
@@ -97517,14 +90333,6 @@
                     "startColumn": 32,
                     "endColumn": 46,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             }
         ]

--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -1292,14 +1292,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 5,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 60,
                     "endColumn": 75,
                     "lineCount": 1
@@ -1572,50 +1564,18 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 24,
+                    "startColumn": 64,
+                    "endColumn": 73,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 9,
-                    "lineCount": 7
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 73,
+                    "startColumn": 22,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             }
@@ -1778,11 +1738,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 9,
-                    "lineCount": 16
+                    "startColumn": 25,
+                    "endColumn": 56,
+                    "lineCount": 1
                 }
             },
             {
@@ -1792,6 +1752,14 @@
                     "endColumn": 17,
                     "lineCount": 5
                 }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
             }
         ],
         "./src/airflow_provider_openmetadata/lineage/operator.py": [
@@ -1800,14 +1768,6 @@
                 "range": {
                     "startColumn": 5,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -1878,11 +1838,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
+                    "startColumn": 26,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -1902,11 +1862,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 10
+                    "startColumn": 22,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -1914,6 +1874,14 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -1934,19 +1902,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 60,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 38,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 46,
+                    "lineCount": 1
                 }
             },
             {
@@ -1974,19 +1966,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 32,
+                    "endColumn": 93,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 26,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 83,
+                    "lineCount": 1
                 }
             },
             {
@@ -1995,38 +2011,6 @@
                     "startColumn": 78,
                     "endColumn": 82,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 103,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -2102,18 +2086,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 106,
+                    "startColumn": 50,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -2123,14 +2099,6 @@
                     "startColumn": 55,
                     "endColumn": 57,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -2150,26 +2118,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 104,
+                    "startColumn": 48,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -2208,11 +2160,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 28,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -2226,25 +2178,33 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 37,
-                    "endColumn": 61,
+                    "startColumn": 22,
+                    "endColumn": 62,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 57,
+                    "startColumn": 20,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 5,
-                    "lineCount": 8
+                    "startColumn": 20,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 18,
+                    "endColumn": 32,
+                    "lineCount": 1
                 }
             },
             {
@@ -3714,138 +3674,6 @@
                 }
             }
         ],
-        "./src/metadata/clients/microsoftfabric/fabric_client.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/clients/microsoftfabric/models.py": [
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/data_quality/api/models.py": [
             {
                 "code": "reportAssignmentType",
@@ -3956,14 +3784,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 16,
                     "endColumn": 59,
                     "lineCount": 1
@@ -4010,14 +3830,6 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 100,
-                    "endColumn": 110,
                     "lineCount": 1
                 }
             }
@@ -4080,18 +3892,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportAssignmentType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 114,
+                    "startColumn": 36,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -4117,14 +3929,6 @@
                     "startColumn": 15,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             }
         ],
@@ -4206,22 +4010,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -4358,11 +4146,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 21,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -4378,6 +4166,22 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -4422,27 +4226,11 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -4491,14 +4279,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             },
             {
@@ -4752,22 +4532,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueLengthsToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4781,22 +4545,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4842,14 +4590,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMaxToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4863,14 +4603,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4884,14 +4616,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMeanToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4905,14 +4629,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4926,14 +4642,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMedianToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4947,14 +4655,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -4968,14 +4668,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueMinToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -4989,14 +4681,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5010,14 +4694,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValueStdDevToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5034,14 +4710,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -5051,14 +4719,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesMissingCount.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5076,14 +4736,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -5094,26 +4746,10 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesSumToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
@@ -5123,14 +4759,6 @@
                     "startColumn": 8,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5170,22 +4798,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeBetween.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5198,22 +4810,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -5268,14 +4864,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeInSet.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5316,14 +4904,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -5341,14 +4921,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotInSet.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5382,14 +4954,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 84,
@@ -5399,14 +4963,6 @@
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeNotNull.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5446,49 +5002,9 @@
                     "endColumn": 31,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
             }
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToBeUnique.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
@@ -5524,14 +5040,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5569,14 +5077,6 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -5590,14 +5090,6 @@
         ],
         "./src/metadata/data_quality/validations/column/base/columnValuesToNotMatchRegex.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportTypedDictNotRequiredAccess",
                 "range": {
                     "startColumn": 38,
@@ -5635,14 +5127,6 @@
                     "startColumn": 8,
                     "endColumn": 31,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -8256,40 +7740,8 @@
             {
                 "code": "reportAssignmentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 9,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
                     "startColumn": 24,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 115,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 96,
-                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -8390,72 +7842,22 @@
                 }
             }
         ],
-        "./src/metadata/data_quality/validations/table/base/tableColumnCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/data_quality/validations/table/base/tableColumnCountToEqual.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
         ],
         "./src/metadata/data_quality/validations/table/base/tableColumnNameToExist.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             }
@@ -8478,26 +7880,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 72,
                     "lineCount": 1
                 }
             }
@@ -8508,76 +7894,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowCountToEqual.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/data_quality/validations/table/base/tableRowInsertedCountToBeBetween.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -8842,22 +8158,6 @@
                     "endColumn": 69,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/data_quality/validations/table/sqlalchemy/tableDiff.py": [
@@ -9006,78 +8306,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
@@ -9170,30 +8398,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -9402,18 +8606,18 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 49,
+                    "startColumn": 64,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 64,
-                    "endColumn": 105,
+                    "startColumn": 17,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -9426,74 +8630,18 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 65,
+                    "startColumn": 33,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
+                    "startColumn": 65,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -9612,10 +8760,26 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 68,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 69,
                     "lineCount": 1
                 }
             },
@@ -9632,70 +8796,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -9798,32 +8898,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/api/delete.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 106,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            }
-        ],
         "./src/metadata/ingestion/api/parser.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -9865,14 +8939,6 @@
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 21,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
                     "endColumn": 68,
                     "lineCount": 1
                 }
@@ -9896,6 +8962,14 @@
                 }
             },
             {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 21,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 73,
@@ -9908,14 +8982,6 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -9948,14 +9014,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
@@ -10142,14 +9200,6 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -10444,38 +9494,6 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 22,
                     "lineCount": 1
@@ -10524,6 +9542,14 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 21,
                     "endColumn": 25,
                     "lineCount": 1
@@ -10548,22 +9574,6 @@
         ],
         "./src/metadata/ingestion/connections/test_connections.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -10572,27 +9582,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -11026,10 +10020,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 78,
+                    "startColumn": 36,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -11074,43 +10068,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 100,
+                    "startColumn": 65,
+                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 106,
+                    "startColumn": 89,
+                    "endColumn": 99,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 50,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -11335,30 +10313,6 @@
                     "startColumn": 32,
                     "endColumn": 42,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             }
         ],
@@ -11976,6 +10930,14 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 37,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 21,
                     "endColumn": 25,
                     "lineCount": 1
@@ -12382,14 +11344,6 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -13330,14 +12284,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 40,
                     "lineCount": 1
@@ -13402,38 +12348,6 @@
         ],
         "./src/metadata/ingestion/ometa/mixins/lineage_mixin.py": [
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 52,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 49,
@@ -13450,14 +12364,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 62,
@@ -13470,22 +12376,6 @@
                 "range": {
                     "startColumn": 53,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
@@ -13534,14 +12424,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -13678,11 +12560,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -13718,22 +12600,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 23,
@@ -13742,18 +12608,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 17,
+                    "endColumn": 21,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 24,
-                    "endColumn": 60,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
@@ -13763,14 +12637,6 @@
                     "startColumn": 82,
                     "endColumn": 99,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
                 }
             }
         ],
@@ -14016,14 +12882,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 25,
@@ -14036,22 +12894,6 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 74,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
                     "lineCount": 1
                 }
             },
@@ -14204,11 +13046,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 20,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -14220,11 +13062,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 14
+                    "startColumn": 20,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -14360,10 +13202,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 80,
+                    "startColumn": 51,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
@@ -14472,10 +13314,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
@@ -15300,14 +14142,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 37,
                     "endColumn": 41,
                     "lineCount": 1
@@ -15448,11 +14282,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 21,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -15472,11 +14314,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -15492,6 +14358,38 @@
                 "range": {
                     "startColumn": 25,
                     "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
                     "lineCount": 1
                 }
             },
@@ -15516,6 +14414,14 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -15674,14 +14580,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 35,
                     "endColumn": 39,
                     "lineCount": 1
@@ -15780,19 +14678,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 27,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 27,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
@@ -15804,11 +14702,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -15820,11 +14718,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -15997,14 +14895,6 @@
                     "startColumn": 28,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -16240,26 +15130,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 12
+                    "startColumn": 38,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 42,
+                    "startColumn": 35,
+                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -16272,11 +15154,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 38,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -16288,11 +15178,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 15
+                    "startColumn": 34,
+                    "endColumn": 103,
+                    "lineCount": 1
                 }
             },
             {
@@ -16300,6 +15190,14 @@
                 "range": {
                     "startColumn": 67,
                     "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 97,
                     "lineCount": 1
                 }
             },
@@ -16406,14 +15304,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 5,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 18,
@@ -16500,6 +15390,16 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 61,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/progress/runner_tracker.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -16668,14 +15568,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 19,
@@ -16750,30 +15642,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 74,
-                    "endColumn": 96,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
@@ -16817,30 +15685,6 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 35,
-                    "lineCount": 1
                 }
             },
             {
@@ -17036,27 +15880,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -17366,64 +16194,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/api/rest/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 71,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/api/rest/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -17471,14 +16241,6 @@
                     "startColumn": 43,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -17530,11 +16292,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 17
+                    "startColumn": 33,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 42,
+                    "endColumn": 83,
+                    "lineCount": 1
                 }
             },
             {
@@ -17658,107 +16428,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
+                    "startColumn": 48,
+                    "endColumn": 54,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 93,
+                    "startColumn": 52,
+                    "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
                 }
             }
         ],
@@ -17780,22 +16462,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/api/rest/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/connections.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
+                    "startColumn": 43,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 51,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -18180,35 +16860,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 19
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 37,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -18292,14 +16948,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 37,
@@ -18313,14 +16961,6 @@
                     "startColumn": 48,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -18340,28 +16980,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/domodashboard/connection.py": [
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 39,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             }
@@ -18453,14 +17083,6 @@
                     "startColumn": 15,
                     "endColumn": 24,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -18600,14 +17222,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 52,
@@ -18680,16 +17294,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/domodashboard/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/grafana/client.py": [
             {
                 "code": "reportMissingParameterType",
@@ -18712,24 +17316,6 @@
                 "range": {
                     "startColumn": 68,
                     "endColumn": 93,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/grafana/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -18789,14 +17375,6 @@
                     "startColumn": 55,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 29
                 }
             },
             {
@@ -18864,11 +17442,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 30,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -18968,16 +17546,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/grafana/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/hex/client.py": [
             {
                 "code": "reportArgumentType",
@@ -19000,16 +17568,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 48,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/hex/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -19053,14 +17611,6 @@
                     "startColumn": 34,
                     "endColumn": 51,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -19116,30 +17666,6 @@
                 "range": {
                     "startColumn": 72,
                     "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -19246,16 +17772,6 @@
                 "range": {
                     "startColumn": 55,
                     "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/hex/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -19392,16 +17908,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/lightdash/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/lightdash/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -19441,14 +17947,6 @@
                     "startColumn": 56,
                     "endColumn": 80,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -19500,18 +17998,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
                     "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -19528,16 +18026,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 39,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/lightdash/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -19586,11 +18074,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
+                    "startColumn": 21,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
@@ -19598,6 +18086,14 @@
                 "range": {
                     "startColumn": 42,
                     "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -19654,24 +18150,6 @@
                 "range": {
                     "startColumn": 1,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/looker/connection.py": [
-            {
-                "code": "reportOptionalIterable",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 100,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -19862,14 +18340,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 22
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -19882,6 +18352,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -19998,14 +18492,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 21
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -20026,6 +18512,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -20182,14 +18692,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -20202,6 +18704,30 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -20342,10 +18868,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 112,
+                    "startColumn": 79,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 102,
+                    "endColumn": 111,
                     "lineCount": 1
                 }
             },
@@ -20574,14 +19108,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 22
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -20758,11 +19284,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -20862,11 +19396,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 30,
+                    "endColumn": 71,
+                    "lineCount": 1
                 }
             },
             {
@@ -21154,16 +19688,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/looker/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/looker/utils.py": [
             {
                 "code": "reportMissingParameterType",
@@ -21296,16 +19820,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/metabase/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/metabase/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -21353,14 +19867,6 @@
                     "startColumn": 67,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -21428,11 +19934,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 30,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -21530,16 +20036,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 34,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/metabase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -21722,16 +20218,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/microstrategy/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/microstrategy/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -21755,14 +20241,6 @@
                     "startColumn": 12,
                     "endColumn": 99,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 19
                 }
             },
             {
@@ -21902,34 +20380,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -21966,11 +20420,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 25,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 84,
+                    "lineCount": 1
                 }
             },
             {
@@ -22006,18 +20468,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -22074,16 +20552,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/microstrategy/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 75,
                     "lineCount": 1
                 }
             }
@@ -22162,16 +20630,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/mode/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/mode/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -22243,14 +20701,6 @@
                     "startColumn": 15,
                     "endColumn": 41,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 23
                 }
             },
             {
@@ -22358,14 +20808,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 51,
@@ -22387,16 +20829,6 @@
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/mode/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
                 }
             }
         ],
@@ -22428,11 +20860,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 29,
+                    "endColumn": 61,
+                    "lineCount": 1
                 }
             },
             {
@@ -22452,18 +20884,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 63,
                     "lineCount": 1
                 }
             },
@@ -22505,14 +20937,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -22569,14 +20993,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 7
                 }
             },
             {
@@ -22714,6 +21130,14 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 27,
                     "lineCount": 1
                 }
             },
@@ -23110,24 +21534,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/powerbi/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/powerbi/databricks_parser.py": [
             {
                 "code": "reportCallIssue",
@@ -23406,14 +21812,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 20,
@@ -23454,14 +21852,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 21,
-                    "lineCount": 25
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -23483,14 +21873,6 @@
                     "startColumn": 95,
                     "endColumn": 106,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 21,
-                    "lineCount": 15
                 }
             },
             {
@@ -23534,11 +21916,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 13
+                    "startColumn": 38,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -23595,6 +21977,30 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 45,
+                    "lineCount": 1
                 }
             },
             {
@@ -23958,10 +22364,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 46,
-                    "endColumn": 112,
+                    "startColumn": 73,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 98,
+                    "endColumn": 111,
                     "lineCount": 1
                 }
             },
@@ -24006,10 +22420,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
@@ -24116,16 +22538,6 @@
                 "range": {
                     "startColumn": 36,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/powerbi/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -24372,16 +22784,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qlikcloud/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/qlikcloud/metadata.py": [
             {
                 "code": "reportIncompatibleVariableOverride",
@@ -24525,14 +22927,6 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -24712,14 +23106,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 44,
@@ -24782,16 +23168,6 @@
                 "range": {
                     "startColumn": 41,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/qlikcloud/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -24990,16 +23366,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qliksense/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/qliksense/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -25047,14 +23413,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 21
                 }
             },
             {
@@ -25159,14 +23517,6 @@
                     "startColumn": 51,
                     "endColumn": 56,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -25282,14 +23632,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 40,
@@ -25310,6 +23652,22 @@
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 71,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -25570,42 +23928,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/qliksense/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/quicksight/connection.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 96,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/quicksight/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -25688,14 +24010,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
@@ -25760,18 +24074,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 53,
+                    "startColumn": 34,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -25848,10 +24162,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 103,
+                    "startColumn": 93,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
@@ -25880,27 +24194,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 41,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 41,
-                    "lineCount": 4
                 }
             },
             {
@@ -25922,33 +24220,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 29,
                     "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 37,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 41,
-                    "lineCount": 4
                 }
             },
             {
@@ -26176,18 +24450,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 89,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
@@ -26205,16 +24479,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/quicksight/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 61,
-                    "lineCount": 1
                 }
             }
         ],
@@ -26276,16 +24540,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/redash/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/redash/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -26333,14 +24587,6 @@
                     "startColumn": 28,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 25
                 }
             },
             {
@@ -26480,14 +24726,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 72,
@@ -26509,16 +24747,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/redash/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
-                    "lineCount": 1
                 }
             }
         ],
@@ -26612,16 +24840,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/sigma/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/sigma/metadata.py": [
             {
                 "code": "reportAssignmentType",
@@ -26661,14 +24879,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 19
                 }
             },
             {
@@ -26725,14 +24935,6 @@
                     "startColumn": 12,
                     "endColumn": 18,
                     "lineCount": 2
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -26864,11 +25066,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 29,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
@@ -26888,18 +25090,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -26920,32 +25130,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/sigma/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/ssrs/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 52,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -26981,14 +25171,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -27048,11 +25230,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 26,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -27104,14 +25286,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -27120,11 +25294,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 26,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -27208,16 +25390,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/ssrs/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/api_source.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -27225,14 +25397,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 18
                 }
             },
             {
@@ -27305,14 +25469,6 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -27398,22 +25554,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 94,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 71,
                     "lineCount": 1
@@ -27436,18 +25576,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -27694,16 +25834,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/superset/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/db_source.py": [
             {
                 "code": "reportReturnType",
@@ -27719,14 +25849,6 @@
                     "startColumn": 8,
                     "endColumn": 27,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 20
                 }
             },
             {
@@ -27791,14 +25913,6 @@
                     "startColumn": 24,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
                 }
             },
             {
@@ -27922,14 +26036,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
@@ -27940,8 +26046,24 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 32,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 53,
                     "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -28094,11 +26216,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 40,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -28166,58 +26296,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 50,
+                    "startColumn": 32,
+                    "endColumn": 41,
                     "lineCount": 1
                 }
             },
@@ -28226,6 +26308,22 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 75,
                     "lineCount": 1
                 }
             },
@@ -28246,9 +26344,9 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
+                    "startColumn": 36,
                     "endColumn": 53,
                     "lineCount": 1
                 }
@@ -28288,16 +26386,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/superset/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/dashboard/superset/utils.py": [
             {
                 "code": "reportUnreachable",
@@ -28326,34 +26414,10 @@
         ],
         "./src/metadata/ingestion/source/dashboard/tableau/client.py": [
             {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 9,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportPrivateImportUsage",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -28488,14 +26552,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 11,
@@ -28586,14 +26642,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 13,
-                    "lineCount": 18
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -28604,8 +26652,40 @@
             {
                 "code": "reportArgumentType",
                 "range": {
+                    "startColumn": 30,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
                     "startColumn": 33,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 72,
                     "lineCount": 1
                 }
             },
@@ -28631,14 +26711,6 @@
                     "startColumn": 8,
                     "endColumn": 23,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 37
                 }
             },
             {
@@ -28794,10 +26866,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 110,
+                    "startColumn": 77,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 100,
+                    "endColumn": 109,
                     "lineCount": 1
                 }
             },
@@ -28930,11 +27010,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 56,
+                    "lineCount": 1
                 }
             },
             {
@@ -28954,10 +27042,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 116,
+                    "startColumn": 83,
+                    "endColumn": 94,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 106,
+                    "endColumn": 115,
                     "lineCount": 1
                 }
             },
@@ -29055,14 +27151,6 @@
                     "startColumn": 47,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 13
                 }
             },
             {
@@ -30004,34 +28092,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/dashboard/tableau/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/athena/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/athena/lineage.py": [
             {
                 "code": "reportIncompatibleMethodOverride",
@@ -30090,11 +28150,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             }
         ],
@@ -30466,14 +28534,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 12
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 41,
@@ -30502,6 +28562,22 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -31028,46 +29104,6 @@
                     "endColumn": 40,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 27,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/bigquery/helper.py": [
@@ -31524,42 +29560,10 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -31588,14 +29592,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -31617,6 +29613,22 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -31696,22 +29708,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 85,
                     "lineCount": 1
                 }
             },
@@ -31812,27 +29808,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalIterable",
                 "range": {
                     "startColumn": 37,
                     "endColumn": 80,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 7
                 }
             },
             {
@@ -31860,11 +29840,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 24
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -32092,14 +30072,6 @@
         ],
         "./src/metadata/ingestion/source/database/bigtable/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 60,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 50,
@@ -32144,14 +30116,6 @@
                 "range": {
                     "startColumn": 100,
                     "endColumn": 111,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -32214,14 +30178,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 40,
@@ -32238,40 +30194,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/bigtable/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/burstiq/client.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 58,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/burstiq/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -32326,34 +30254,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 73,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 97,
+                    "endColumn": 107,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 46,
-                    "endColumn": 108,
+                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 75,
+                    "startColumn": 44,
+                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -32456,14 +30384,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -32477,14 +30397,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -32584,22 +30496,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 52,
@@ -32645,14 +30541,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 16
                 }
             },
             {
@@ -32732,126 +30620,6 @@
         ],
         "./src/metadata/ingestion/source/database/cassandra/connection.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 64,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 45,
@@ -32926,32 +30694,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 30,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/clickhouse/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 41,
                     "lineCount": 1
                 }
             }
@@ -33654,16 +31396,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/cockroach/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/column_type_parser.py": [
             {
                 "code": "reportReturnType",
@@ -33822,14 +31554,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -33851,14 +31575,6 @@
                     "startColumn": 83,
                     "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 15
                 }
             },
             {
@@ -34078,11 +31794,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 27
+                    "startColumn": 24,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -34107,6 +31831,14 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -34392,18 +32124,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 70,
                     "lineCount": 1
                 }
             },
@@ -34448,14 +32180,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 15
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -34477,6 +32201,14 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -34568,14 +32300,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 25
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -34605,6 +32329,14 @@
                     "startColumn": 57,
                     "endColumn": 65,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 6
                 }
             },
             {
@@ -34660,40 +32392,6 @@
                 "range": {
                     "startColumn": 46,
                     "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/couchbase/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -34784,16 +32482,6 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 62,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/couchbase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
                     "lineCount": 1
                 }
             }
@@ -35532,14 +33220,6 @@
         ],
         "./src/metadata/ingestion/source/database/databricks/client.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 29,
@@ -35792,32 +33472,6 @@
                 "range": {
                     "startColumn": 47,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/databricks/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -36806,14 +34460,6 @@
                     "endColumn": 72,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/databricks/query_parser.py": [
@@ -37208,14 +34854,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -37277,30 +34915,6 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -37384,11 +34998,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 17
+                    "startColumn": 25,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -37412,6 +35026,14 @@
                 "range": {
                     "startColumn": 61,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -37563,22 +35185,6 @@
             }
         ],
         "./src/metadata/ingestion/source/database/db2/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
@@ -38008,110 +35614,6 @@
         ],
         "./src/metadata/ingestion/source/database/dbt/dbt_service.py": [
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 14,
@@ -38132,118 +35634,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 80,
-                    "endColumn": 88,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 59,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 65,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -38270,6 +35660,14 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 46,
                     "lineCount": 1
                 }
             },
@@ -38320,17 +35718,33 @@
                     "endColumn": 37,
                     "lineCount": 1
                 }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/dbt/metadata.py": [
+            },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 60,
+                    "startColumn": 36,
+                    "endColumn": 42,
                     "lineCount": 1
                 }
             },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 4,
+                    "endColumn": 10,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 38,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/ingestion/source/database/dbt/metadata.py": [
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -38404,27 +35818,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 36,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 7
                 }
             },
             {
@@ -38460,30 +35858,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 41,
@@ -38496,22 +35870,6 @@
                 "range": {
                     "startColumn": 56,
                     "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -38536,30 +35894,6 @@
                 "range": {
                     "startColumn": 54,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -38592,62 +35926,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             },
@@ -38700,38 +35978,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -38780,11 +36026,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 25,
+                    "lineCount": 3
                 }
             },
             {
@@ -38825,46 +36071,6 @@
                     "startColumn": 29,
                     "endColumn": 63,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 10
                 }
             },
             {
@@ -38932,22 +36138,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -38956,51 +36146,211 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 38,
                     "endColumn": 33,
                     "lineCount": 4
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 67,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 64,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 62,
+                    "endColumn": 73,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 46,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -39084,22 +36434,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
@@ -39124,27 +36458,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 53,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 48,
+                    "endColumn": 101,
+                    "lineCount": 1
                 }
             },
             {
@@ -39164,51 +36490,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 65,
+                    "startColumn": 43,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 80,
+                    "startColumn": 48,
+                    "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 17,
-                    "lineCount": 12
                 }
             },
             {
@@ -39217,14 +36511,6 @@
                     "startColumn": 62,
                     "endColumn": 75,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -39530,11 +36816,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 25,
+                    "endColumn": 33,
+                    "lineCount": 1
                 }
             }
         ],
@@ -39700,14 +36986,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 21,
@@ -39788,14 +37066,6 @@
                     "endColumn": 30,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/deltalake/metadata.py": [
@@ -39848,11 +37118,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -39917,14 +37187,6 @@
                     "startColumn": 35,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -40080,14 +37342,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 18
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 47,
@@ -40176,34 +37430,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/deltalake/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/domodatabase/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/domodatabase/metadata.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -40246,14 +37472,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 39,
@@ -40267,14 +37485,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -40390,11 +37600,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 21
+                    "endColumn": 52,
+                    "lineCount": 1
                 }
             },
             {
@@ -40430,6 +37640,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -40454,11 +37672,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 44,
+                    "lineCount": 1
                 }
             },
             {
@@ -40508,16 +37734,6 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 6,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/domodatabase/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 74,
                     "lineCount": 1
                 }
             }
@@ -40750,19 +37966,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 11
+                    "startColumn": 33,
+                    "endColumn": 72,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 25,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             }
         ],
@@ -40968,14 +38184,6 @@
                     "endColumn": 28,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/dynamodb/metadata.py": [
@@ -41042,64 +38250,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 30,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/exasol/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             }
@@ -41182,16 +38332,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/exasol/sqla_utils.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 8,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/external_table_lineage_mixin.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -41250,30 +38390,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportUnreachable",
                 "range": {
                     "startColumn": 12,
@@ -41306,44 +38422,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/glue/connection.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 40,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             }
@@ -41470,11 +38560,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -41558,14 +38648,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -41587,6 +38669,14 @@
                     "startColumn": 53,
                     "endColumn": 61,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 13,
+                    "lineCount": 4
                 }
             },
             {
@@ -41726,14 +38816,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 23
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 29,
@@ -41755,6 +38837,14 @@
                     "startColumn": 56,
                     "endColumn": 72,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 5
                 }
             },
             {
@@ -41930,16 +39020,6 @@
                 "range": {
                     "startColumn": 46,
                     "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/glue/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 66,
                     "lineCount": 1
                 }
             }
@@ -42482,66 +39562,10 @@
         ],
         "./src/metadata/ingestion/source/database/hive/connection.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
+                "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -42558,6 +39582,14 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 19,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportGeneralTypeIssues",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 14,
                     "lineCount": 1
                 }
             },
@@ -43674,56 +40706,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/impala/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/impala/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -44190,38 +41172,6 @@
         ],
         "./src/metadata/ingestion/source/database/life_cycle_query_mixin.py": [
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 76,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 99,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -44310,30 +41260,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -44384,38 +41310,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -44440,14 +41334,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 9,
-                    "lineCount": 12
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 59,
@@ -44456,11 +41342,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 20,
+                    "endColumn": 32,
+                    "lineCount": 1
                 }
             },
             {
@@ -44512,14 +41398,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 24,
@@ -44528,18 +41406,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 5,
-                    "endColumn": 40,
+                    "startColumn": 40,
+                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -44650,11 +41520,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -44666,11 +41536,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -44850,10 +41720,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 92,
+                    "endColumn": 101,
                     "lineCount": 1
                 }
             },
@@ -44871,30 +41749,6 @@
                     "startColumn": 19,
                     "endColumn": 13,
                     "lineCount": 12
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 94,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -45094,11 +41948,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -45164,354 +42018,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 43,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/lineage.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/metadata.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 73,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 63,
-                    "endColumn": 78,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/query_parser.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 19,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 48,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 77,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/microsoftfabric/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/mongodb/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -45854,11 +42360,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 28,
+                    "endColumn": 88,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -46146,6 +42660,30 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 24,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 49,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -46204,22 +42742,6 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
                     "lineCount": 1
                 }
             },
@@ -46584,158 +43106,6 @@
         ],
         "./src/metadata/ingestion/source/database/mysql/connection.py": [
             {
-                "code": "reportMissingImports",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
@@ -46744,10 +43114,26 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 65,
-                    "endColumn": 70,
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 56,
                     "lineCount": 1
                 }
             }
@@ -46786,19 +43172,11 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 82,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 16
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -47174,22 +43552,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOperatorIssue",
                 "range": {
                     "startColumn": 8,
@@ -47418,11 +43780,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -47718,6 +44080,86 @@
                 "range": {
                     "startColumn": 47,
                     "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 42,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 35,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 47,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 55,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 62,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -48250,16 +44692,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/pinotdb/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/pinotdb/lineage.py": [
             {
                 "code": "reportMissingParameterType",
@@ -48438,11 +44870,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 11
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             }
         ],
@@ -48696,11 +45128,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 16
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -48878,14 +45310,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportGeneralTypeIssues",
                 "range": {
                     "startColumn": 16,
@@ -48922,30 +45346,6 @@
                 "range": {
                     "startColumn": 16,
                     "endColumn": 28,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 91,
                     "lineCount": 1
                 }
             }
@@ -49150,18 +45550,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 11
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -49656,40 +46056,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/presto/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/presto/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -50038,26 +46404,34 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 35,
+                    "startColumn": 32,
                     "endColumn": 40,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 26,
+                    "startColumn": 42,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 59,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 35,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             }
@@ -50072,11 +46446,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -50298,22 +46672,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
@@ -50322,19 +46680,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 47,
+                    "lineCount": 1
                 }
             },
             {
@@ -50346,11 +46704,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 14
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -51306,40 +47664,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/salesforce/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/salesforce/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -51414,11 +47738,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -51435,14 +47759,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -51558,11 +47874,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -51598,6 +47914,14 @@
                 }
             },
             {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 17,
+                    "lineCount": 3
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 18,
@@ -51614,11 +47938,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 29,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -51654,22 +47978,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/salesforce/service_spec.py": [
+        "./src/metadata/ingestion/source/database/sample_data.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 56,
-                    "endColumn": 72,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sample_data.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 63,
+                    "startColumn": 23,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
@@ -51678,38 +47992,6 @@
                 "range": {
                     "startColumn": 27,
                     "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 79,
                     "lineCount": 1
                 }
             },
@@ -52172,14 +48454,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 21,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 46,
                     "lineCount": 1
@@ -52220,14 +48494,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 46,
                     "lineCount": 1
@@ -52242,11 +48508,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 14
+                    "startColumn": 24,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52314,11 +48580,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 24,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52362,19 +48628,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
+                    "startColumn": 20,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -52399,14 +48657,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52442,14 +48692,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52466,11 +48708,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
+                    "startColumn": 20,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -52495,14 +48737,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52538,14 +48772,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52559,14 +48785,6 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 17,
-                    "lineCount": 11
                 }
             },
             {
@@ -52586,11 +48804,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 20,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -52615,14 +48833,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             },
             {
@@ -52655,14 +48865,6 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 9
                 }
             },
             {
@@ -52698,14 +48900,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -52719,14 +48913,6 @@
                     "startColumn": 18,
                     "endColumn": 45,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
                 }
             },
             {
@@ -52754,14 +48940,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 37,
@@ -52783,14 +48961,6 @@
                     "startColumn": 86,
                     "endColumn": 108,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 12
                 }
             },
             {
@@ -52946,14 +49116,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 13,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 86,
@@ -52975,14 +49137,6 @@
                     "startColumn": 73,
                     "endColumn": 88,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             },
             {
@@ -53010,14 +49164,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 54,
@@ -53042,26 +49188,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 65,
                     "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 83,
                     "lineCount": 1
                 }
             },
@@ -53074,22 +49204,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -53098,19 +49212,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 97,
+                    "startColumn": 24,
+                    "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 11
                 }
             },
             {
@@ -53146,19 +49252,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 102,
+                    "startColumn": 24,
+                    "endColumn": 62,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -53170,11 +49268,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53186,11 +49284,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53202,11 +49300,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 28,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
@@ -53226,34 +49324,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 62,
                     "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 98,
                     "lineCount": 1
                 }
             },
@@ -53271,22 +49345,6 @@
                     "startColumn": 14,
                     "endColumn": 9,
                     "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 101,
-                    "lineCount": 1
                 }
             },
             {
@@ -53298,14 +49356,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 63,
@@ -53322,18 +49372,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 100,
+                    "startColumn": 65,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -53346,27 +49388,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 91,
+                    "startColumn": 28,
+                    "endColumn": 69,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 8
                 }
             },
             {
@@ -53386,11 +49412,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 28,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -53402,11 +49428,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -53418,11 +49444,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -53431,14 +49457,6 @@
                     "startColumn": 18,
                     "endColumn": 43,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             },
             {
@@ -53468,56 +49486,16 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 7
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 23
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 82,
+                    "startColumn": 28,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
@@ -53530,11 +49508,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 14
+                    "startColumn": 28,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -53570,18 +49548,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 81,
+                    "startColumn": 28,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -53618,35 +49588,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 25,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 89,
+                    "startColumn": 33,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 75,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 75,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 70,
+                    "lineCount": 1
                 }
             },
             {
@@ -53655,14 +49625,6 @@
                     "startColumn": 38,
                     "endColumn": 47,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 5
                 }
             },
             {
@@ -53684,14 +49646,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 29,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 53,
                     "lineCount": 1
@@ -53703,14 +49657,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 21,
-                    "lineCount": 5
                 }
             },
             {
@@ -53730,11 +49676,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 54,
-                    "endColumn": 25,
-                    "lineCount": 5
+                    "startColumn": 46,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -53754,11 +49700,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 6
+                    "startColumn": 39,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -53778,11 +49724,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 6
+                    "startColumn": 39,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -53799,14 +49745,6 @@
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 10
                 }
             },
             {
@@ -53831,38 +49769,6 @@
                     "startColumn": 20,
                     "endColumn": 24,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 11
                 }
             },
             {
@@ -53930,11 +49836,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 29,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -53954,11 +49860,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
@@ -54066,43 +49972,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 70,
                     "endColumn": 72,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 33,
-                    "lineCount": 6
                 }
             },
             {
@@ -54130,10 +50004,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 95,
+                    "startColumn": 65,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 82,
+                    "endColumn": 94,
                     "lineCount": 1
                 }
             },
@@ -54186,10 +50068,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 110,
+                    "startColumn": 75,
+                    "endColumn": 86,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 97,
+                    "endColumn": 109,
                     "lineCount": 1
                 }
             },
@@ -54242,18 +50132,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 21,
-                    "lineCount": 16
+                    "startColumn": 29,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 57,
-                    "endColumn": 98,
+                    "startColumn": 39,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 95,
                     "lineCount": 1
                 }
             },
@@ -54316,11 +50214,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
+                    "startColumn": 32,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             }
         ],
@@ -54394,16 +50300,6 @@
                 "range": {
                     "startColumn": 19,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saperp/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -54522,14 +50418,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -54546,11 +50434,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 40,
+                    "lineCount": 1
                 }
             },
             {
@@ -54567,14 +50455,6 @@
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 16
                 }
             },
             {
@@ -54598,6 +50478,14 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -54638,16 +50526,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 114,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saperp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 68,
                     "lineCount": 1
                 }
             }
@@ -54707,30 +50585,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 18
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 4
                 }
             },
             {
@@ -55078,56 +50932,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/saphana/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/saphana/lineage.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -55284,11 +51088,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 36,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -55339,24 +51151,6 @@
                     "startColumn": 15,
                     "endColumn": 9,
                     "lineCount": 8
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/saphana/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 92,
-                    "endColumn": 112,
-                    "lineCount": 1
                 }
             }
         ],
@@ -55778,16 +51572,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/sas/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/sas/metadata.py": [
             {
                 "code": "reportAttributeAccessIssue",
@@ -55974,14 +51758,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 9,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportIndexIssue",
                 "range": {
                     "startColumn": 17,
@@ -56010,6 +51786,14 @@
                 "range": {
                     "startColumn": 24,
                     "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 40,
                     "lineCount": 1
                 }
             },
@@ -56022,18 +51806,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 25,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 28,
-                    "endColumn": 119,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -56058,14 +51850,6 @@
                 "range": {
                     "startColumn": 30,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 110,
                     "lineCount": 1
                 }
             },
@@ -56342,11 +52126,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 32,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
             {
@@ -56354,6 +52146,14 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -56379,22 +52179,6 @@
                     "startColumn": 76,
                     "endColumn": 79,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 21,
-                    "lineCount": 7
                 }
             },
             {
@@ -56520,22 +52304,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 13,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 21,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 57,
                     "lineCount": 1
@@ -56638,30 +52406,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 80,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 35,
@@ -56670,11 +52414,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -56726,11 +52478,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 24,
+                    "endColumn": 51,
+                    "lineCount": 1
                 }
             },
             {
@@ -56763,14 +52515,6 @@
                     "startColumn": 24,
                     "endColumn": 38,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 4
                 }
             },
             {
@@ -56814,11 +52558,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 9
+                    "startColumn": 17,
+                    "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 13,
+                    "lineCount": 6
                 }
             },
             {
@@ -56882,16 +52634,6 @@
                 "range": {
                     "startColumn": 63,
                     "endColumn": 109,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sas/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -56998,46 +52740,6 @@
                     "endColumn": 40,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/snowflake/data_diff/data_diff.py": [
@@ -57132,11 +52834,67 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 57,
+                    "endColumn": 62,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 74,
+                    "endColumn": 79,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 46,
+                    "endColumn": 70,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             }
         ],
@@ -57258,6 +53016,14 @@
                 "range": {
                     "startColumn": 10,
                     "endColumn": 31,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 20,
                     "lineCount": 1
                 }
             },
@@ -57394,30 +53160,6 @@
                 "range": {
                     "startColumn": 66,
                     "endColumn": 74,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -57582,11 +53324,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 25
+                    "startColumn": 28,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 112,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -58370,6 +54128,30 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 33,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 23,
                     "endColumn": 27,
                     "lineCount": 1
@@ -58594,6 +54376,38 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
+                    "startColumn": 35,
+                    "endColumn": 39,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 53,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 65,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
                     "startColumn": 16,
                     "endColumn": 20,
                     "lineCount": 1
@@ -58746,22 +54560,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 20,
@@ -58770,11 +54568,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 29,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
@@ -58936,16 +54734,6 @@
                 "range": {
                     "startColumn": 14,
                     "endColumn": 24,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/sqlite/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 37,
                     "lineCount": 1
                 }
             }
@@ -59190,27 +54978,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 66,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 25,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -59490,14 +55270,6 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 52,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 84,
                     "endColumn": 96,
                     "lineCount": 1
@@ -59564,16 +55336,6 @@
                 "range": {
                     "startColumn": 24,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/teradata/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
                     "lineCount": 1
                 }
             }
@@ -59670,11 +55432,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 13,
-                    "lineCount": 15
+                    "startColumn": 31,
+                    "endColumn": 17,
+                    "lineCount": 7
                 }
             },
             {
@@ -59832,16 +55594,6 @@
                 "range": {
                     "startColumn": 26,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/timescale/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 65,
                     "lineCount": 1
                 }
             }
@@ -60700,26 +56452,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 35,
                     "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 99,
-                    "endColumn": 104,
                     "lineCount": 1
                 }
             },
@@ -60782,11 +56518,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 29,
-                    "lineCount": 7
+                    "startColumn": 44,
+                    "endColumn": 67,
+                    "lineCount": 1
                 }
             },
             {
@@ -61400,66 +57136,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/database/unitycatalog/client.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 82,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/database/unitycatalog/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/database/unitycatalog/lineage.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -61542,19 +57218,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 102,
+                    "startColumn": 69,
+                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 4
+                    "startColumn": 92,
+                    "endColumn": 101,
+                    "lineCount": 1
                 }
             },
             {
@@ -61566,17 +57242,17 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 101,
+                    "startColumn": 66,
+                    "endColumn": 78,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
+                    "startColumn": 90,
                     "endColumn": 100,
                     "lineCount": 1
                 }
@@ -61587,22 +57263,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
                 }
             },
             {
@@ -61619,22 +57279,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 87,
-                    "lineCount": 1
                 }
             },
             {
@@ -61708,14 +57352,6 @@
                 "range": {
                     "startColumn": 88,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -61800,11 +57436,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 17,
+                    "endColumn": 30,
+                    "lineCount": 1
                 }
             },
             {
@@ -61877,14 +57513,6 @@
                     "startColumn": 39,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 9,
-                    "lineCount": 14
                 }
             },
             {
@@ -61976,11 +57604,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 20
+                    "startColumn": 33,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -62021,14 +57649,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 4
                 }
             },
             {
@@ -62254,206 +57874,6 @@
                     "endColumn": 21,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 51,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportRedeclaration",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 34,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportIndexIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 81,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/database/unitycatalog/query_parser.py": [
@@ -62640,18 +58060,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 14
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 53,
                     "endColumn": 58,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 67,
                     "lineCount": 1
                 }
             },
@@ -63486,64 +58922,8 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 41,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 106,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -63694,11 +59074,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 105,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
@@ -63782,11 +59194,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 33,
-                    "lineCount": 10
+                    "startColumn": 41,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 69,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 48,
+                    "endColumn": 69,
+                    "lineCount": 1
                 }
             },
             {
@@ -63806,11 +59242,43 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 61,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 57,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 61,
+                    "lineCount": 1
                 }
             },
             {
@@ -63846,11 +59314,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 21,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -63858,6 +59334,38 @@
                 "range": {
                     "startColumn": 43,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 60,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 93,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 25,
+                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -63918,11 +59426,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 18
+                    "startColumn": 25,
+                    "endColumn": 63,
+                    "lineCount": 1
                 }
             },
             {
@@ -63931,6 +59439,22 @@
                     "startColumn": 47,
                     "endColumn": 60,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 21,
+                    "lineCount": 7
                 }
             },
             {
@@ -63978,26 +59502,10 @@
         ],
         "./src/metadata/ingestion/source/drive/sftp/connection.py": [
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 17,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -64140,11 +59648,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 8
+                    "startColumn": 21,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
@@ -64212,11 +59736,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 33,
-                    "lineCount": 10
+                    "startColumn": 41,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -64236,11 +59768,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 25,
-                    "lineCount": 10
+                    "startColumn": 33,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 38,
+                    "endColumn": 57,
+                    "lineCount": 1
                 }
             },
             {
@@ -64308,11 +59856,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -64320,16 +59868,6 @@
                 "range": {
                     "startColumn": 28,
                     "endColumn": 60,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/drive/sftp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -64366,16 +59904,6 @@
                 "range": {
                     "startColumn": 45,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mcp/mcp/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
                     "lineCount": 1
                 }
             }
@@ -64478,76 +60006,26 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 6
+                    "startColumn": 17,
+                    "endColumn": 49,
+                    "lineCount": 1
                 }
             },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mcp/service_spec.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
+                    "startColumn": 24,
+                    "endColumn": 35,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 43,
                     "lineCount": 1
                 }
             }
@@ -64566,14 +60044,6 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
@@ -64599,14 +60069,6 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -64706,14 +60168,6 @@
                 }
             },
             {
-                "code": "reportUnusedExcept",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 22,
@@ -64751,7 +60205,7 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 61,
-                    "endColumn": 76,
+                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -64830,34 +60284,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/messaging/kafka/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/kinesis/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/messaging/kinesis/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -64913,14 +60339,6 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -65044,16 +60462,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/messaging/kinesis/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/messaging/messaging_service.py": [
             {
                 "code": "reportCallIssue",
@@ -65160,16 +60568,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/messaging/pubsub/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/messaging/pubsub/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -65217,14 +60615,6 @@
                     "startColumn": 8,
                     "endColumn": 22,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 7
                 }
             },
             {
@@ -65314,40 +60704,6 @@
                     "endColumn": 17,
                     "lineCount": 21
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 29,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 29,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/pubsub/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/messaging/redpanda/metadata.py": [
@@ -65380,16 +60736,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 94,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/messaging/redpanda/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -65580,16 +60926,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/metadata/alationsink/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/metadata/alationsink/metadata.py": [
             {
                 "code": "reportOptionalMemberAccess",
@@ -65746,56 +61082,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/metadata/alationsink/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 62,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/metadata/amundsen/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 17,
                     "endColumn": 57,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/amundsen/connection.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -65898,19 +61190,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 25,
+                    "endColumn": 55,
+                    "lineCount": 1
                 }
             },
             {
@@ -65970,14 +61254,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 64,
@@ -66034,11 +61310,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 4
+                    "startColumn": 21,
+                    "endColumn": 113,
+                    "lineCount": 1
                 }
             },
             {
@@ -66046,6 +61322,14 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -66079,14 +61363,6 @@
                     "startColumn": 44,
                     "endColumn": 49,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 13,
-                    "lineCount": 4
                 }
             },
             {
@@ -66202,11 +61478,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 13
+                    "startColumn": 26,
+                    "endColumn": 35,
+                    "lineCount": 1
                 }
             },
             {
@@ -66258,11 +61534,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
-                    "endColumn": 13,
-                    "lineCount": 11
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -66290,11 +61566,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 26,
+                    "endColumn": 67,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 65,
+                    "lineCount": 1
                 }
             },
             {
@@ -66314,11 +61598,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 10
+                    "startColumn": 21,
+                    "endColumn": 33,
+                    "lineCount": 1
                 }
             },
             {
@@ -66342,16 +61626,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 19,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/amundsen/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -66474,16 +61748,6 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 48,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/atlas/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -66754,11 +62018,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 8
+                    "startColumn": 29,
+                    "endColumn": 89,
+                    "lineCount": 1
                 }
             },
             {
@@ -67010,14 +62274,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalSubscript",
                 "range": {
                     "startColumn": 21,
@@ -67031,14 +62287,6 @@
                     "startColumn": 28,
                     "endColumn": 59,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -67084,14 +62332,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 109,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 39,
                     "lineCount": 1
@@ -67106,10 +62346,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 70,
+                    "startColumn": 42,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -67122,30 +62362,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 76,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/metadata/atlas/service_spec.py": [
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mlmodel/mlflow/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 42,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -67184,78 +62404,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 115,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 121,
-                    "endColumn": 136,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 10
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 55,
@@ -67280,44 +62428,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 71,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 8,
                     "endColumn": 11,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mlmodel/mlflow/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -67524,24 +62638,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/mlmodel/sagemaker/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/mlmodel/sagemaker/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -67576,14 +62672,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -67604,14 +62692,6 @@
                 "range": {
                     "startColumn": 18,
                     "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
                     "lineCount": 7
                 }
             },
@@ -67644,16 +62724,6 @@
                 "range": {
                     "startColumn": 40,
                     "endColumn": 46,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/mlmodel/sagemaker/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 60,
                     "lineCount": 1
                 }
             }
@@ -67844,16 +62914,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/airbyte/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/airbyte/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -67904,22 +62964,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -67936,19 +62980,51 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
+                    "startColumn": 40,
+                    "endColumn": 104,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "endColumn": 44,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 36,
+                    "endColumn": 100,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 87,
+                    "lineCount": 1
                 }
             },
             {
@@ -67984,19 +63060,51 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 36,
+                    "endColumn": 96,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 71,
+                    "lineCount": 1
                 }
             },
             {
@@ -68056,22 +63164,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -68088,22 +63180,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 83,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 79,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -68116,16 +63192,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/airbyte/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
                     "lineCount": 1
                 }
             }
@@ -68187,78 +63253,6 @@
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 35,
                     "endColumn": 44,
                     "lineCount": 1
                 }
@@ -68392,6 +63386,64 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/airflow/api/diagnostics.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 45,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 43,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 44,
+                    "endColumn": 55,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/airflow/api/mwaa.py": [
             {
                 "code": "reportArgumentType",
@@ -68444,19 +63496,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 19
+                    "startColumn": 26,
+                    "endColumn": 108,
+                    "lineCount": 1
                 }
             },
             {
@@ -68516,11 +63560,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
+                    "startColumn": 40,
+                    "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 34,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 59,
+                    "lineCount": 1
                 }
             },
             {
@@ -68532,11 +63592,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 91,
+                    "lineCount": 1
                 }
             },
             {
@@ -68634,46 +63694,6 @@
                 "range": {
                     "startColumn": 29,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -68794,46 +63814,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 33,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 53,
@@ -68850,70 +63830,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 39,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -68922,59 +63838,35 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 68,
-                    "endColumn": 97,
+                    "startColumn": 44,
+                    "endColumn": 102,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 32,
+                    "startColumn": 38,
                     "endColumn": 69,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 67,
+                    "startColumn": 36,
+                    "endColumn": 65,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 62,
+                    "startColumn": 40,
+                    "endColumn": 95,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 6
                 }
             },
             {
@@ -69026,27 +63918,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 13,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 32,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
                 }
             },
             {
@@ -69090,14 +63966,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 17
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -69106,11 +63974,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 19
+                    "startColumn": 26,
+                    "endColumn": 108,
+                    "lineCount": 1
                 }
             },
             {
@@ -69234,22 +64102,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 27,
@@ -69284,22 +64136,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 34,
                     "endColumn": 55,
                     "lineCount": 1
@@ -69314,35 +64150,11 @@
                 }
             },
             {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 29,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
+                    "startColumn": 19,
+                    "endColumn": 107,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 9
                 }
             },
             {
@@ -69364,40 +64176,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 48,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 72,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 31,
                     "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 46,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 66,
-                    "endColumn": 80,
                     "lineCount": 1
                 }
             },
@@ -69412,16 +64192,8 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 50,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportGeneralTypeIssues",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 84,
+                    "startColumn": 26,
+                    "endColumn": 81,
                     "lineCount": 1
                 }
             },
@@ -69490,16 +64262,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/airflow/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/dagster/client.py": [
             {
                 "code": "reportArgumentType",
@@ -69514,16 +64276,6 @@
                 "range": {
                     "startColumn": 23,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dagster/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -69586,22 +64338,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 14
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -69658,11 +64394,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 26,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
                 }
             },
             {
@@ -69674,11 +64410,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 26,
+                    "endColumn": 78,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 72,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 92,
+                    "lineCount": 1
                 }
             },
             {
@@ -69686,6 +64438,14 @@
                 "range": {
                     "startColumn": 58,
                     "endColumn": 63,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 89,
                     "lineCount": 1
                 }
             },
@@ -69828,33 +64588,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 26,
                     "endColumn": 21,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -69863,14 +64599,6 @@
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -69926,34 +64654,6 @@
                 "range": {
                     "startColumn": 75,
                     "endColumn": 84,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dagster/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/databrickspipeline/connection.py": [
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -70050,14 +64750,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -70098,11 +64790,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
                 }
             },
             {
@@ -70111,14 +64803,6 @@
                     "startColumn": 8,
                     "endColumn": 29,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 7
                 }
             },
             {
@@ -70154,11 +64838,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 8
+                    "startColumn": 32,
+                    "endColumn": 48,
+                    "lineCount": 1
                 }
             },
             {
@@ -70234,11 +64918,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 29,
-                    "lineCount": 4
+                    "startColumn": 45,
+                    "endColumn": 56,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 50,
+                    "lineCount": 1
                 }
             },
             {
@@ -70298,35 +64990,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 63,
+                    "endColumn": 61,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 67,
-                    "endColumn": 57,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 57,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 71,
-                    "endColumn": 57,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 61,
-                    "lineCount": 4
+                    "endColumn": 90,
+                    "lineCount": 1
                 }
             },
             {
@@ -70354,35 +65030,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 71,
+                    "endColumn": 69,
+                    "lineCount": 8
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 75,
-                    "endColumn": 65,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 65,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 79,
-                    "endColumn": 65,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 77,
-                    "endColumn": 69,
-                    "lineCount": 4
+                    "endColumn": 98,
+                    "lineCount": 1
                 }
             },
             {
@@ -70410,35 +65070,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 57,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 59,
+                    "endColumn": 57,
+                    "lineCount": 5
+                }
+            },
+            {
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 63,
-                    "endColumn": 53,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 53,
-                    "lineCount": 8
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 67,
-                    "endColumn": 53,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 65,
-                    "endColumn": 57,
-                    "lineCount": 4
+                    "endColumn": 86,
+                    "lineCount": 1
                 }
             },
             {
@@ -70490,22 +65142,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
@@ -70524,35 +65160,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/databrickspipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 69,
-                    "lineCount": 1
                 }
             }
         ],
@@ -70610,14 +65220,6 @@
                 "range": {
                     "startColumn": 44,
                     "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 23,
                     "lineCount": 1
                 }
             },
@@ -70682,16 +65284,6 @@
                 "range": {
                     "startColumn": 57,
                     "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dbtcloud/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -70762,14 +65354,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 35,
@@ -70791,14 +65375,6 @@
                     "startColumn": 35,
                     "endColumn": 47,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 8
                 }
             },
             {
@@ -70964,41 +65540,9 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 30,
                     "endColumn": 25,
                     "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
                 }
             },
             {
@@ -71050,19 +65594,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 14
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 13,
-                    "lineCount": 7
+                    "startColumn": 19,
+                    "endColumn": 105,
+                    "lineCount": 1
                 }
             },
             {
@@ -71070,6 +65606,14 @@
                 "range": {
                     "startColumn": 70,
                     "endColumn": 74,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 71,
                     "lineCount": 1
                 }
             },
@@ -71140,38 +65684,6 @@
             {
                 "code": "reportAttributeAccessIssue",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 32,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 46,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
                     "startColumn": 23,
                     "endColumn": 35,
                     "lineCount": 1
@@ -71186,19 +65698,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 82,
+                    "lineCount": 1
                 }
             },
             {
@@ -71223,42 +65727,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/dbtcloud/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/domopipeline/connection.py": [
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
                 }
             }
         ],
@@ -71336,22 +65804,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
@@ -71416,19 +65868,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 36,
+                    "endColumn": 95,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 38,
+                    "lineCount": 1
                 }
             },
             {
@@ -71488,32 +65948,12 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/domopipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/fivetran/client.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 39,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/fivetran/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -71541,54 +65981,6 @@
                     "startColumn": 44,
                     "endColumn": 54,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 9,
-                    "lineCount": 6
                 }
             }
         ],
@@ -71666,14 +66058,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 21,
-                    "lineCount": 5
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 44,
@@ -71687,14 +66071,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 5
                 }
             },
             {
@@ -71727,14 +66103,6 @@
                     "startColumn": 22,
                     "endColumn": 17,
                     "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 40,
-                    "endColumn": 25,
-                    "lineCount": 5
                 }
             },
             {
@@ -71826,10 +66194,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 85,
+                    "startColumn": 58,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 78,
+                    "endColumn": 84,
                     "lineCount": 1
                 }
             },
@@ -71838,16 +66214,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/fivetran/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 59,
                     "lineCount": 1
                 }
             }
@@ -71902,16 +66268,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/flink/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/flink/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -71943,22 +66299,6 @@
                     "startColumn": 12,
                     "endColumn": 91,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -72010,19 +66350,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 40,
+                    "endColumn": 72,
+                    "lineCount": 1
                 }
             },
             {
@@ -72074,34 +66406,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/flink/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 56,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/gluepipeline/connection.py": [
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 4,
-                    "endColumn": 10,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/gluepipeline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -72144,14 +66448,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 64,
@@ -72165,14 +66461,6 @@
                     "startColumn": 14,
                     "endColumn": 44,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             },
             {
@@ -72208,27 +66496,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 29,
-                    "lineCount": 6
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 83,
                     "endColumn": 87,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 21,
-                    "lineCount": 6
                 }
             },
             {
@@ -72272,19 +66544,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 25,
-                    "lineCount": 6
+                    "startColumn": 44,
+                    "endColumn": 116,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 38,
-                    "endColumn": 21,
-                    "lineCount": 5
+                    "startColumn": 40,
+                    "endColumn": 112,
+                    "lineCount": 1
                 }
             },
             {
@@ -72344,22 +66616,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 60,
@@ -72413,16 +66669,6 @@
                     "startColumn": 18,
                     "endColumn": 13,
                     "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/gluepipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
-                    "lineCount": 1
                 }
             }
         ],
@@ -72520,16 +66766,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 25,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             }
@@ -72960,22 +67196,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 12
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 3
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 43,
@@ -73272,6 +67492,118 @@
                 }
             },
             {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 32,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 64,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 66,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 53,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 23,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 52,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 54,
+                    "endColumn": 66,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 68,
+                    "endColumn": 84,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 86,
+                    "endColumn": 101,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 37,
+                    "endColumn": 48,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 50,
+                    "endColumn": 59,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 61,
+                    "endColumn": 76,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 78,
+                    "endColumn": 92,
+                    "lineCount": 1
+                }
+            },
+            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 48,
@@ -73296,43 +67628,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 25,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 72,
                     "endColumn": 74,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 33,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -73360,43 +67660,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 64,
                     "endColumn": 66,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 25,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 25,
-                    "lineCount": 4
                 }
             },
             {
@@ -73434,14 +67702,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 82,
                     "lineCount": 1
@@ -73453,14 +67713,6 @@
                     "startColumn": 51,
                     "endColumn": 61,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 13,
-                    "lineCount": 6
                 }
             },
             {
@@ -73534,246 +67786,6 @@
                 "range": {
                     "startColumn": 4,
                     "endColumn": 10,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/kafkaconnect/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/metadata.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 31,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 56,
-                    "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 81,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnreachable",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 84,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 31,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 36,
-                    "endColumn": 64,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 59,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 84,
-                    "endColumn": 94,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 33,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 68,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 53,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 6
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/microsoftfabricpipeline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 74,
                     "lineCount": 1
                 }
             }
@@ -73852,16 +67864,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/nifi/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/nifi/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -73893,22 +67895,6 @@
                     "startColumn": 12,
                     "endColumn": 90,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
                 }
             },
             {
@@ -73946,14 +67932,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 36,
                     "endColumn": 87,
                     "lineCount": 1
@@ -73968,11 +67946,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 7
+                    "startColumn": 30,
+                    "endColumn": 21,
+                    "lineCount": 3
                 }
             },
             {
@@ -74080,30 +68058,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 43,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 42,
@@ -74128,44 +68082,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 86,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 91,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportReturnType",
                 "range": {
                     "startColumn": 15,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/nifi/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -74258,30 +68178,6 @@
                     "endColumn": 67,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 42,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/pipeline/openlineage/metadata.py": [
@@ -74366,74 +68262,18 @@
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 7
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 17,
-                    "lineCount": 5
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 68,
+                    "startColumn": 73,
+                    "endColumn": 86,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 24,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 114,
+                    "startColumn": 100,
+                    "endColumn": 113,
                     "lineCount": 1
                 }
             },
@@ -74446,14 +68286,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 38,
@@ -74462,11 +68294,27 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 39,
+                    "lineCount": 1
                 }
             },
             {
@@ -74510,42 +68358,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 93,
+                    "startColumn": 47,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 76,
+                    "startColumn": 47,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 76,
+                    "startColumn": 47,
+                    "endColumn": 58,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 28,
-                    "endColumn": 93,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 54,
-                    "endColumn": 104,
+                    "startColumn": 47,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -74554,14 +68394,6 @@
                 "range": {
                     "startColumn": 99,
                     "endColumn": 103,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 24,
-                    "endColumn": 52,
                     "lineCount": 1
                 }
             },
@@ -74606,42 +68438,10 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 61,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 92,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 73,
-                    "endColumn": 85,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -74654,35 +68454,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 35,
-                    "endColumn": 105,
+                    "startColumn": 54,
+                    "endColumn": 73,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 33,
-                    "endColumn": 99,
+                    "startColumn": 52,
+                    "endColumn": 69,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 39,
-                    "endColumn": 25,
-                    "lineCount": 15
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 33,
-                    "lineCount": 4
                 }
             },
             {
@@ -74734,14 +68518,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 40,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportPossiblyUnboundVariable",
                 "range": {
                     "startColumn": 12,
@@ -74782,14 +68558,6 @@
                 }
             },
             {
-                "code": "reportReturnType",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 44,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 31,
@@ -74814,22 +68582,20 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/service_resolver.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 14,
-                    "endColumn": 5,
-                    "lineCount": 4
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/openlineage/service_spec.py": [
+        "./src/metadata/ingestion/source/pipeline/openlineage/ownership_resolver.py": [
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 45,
-                    "endColumn": 62,
+                    "startColumn": 31,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 49,
                     "lineCount": 1
                 }
             }
@@ -75132,6 +68898,56 @@
                 }
             }
         ],
+        "./src/metadata/ingestion/source/pipeline/prefect/metadata.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 85,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 54,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 24,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 21,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 40,
+                    "endColumn": 63,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/ingestion/source/pipeline/spline/client.py": [
             {
                 "code": "reportOperatorIssue",
@@ -75222,16 +69038,6 @@
                 }
             }
         ],
-        "./src/metadata/ingestion/source/pipeline/spline/connection.py": [
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            }
-        ],
         "./src/metadata/ingestion/source/pipeline/spline/metadata.py": [
             {
                 "code": "reportMissingParameterType",
@@ -75266,19 +69072,35 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 21,
+                    "endColumn": 54,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 26,
+                    "endColumn": 40,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 17,
+                    "endColumn": 50,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 36,
+                    "lineCount": 1
                 }
             },
             {
@@ -75378,22 +69200,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 33,
-                    "lineCount": 16
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 37,
-                    "lineCount": 4
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 59,
@@ -75402,26 +69208,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 40,
-                    "endColumn": 41,
-                    "lineCount": 6
+                    "startColumn": 56,
+                    "endColumn": 45,
+                    "lineCount": 3
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 43,
-                    "endColumn": 90,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 41,
-                    "endColumn": 86,
+                    "startColumn": 53,
+                    "endColumn": 92,
                     "lineCount": 1
                 }
             },
@@ -75438,16 +69236,6 @@
                 "range": {
                     "startColumn": 15,
                     "endColumn": 47,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/pipeline/spline/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 57,
                     "lineCount": 1
                 }
             }
@@ -75776,18 +69564,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
+                    "startColumn": 23,
+                    "endColumn": 33,
                     "lineCount": 1
                 }
             }
@@ -75866,18 +69646,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -75986,18 +69766,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -76032,24 +69812,6 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/search/elasticsearch/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 64,
                     "lineCount": 1
                 }
             }
@@ -76310,30 +70072,6 @@
                     "endColumn": 56,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/search/opensearch/metadata.py": [
@@ -76410,18 +70148,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 35,
-                    "endColumn": 13,
-                    "lineCount": 8
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 68,
                     "endColumn": 82,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 103,
                     "lineCount": 1
                 }
             },
@@ -76546,18 +70284,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 21,
-                    "lineCount": 9
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 90,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 31,
+                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -76592,24 +70330,6 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 7
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/search/opensearch/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 61,
                     "lineCount": 1
                 }
             }
@@ -76818,14 +70538,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 14,
@@ -77014,25 +70726,9 @@
                     "endColumn": 42,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/storage/gcs/metadata.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -77098,19 +70794,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 17,
-                    "lineCount": 3
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 12
+                    "startColumn": 23,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -77194,10 +70882,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 76,
+                    "startColumn": 48,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -77214,14 +70902,6 @@
                 "range": {
                     "startColumn": 33,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 87,
                     "lineCount": 1
                 }
             },
@@ -77266,10 +70946,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -77294,24 +70974,6 @@
                 "range": {
                     "startColumn": 37,
                     "endColumn": 41,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/storage/gcs/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 80,
                     "lineCount": 1
                 }
             }
@@ -77364,49 +71026,9 @@
                     "endColumn": 76,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 55,
-                    "endColumn": 67,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/ingestion/source/storage/s3/metadata.py": [
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 50,
-                    "endColumn": 60,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportMissingParameterType",
                 "range": {
@@ -77472,11 +71094,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 49,
-                    "endColumn": 17,
-                    "lineCount": 3
+                    "startColumn": 23,
+                    "endColumn": 62,
+                    "lineCount": 1
                 }
             },
             {
@@ -77493,22 +71115,6 @@
                     "startColumn": 55,
                     "endColumn": 59,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 61,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 9,
-                    "lineCount": 13
                 }
             },
             {
@@ -77568,10 +71174,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 29,
-                    "endColumn": 76,
+                    "startColumn": 48,
+                    "endColumn": 57,
                     "lineCount": 1
                 }
             },
@@ -77616,14 +71222,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 87,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 61,
@@ -77664,10 +71262,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 27,
-                    "endColumn": 74,
+                    "startColumn": 46,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             },
@@ -77685,14 +71283,6 @@
                     "startColumn": 24,
                     "endColumn": 58,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 9,
-                    "lineCount": 11
                 }
             },
             {
@@ -77716,24 +71306,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 27,
-                    "lineCount": 1
-                }
-            }
-        ],
-        "./src/metadata/ingestion/source/storage/s3/service_spec.py": [
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 45,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 69,
-                    "endColumn": 78,
                     "lineCount": 1
                 }
             }
@@ -77812,14 +71384,6 @@
                 }
             },
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 93,
-                    "endColumn": 111,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportAttributeAccessIssue",
                 "range": {
                     "startColumn": 44,
@@ -77868,11 +71432,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 28,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -77881,22 +71445,6 @@
                     "startColumn": 15,
                     "endColumn": 54,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 17,
-                    "lineCount": 10
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 18,
-                    "endColumn": 13,
-                    "lineCount": 10
                 }
             }
         ],
@@ -77918,19 +71466,19 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 16,
-                    "endColumn": 17,
-                    "lineCount": 11
+                    "startColumn": 26,
+                    "endColumn": 31,
+                    "lineCount": 1
                 }
             },
             {
@@ -77942,11 +71490,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 36,
-                    "endColumn": 17,
-                    "lineCount": 9
+                    "startColumn": 25,
+                    "endColumn": 41,
+                    "lineCount": 1
                 }
             },
             {
@@ -78758,11 +72306,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 9,
-                    "lineCount": 7
+                    "startColumn": 19,
+                    "endColumn": 26,
+                    "lineCount": 1
                 }
             }
         ],
@@ -78958,19 +72506,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 23,
-                    "endColumn": 82,
+                    "startColumn": 19,
+                    "endColumn": 52,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 20,
-                    "endColumn": 9,
-                    "lineCount": 8
                 }
             },
             {
@@ -79276,6 +72816,16 @@
                 "range": {
                     "startColumn": 9,
                     "endColumn": 12,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/profiler/api/models.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             }
@@ -80306,6 +73856,24 @@
                 }
             }
         ],
+        "./src/metadata/profiler/interface/sqlalchemy/exasol/profiler_interface.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 9,
+                    "endColumn": 13,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/profiler/interface/sqlalchemy/mariadb/profiler_interface.py": [
             {
                 "code": "reportMissingParameterType",
@@ -80658,14 +74226,6 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 64,
                     "lineCount": 1
                 }
             },
@@ -84108,38 +77668,6 @@
                 "range": {
                     "startColumn": 64,
                     "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 105,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 102,
-                    "endColumn": 104,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAssignmentType",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 89,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 86,
-                    "endColumn": 88,
                     "lineCount": 1
                 }
             }
@@ -87970,14 +81498,6 @@
         ],
         "./src/metadata/profiler/source/database/base/profiler_source.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 85,
-                    "endColumn": 95,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -88456,31 +81976,7 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 95,
-                    "endColumn": 99,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 89,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 27,
                     "endColumn": 97,
                     "lineCount": 1
                 }
@@ -88636,14 +82132,6 @@
                 }
             },
             {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 33,
-                    "endColumn": 66,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 49,
@@ -88762,6 +82250,104 @@
                 "range": {
                     "startColumn": 42,
                     "endColumn": 57,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/readers/archive.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 32,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 36,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 45,
+                    "endColumn": 49,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 26,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 39,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 26,
+                    "endColumn": 28,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 24,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 41,
+                    "endColumn": 45,
                     "lineCount": 1
                 }
             }
@@ -90626,6 +84212,32 @@
                 }
             }
         ],
+        "./src/metadata/sampler/messaging/sampler.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 10,
+                    "endColumn": 16,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 28,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 29,
+                    "endColumn": 34,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/sampler/models.py": [
             {
                 "code": "reportArgumentType",
@@ -90670,26 +84282,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 68,
-                    "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportArgumentType",
                 "range": {
                     "startColumn": 96,
                     "endColumn": 101,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 109,
-                    "endColumn": 116,
                     "lineCount": 1
                 }
             },
@@ -90722,14 +84318,6 @@
                 "range": {
                     "startColumn": 35,
                     "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 70,
-                    "endColumn": 77,
                     "lineCount": 1
                 }
             },
@@ -90788,14 +84376,6 @@
                     "endColumn": 19,
                     "lineCount": 1
                 }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 91,
-                    "endColumn": 98,
-                    "lineCount": 1
-                }
             }
         ],
         "./src/metadata/sampler/pandas/burstiq/sampler.py": [
@@ -90840,18 +84420,18 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 46,
+                    "startColumn": 26,
+                    "endColumn": 36,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 31,
-                    "endColumn": 38,
+                    "startColumn": 20,
+                    "endColumn": 25,
                     "lineCount": 1
                 }
             }
@@ -90990,14 +84570,6 @@
         ],
         "./src/metadata/sampler/processor.py": [
             {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 90,
-                    "endColumn": 100,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -91040,38 +84612,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 19,
-                    "endColumn": 25,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 47,
-                    "endColumn": 53,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 57,
-                    "endColumn": 63,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -91098,14 +84638,6 @@
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 80,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportArgumentType",
-                "range": {
                     "startColumn": 31,
                     "endColumn": 42,
                     "lineCount": 1
@@ -91118,14 +84650,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -91164,58 +84688,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/bigquery/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 37,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 89,
-                    "endColumn": 97,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 30,
-                    "endColumn": 41,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91224,14 +84708,6 @@
                 "range": {
                     "startColumn": 85,
                     "endColumn": 110,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 97,
-                    "endColumn": 105,
                     "lineCount": 1
                 }
             },
@@ -91310,14 +84786,6 @@
                 }
             },
             {
-                "code": "reportArgumentType",
-                "range": {
-                    "startColumn": 52,
-                    "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 24,
@@ -91342,30 +84810,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 105,
-                    "endColumn": 112,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportIncompatibleMethodOverride",
                 "range": {
                     "startColumn": 8,
@@ -91380,14 +84824,6 @@
                 "range": {
                     "startColumn": 8,
                     "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 23,
-                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -91426,18 +84862,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/postgres/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91718,18 +85154,18 @@
         ],
         "./src/metadata/sampler/sqlalchemy/snowflake/sampler.py": [
             {
-                "code": "reportArgumentType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 44,
-                    "endColumn": 48,
+                    "startColumn": 24,
+                    "endColumn": 28,
                     "lineCount": 1
                 }
             },
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
+                    "startColumn": 32,
+                    "endColumn": 38,
                     "lineCount": 1
                 }
             },
@@ -91962,6 +85398,16 @@
                 }
             }
         ],
+        "./src/metadata/sampler/sqlalchemy/tsql.py": [
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
+                }
+            }
+        ],
         "./src/metadata/sampler/sqlalchemy/unitycatalog/sampler.py": [
             {
                 "code": "reportMissingParameterType",
@@ -92030,14 +85476,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
@@ -92060,14 +85498,6 @@
                 "range": {
                     "startColumn": 51,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
@@ -92098,46 +85528,6 @@
                 }
             },
             {
-                "code": "reportIncompatibleMethodOverride",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 14,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 21,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 20,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 10,
-                    "endColumn": 16,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 28,
@@ -92154,34 +85544,10 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 27,
-                    "endColumn": 38,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 58,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 71,
                     "endColumn": 75,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 45,
                     "lineCount": 1
                 }
             },
@@ -92214,6 +85580,64 @@
                 "range": {
                     "startColumn": 93,
                     "endColumn": 97,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/sdk/data_quality/dataframes/models.py": [
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 11,
+                    "endColumn": 18,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 13,
+                    "endColumn": 33,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 27,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 20,
+                    "endColumn": 47,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 30,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 15,
+                    "endColumn": 22,
                     "lineCount": 1
                 }
             }
@@ -92716,11 +86140,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
                     "startColumn": 25,
-                    "endColumn": 17,
-                    "lineCount": 6
+                    "endColumn": 58,
+                    "lineCount": 1
                 }
             },
             {
@@ -92810,6 +86234,16 @@
                 "range": {
                     "startColumn": 50,
                     "endColumn": 56,
+                    "lineCount": 1
+                }
+            }
+        ],
+        "./src/metadata/utils/entity_reference.py": [
+            {
+                "code": "reportUnreachable",
+                "range": {
+                    "startColumn": 8,
+                    "endColumn": 55,
                     "lineCount": 1
                 }
             }
@@ -93998,11 +87432,11 @@
         ],
         "./src/metadata/utils/path_pattern.py": [
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 12,
-                    "endColumn": 13,
-                    "lineCount": 5
+                    "startColumn": 21,
+                    "endColumn": 29,
+                    "lineCount": 1
                 }
             }
         ],
@@ -94054,14 +87488,6 @@
             {
                 "code": "reportCallIssue",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
                     "startColumn": 41,
                     "endColumn": 56,
                     "lineCount": 1
@@ -94072,14 +87498,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 15,
-                    "endColumn": 51,
                     "lineCount": 1
                 }
             },
@@ -94138,11 +87556,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 11,
-                    "endColumn": 5,
-                    "lineCount": 6
+                    "startColumn": 21,
+                    "endColumn": 34,
+                    "lineCount": 1
                 }
             },
             {
@@ -94150,14 +87568,6 @@
                 "range": {
                     "startColumn": 21,
                     "endColumn": 37,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 11,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -94188,18 +87598,18 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportUndefinedVariable",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
+                    "startColumn": 21,
+                    "endColumn": 35,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -94212,42 +87622,10 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUndefinedVariable",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 35,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 17,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 22,
-                    "endColumn": 54,
+                    "startColumn": 58,
+                    "endColumn": 68,
                     "lineCount": 1
                 }
             },
@@ -95526,14 +88904,6 @@
             {
                 "code": "reportOptionalMemberAccess",
                 "range": {
-                    "startColumn": 55,
-                    "endColumn": 58,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
                     "startColumn": 32,
                     "endColumn": 36,
                     "lineCount": 1
@@ -95552,14 +88922,6 @@
                 "range": {
                     "startColumn": 32,
                     "endColumn": 36,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
                     "lineCount": 1
                 }
             },
@@ -95604,42 +88966,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 76,
                     "endColumn": 81,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -95673,14 +89003,6 @@
                     "startColumn": 8,
                     "endColumn": 9,
                     "lineCount": 7
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 42,
-                    "endColumn": 48,
-                    "lineCount": 1
                 }
             },
             {
@@ -95748,50 +89070,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 8,
-                    "endColumn": 43,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalMemberAccess",
-                "range": {
-                    "startColumn": 44,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 47,
                     "lineCount": 1
                 }
             },
@@ -95812,22 +89094,6 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportOptionalMemberAccess",
                 "range": {
                     "startColumn": 31,
@@ -95836,66 +89102,10 @@
                 }
             },
             {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 51,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 16,
                     "endColumn": 26,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 45,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 16,
-                    "endColumn": 49,
                     "lineCount": 1
                 }
             },
@@ -96198,16 +89408,8 @@
             {
                 "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 23,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportMissingParameterType",
-                "range": {
-                    "startColumn": 26,
-                    "endColumn": 30,
+                    "startColumn": 24,
+                    "endColumn": 32,
                     "lineCount": 1
                 }
             },
@@ -96215,15 +89417,23 @@
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 34,
-                    "endColumn": 40,
+                    "endColumn": 37,
                     "lineCount": 1
                 }
             },
             {
-                "code": "reportReturnType",
+                "code": "reportMissingParameterType",
                 "range": {
-                    "startColumn": 15,
-                    "endColumn": 103,
+                    "startColumn": 39,
+                    "endColumn": 41,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportMissingParameterType",
+                "range": {
+                    "startColumn": 30,
+                    "endColumn": 34,
                     "lineCount": 1
                 }
             }
@@ -96246,19 +89456,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 39,
-                    "endColumn": 17,
-                    "lineCount": 4
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 28,
-                    "endColumn": 17,
-                    "lineCount": 5
+                    "startColumn": 32,
+                    "endColumn": 106,
+                    "lineCount": 1
                 }
             },
             {
@@ -96286,18 +89488,34 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 19,
-                    "endColumn": 13,
-                    "lineCount": 6
+                    "startColumn": 30,
+                    "endColumn": 37,
+                    "lineCount": 1
                 }
             },
             {
                 "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 30,
-                    "endColumn": 37,
+                    "startColumn": 26,
+                    "endColumn": 51,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 22,
+                    "endColumn": 43,
+                    "lineCount": 1
+                }
+            },
+            {
+                "code": "reportArgumentType",
+                "range": {
+                    "startColumn": 23,
+                    "endColumn": 29,
                     "lineCount": 1
                 }
             }
@@ -96794,19 +90012,11 @@
                 }
             },
             {
-                "code": "reportCallIssue",
+                "code": "reportArgumentType",
                 "range": {
-                    "startColumn": 20,
-                    "endColumn": 21,
-                    "lineCount": 11
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 32,
-                    "endColumn": 25,
-                    "lineCount": 4
+                    "startColumn": 29,
+                    "endColumn": 42,
+                    "lineCount": 1
                 }
             },
             {
@@ -96830,14 +90040,6 @@
                 "range": {
                     "startColumn": 49,
                     "endColumn": 55,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 38,
-                    "endColumn": 53,
                     "lineCount": 1
                 }
             },
@@ -96888,30 +90090,6 @@
                 "range": {
                     "startColumn": 22,
                     "endColumn": 82,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 69,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 29,
-                    "endColumn": 54,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 25,
-                    "endColumn": 50,
                     "lineCount": 1
                 }
             },
@@ -97332,14 +90510,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 47,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 17,
@@ -97389,14 +90559,6 @@
             }
         ],
         "./src/metadata/workflow/usage.py": [
-            {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 50,
-                    "lineCount": 1
-                }
-            },
             {
                 "code": "reportAssignmentType",
                 "range": {
@@ -97517,14 +90679,6 @@
                     "startColumn": 32,
                     "endColumn": 46,
                     "lineCount": 1
-                }
-            },
-            {
-                "code": "reportCallIssue",
-                "range": {
-                    "startColumn": 34,
-                    "endColumn": 17,
-                    "lineCount": 6
                 }
             }
         ]

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -1,6 +1,6 @@
 FROM mysql:8.3 AS mysql
 
-FROM apache/airflow:3.2.2-python3.10
+FROM apache/airflow:3.2.2-python3.12
 USER root
 RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
   && echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/mssql-release.list
@@ -89,6 +89,17 @@ COPY --chown=airflow:0 --chmod=775 ingestion/ingestion_dependency.sh /opt/airflo
 COPY --chown=airflow:0 ingestion/examples/sample_data /home/airflow/ingestion/examples/sample_data
 # Required for Airflow DAGs of Sample Data
 COPY --chown=airflow:0 ingestion/examples/airflow/dags /opt/airflow/dags
+
+# Refresh the interpreter-level pip before dropping privileges. The per-user
+# pip upgrade below only reaches ~/.local, leaving the base image's
+# own copy (/usr/python/lib/python3.12/site-packages, pip 25.0.1) on disk for image
+# scanners (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
+# The explicit interpreter path is required, not stylistic: as root, `pip` resolves to
+# airflow's /root/bin/pip wrapper, which exits 1 (and for non-root execs ~/.local/bin/pip),
+# and bare `python` resolves to /home/airflow/.local/bin/python. Both would miss the very
+# copy this line exists to fix.
+RUN /usr/local/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
 USER airflow
 # Argument to provide for Ingestion Dependencies to install. Defaults to all
 ARG INGESTION_DEPENDENCY="all"
@@ -101,10 +112,10 @@ ENV PIP_QUIET=1
 ARG RI_VERSION="2.0.0.0"
 # Pin setuptools<81 as pkg_resources was removed in setuptools 81.0.0+
 # cx-Oracle's setup.py still uses pkg_resources
-RUN pip install --upgrade pip "setuptools<81"
+RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"
 # Pre-install cx-Oracle without build isolation to use the pinned setuptools
 RUN pip install --no-build-isolation "cx_Oracle>=8.3.0,<9"
-RUN pip install "openmetadata-managed-apis~=${RI_VERSION}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.2.2/constraints-3.10.txt"
+RUN pip install "openmetadata-managed-apis~=${RI_VERSION}" --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-3.2.2/constraints-3.12.txt"
 RUN pip install "openmetadata-ingestion[${INGESTION_DEPENDENCY}]~=${RI_VERSION}"
 
 # Temporary workaround for https://github.com/open-metadata/OpenMetadata/issues/9593

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -1,6 +1,6 @@
 FROM mysql:8.3 AS mysql
 
-FROM apache/airflow:3.2.2-python3.10
+FROM apache/airflow:3.2.2-python3.12
 USER root
 RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
   && echo "deb [arch=amd64,arm64,armhf signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/mssql-release.list
@@ -96,6 +96,16 @@ COPY --chown=airflow:0 ingestion/examples/airflow/dags /opt/airflow/dags
 COPY --chown=airflow:0 ingestion/examples/airflow/test_dags /opt/airflow/dags
 COPY --chown=airflow:0 ingestion/airflow-constraints-3.2.2.txt /home/airflow/airflow-constraints-3.2.2.txt
 
+# Refresh the interpreter-level pip before dropping privileges. The per-user
+# pip upgrade below only reaches ~/.local, leaving the base image's
+# own copy (/usr/python/lib/python3.12/site-packages, pip 25.0.1) on disk for image
+# scanners (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
+# The explicit interpreter path is required, not stylistic: as root, `pip` resolves to
+# airflow's /root/bin/pip wrapper, which exits 1 (and for non-root execs ~/.local/bin/pip),
+# and bare `python` resolves to /home/airflow/.local/bin/python. Both would miss the very
+# copy this line exists to fix.
+RUN /usr/local/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
 USER airflow
 
 # Disable pip cache dir
@@ -106,7 +116,7 @@ ENV PIP_QUIET=1
 
 # Pin setuptools<81 as pkg_resources was removed in setuptools 81.0.0+
 # cx-Oracle's setup.py still uses pkg_resources
-RUN pip install --upgrade pip "setuptools<81"
+RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"
 
 # Pre-install cx-Oracle without build isolation to use the pinned setuptools
 RUN pip install --no-build-isolation "cx_Oracle>=8.3.0,<9"
@@ -123,7 +133,7 @@ WORKDIR /home/airflow/ingestion
 # Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
 # but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
 RUN pip install --no-deps "sqlalchemy-redshift==0.8.14" "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
-RUN pip install "datamodel-code-generator==0.25.6"
+RUN pip install "datamodel-code-generator==0.64.0"
 RUN mkdir -p /home/airflow/ingestion/src/metadata/generated
 RUN python /home/airflow/scripts/datamodel_generation.py
 RUN wget -q https://repo1.maven.org/maven2/org/antlr/antlr4/4.9.2/antlr4-4.9.2-complete.jar -O /tmp/antlr.jar \

--- a/ingestion/airflow-constraints-3.2.2.txt
+++ b/ingestion/airflow-constraints-3.2.2.txt
@@ -1,6 +1,6 @@
 
 #
-# This constraints file was automatically generated on 2026-05-26T15:18:42.823061
+# This constraints file was automatically generated on 2026-05-26T15:21:58.290132
 # via `uv pip install --resolution highest` for the "v3-2-test" branch of Airflow.
 # This variant of constraints install uses the HEAD of the branch version for 'apache-airflow' but installs
 # the providers from PIP-released packages at the moment of the constraint generation.
@@ -16,14 +16,14 @@
 # commands that might change the installed version of apache-airflow should include "apache-airflow==X.Y.Z"
 # in the list of install targets to prevent Airflow accidental upgrade or downgrade.
 #
-# Typical installation process of airflow for Python 3.10 is (with random selection of extras and custom
+# Typical installation process of airflow for Python 3.12 is (with random selection of extras and custom
 # dependencies added), usually consists of two steps:
 #
 # 1. Reproducible installation of airflow with selected providers (note constraints are used):
 #
 # pip install "apache-airflow[celery,cncf.kubernetes,google,amazon,snowflake]==X.Y.Z" \
 #     --constraint \
-#    "https://raw.githubusercontent.com/apache/airflow/constraints-X.Y.Z/constraints-3.10.txt"
+#    "https://raw.githubusercontent.com/apache/airflow/constraints-X.Y.Z/constraints-3.12.txt"
 #
 # 2. Installing own dependencies that are potentially not matching the constraints (note constraints are not
 #    used, and apache-airflow==X.Y.Z is used to make sure there is no accidental airflow upgrade/downgrade.
@@ -111,7 +111,7 @@ apache-airflow-providers-apache-livy==4.5.6
 apache-airflow-providers-apache-pig==4.8.4
 apache-airflow-providers-apache-pinot==4.10.2
 apache-airflow-providers-apache-spark==6.0.2
-apache-airflow-providers-apache-tinkerpop==1.0.2
+apache-airflow-providers-apache-tinkerpop==1.1.3
 apache-airflow-providers-apprise==2.3.3
 apache-airflow-providers-arangodb==2.9.4
 apache-airflow-providers-asana==2.11.3
@@ -199,7 +199,7 @@ asana==5.2.4
 asgiref==3.11.1
 asn1crypto==1.5.1
 asttokens==3.0.1
-async-timeout==5.0.1
+async-timeout==4.0.3
 asyncpg==0.31.0
 asyncssh==2.23.0
 atlasclient==1.0.0
@@ -233,8 +233,6 @@ azure-synapse-artifacts==0.22.0
 azure-synapse-spark==0.7.0
 babel==2.18.0
 backoff==2.2.1
-backports.strenum==1.3.1
-backports.tarfile==1.2.0
 bcrypt==5.0.0
 beautifulsoup4==4.14.3
 billiard==4.2.4
@@ -293,7 +291,6 @@ email-validator==2.3.0
 entrypoints==0.4
 et_xmlfile==2.0.0
 eventlet==0.41.0
-exceptiongroup==1.3.1
 executing==2.2.1
 facebook_business==25.0.1
 fastapi-cli==0.0.24
@@ -375,7 +372,7 @@ googleapis-common-protos==1.75.0
 graphviz==0.21
 greenback==1.3.0
 greenlet==3.5.1
-gremlinpython==3.7.2
+gremlinpython==3.8.1
 griffelib==2.0.2
 grpc-google-iam-v1==0.14.4
 grpc-interceptor==0.15.4
@@ -415,7 +412,8 @@ inflection==0.5.1
 influxdb-client==1.50.0
 influxdb3-python==0.19.0
 ipykernel==7.2.0
-ipython==8.39.0
+ipython==9.13.0
+ipython_pygments_lexers==1.1.1
 isodate==0.7.2
 itsdangerous==2.2.0
 jaraco.classes==3.4.0
@@ -480,7 +478,7 @@ msrestazure==0.6.4.post1
 multi_key_dict==2.0.3
 multidict==6.7.1
 mypy_extensions==1.1.0
-mysql-connector-python==9.7.0
+mysql-connector-python==9.6.0
 mysqlclient==2.2.8
 natsort==8.4.0
 nbclient==0.10.4
@@ -488,7 +486,7 @@ nbconvert==7.17.1
 nbformat==5.10.4
 neo4j==6.2.0
 nest-asyncio==1.6.0
-numpy==2.2.6
+numpy==2.4.6
 oauthlib==3.3.1
 openai==2.38.0
 opencensus-context==0.1.3
@@ -517,7 +515,7 @@ outcome==1.3.0.post0
 packaging==26.2
 pagerduty==6.2.1
 pandas-gbq==0.35.0
-pandas-stubs==2.3.3.260113
+pandas-stubs==3.0.0.260204
 pandas==2.3.3
 pandocfilters==1.5.1
 papermill==2.7.0
@@ -616,14 +614,15 @@ ruamel.yaml==0.19.1
 s3fs==2026.4.0
 s3transfer==0.17.0
 sagemaker_studio==1.0.26
-scikit-learn==1.5.2
-scipy==1.15.3
+scikit-learn==1.8.0
+scipy==1.17.1
 scramp==1.4.8
 scrapbook==0.5.0
 segment-analytics-python==2.3.6
 sendgrid==6.12.5
 sentry-sdk==2.60.0
 setproctitle==1.3.7
+setuptools==82.0.1
 shellingham==1.5.4
 simple-salesforce==1.12.9
 six==1.17.0
@@ -664,7 +663,6 @@ thrift==0.24.0
 tiktoken==0.13.0
 tinycss2==1.4.0
 tokenizers==0.23.1
-tomli==2.4.1
 tomlkit==0.15.0
 tornado==6.5.5
 tqdm==4.67.3
@@ -672,7 +670,6 @@ traitlets==5.15.0
 trino==0.337.0
 typer==0.25.1
 types-protobuf==7.34.1.20260518
-types-pytz==2026.2.0.20260518
 types-requests==2.33.0.20260518
 typing-inspect==0.9.0
 typing-inspection==0.4.2
@@ -698,6 +695,7 @@ weaviate-client==4.16.2
 webencodings==0.5.1
 websocket-client==1.8.0
 websockets==16.0
+wheel==0.47.0
 wirerope==1.0.0
 wrapt==2.2.1
 xmlsec==1.3.17

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 # The -slim base ships without curl/gnupg/ca-certificates, so bootstrap them
 # before configuring third-party apt repositories.
@@ -35,7 +35,7 @@ RUN dpkg --configure -a \
     openssl \
     # mysqlclient 2.2+ locates libmysqlclient through pkg-config (2.1.x used
     # mysql_config) and has no Linux wheels, so it always builds from source.
-    # The slim base omits pkg-config, unlike the python:3.10-bookworm base.
+    # The slim base omits pkg-config, unlike the python:3.12-bookworm base.
     pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
@@ -112,6 +112,13 @@ RUN groupadd -g 1000 openmetadata && useradd -m -u 1000 -g 1000 openmetadata
 RUN chown -R openmetadata:openmetadata /ingestion
 ENV HOME=/home/openmetadata
 ENV PATH="/home/openmetadata/.local/bin:${PATH}"
+
+# Refresh the interpreter-level pip before dropping privileges. The per-user
+# pip upgrade below only writes to ~/.local, so the base image's
+# /usr/local copy stays on disk and image scanners keep reporting it
+# (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
+RUN pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
 USER openmetadata
 
 # Disable pip cache dir
@@ -122,7 +129,7 @@ ENV PIP_QUIET=1
 
 # Pin setuptools<81 as pkg_resources was removed in setuptools 81.0.0+
 # cx-Oracle's setup.py still uses pkg_resources
-RUN pip install --upgrade pip "setuptools<81"
+RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"
 # Pre-install cx-Oracle without build isolation to use the pinned setuptools
 RUN pip install --no-build-isolation "cx_Oracle>=8.3.0,<9"
 

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 # The -slim base ships without curl/gnupg/ca-certificates, so bootstrap them
 # before configuring third-party apt repositories.
@@ -34,7 +34,7 @@ RUN apt-get -qq update \
     openssl \
     # mysqlclient 2.2+ locates libmysqlclient through pkg-config (2.1.x used
     # mysql_config) and has no Linux wheels, so it always builds from source.
-    # The slim base omits pkg-config, unlike the python:3.10-bookworm base.
+    # The slim base omits pkg-config, unlike the python:3.12-bookworm base.
     pkg-config \
     # To ensure compatibility with unixodbc package
     odbcinst=2.3.11-2+deb12u1 \
@@ -113,6 +113,13 @@ RUN groupadd -g 1000 openmetadata && useradd -m -u 1000 -g 1000 openmetadata
 RUN chown -R openmetadata:openmetadata /ingestion
 ENV HOME=/home/openmetadata
 ENV PATH="/home/openmetadata/.local/bin:${PATH}"
+
+# Refresh the interpreter-level pip before dropping privileges. The per-user
+# pip upgrade below only writes to ~/.local, so the base image's
+# /usr/local copy stays on disk and image scanners keep reporting it
+# (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
+RUN pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
 USER openmetadata
 
 # Disable pip cache dir
@@ -123,7 +130,7 @@ ENV PIP_QUIET=1
 
 # Pin setuptools<81 as pkg_resources was removed in setuptools 81.0.0+
 # cx-Oracle's setup.py still uses pkg_resources
-RUN pip install --upgrade pip "setuptools<81"
+RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"
 # Pre-install cx-Oracle without build isolation to use the pinned setuptools
 RUN pip install --no-build-isolation "cx_Oracle>=8.3.0,<9"
 
@@ -131,7 +138,7 @@ ARG INGESTION_DEPENDENCY="all"
 # Pre-install dialect packages that declare SQLAlchemy<2 in their metadata
 # but work fine at runtime with SQLAlchemy 2.0 (unmaintained packages).
 RUN pip install --no-deps "sqlalchemy-redshift==0.8.14" "sqlalchemy-ibmi==0.9.3" "pydoris-custom==1.1.0"
-RUN pip install "datamodel-code-generator==0.25.6"
+RUN pip install "datamodel-code-generator==0.64.0"
 RUN mkdir -p /ingestion/src/metadata/generated
 RUN python /scripts/datamodel_generation.py
 RUN pip install ".[airflow]"

--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -434,7 +434,7 @@ plugins: Dict[str, Set[str]] = {  # noqa: UP006
 dev = {
     "ruff~=0.15.12",
     "uvloop==0.21.0",
-    "datamodel-code-generator==0.25.6",
+    "datamodel-code-generator==0.64.0",
     "boto3-stubs",
     "mypy-boto3-glue",
     "google-api-python-client-stubs",

--- a/ingestion/src/metadata/ingestion/connections/builders.py
+++ b/ingestion/src/metadata/ingestion/connections/builders.py
@@ -138,9 +138,9 @@ def init_empty_connection_arguments() -> ConnectionArguments:
     Initialize a ConnectionArguments model with an empty dictionary.
     This helps set keys without further validations.
 
-    Running `ConnectionArguments()` returns `ConnectionArguments(root=None)`.
+    `ConnectionArguments()` raises a ValidationError since `root` is required.
 
-    Instead, we want `ConnectionArguments(root={}})` so that
+    Instead, we want `ConnectionArguments(root={})` so that
     we can pass new keys easily as `connectionArguments.root["key"] = "value"`
     """
     return ConnectionArguments(root={})
@@ -151,9 +151,9 @@ def init_empty_connection_options() -> ConnectionOptions:
     Initialize a ConnectionOptions model with an empty dictionary.
     This helps set keys without further validations.
 
-    Running `ConnectionOptions()` returns `ConnectionOptions(root=None)`.
+    `ConnectionOptions()` raises a ValidationError since `root` is required.
 
-    Instead, we want `ConnectionOptions(root={}})` so that
+    Instead, we want `ConnectionOptions(root={})` so that
     we can pass new keys easily as `ConnectionOptions.root["key"] = "value"`
     """
     return ConnectionOptions(root={})

--- a/ingestion/src/metadata/ingestion/ometa/ometa_api.py
+++ b/ingestion/src/metadata/ingestion/ometa/ometa_api.py
@@ -16,6 +16,7 @@ working with OpenMetadata entities.
 """
 
 import traceback
+import types
 from collections import OrderedDict
 from collections.abc import Generator
 from itertools import chain
@@ -145,7 +146,10 @@ class CaseInsensitiveEnvSettingsSource(EnvSettingsSource):
     def _unwrap_annotation(annotation):
         """Unwrap Optional and other Union types to get the actual model class."""
         origin = get_origin(annotation)
-        if origin is Union:
+        # PEP 604 unions (`X | None`) report `types.UnionType`, not `typing.Union`. Generated
+        # models emit that form, so matching only `Union` here silently stops unwrapping and
+        # nested env keys never get case-normalized.
+        if origin in (Union, types.UnionType):
             args = get_args(annotation)
             for arg in args:
                 if arg is not type(None) and hasattr(arg, "model_fields"):

--- a/ingestion/src/metadata/ingestion/source/dashboard/superset/api_source.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/superset/api_source.py
@@ -297,7 +297,7 @@ class SupersetAPISource(SupersetSourceMixin):
                             else None
                         ),
                         service=FullyQualifiedEntityName(self.context.get().dashboard_service),
-                        columns=self.get_column_info(result.columns),
+                        columns=self.get_column_info(result.columns) or [],
                         dataModelType=DataModelType.SupersetDataModel.value,
                     )
                     yield Either(right=data_model_request)

--- a/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/superset/mixin.py
@@ -21,7 +21,7 @@ from collate_sqllineage.core.models import Table as LineageTable
 
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.entity.data.dashboardDataModel import DashboardDataModel
-from metadata.generated.schema.entity.data.table import Column, DataType, Table
+from metadata.generated.schema.entity.data.table import Column, ColumnName, DataType, Table
 from metadata.generated.schema.entity.services.connections.dashboard.supersetConnection import (
     SupersetConnection,
 )
@@ -401,7 +401,7 @@ class SupersetSourceMixin(DashboardServiceSource):
                         dataType=col_parse["dataType"],
                         arrayDataType=self.parse_array_data_type(col_parse),
                         children=self.parse_row_data_type(col_parse),
-                        name=truncate_column_name(field.column_name or str(field.id)),
+                        name=ColumnName(truncate_column_name(field.column_name or str(field.id))),
                         displayName=field.column_name,
                         description=field.description,
                         dataLength=int(col_parse.get("dataLength", 0)),

--- a/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/airflow/metadata.py
@@ -751,6 +751,17 @@ class AirflowSource(PipelineServiceSource):
         """
         return PipelineState[pipeline_details.state]
 
+    @staticmethod
+    def _task_description(task: BaseOperator) -> Markdown | None:
+        """
+        Pick the first populated doc field Airflow exposes for a task.
+        """
+        doc = next(
+            (doc for doc in (task.doc_md, task.doc, task.doc_json, task.doc_yaml, task.doc_rst) if doc),
+            None,
+        )
+        return Markdown(doc) if doc else None
+
     def get_tasks_from_dag(self, dag: AirflowDagDetails, host_port: str) -> List[Task]:  # noqa: UP006
         """
         Obtain the tasks from a SerializedDAG
@@ -761,10 +772,7 @@ class AirflowSource(PipelineServiceSource):
         return [
             Task(  # pyright: ignore[reportCallIssue]
                 name=task.task_id,
-                description=next(
-                    (doc for doc in (task.doc_md, task.doc, task.doc_json, task.doc_yaml, task.doc_rst) if doc),
-                    None,
-                ),
+                description=self._task_description(task),
                 sourceUrl=SourceUrl(
                     (  # noqa: UP034
                         f"{clean_uri(host_port)}/dags/{quote(dag.dag_id)}/tasks/{quote(task.task_id)}"

--- a/ingestion/src/metadata/utils/dependency_injector/dependency_injector.py
+++ b/ingestion/src/metadata/utils/dependency_injector/dependency_injector.py
@@ -34,6 +34,7 @@ Example:
     ```
 """
 
+import types
 from functools import wraps
 from threading import RLock
 from typing import (  # noqa: UP035
@@ -318,7 +319,8 @@ def is_inject_type(tp: Any) -> bool:
     origin = get_origin(tp)
     if origin is Inject:
         return True
-    if origin is Union:
+    # PEP 604 unions (`Inject[X] | None`) report `types.UnionType`, not `typing.Union`.
+    if origin in (Union, types.UnionType):
         args = get_args(tp)
         return any(get_origin(arg) is Inject for arg in args)
     return False
@@ -340,7 +342,7 @@ def extract_inject_arg(tp: Any) -> Any:
     origin = get_origin(tp)
     if origin is Inject:
         return get_args(tp)[0]
-    if origin is Union:
+    if origin in (Union, types.UnionType):
         for arg in get_args(tp):
             if get_origin(arg) is Inject:
                 return get_args(arg)[0]

--- a/ingestion/tests/integration/data_quality/test_data_quality.py
+++ b/ingestion/tests/integration/data_quality/test_data_quality.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from metadata.generated.schema.entity.data.table import Table
 from metadata.generated.schema.entity.services.databaseService import DatabaseService
 from metadata.generated.schema.metadataIngestion.testSuitePipeline import (
-    List,
     TestSuiteConfigType,
 )
 from metadata.ingestion.ometa.routes import TestDefinition
@@ -55,7 +54,7 @@ def test_all_definition_exists(metadata):
     test_definition_path = cwd.parents[3] / "openmetadata-service/src/main/resources/json/data/tests"
     test_difinitions_glob = test_definition_path.glob("*.json")
 
-    test_definitions_names: List[str] = []
+    test_definitions_names: list[str] = []
     for test_definition_file in test_difinitions_glob:
         with open(test_definition_file, encoding="utf-8") as fle:  # noqa: PTH123
             test_definitions_names.append(json.load(fle)["name"])

--- a/scripts/datamodel_generation.py
+++ b/scripts/datamodel_generation.py
@@ -15,9 +15,12 @@ from a configured secrets' manager.
 """
 import glob
 import os
+import re
 
 from datamodel_code_generator.imports import Import
-from datamodel_code_generator.model import pydantic as pydantic_model
+# `model.pydantic` held the Pydantic v1 models and was removed in datamodel-code-generator 0.60+.
+# We generate with `--output-model-type pydantic_v2.BaseModel`, so patch the v2 type map.
+from datamodel_code_generator.model import pydantic_v2 as pydantic_model
 from datamodel_code_generator.__main__ import main
 
 pydantic_model.types.IMPORT_SECRET_STR = Import.from_full_path(
@@ -116,5 +119,54 @@ for file_path in DATETIME_AWARE_FILE_PATHS:
         content = content.replace("AwareDatetime", "datetime")
     with open(file_path, "w", encoding=UTF_8) as f:
         f.write(content)
+
+
+# -------------------------------------------------------------------------
+# PIN UNION RESOLUTION FOR SourceConfig.config
+# -------------------------------------------------------------------------
+# `sourceConfig.config` is an undiscriminated `oneOf`: every member declares a
+# `type` with a JSON Schema default and none of them list it as required, so a
+# config that omits `type` validates against several members at once and pydantic
+# has to break the tie itself. Under datamodel-code-generator 0.25.6 smart mode
+# resolved to the leftmost match (DatabaseServiceMetadataPipeline); under 0.64.0
+# it resolves to DatabaseServiceProfilerPipeline, so a metadata workflow silently
+# receives a profiler config and then dies on `source_config.threads`.
+# `left_to_right` restores the previous winner.
+#
+# This is a stopgap for the Python models only. The real fix is a discriminator on
+# `type` in openmetadata-spec/.../metadataIngestion/workflow.json, which would
+# resolve the union deterministically for the Java and TypeScript consumers too.
+UNION_MODE_FILE = f"{ingestion_path}src/metadata/generated/schema/metadataIngestion/workflow.py"
+# datamodel-code-generator formats its output with whatever black the environment
+# resolves (it only requires black>=19.10b0), and black renders this annotation two
+# different ways depending on its version. 23.x+ parenthesizes the annotation; 22.3.0
+# cannot split it, so it leaves the annotation on one line and wraps the value instead:
+#   black >= 23.x    ->  config: (\n        A\n        | B\n    ) = None
+#   black == 22.3.0  ->  config: A | B | None = None
+#                    ->  config: A | B | None = (\n        None\n    )   # very long lines
+# 1.13 pins black==22.3.0 while main uses ruff and resolves the latest black, so the
+# pattern has to accept both. The `(?!\nclass )` guards keep the match inside
+# SourceConfig, so a genuinely new layout still fails loudly below instead of
+# silently pinning union_mode on some other class's `config` field.
+SOURCE_CONFIG_BLOCK = re.compile(
+    r"(class SourceConfig\(BaseModel\):(?:(?!\nclass ).)*?\n    config: (?:(?!\nclass ).)*?)"
+    r"= (?:None|\(\s*None\s*\))\n",
+    re.DOTALL,
+)
+
+with open(UNION_MODE_FILE, "r", encoding=UTF_8) as f:
+    content = f.read()
+
+content, applied = SOURCE_CONFIG_BLOCK.subn(r'\1= Field(None, union_mode="left_to_right")\n', content, count=1)
+if applied != 1:
+    # Fail loudly: silently skipping this leaves every `type`-less workflow config
+    # resolving to the wrong pipeline model at runtime.
+    raise RuntimeError(
+        f"Could not pin union_mode on SourceConfig.config in {UNION_MODE_FILE}. "
+        "The generated layout changed -- update SOURCE_CONFIG_BLOCK."
+    )
+
+with open(UNION_MODE_FILE, "w", encoding=UTF_8) as f:
+    f.write(content)
 
 print("Model generation and post-processing completed successfully.")


### PR DESCRIPTION
fix(security): move ingestion images to Python 3.12, upgrade datamodel-code-gen [2.0 backport]

Backport of c6190e64 and 8e140950 to 2.0.

python:3.10-slim-bookworm is EOL and no longer rebuilt, so its Debian layer and
bundled Python tooling are frozen. Move all four ingestion images to
python:3.12-slim-bookworm / apache/airflow:3.2.2-python3.12, point
ingestion/Dockerfile at the Airflow constraints-3.12 file, regenerate the
vendored airflow-constraints-3.2.2.txt from upstream's 3.12 variant, and raise
the interpreter-level pip to >=26.2,<27 before dropping privileges (the existing
post-USER upgrade only reached ~/.local and left the base image's copy on disk
for scanners -- CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643).

Bump datamodel-code-generator 0.25.6 -> 0.64.0 (CVE-2026-54621, -54653, -54654,
-54690, -54691, -55389, -55391, -55415). `model.pydantic` held the Pydantic v1
models and was removed upstream in 0.60+, so the IMPORT_SECRET_STR patch that
swaps pydantic.SecretStr for CustomSecretStr moves to `model.pydantic_v2` --
the map actually consulted, since we generate with --output-model-type
pydantic_v2.BaseModel.

Carries the follow-on fixes the bump required: PEP 604 union matching in
_unwrap_annotation and dependency_injector, the stale List import in the data
quality integration test, three type errors at stricter generated-model call
sites (superset api_source/mixin, airflow metadata), and the
union_mode="left_to_right" pin on SourceConfig.config.

Two 2.0-specific deviations from the main commits:

- The basedpyright baseline is deliberately not taken. main's version is a full
  regeneration against main's file set (928 -> 806 files) and does not describe
  2.0's tree. 2.0's own baseline still holds: measured against a clean
  origin/2.0 control in the same environment, this change produces 0 new errors
  and removes 2 -- exactly the two superset diagnostics it fixes.
  `--baselinemode=discard` tolerates baseline entries that no longer fire, so no
  baseline edit is needed.

- 8e140950 (layout-agnostic SOURCE_CONFIG_BLOCK) is squashed in even though 2.0
  does not need it. 2.0 resolves black 26.5.1 like main, not the black==22.3.0
  that broke 1.13, and the original regex matches cleanly here -- verified by
  running the codegen under dcg 0.64.0, which produces byte-identical generated
  models with either regex. It is included so datamodel_generation.py does not
  diverge on 2.0 alone against main and 1.13, and so a future black pin cannot
  reintroduce the 1.13 failure.

(cherry picked from commit c6190e6415970b17bbe7005b5b1690eb2d570133)
(cherry picked from commit 8e140950a09b5c6bb215c1c433f931542c7b77f5)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
