### PR TITLE
fix(ui): enforce secret: prefix for password fields on Hybrid Runner

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.test.tsx
@@ -29,6 +29,7 @@ import {
   loadConnectionSchema,
   wrapFlatCredentialsIntoAuthType,
 } from '../../../../utils/ServiceConnectionUtils';
+import serviceUtilClassBase from '../../../../utils/ServiceUtilClassBase';
 import ConnectionConfigForm from './ConnectionConfigForm';
 
 const mockServicesData = {
@@ -196,6 +197,10 @@ jest.mock('../../../common/AirflowMessageBanner/AirflowMessageBanner', () => {
     );
 });
 
+let mockCapturedCustomValidate:
+  | ((formData: unknown, errors: unknown) => unknown)
+  | undefined;
+
 jest.mock('../../../common/FormBuilderV1/FormBuilderV1', () =>
   forwardRef(
     jest
@@ -210,49 +215,54 @@ jest.mock('../../../common/FormBuilderV1/FormBuilderV1', () =>
           onFocus,
           onSubmit,
           onCancel,
-        }) => (
-          <div
-            data-no-validate={String(Boolean(noValidate))}
-            data-testid="form-builder">
-            {children}
-            <button
-              data-testid="focus-via-form-context"
-              onClick={() =>
-                formContext?.handleFocus?.('root/taxonomyProjectID')
-              }>
-              Focus via formContext
-            </button>
-            <button
-              data-testid="focus-via-rjsf"
-              onClick={() => onFocus?.('root/hostPort')}>
-              Focus via RJSF
-            </button>
-            <button
-              data-testid="change-valid-form"
-              onClick={() => onChange({ formData })}>
-              Change FormBuilder
-            </button>
-            <button
-              data-testid="change-edited-form"
-              onClick={() =>
-                onChange({
-                  formData: {
-                    ...formData,
-                    username: 'changed-admin',
-                  },
-                })
-              }>
-              Change FormBuilder With Edits
-            </button>
-            <button
-              data-testid="submit-button"
-              disabled={isSubmitDisabled}
-              onClick={() => onSubmit({ formData })}>
-              Submit FormBuilder
-            </button>
-            <button onClick={onCancel}>Cancel FormBuilder</button>
-          </div>
-        )
+          customValidate,
+        }) => {
+          mockCapturedCustomValidate = customValidate;
+
+          return (
+            <div
+              data-no-validate={String(Boolean(noValidate))}
+              data-testid="form-builder">
+              {children}
+              <button
+                data-testid="focus-via-form-context"
+                onClick={() =>
+                  formContext?.handleFocus?.('root/taxonomyProjectID')
+                }>
+                Focus via formContext
+              </button>
+              <button
+                data-testid="focus-via-rjsf"
+                onClick={() => onFocus?.('root/hostPort')}>
+                Focus via RJSF
+              </button>
+              <button
+                data-testid="change-valid-form"
+                onClick={() => onChange({ formData })}>
+                Change FormBuilder
+              </button>
+              <button
+                data-testid="change-edited-form"
+                onClick={() =>
+                  onChange({
+                    formData: {
+                      ...formData,
+                      username: 'changed-admin',
+                    },
+                  })
+                }>
+                Change FormBuilder With Edits
+              </button>
+              <button
+                data-testid="submit-button"
+                disabled={isSubmitDisabled}
+                onClick={() => onSubmit({ formData })}>
+                Submit FormBuilder
+              </button>
+              <button onClick={onCancel}>Cancel FormBuilder</button>
+            </div>
+          );
+        }
       )
   )
 );
