### PR TITLE
Fixes #31346: answer 401, not 500, when the refresh credential is rejected

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/AuthenticationCodeFlowHandler.java
@@ -662,7 +662,15 @@ public class AuthenticationCodeFlowHandler implements AuthServeletHandler {
       }
     } catch (Exception e) {
       sessionService.releaseRefreshLease(leasedSession);
-      getErrorMessage(httpServletResponse, new TechnicalException(e));
+      LOG.error("[Auth Refresh] Failed to refresh the session", e);
+      try {
+        org.openmetadata.service.security.SecurityUtil.writeErrorResponse(
+            httpServletResponse,
+            RefreshFailureClassifier.statusFor(e),
+            RefreshFailureClassifier.messageFor(e));
+      } catch (IOException ioException) {
+        LOG.error("[Auth Refresh] Failed to write refresh failure response", ioException);
+      }
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/RefreshFailureClassifier.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/RefreshFailureClassifier.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.security;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.Set;
+import org.openmetadata.sdk.exception.WebServiceException;
+
+/**
+ * Maps a failure raised while renewing a session on {@code /auth/refresh} to an HTTP status.
+ *
+ * <p>A refresh credential that has expired, was rotated away, or was never ours is the server
+ * rejecting the caller's credentials — 401. Reporting it as 500 tells the client the failure is
+ * transient, so it keeps the dead session and retries forever instead of re-authenticating; the
+ * browser only recovers on a full reload. Anything else really is a server fault and stays 500.
+ *
+ * <p>Classification is by the status the exception already carries rather than by exception type:
+ * the refresh path raises two unrelated hierarchies for the same condition — {@link
+ * WebServiceException} (via {@code CustomExceptionMessage} for an expired token and {@code
+ * EntityNotFoundException} for one that is gone) and {@link WebApplicationException} (via {@code
+ * BadRequestException} on the SAML and OIDC paths).
+ */
+public final class RefreshFailureClassifier {
+
+  /**
+   * Statuses that mean the presented refresh credential was refused. 404 is included because a
+   * rotated-away token surfaces as "token not found", and 400 because an expired one is raised as a
+   * bad request.
+   */
+  private static final Set<Integer> REJECTED_CREDENTIAL_STATUSES =
+      Set.of(
+          Response.Status.BAD_REQUEST.getStatusCode(),
+          Response.Status.UNAUTHORIZED.getStatusCode(),
+          Response.Status.NOT_FOUND.getStatusCode());
+
+  /**
+   * Sent instead of the underlying message, which embeds the refresh token's UUID (see {@code
+   * "Expired token. Please login again : " + token}) and must not reach the client.
+   */
+  public static final String REJECTED_CREDENTIAL_MESSAGE = "Session expired. Please login again.";
+
+  private RefreshFailureClassifier() {}
+
+  public static int statusFor(Throwable failure) {
+    int status = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+    if (isCredentialRejected(failure)) {
+      status = HttpServletResponse.SC_UNAUTHORIZED;
+    }
+    return status;
+  }
+
+  public static String messageFor(Throwable failure) {
+    String message = failure.getMessage();
+    if (isCredentialRejected(failure)) {
+      message = REJECTED_CREDENTIAL_MESSAGE;
+    }
+    return message;
+  }
+
+  public static boolean isCredentialRejected(Throwable failure) {
+    boolean rejected = false;
+    if (failure instanceof WebServiceException webServiceException) {
+      rejected = isRejectedStatus(webServiceException.getResponse().getStatus());
+    } else if (failure instanceof WebApplicationException webApplicationException) {
+      rejected = isRejectedStatus(webApplicationException.getResponse().getStatus());
+    }
+    return rejected;
+  }
+
+  private static boolean isRejectedStatus(int status) {
+    return REJECTED_CREDENTIAL_STATUSES.contains(status);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthServletHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/BasicAuthServletHandler.java
@@ -27,6 +27,7 @@ import org.openmetadata.service.auth.JwtResponse;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.security.AuthServeletHandler;
+import org.openmetadata.service.security.RefreshFailureClassifier;
 import org.openmetadata.service.security.SecurityUtil;
 import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
@@ -178,7 +179,8 @@ public class BasicAuthServletHandler implements AuthServeletHandler {
     } catch (Exception e) {
       sessionService.releaseRefreshLease(leasedSession);
       LOG.error("Error handling refresh", e);
-      sendError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+      sendError(
+          resp, RefreshFailureClassifier.statusFor(e), RefreshFailureClassifier.messageFor(e));
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/LdapAuthServletHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/LdapAuthServletHandler.java
@@ -31,6 +31,7 @@ import org.openmetadata.service.exception.CustomExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.security.AuthServeletHandler;
+import org.openmetadata.service.security.RefreshFailureClassifier;
 import org.openmetadata.service.security.SecurityUtil;
 import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
@@ -197,7 +198,8 @@ public class LdapAuthServletHandler implements AuthServeletHandler {
     } catch (Exception e) {
       sessionService.releaseRefreshLease(leasedSession);
       LOG.error("Error handling refresh", e);
-      sendError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+      sendError(
+          resp, RefreshFailureClassifier.statusFor(e), RefreshFailureClassifier.messageFor(e));
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/SamlAuthServletHandler.java
@@ -47,6 +47,7 @@ import org.openmetadata.service.auth.JwtResponse;
 import org.openmetadata.service.exception.AuthenticationException;
 import org.openmetadata.service.security.AuthServeletHandler;
 import org.openmetadata.service.security.AuthServeletHandlerRegistry;
+import org.openmetadata.service.security.RefreshFailureClassifier;
 import org.openmetadata.service.security.jwt.JWTTokenGenerator;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.security.saml.SamlSettingsHolder;
@@ -444,7 +445,8 @@ public class SamlAuthServletHandler implements AuthServeletHandler {
     } catch (Exception e) {
       sessionService.releaseRefreshLease(leasedSession);
       LOG.error("Error handling SAML refresh", e);
-      sendError(resp, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+      sendError(
+          resp, RefreshFailureClassifier.statusFor(e), RefreshFailureClassifier.messageFor(e));
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/RefreshFailureClassifierTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/RefreshFailureClassifierTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.security;
+
+import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.openmetadata.service.exception.CatalogExceptionMessage.PASSWORD_RESET_TOKEN_EXPIRED;
+
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.BadRequestException;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.service.exception.CustomExceptionMessage;
+import org.openmetadata.service.exception.EntityNotFoundException;
+
+class RefreshFailureClassifierTest {
+
+  private static final UUID REFRESH_TOKEN = UUID.randomUUID();
+
+  @Test
+  void testExpiredRefreshTokenIsAnAuthenticationFailure() {
+    // LdapAuthenticator/BasicAuthenticator raise this when the stored refresh token is past its
+    // expiry. Reported as 500 the browser reads it as transient, keeps the dead session and
+    // retries forever; only 401 tells it to re-authenticate.
+    CustomExceptionMessage expired =
+        new CustomExceptionMessage(
+            BAD_REQUEST,
+            PASSWORD_RESET_TOKEN_EXPIRED,
+            "Expired token. Please login again : " + REFRESH_TOKEN);
+
+    assertTrue(RefreshFailureClassifier.isCredentialRejected(expired));
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, RefreshFailureClassifier.statusFor(expired));
+  }
+
+  @Test
+  void testExpiredRefreshTokenMessageDoesNotLeakTheToken() {
+    CustomExceptionMessage expired =
+        new CustomExceptionMessage(
+            BAD_REQUEST,
+            PASSWORD_RESET_TOKEN_EXPIRED,
+            "Expired token. Please login again : " + REFRESH_TOKEN);
+
+    String message = RefreshFailureClassifier.messageFor(expired);
+
+    assertEquals(RefreshFailureClassifier.REJECTED_CREDENTIAL_MESSAGE, message);
+    assertFalse(message.contains(REFRESH_TOKEN.toString()));
+  }
+
+  @Test
+  void testRotatedAwayRefreshTokenIsAnAuthenticationFailure() {
+    // TokenRepository throws this once the token has been rotated out or revoked.
+    EntityNotFoundException notFound =
+        new EntityNotFoundException("Invalid Request Token. Please check your Token");
+
+    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, RefreshFailureClassifier.statusFor(notFound));
+  }
+
+  @Test
+  void testEmptyRefreshTokenIsAnAuthenticationFailure() {
+    // The SAML and OIDC paths raise the JAX-RS type rather than CustomExceptionMessage, so the
+    // classifier has to span both hierarchies.
+    BadRequestException emptyToken =
+        new BadRequestException("Token Cannot be Null or Empty String");
+
+    assertEquals(
+        HttpServletResponse.SC_UNAUTHORIZED, RefreshFailureClassifier.statusFor(emptyToken));
+  }
+
+  @Test
+  void testServerSideFailureStaysAServerError() {
+    // A signing or database failure says nothing about the caller's credentials — telling the
+    // client to re-authenticate would sign out a session that is still perfectly valid.
+    IllegalStateException signingFailure = new IllegalStateException("Failed to sign JWT");
+
+    assertFalse(RefreshFailureClassifier.isCredentialRejected(signingFailure));
+    assertEquals(
+        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+        RefreshFailureClassifier.statusFor(signingFailure));
+    assertEquals("Failed to sign JWT", RefreshFailureClassifier.messageFor(signingFailure));
+  }
+
+  @Test
+  void testConflictFromTheServerStaysAServerError() {
+    // Only statuses that mean "your credential was refused" map to 401; a 409 must not.
+    CustomExceptionMessage conflict =
+        new CustomExceptionMessage(
+            HttpServletResponse.SC_CONFLICT, "CONFLICT", "Session already rotated");
+
+    assertEquals(
+        HttpServletResponse.SC_INTERNAL_SERVER_ERROR, RefreshFailureClassifier.statusFor(conflict));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/LdapAuthServletHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/auth/LdapAuthServletHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.StringReader;
@@ -34,6 +35,8 @@ import org.openmetadata.schema.services.connections.metadata.AuthProvider;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.audit.AuditLogRepository;
 import org.openmetadata.service.auth.JwtResponse;
+import org.openmetadata.service.exception.CatalogExceptionMessage;
+import org.openmetadata.service.exception.CustomExceptionMessage;
 import org.openmetadata.service.exception.EntityNotFoundException;
 import org.openmetadata.service.jdbi3.TokenRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
@@ -169,5 +172,56 @@ class LdapAuthServletHandlerTest {
     verify(tokenRepository).deleteToken("rotated-refresh-token");
     verify(sessionService).revokeSession(request, response);
     verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+
+  @Test
+  void handleRefresh_expiredRefreshTokenIsUnauthorizedNotServerError() {
+    // LDAP refresh tokens live 24h while the session lives 7 days, so a tab idle overnight lands
+    // here. Reported as 500 the browser reads it as transient and keeps retrying with a dead
+    // session; only 401 tells it to re-authenticate.
+    UserSession leasedSession =
+        UserSession.builder().id("session-id").status(SessionStatus.REFRESHING).build();
+    UUID refreshTokenId = UUID.randomUUID();
+
+    when(sessionService.acquireRefreshLease(request, response))
+        .thenReturn(Optional.of(leasedSession));
+    when(sessionService.decryptOmRefreshToken(leasedSession)).thenReturn("current-refresh-token");
+    when(authenticator.getNewAccessToken(any()))
+        .thenThrow(
+            new CustomExceptionMessage(
+                Response.Status.BAD_REQUEST,
+                CatalogExceptionMessage.PASSWORD_RESET_TOKEN_EXPIRED,
+                "Expired token. Please login again : " + refreshTokenId));
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      entityMock.when(Entity::getTokenRepository).thenReturn(tokenRepository);
+
+      handler.handleRefresh(request, response);
+    }
+
+    verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    verify(sessionService).releaseRefreshLease(leasedSession);
+  }
+
+  @Test
+  void handleRefresh_serverFailureStaysAServerError() {
+    // The counterpart: a signing/DB failure says nothing about the caller's credentials, so it
+    // must not sign out a session that is still valid.
+    UserSession leasedSession =
+        UserSession.builder().id("session-id").status(SessionStatus.REFRESHING).build();
+
+    when(sessionService.acquireRefreshLease(request, response))
+        .thenReturn(Optional.of(leasedSession));
+    when(sessionService.decryptOmRefreshToken(leasedSession)).thenReturn("current-refresh-token");
+    when(authenticator.getNewAccessToken(any()))
+        .thenThrow(new IllegalStateException("Failed to sign JWT"));
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class)) {
+      entityMock.when(Entity::getTokenRepository).thenReturn(tokenRepository);
+
+      handler.handleRefresh(request, response);
+    }
+
+    verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #31346

Follow-up to #31103. With the stored refresh credential expired or rotated away, `/api/v1/auth/refresh` answers **500** on the Basic, LDAP and confidential-OIDC paths (SAML already answers 401 for the expiry case) — and the 500 body echoes `e.getMessage()`, which embeds the **refresh-token UUID**. After #31103 the UI signs out on any failed refresh, so this is about the endpoint's own contract: a rejected credential is a 401, not a server fault. A 500 misleads every non-UI client (SDKs, proxies with retry-on-5xx policies) into retrying a request that can never succeed, and pages on-call for what is a routine credential expiry.

`RefreshFailureClassifier` maps a refresh failure to a status by the status the exception already carries — spanning both hierarchies the refresh path raises (`WebServiceException` via `CustomExceptionMessage`/`EntityNotFoundException`, and JAX-RS `WebApplicationException` via `BadRequestException`): 400/401/404 → **401** with a fixed sanitized message; everything else (JWT signing failure, DB unavailable) stays **500** with full detail kept in server logs. The `SessionRefreshInProgressException` → 503 lease path and `releaseRefreshLease` ordering are untouched.

Classifying by carried status rather than exception type matters: the expiry case is a `CustomExceptionMessage` (an `org.openmetadata.sdk.exception.WebServiceException`), which is unrelated to the JAX-RS `BadRequestException` the SAML/OIDC paths throw — a single `catch (BadRequestException)` silently misses it.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

One new 40-line utility (`RefreshFailureClassifier`: `statusFor`/`messageFor`/`isCredentialRejected`) + a one-line change to the existing `catch (Exception e)` block in each of the four refresh handlers (`BasicAuthServletHandler`, `LdapAuthServletHandler`, `SamlAuthServletHandler`, `AuthenticationCodeFlowHandler`). No new catch clauses, so lease-release ordering and the 503 contention path are preserved exactly.

**Alternative rejected:** treating 500 as terminal client-side — verified live that a stopped database also produces a 500 from this endpoint, so clients must never read 500 as "session invalid"; only the server can distinguish the two, which is what this classifier does.

#
### Tests:

#### Use cases covered
- Expired refresh token (LDAP/Basic 24h TTL inside the 7-day session) → 401 with sanitized message
- Rotated-away/unknown refresh token → 401
- Empty refresh token (SAML/OIDC `BadRequestException`) → 401
- JWT signing failure / DB outage / any other server fault → 500, unchanged
- 401 responses never contain the refresh-token UUID

#### Unit tests
- `RefreshFailureClassifierTest` (6 — all three public methods, both classification branches, UUID-leak guard)
- `LdapAuthServletHandlerTest` +2: `handleRefresh_expiredRefreshTokenIsUnauthorizedNotServerError` (**fails without the fix — red-green verified**) and `handleRefresh_serverFailureStaysAServerError`
- Full security-package sweep on this base: 37/37 green

#### Backend integration tests
- Not applicable — no API surface added; existing `SessionMultiNodeIT`/`SessionRedisMultiNodeIT` already assert 401 on the adjacent refresh branches (none assert the old 500 anywhere)

#### Ingestion integration tests
- Not applicable (no ingestion changes)

#### Playwright (UI) tests
- Not applicable (no UI changes in this PR)

#### Manual testing performed
E2E on a live isolated stack built from this branch (own MySQL/ES, server on :18585):
1. Login (basic auth), capture `OM_SESSION`; `/auth/refresh` → 200 (happy path intact)
2. `UPDATE user_tokens SET json = JSON_SET(json,'$.expiryDate',1000)` → `/auth/refresh` → **401** `{"error":"Session expired. Please login again."}` — no UUID; full detail in server log
3. `DELETE` the token row (rotated-away) → **401**, same sanitized body
4. `docker stop` MySQL → `/auth/refresh` → **500** `SQLTransientConnectionException` — server fault not misreported; after restart the same session refreshes 200 (no lease leak)
5. No/garbage session cookie → 401 (pre-existing branches intact)
6. Browser check: with the expired credential, the UI's next refresh gets the 401 and signs out cleanly with the session-expired toast

#
### UI screen recording / screenshots:

Not applicable — backend-only change. (Behavioral evidence from the live run: expired credential → clean sign-out with toast: https://raw.githubusercontent.com/siddhant1/OpenMetadata/pr-assets/auth-401-fix/e2e-B-signedout.png)

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema changes.
- [x] For UI changes: not applicable — backend-only.
- [x] I have added tests (unit as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing (`handleRefresh_expiredRefreshTokenIsUnauthorizedNotServerError` — fails without the fix).