### PR TITLE
Backport #31205 preserve tag recognizer config on ingestion PUT to 1.13

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/TagResourceIT.java
@@ -845,6 +845,96 @@ public class TagResourceIT extends BaseEntityIT<Tag, CreateTag> {
   }
 
   @Test
+  void test_putPreservesRecognizers_ingestionScenario(TestNamespace ns) {
+    // A metadata connector re-creates a source tag with a bare PUT (name + classification +
+    // description only, no recognizers). This must NOT wipe the tag's configured recognizers
+    // nor turn off autoClassificationEnabled.
+    Classification classification = createClassification(ns);
+
+    CreateTag createTag = new CreateTag();
+    createTag.setName(ns.shortPrefix("pii_tag"));
+    createTag.setClassification(classification.getFullyQualifiedName());
+    createTag.setDescription("Tag with recognizers");
+    createTag.setAutoClassificationEnabled(true);
+    createTag.setRecognizers(
+        List.of(
+            new Recognizer()
+                .withName("email_pattern_recognizer")
+                .withEnabled(true)
+                .withRecognizerConfig(
+                    new PredefinedRecognizer()
+                        .withName(PredefinedRecognizer.Name.EMAIL_RECOGNIZER))));
+
+    Tag tag = createEntity(createTag);
+    Tag created = getEntityWithFields(tag.getId().toString(), "recognizers");
+    assertNotNull(created.getRecognizers());
+    assertEquals(1, created.getRecognizers().size());
+    assertTrue(created.getAutoClassificationEnabled());
+
+    // Byte-for-byte the ingestion sink's body: CreateTagRequest.model_dump_json() with no
+    // exclude_none, so every unset field is serialized as its Pydantic default.
+    String ingestionBody =
+        "{\"classification\":\""
+            + classification.getFullyQualifiedName()
+            + "\",\"parent\":null,\"name\":\""
+            + tag.getName()
+            + "\",\"displayName\":null,\"description\":\"Updated by metadata ingestion\","
+            + "\"style\":null,\"associatedTags\":null,\"provider\":null,\"mutuallyExclusive\":false,"
+            + "\"domains\":null,\"owners\":null,\"reviewers\":null,\"recognizers\":null,"
+            + "\"autoClassificationEnabled\":false,\"autoClassificationPriority\":50}";
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/tags", ingestionBody, Tag.class);
+
+    Tag afterIngestion =
+        getEntityWithFields(tag.getId().toString(), "recognizers,autoClassificationEnabled");
+    int recognizerCount =
+        afterIngestion.getRecognizers() == null ? -1 : afterIngestion.getRecognizers().size();
+    assertEquals(
+        1,
+        recognizerCount,
+        "Bare PUT from ingestion must not drop recognizers (-1 means the field was deleted);"
+            + " autoClassificationEnabled is now "
+            + afterIngestion.getAutoClassificationEnabled());
+    assertTrue(
+        afterIngestion.getAutoClassificationEnabled(),
+        "Bare PUT from ingestion must not disable autoClassificationEnabled");
+
+    // A PUT that does name recognizers is an intentional write and must still apply.
+    CreateTag explicitUpsert =
+        new CreateTag()
+            .withName(tag.getName())
+            .withClassification(classification.getFullyQualifiedName())
+            .withDescription("Explicit recognizer update")
+            .withRecognizers(
+                List.of(
+                    new Recognizer()
+                        .withName("us_ssn_recognizer")
+                        .withEnabled(true)
+                        .withRecognizerConfig(
+                            new PredefinedRecognizer()
+                                .withName(PredefinedRecognizer.Name.US_SSN_RECOGNIZER))));
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/tags", explicitUpsert, Tag.class);
+
+    Tag afterExplicitPut = getEntityWithFields(tag.getId().toString(), "recognizers");
+    assertEquals(1, afterExplicitPut.getRecognizers().size());
+    assertEquals(
+        "us_ssn_recognizer",
+        afterExplicitPut.getRecognizers().get(0).getName(),
+        "PUT naming recognizers must replace them");
+
+    // An explicit PATCH clearing recognizers must still delete them.
+    afterExplicitPut.setRecognizers(null);
+    patchEntity(afterExplicitPut.getId().toString(), afterExplicitPut);
+    Tag afterPatch = getEntityWithFields(tag.getId().toString(), "recognizers");
+    assertTrue(
+        afterPatch.getRecognizers() == null || afterPatch.getRecognizers().isEmpty(),
+        "Explicit PATCH clearing recognizers must still delete them");
+  }
+
+  @Test
   void test_recognizerFeedback_withRecognizerMetadata_targetsSpecificRecognizer(TestNamespace ns) {
     Classification classification = createClassification(ns);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -998,6 +998,7 @@ public class TagRepository extends EntityRepository<Tag> {
     @Transaction
     @Override
     public void entitySpecificUpdate(boolean consolidatingChanges) {
+      preserveRecognizerConfigOnPut();
       compareAndUpdate("mutuallyExclusive", this::run);
       compareAndUpdate(
           "disabled",
@@ -1022,6 +1023,17 @@ public class TagRepository extends EntityRepository<Tag> {
                   original.getAutoClassificationPriority(),
                   updated.getAutoClassificationPriority()));
       compareAndUpdateAny(() -> updateNameAndParent(updated), "name", "parent", "classification");
+    }
+
+    // CreateTag defaults recognizers to empty and autoClassificationEnabled to false, so a PUT
+    // that never mentions them is indistinguishable from one clearing them. Clear via PATCH.
+    private void preserveRecognizerConfigOnPut() {
+      if (operation != Operation.PUT || !nullOrEmpty(updated.getRecognizers())) {
+        return;
+      }
+      updated.setRecognizers(original.getRecognizers());
+      updated.setAutoClassificationEnabled(original.getAutoClassificationEnabled());
+      updated.setAutoClassificationPriority(original.getAutoClassificationPriority());
     }
 
     /**


### PR DESCRIPTION
### Describe your changes:

Backport of #31205.

Metadata ingestion upserts source tags with a bare `CreateTag` carrying only classification, name and description. `CreateTag` defaults `recognizers` to an empty list and `autoClassificationEnabled` to `false`, so `TagUpdater` could not tell a caller that never heard of those fields from one deliberately clearing them — every ingestion run stripped the tag's recognizers and switched auto-classification off.

This branch is affected: `TagUpdater.entitySpecificUpdate` records all three fields unconditionally, `preserveRecognizerConfigOnPut` is absent, `piiTagsWithRecognizers.json` seeds `PII.Sensitive` with 39 recognizers, and `tag_utils` sends the bare `CreateTagRequest`.

The classification-level twin of this bug (`autoClassificationConfig`, #29668) is already present on this branch, so without this backport the branch is half-fixed: a bare ingestion PUT can no longer wipe a classification's config, but it still wipes a tag's recognizers. Both surface to users as auto-classification silently stopping.

Cherry-picked clean with no conflicts. `TagResourceIT#test_putPreservesRecognizers_ingestionScenario` passes on this branch.

#
### Type of change:
- [x] Bug fix