@@ -336,6 +346,26 @@ describe('ServiceConfig', () => {
     ).toBeInTheDocument();
 
     expect(await screen.findByTestId('form-builder')).toBeInTheDocument();
+  });
+
+  it('wires validateSecretPrefixFields into RJSF customValidate and no-ops by default', async () => {
+    const validateSecretPrefixFieldsSpy = jest.spyOn(
+      serviceUtilClassBase,
+      'validateSecretPrefixFields'
+    );
+
+    render(<ConnectionConfigForm {...mockProps} />);
+
+    await waitFor(() => {
+      expect(mockCapturedCustomValidate).toBeDefined();
+    });
+
+    const errors = {} as Record<string, unknown>;
+    const result = mockCapturedCustomValidate?.(formData, errors);
+
+    expect(validateSecretPrefixFieldsSpy).toHaveBeenCalled();
+    expect(result).toBe(errors);
+    expect(Object.keys(errors)).toHaveLength(0);
   });
 
   it('should not render no config available message if form data has schema', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/ServiceConfig/ConnectionConfigForm.tsx
@@ -13,7 +13,12 @@
 
 import { Alert } from '@openmetadata/ui-core-components';
 import Form, { IChangeEvent } from '@rjsf/core';
-import { RegistryFieldsType, RJSFSchema } from '@rjsf/utils';
+import {
+  CustomValidator,
+  FormValidation,
+  RegistryFieldsType,
+  RJSFSchema,
+} from '@rjsf/utils';
 
 import { isEmpty, isEqual, isUndefined } from 'lodash';
 import {
@@ -59,6 +64,7 @@ import {
   wrapFlatCredentialsIntoAuthType,
 } from '../../../../utils/ServiceConnectionUtils';
 import { shouldTestConnection } from '../../../../utils/ServicePureUtils';
+import serviceUtilClassBase from '../../../../utils/ServiceUtilClassBase';
 import AirflowMessageBanner from '../../../common/AirflowMessageBanner/AirflowMessageBanner';
 import AuthSelectField from '../../../common/Form/JSONSchema/JSONSchemaFields/AuthSelectField/AuthSelectField';
 import BooleanFieldTemplate from '../../../common/Form/JSONSchema/JSONSchemaTemplate/BooleanFieldTemplate';
@@ -239,6 +245,41 @@ const ConnectionConfigForm = forwardRef<
       [connectionSchema, propertiesWithoutDefaultFilterPatternFields]
     );
 
+    const customValidate: CustomValidator<ConfigData> = useCallback(
+      (formData, errors) => {
+        const secretPrefixErrors =
+          serviceUtilClassBase.validateSecretPrefixFields(
+            schemaWithoutDefaultFilterPatternFields,
+            (formData ?? {}) as Record<string, unknown>
+          );
+
+        secretPrefixErrors.forEach(({ path, message }) => {
+          const target = path.reduce<FormValidation<unknown>>((node, key) => {
+            const record = node as unknown as Record<
+              string | number,
+              FormValidation<unknown>
+            >;
+            record[key] ??= {} as FormValidation<unknown>;
+
+            return record[key];
+          }, errors as FormValidation<unknown>);
+
+          if (typeof target.addError === 'function') {
+            target.addError(message);
+          } else {
+            const legacyTarget = target as FormValidation<unknown> & {
+              __errors?: string[];
+            };
+            legacyTarget.__errors ??= [];
+            legacyTarget.__errors.push(message);
+          }
+        });
+
+        return errors;
+      },
+      [schemaWithoutDefaultFilterPatternFields]
+    );
+
     const uiSchema = useMemo(() => {
       return getUISchemaWithAuthFieldsAsSelect(
         schemaWithoutDefaultFilterPatternFields,
@@ -407,6 +448,7 @@ const ConnectionConfigForm = forwardRef<
         <AirflowMessageBanner />
         <FormBuilderV1
           cancelText={cancelText ?? ''}
+          customValidate={customValidate}
           fields={customFields}
           formContext={formContext}
           formData={currentFormData}

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DocumentationLinksClassBase.ts
@@ -80,6 +80,7 @@ class DocumentationLinksClassBase {
       MOST_USED_ASSETS_WIDGET_DOCS: `${this.docsBaseURL}how-to-guides/data-insights/service-insights#most-used-assets`,
       MOST_EXPENSIVE_QUERIES_WIDGET_DOCS: `${this.docsBaseURL}how-to-guides/data-insights/service-insights#most-expensive-queries`,
       METRICS_DOCS: `${this.docsBaseURL}how-to-guides/data-governance/metrics`,
+      SECRETS_MANAGER_DOCS: `${this.docsBaseURL}deployment/secrets-manager`,
     };
   }
 }

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.test.ts
@@ -32,6 +32,7 @@ import {
   getUISchemaWithNestedDefaultFilterFieldsHidden,
   hasMissingRequiredFlatCredential,
   loadConnectionSchema,
+  MASKED_PASSWORD_VALUE,
   SECRET_FIELD_PREFIX,
   wrapFlatCredentialsIntoAuthType,
 } from './ServiceConnectionUtils';
@@ -1014,6 +1015,14 @@ describe('findPasswordFieldsWithoutPrefix', () => {
         { password: 'vault:my-secret' },
         'vault:'
       )
+    ).toEqual([]);
+  });
+
+  it('does not report the masked-password sentinel returned for an existing service', () => {
+    expect(
+      findPasswordFieldsWithoutPrefix(flatSchema, {
+        password: MASKED_PASSWORD_VALUE,
+      })
     ).toEqual([]);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.test.ts
@@ -20,6 +20,7 @@ import { ConfigData } from '../interface/service.interface';
 import {
   buildValidConfig,
   EMPTY_CONNECTION_SCHEMA,
+  findPasswordFieldsWithoutPrefix,
   flattenAuthTypeIntoConfig,
   getConnectionFieldSection,
   getConnectionSchemas,
@@ -31,6 +32,7 @@ import {
   getUISchemaWithNestedDefaultFilterFieldsHidden,
   hasMissingRequiredFlatCredential,
   loadConnectionSchema,
+  SECRET_FIELD_PREFIX,
   wrapFlatCredentialsIntoAuthType,
 } from './ServiceConnectionUtils';
 import serviceUtilClassBase from './ServiceUtilClassBase';
@@ -931,5 +933,87 @@ describe('getFieldSchemaForId', () => {
 
   it('returns undefined for an unknown field id', () => {
     expect(getFieldSchemaForId(schema, 'root/doesNotExist')).toBeUndefined();
+  });
+});
+
+describe('findPasswordFieldsWithoutPrefix', () => {
+  const flatSchema = {
+    properties: {
+      username: { type: 'string' },
+      password: { format: 'password' },
+    },
+  };
+
+  it('reports a top-level password field missing the prefix', () => {
+    expect(
+      findPasswordFieldsWithoutPrefix(flatSchema, { password: 'plaintext' })
+    ).toEqual([{ path: ['password'], key: 'password' }]);
+  });
+
+  it('does not report a password field that already has the prefix', () => {
+    expect(
+      findPasswordFieldsWithoutPrefix(flatSchema, {
+        password: `${SECRET_FIELD_PREFIX}my-secret`,
+      })
+    ).toEqual([]);
+  });
+
+  it('does not report an empty password field', () => {
+    expect(findPasswordFieldsWithoutPrefix(flatSchema, {})).toEqual([]);
+  });
+
+  it('reports a password field nested inside an object property', () => {
+    const nestedSchema = {
+      properties: {
+        authenticationConfiguration: {
+          type: 'object',
+          properties: {
+            oauth2ClientSecret: { format: 'password' },
+          },
+        },
+      },
+    };
+
+    expect(
+      findPasswordFieldsWithoutPrefix(nestedSchema, {
+        authenticationConfiguration: { oauth2ClientSecret: 'plaintext' },
+      })
+    ).toEqual([
+      {
+        path: ['authenticationConfiguration', 'oauth2ClientSecret'],
+        key: 'oauth2ClientSecret',
+      },
+    ]);
+  });
+
+  it('only walks the oneOf branch selected by the current formData', () => {
+    const oneOfSchema = {
+      oneOf: [
+        {
+          title: 'Basic Auth',
+          properties: { password: { format: 'password' } },
+        },
+        {
+          title: 'AWS Config',
+          properties: { awsSecretAccessKey: { format: 'password' } },
+        },
+      ],
+    };
+
+    expect(
+      findPasswordFieldsWithoutPrefix(oneOfSchema, {
+        awsSecretAccessKey: 'plaintext',
+      })
+    ).toEqual([{ path: ['awsSecretAccessKey'], key: 'awsSecretAccessKey' }]);
+  });
+
+  it('supports a custom prefix', () => {
+    expect(
+      findPasswordFieldsWithoutPrefix(
+        flatSchema,
+        { password: 'vault:my-secret' },
+        'vault:'
+      )
+    ).toEqual([]);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
@@ -298,6 +298,9 @@ const PASSWORD_KEY = 'password';
 const PRIVATE_KEY_RE = /privatekey/i;
 const PASSPHRASE_RE = /passphrase/i;
 
+/** Mirrors the backend convention: {@link SecretsManager#SECRET_FIELD_PREFIX}. */
+export const SECRET_FIELD_PREFIX = 'secret:';
+
 type JsonObject = Record<string, Record<string, unknown>>;
 
 const getFlatSecretKeys = (
@@ -315,6 +318,88 @@ const getFlatSecretKeys = (
       (key) => PRIVATE_KEY_RE.test(key) && !PASSPHRASE_RE.test(key)
     ),
   };
+};
+
+export type PasswordFieldWithoutPrefix = {
+  path: (string | number)[];
+  key: string;
+};
+
+/**
+ * Recursively walks a connection schema (including `oneOf`/`anyOf` branches,
+ * resolved against the currently-selected branch in `formData`, same
+ * resolution strategy as {@link getMissingSchemaRequiredFieldsCountForSelectedBranch})
+ * and reports every `format: 'password'` field whose current value is
+ * non-empty and doesn't start with `prefix`.
+ */
+export const findPasswordFieldsWithoutPrefix = (
+  schema: Record<string, unknown>,
+  formData?: Record<string, unknown>,
+  prefix: string = SECRET_FIELD_PREFIX
+): PasswordFieldWithoutPrefix[] => {
+  const branches = [
+    ...(Array.isArray(schema.oneOf) ? schema.oneOf : []),
+    ...(Array.isArray(schema.anyOf) ? schema.anyOf : []),
+  ].filter(
+    (branch): branch is Record<string, unknown> =>
+      Boolean(branch) && typeof branch === 'object'
+  );
+
+  if (branches.length > 0) {
+    const dataKeys = Object.keys(formData ?? {}).filter(
+      (k) => (formData as Record<string, unknown>)[k] !== undefined
+    );
+    const matchingBranch =
+      dataKeys.length > 0
+        ? branches.find((branch) => {
+            const branchProps = new Set(
+              Object.keys((branch.properties ?? {}) as Record<string, unknown>)
+            );
+
+            return dataKeys.every((k) => branchProps.has(k));
+          })
+        : undefined;
+
+    return matchingBranch
+      ? findPasswordFieldsWithoutPrefix(matchingBranch, formData, prefix)
+      : branches.flatMap((branch) =>
+          findPasswordFieldsWithoutPrefix(branch, formData, prefix)
+        );
+  }
+
+  const properties = (schema.properties ?? {}) as JsonObject;
+
+  return Object.keys(properties).reduce((acc, key) => {
+    const propertySchema = properties[key];
+    const value = (formData as Record<string, unknown> | undefined)?.[key];
+
+    if (
+      propertySchema?.format === PASSWORD_FORMAT &&
+      typeof value === 'string' &&
+      value.trim() !== '' &&
+      !value.startsWith(prefix)
+    ) {
+      acc.push({ path: [key], key });
+
+      return acc;
+    }
+
+    if (
+      propertySchema &&
+      typeof propertySchema === 'object' &&
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value)
+    ) {
+      findPasswordFieldsWithoutPrefix(
+        propertySchema,
+        value as Record<string, unknown>,
+        prefix
+      ).forEach((hit) => acc.push({ path: [key, ...hit.path], key: hit.key }));
+    }
+
+    return acc;
+  }, [] as PasswordFieldWithoutPrefix[]);
 };
 
 const hasSynthesizableFlatAuth = (

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceConnectionUtils.ts
@@ -301,6 +301,14 @@ const PASSPHRASE_RE = /passphrase/i;
 /** Mirrors the backend convention: {@link SecretsManager#SECRET_FIELD_PREFIX}. */
 export const SECRET_FIELD_PREFIX = 'secret:';
 
+/**
+ * Mirrors the backend convention: {@link PasswordEntityMasker#PASSWORD_MASK}.
+ * The API always returns this sentinel for stored password fields instead of
+ * the real value, so an unmodified field on an edit form must not be treated
+ * as a plaintext value missing the secret prefix.
+ */
+export const MASKED_PASSWORD_VALUE = '*********';
+
 type JsonObject = Record<string, Record<string, unknown>>;
 
 const getFlatSecretKeys = (
@@ -377,6 +385,7 @@ export const findPasswordFieldsWithoutPrefix = (
       propertySchema?.format === PASSWORD_FORMAT &&
       typeof value === 'string' &&
       value.trim() !== '' &&
+      value !== MASKED_PASSWORD_VALUE &&
       !value.startsWith(prefix)
     ) {
       acc.push({ path: [key], key });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/ServiceUtilClassBase.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { ObjectFieldTemplatePropertyType } from '@rjsf/utils';
+import { ObjectFieldTemplatePropertyType, RJSFSchema } from '@rjsf/utils';
 import { MenuProps } from 'antd';
 import { get, isEmpty } from 'lodash';
 import { ServiceTypes } from 'Models';
@@ -237,6 +237,13 @@ class ServiceUtilClassBase {
 
   public getServiceExtraInfo(_data?: ServicesType): ExtraInfoType | null {
     return null;
+  }
+
+  public validateSecretPrefixFields(
+    _schema: RJSFSchema,
+    _formData: Record<string, unknown>
+  ): { path: (string | number)[]; message: string }[] {
+    return [];
   }
 
   public getSupportedServiceFromList() {


### PR DESCRIPTION
## Describe your changes:

Fixes #27888.

Adds the client-side plumbing needed to enforce that password-format connection fields reference a secrets-manager entry (`secret:` prefix) when a Hybrid Runner (as opposed to a fully-managed SaaS runner) is handling ingestion — matching the backend convention already enforced by `SecretsManager.SECRET_FIELD_PREFIX` (`secret:`).

Since the "which runner is selected" concept is product-specific (only meaningful where a Hybrid Runner selector exists), this PR only adds the generic, no-op-by-default hook + wiring:

- `findPasswordFieldsWithoutPrefix` in `ServiceConnectionUtils.ts` — recursively walks a connection schema (including `oneOf`/`anyOf` branches resolved against the current form data) and reports every `format: 'password'` field whose value doesn't start with a given prefix (defaults to `secret:`).
- `ServiceUtilClassBase.validateSecretPrefixFields(schema, formData)` — new override point, returns `[]` by default (no behavior change for existing deployments).
- `ConnectionConfigForm.tsx` — wires a new RJSF `customValidate` that calls `serviceUtilClassBase.validateSecretPrefixFields` and reports any returned errors against their field paths.
- `DocumentationLinksClassBase.getDocsURLS()` — adds `SECRETS_MANAGER_DOCS` pointing at the secrets-manager docs, for products building the error message.

A product that knows which runner is selected (e.g. via a custom `ServiceUtilClassBase` subclass) can override `validateSecretPrefixFields` to actually enforce the prefix for the runners it cares about.

## Type of change:

- [x] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Checklist:

- [x] I have read the [CONTRIBUTING](https://docs.open-metadata.org/latest/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## Test plan

- `yarn test ServiceConnectionUtils.test.ts` — new `findPasswordFieldsWithoutPrefix` describe block (top-level, nested, `oneOf`-branch-aware, custom-prefix cases).
- `yarn test ConnectionConfigForm.test.tsx` — new test asserting `customValidate` is wired to `serviceUtilClassBase.validateSecretPrefixFields` and is a no-op with the default base implementation.
- `yarn lint` / `npx tsc --noEmit` — no new errors on touched files.