### PR TITLE
fix(ingestion): backport Power BI pagination rate-limit fix to 2.0

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/client.py
@@ -62,6 +62,13 @@ API_RESPONSE_MESSAGE_KEY = "message"
 AUTH_TOKEN_MAX_RETRIES = 5
 AUTH_TOKEN_RETRY_WAIT = 120
 
+# GetGroupsAsAdmin caps $top at 5000 and is rate limited to 50 requests/hour per
+# tenant, so paging in the largest allowed chunks keeps the shared quota intact.
+# https://learn.microsoft.com/en-us/rest/api/power-bi/admin/groups-get-groups-as-admin#limitations
+MAX_PAGINATION_ENTITY_PER_PAGE = 5000
+# Mirrors the schema default, applied when the connection sets the field to null.
+DEFAULT_PAGINATION_ENTITY_PER_PAGE = 100
+
 # Bounds the error body kept in the step's error log.
 ERROR_DETAIL_LIMIT = 200
 
@@ -94,7 +101,10 @@ class PowerBiApiClient:
 
     def __init__(self, config: PowerBIConnection):
         self.config = config
-        self.pagination_entity_per_page = min(100, self.config.pagination_entity_per_page)
+        self.pagination_entity_per_page = min(
+            MAX_PAGINATION_ENTITY_PER_PAGE,
+            self.config.pagination_entity_per_page or DEFAULT_PAGINATION_ENTITY_PER_PAGE,
+        )
         self.msal_client = msal.ConfidentialClientApplication(
             client_id=self.config.clientId,
             client_credential=self.config.clientSecret.get_secret_value(),

--- a/ingestion/tests/unit/topology/dashboard/test_powerbi_client.py
+++ b/ingestion/tests/unit/topology/dashboard/test_powerbi_client.py
@@ -1,0 +1,42 @@
+#  Copyright 2026 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Test PowerBI API Client
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.dashboard.powerBIConnection import (
+    PowerBIConnection,
+)
+from metadata.ingestion.source.dashboard.powerbi.client import PowerBiApiClient
+
+CONNECTION_CONFIG = {
+    "clientId": "client_id",
+    "clientSecret": "client_secret",
+    "tenantId": "tenant_id",
+}
+
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [(None, 100), (1, 1), (100, 100), (5000, 5000), (100_000, 5000)],
+    ids=["null", "one", "old-ceiling", "at-ceiling", "above-ceiling"],
+)
+@patch("metadata.ingestion.source.dashboard.powerbi.client.msal")
+def test_page_size_is_clamped_to_the_groups_ceiling(_msal, configured, expected):
+    """GetGroupsAsAdmin documents a $top ceiling of 5000, and the field is nullable."""
+    connection = PowerBIConnection(**CONNECTION_CONFIG, pagination_entity_per_page=configured)
+
+    assert PowerBiApiClient(connection).pagination_entity_per_page == expected


### PR DESCRIPTION
Backports #30954 to the 2.0 branch.\n\nChanges:\n- use the configured Power BI pagination size up to the GetGroupsAsAdmin limit of 5000\n- retain the default page size of 100 when unset\n- add focused page-size clamping coverage\n\nValidation:\n- targeted pytest: 5 passed\n- Ruff check: passed\n- Ruff format check: passed