### PR TITLE
fix(api): log async delete failures instead of only notifying a websocket

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
@@ -742,6 +742,19 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
                 WebsocketNotificationHandler.sendDeleteOperationCompleteNotification(
                     jobId, securityContext, deleteResponse.entity());
               } catch (Exception e) {
+                // Log before notifying. The WebSocket notification is the ONLY report this path
+                // had, so a failed async delete was invisible to anyone not holding a live socket
+                // — no stack trace, no error line, nothing. A 100k-table service delete that dies
+                // here looks exactly like one still grinding, which is precisely the ambiguity
+                // that made the nightly scale failures undiagnosable.
+                LOG.error(
+                    "Async delete failed for {} {} (jobId {}, recursive={}, hardDelete={})",
+                    entityType,
+                    id,
+                    jobId,
+                    recursive,
+                    hardDelete,
+                    e);
                 WebsocketNotificationHandler.sendDeleteOperationFailedNotification(
                     jobId,
                     securityContext,


### PR DESCRIPTION
`EntityResource.deleteByIdAsync` caught `Exception` and reported it **solely** via `WebsocketNotificationHandler.sendDeleteOperationFailedNotification`:

```java
} catch (Exception e) {
  WebsocketNotificationHandler.sendDeleteOperationFailedNotification(
      jobId, securityContext, entity, e.getMessage() == null ? e.toString() : e.getMessage());
}
```

That was the only report this path had. Unless a client happened to be holding a live socket, the failure vanished — no stack trace, no error line, nothing in the server log.

## Why this matters beyond a missing log

A recursive hard delete that dies here is **indistinguishable from one still running**. The caller keeps polling an entity that will never disappear, and the server looks idle.

That is exactly what the nightly scale suite has been hitting. `ServiceDeleteSearchCleanupScaleIT` waits for a 100k-table service's search docs to reach zero, and across five separate investigations the server log for the delete window contained **no `EntityRepository` activity and no error** — leaving "slow" and "dead" impossible to tell apart. The evidence was being thrown away at this line.

## The change

Log at `ERROR` with the entity type, id, jobId and the `recursive`/`hardDelete` flags before sending the notification. Notification behaviour is unchanged; nothing else moves.

## Verification

`mvn compile -pl openmetadata-service` — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
