### PR TITLE
fix(ingestion): fix Prefect connector basedpyright errors (2.0)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/pipeline/prefect/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/pipeline/prefect/metadata.py
@@ -45,7 +45,12 @@ from metadata.generated.schema.entity.services.ingestionPipelines.status import 
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
-from metadata.generated.schema.type.basic import FullyQualifiedEntityName, SourceUrl
+from metadata.generated.schema.type.basic import (
+    EntityName,
+    FullyQualifiedEntityName,
+    SourceUrl,
+    Timestamp,
+)
 from metadata.generated.schema.type.entityLineage import EntitiesEdge, LineageDetails
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.entityReference import EntityReference
@@ -93,13 +98,13 @@ PREFECT_STATE_MAP = {
 }
 
 
-def _parse_timestamp(ts_str: str | None) -> int | None:
+def _parse_timestamp(ts_str: str | None) -> Timestamp | None:
     """Convert an ISO timestamp string to a Unix timestamp in milliseconds."""
     if not ts_str:
         return None
     try:
         dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
-        return int(dt.timestamp() * 1000)
+        return Timestamp(int(dt.timestamp() * 1000))
     except Exception:
         logger.debug("Failed to parse timestamp %r", ts_str, exc_info=True)
         return None
@@ -463,7 +468,7 @@ class PrefectSource(PipelineServiceSource):
             service_fqn = self.context.get().pipeline_service  # pyright: ignore[reportAttributeAccessIssue]
 
             create_request = CreatePipelineRequest(  # pyright: ignore[reportCallIssue]
-                name=flow_name,
+                name=EntityName(flow_name),
                 displayName=flow_name,
                 scheduleInterval=schedule_interval,
                 sourceUrl=SourceUrl(source_url),
@@ -528,7 +533,7 @@ class PrefectSource(PipelineServiceSource):
             return
 
         lineage_details = LineageDetails(  # pyright: ignore[reportCallIssue]
-            pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),  # pyright: ignore[reportCallIssue]
+            pipeline=EntityReference(id=pipeline_entity.id, type="pipeline"),  # pyright: ignore[reportCallIssue]
             source=LineageSource.PipelineLineage,
         )
         for entry in materializations:
@@ -605,7 +610,7 @@ class PrefectSource(PipelineServiceSource):
                 return
 
             lineage_details = LineageDetails(  # pyright: ignore[reportCallIssue]
-                pipeline=EntityReference(id=pipeline_entity.id.root, type="pipeline"),  # pyright: ignore[reportCallIssue]
+                pipeline=EntityReference(id=pipeline_entity.id, type="pipeline"),  # pyright: ignore[reportCallIssue]
                 source=LineageSource.PipelineLineage,
             )
 

--- a/ingestion/tests/unit/topology/pipeline/test_prefect.py
+++ b/ingestion/tests/unit/topology/pipeline/test_prefect.py
@@ -32,6 +32,7 @@ from metadata.generated.schema.entity.services.connections.pipeline.prefectConne
 from metadata.generated.schema.metadataIngestion.workflow import (
     Source as WorkflowSource,
 )
+from metadata.generated.schema.type.basic import Uuid
 from metadata.generated.schema.type.entityLineage import Source as LineageSource
 from metadata.generated.schema.type.tagLabel import LabelType, State, TagLabel, TagSource
 from metadata.ingestion.source.pipeline.pipeline_service import PipelineServiceSource
@@ -333,7 +334,7 @@ class TestSplitLineageTagIdentifier:
 
 class TestParseTimestamp:
     def test_parses_iso_string_with_z_suffix(self):
-        assert _parse_timestamp("2024-04-19T10:00:00Z") == 1713520800000
+        assert _parse_timestamp("2024-04-19T10:00:00Z").root == 1713520800000
 
     def test_none_when_input_is_none_or_empty(self):
         assert _parse_timestamp(None) is None
@@ -808,7 +809,7 @@ class TestPrefectSource:
 
     def test_yield_pipeline_lineage_details_builds_table_to_table_edges(self, prefect_source):
         pipeline_entity = Mock()
-        pipeline_entity.id.root = uuid.uuid4()
+        pipeline_entity.id = Uuid(uuid.uuid4())
         source_table = Mock(id=uuid.uuid4())
         dest_table = Mock(id=uuid.uuid4())
 
@@ -857,7 +858,7 @@ class TestPrefectSource:
         to every detected destination. A source/destination identifier that
         doesn't resolve to a real table is dropped, not sent as a broken edge."""
         pipeline_entity = Mock()
-        pipeline_entity.id.root = uuid.uuid4()
+        pipeline_entity.id = Uuid(uuid.uuid4())
         source_table = Mock(id=uuid.uuid4())
         dest_table = Mock(id=uuid.uuid4())
 
@@ -1033,7 +1034,7 @@ class TestYieldLineageFromAssets:
 
     def test_builds_edge_for_resolved_pair(self, prefect_source):
         pipeline_entity = Mock()
-        pipeline_entity.id.root = uuid.uuid4()
+        pipeline_entity.id = Uuid(uuid.uuid4())
         prefect_source.client.get_asset_materializations.return_value = [
             AssetMaterialization(
                 asset_key="postgres://host/mydb/public/dest_table",
@@ -1072,7 +1073,7 @@ class TestYieldLineageFromAssets:
 
     def test_skips_materialization_when_destination_table_not_found(self, prefect_source):
         pipeline_entity = Mock()
-        pipeline_entity.id.root = uuid.uuid4()
+        pipeline_entity.id = Uuid(uuid.uuid4())
         prefect_source.client.get_asset_materializations.return_value = [
             AssetMaterialization(asset_key="postgres://host/mydb/public/dest_table", upstream_assets=[])
         ]
@@ -1084,7 +1085,7 @@ class TestYieldLineageFromAssets:
 
     def test_skips_upstream_asset_when_source_table_not_found(self, prefect_source):
         pipeline_entity = Mock()
-        pipeline_entity.id.root = uuid.uuid4()
+        pipeline_entity.id = Uuid(uuid.uuid4())
         dest_table = Mock(id=uuid.uuid4())
         prefect_source.client.get_asset_materializations.return_value = [
             AssetMaterialization(


### PR DESCRIPTION
Cherry-pick of #31263 onto `2.0`. Applied cleanly — both touched files were byte-identical to their pre-fix state on `main`.

## Summary

The Prefect connector passes raw `int` / `str` / `UUID` where the generated models declare the `Timestamp`, `EntityName` and `Uuid` `RootModel` wrappers. Pydantic coerces these at runtime, so this is a typing defect only — no behaviour change.

## Changes

- `_parse_timestamp` returns `Timestamp | None` instead of `int | None`, matching the dbtCloud connector's equivalent helper.
- `CreatePipelineRequest(name=...)` wraps the flow name in `EntityName`, consistent with the neighbouring `SourceUrl(...)` / `FullyQualifiedEntityName(...)` arguments.
- The lineage `EntityReference` takes `pipeline_entity.id` (already a `Uuid`) instead of unwrapping it to a bare `UUID`, at both call sites.

Unit tests updated for the new `_parse_timestamp` return type and for the `Uuid`-typed mock ids.

## Note on CI impact

On `main` this unblocks a red `Unit Tests & Static Checks` job. On `2.0` the same errors are currently latent: `2.0` pins `datamodel-code-generator==0.25.6`, whose generated models make basedpyright raise a missing-arguments `reportCallIssue` first — which the file's existing `# pyright: ignore[reportCallIssue]` comments swallow, hiding the `reportArgumentType` errors. `main` is on `0.64.0`, where they surface. So this pick is correctness plus forward-compat for a future codegen bump on `2.0`, not a CI unblock here.