### PR TITLE
fix: navigate to metric details on row click and handle edit selection separately

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1715,8 +1715,14 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
-      const { row } = await getFirstVisibleFixtureMetricRow(page);
+      await filterMetrics(page, fixtures.prefix);
 
+      const row = page
+        .locator('tr')
+        .filter({ has: page.getByTestId('metric-name') })
+        .first();
+      await expect(row).toBeVisible();
+      
       await row.locator('.metric-status-pill').first().click();
 
       await expect(page).toHaveURL(/\/metric\//);
@@ -1727,7 +1733,13 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
-      const { row } = await getFirstVisibleFixtureMetricRow(page);
+      await filterMetrics(page, fixtures.prefix);
+
+      const row = page
+        .locator('tr')
+        .filter({ has: page.getByTestId('metric-name') })
+        .first();
+      await expect(row).toBeVisible();
 
       await row.locator('label[slot="selection"]').click();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1722,7 +1722,7 @@ test.describe(
         .filter({ has: page.getByTestId('metric-name') })
         .first();
       await expect(row).toBeVisible();
-      
+
       await row.locator('.metric-status-pill').first().click();
 
       await expect(page).toHaveURL(/\/metric\//);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1709,5 +1709,30 @@ test.describe(
         page.locator('.metric-list-selection-bar')
       ).not.toBeVisible();
     });
+
+    test('MetricListPage clicking anywhere in a row navigates to metric details', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      const { row } = await getFirstVisibleFixtureMetricRow(page);
+
+      await row.locator('.metric-status-pill').first().click();
+
+      await expect(page).toHaveURL(/\/metric\//);
+    });
+
+    test('MetricListPage clicking the row checkbox selects without navigating', async ({
+      page,
+    }) => {
+      await redirectToHomePage(page);
+      await waitForMetricsPage(page);
+      const { row } = await getFirstVisibleFixtureMetricRow(page);
+
+      await row.locator('label[slot="selection"]').click();
+
+      await expect(page.locator('.metric-list-selection-count')).toHaveText('1');
+      await expect(page).toHaveURL(/\/metrics/);
+    });
   }
 );

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1731,7 +1731,9 @@ test.describe(
 
       await row.locator('label[slot="selection"]').click();
 
-      await expect(page.locator('.metric-list-selection-count')).toHaveText('1');
+      await expect(page.locator('.metric-list-selection-count')).toHaveText(
+        '1'
+      );
       await expect(page).toHaveURL(/\/metrics/);
     });
   }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1715,11 +1715,13 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
+      const searchResponse = waitForMetricsSearchResponse(page);
       await filterMetrics(page, fixtures.prefix);
+      await searchResponse;
 
       const row = page
         .locator('tr')
-        .filter({ has: page.getByTestId('metric-name') })
+        .filter({ hasText: fixtures.prefix })
         .first();
       await expect(row).toBeVisible();
 
@@ -1733,11 +1735,13 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
+      const searchResponse = waitForMetricsSearchResponse(page);
       await filterMetrics(page, fixtures.prefix);
+      await searchResponse;
 
       const row = page
         .locator('tr')
-        .filter({ has: page.getByTestId('metric-name') })
+        .filter({ hasText: fixtures.prefix })
         .first();
       await expect(row).toBeVisible();
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/Table.interface.ts
@@ -34,6 +34,12 @@ export interface TableComponentProps<T> extends TableProps<T> {
   cellClassName?: string;
   /** React Aria drag-and-drop hooks returned by `useDragAndDrop`. */
   dragAndDropHooks?: DragAndDropHooks;
+  /**
+   * Called when a row is activated (clicked/Enter). When provided together with
+   * `rowSelection`, React Aria performs this action on row click while selection
+   * is limited to the selection checkbox — the row no longer toggles selection.
+   */
+  onRowAction?: (key: React.Key) => void;
   'data-testid'?: string;
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/Table/TableV2.tsx
@@ -662,6 +662,7 @@ const TableV2 = <T extends object>(
                     }
                   : undefined
               }
+              onRowAction={rest.onRowAction}
               onSelectionChange={handleSelectionChange}
               onSortChange={handleSortChange}>
               <UntitledTable.Header className="tw:px-2">

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ar-sa.json
@@ -307,6 +307,8 @@
     "browse-estate": "استعراض المنظومة البيانية",
     "browse-glossary": "تصفّح المسرد",
     "bulk-edit": "تعديل مجمع",
+    "bulk-edit-all": "تعديل مجمع للكل",
+    "bulk-edit-count": "تعديل مجمع ({{count}} محدد)",
     "bulk-import-entity": "استيراد {{entity}} بالجملة",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/de-de.json
@@ -307,6 +307,8 @@
     "browse-estate": "Datenbestand durchsuchen",
     "browse-glossary": "Glossar durchsuchen",
     "bulk-edit": "Massenbearbeitung",
+    "bulk-edit-all": "Alle massenbearbeiten",
+    "bulk-edit-count": "Massenbearbeitung ({{count}} ausgewählt)",
     "bulk-import-entity": "Massenimport von {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/en-us.json
@@ -307,6 +307,8 @@
     "browse-estate": "Browse estate",
     "browse-glossary": "Browse Glossary",
     "bulk-edit": "Bulk Edit",
+    "bulk-edit-all": "Bulk Edit All",
+    "bulk-edit-count": "Bulk Edit ({{count}} selected)",
     "bulk-import-entity": "Bulk Import {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/es-es.json
@@ -307,6 +307,8 @@
     "browse-estate": "Explorar el patrimonio",
     "browse-glossary": "Explorar glosario",
     "bulk-edit": "Edición masiva",
+    "bulk-edit-all": "Edición masiva de todos",
+    "bulk-edit-count": "Edición masiva ({{count}} seleccionados)",
     "bulk-import-entity": "Importación masiva de {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/fr-fr.json
@@ -307,6 +307,8 @@
     "browse-estate": "Parcourir le patrimoine",
     "browse-glossary": "Parcourir le glossaire",
     "bulk-edit": "Modification en masse",
+    "bulk-edit-all": "Tout modifier en masse",
+    "bulk-edit-count": "Modification en masse ({{count}} sélectionné(s))",
     "bulk-import-entity": "Importation en masse de {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/gl-es.json
@@ -307,6 +307,8 @@
     "browse-estate": "Explorar o patrimonio",
     "browse-glossary": "Explorar o glosario",
     "bulk-edit": "Edición masiva",
+    "bulk-edit-all": "Edición masiva de todos",
+    "bulk-edit-count": "Edición masiva ({{count}} seleccionados)",
     "bulk-import-entity": "Importación masiva de {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/he-he.json
@@ -307,6 +307,8 @@
     "browse-estate": "עיין במאגר הנתונים",
     "browse-glossary": "עיון במילון המונחים",
     "bulk-edit": "עריכה מרובה",
+    "bulk-edit-all": "עריכה מרובה של הכול",
+    "bulk-edit-count": "עריכה מרובה ({{count}} נבחרו)",
     "bulk-import-entity": "ייבוא מרוכז של {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ja-jp.json
@@ -307,6 +307,8 @@
     "browse-estate": "データ基盤を参照",
     "browse-glossary": "用語集を参照",
     "bulk-edit": "一括編集",
+    "bulk-edit-all": "すべてを一括編集",
+    "bulk-edit-count": "一括編集（{{count}} 件選択中）",
     "bulk-import-entity": "{{entity}}の一括インポート",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ko-kr.json
@@ -307,6 +307,8 @@
     "browse-estate": "에스테이트 탐색",
     "browse-glossary": "용어집 찾아보기",
     "bulk-edit": "일괄 편집",
+    "bulk-edit-all": "전체 일괄 편집",
+    "bulk-edit-count": "일괄 편집 ({{count}}개 선택됨)",
     "bulk-import-entity": "{{entity}} 일괄 가져오기",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/mr-in.json
@@ -307,6 +307,8 @@
     "browse-estate": "डेटा संपदा ब्राउझ करा",
     "browse-glossary": "शब्दकोश ब्राउझ करा",
     "bulk-edit": "सामूहिक संपादन",
+    "bulk-edit-all": "सर्व सामूहिक संपादन",
+    "bulk-edit-count": "सामूहिक संपादन ({{count}} निवडले)",
     "bulk-import-entity": "{{entity}} मोठ्या प्रमाणात आयात",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/nl-nl.json
@@ -307,6 +307,8 @@
     "browse-estate": "Databestand doorzoeken",
     "browse-glossary": "Woordenlijst verkennen",
     "bulk-edit": "Bulk bewerken",
+    "bulk-edit-all": "Alles bulk bewerken",
+    "bulk-edit-count": "Bulk bewerken ({{count}} geselecteerd)",
     "bulk-import-entity": "Bulkimport van {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pr-pr.json
@@ -307,6 +307,8 @@
     "browse-estate": "مرور مجموعه داده",
     "browse-glossary": "مرور واژه‌نامه",
     "bulk-edit": "ویرایش دسته‌ای",
+    "bulk-edit-all": "ویرایش دسته‌ای همه",
+    "bulk-edit-count": "ویرایش دسته‌ای ({{count}} انتخاب‌شده)",
     "bulk-import-entity": "درون‌ریزی انبوه {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-br.json
@@ -307,6 +307,8 @@
     "browse-estate": "Navegar pelo acervo",
     "browse-glossary": "Navegar no glossário",
     "bulk-edit": "Edição em massa",
+    "bulk-edit-all": "Edição em massa de todos",
+    "bulk-edit-count": "Edição em massa ({{count}} selecionados)",
     "bulk-import-entity": "Importação em massa de {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/pt-pt.json
@@ -307,6 +307,8 @@
     "browse-estate": "Navegar pelo acervo",
     "browse-glossary": "Navegar no glossário",
     "bulk-edit": "Edição em massa",
+    "bulk-edit-all": "Edição em massa de todos",
+    "bulk-edit-count": "Edição em massa ({{count}} selecionados)",
     "bulk-import-entity": "Importação em massa de {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/ru-ru.json
@@ -307,6 +307,8 @@
     "browse-estate": "Просмотр активов",
     "browse-glossary": "Открыть глоссарий",
     "bulk-edit": "Массовое редактирование",
+    "bulk-edit-all": "Массовое редактирование всех",
+    "bulk-edit-count": "Массовое редактирование ({{count}} выбрано)",
     "bulk-import-entity": "Массовый импорт {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/sv-se.json
@@ -307,6 +307,8 @@
     "browse-estate": "Browse estate",
     "browse-glossary": "Bläddra i ordlistan",
     "bulk-edit": "Massredigera",
+    "bulk-edit-all": "Massredigera alla",
+    "bulk-edit-count": "Massredigera ({{count}} markerade)",
     "bulk-import-entity": "Massimportera {{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/th-th.json
@@ -307,6 +307,8 @@
     "browse-estate": "เรียกดูคลังข้อมูล",
     "browse-glossary": "เรียกดูอภิธานศัพท์",
     "bulk-edit": "แก้ไขเป็นกลุ่ม",
+    "bulk-edit-all": "แก้ไขเป็นกลุ่มทั้งหมด",
+    "bulk-edit-count": "แก้ไขเป็นกลุ่ม ({{count}} รายการที่เลือก)",
     "bulk-import-entity": "นำเข้า {{entity}} จำนวนมาก",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/tr-tr.json
@@ -307,6 +307,8 @@
     "browse-estate": "Veri Mirasına Gözat",
     "browse-glossary": "Sözlüğe göz at",
     "bulk-edit": "Toplu Düzenleme",
+    "bulk-edit-all": "Tümünü Toplu Düzenle",
+    "bulk-edit-count": "Toplu Düzenleme ({{count}} seçili)",
     "bulk-import-entity": "{{entity}} toplu içe aktarma",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-cn.json
@@ -307,6 +307,8 @@
     "browse-estate": "浏览数据资产",
     "browse-glossary": "浏览术语表",
     "bulk-edit": "批量编辑",
+    "bulk-edit-all": "批量编辑全部",
+    "bulk-edit-count": "批量编辑（已选择 {{count}} 项）",
     "bulk-import-entity": "批量导入{{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
+++ b/openmetadata-ui/src/main/resources/ui/src/locale/languages/zh-tw.json
@@ -307,6 +307,8 @@
     "browse-estate": "瀏覽資料資產",
     "browse-glossary": "瀏覽詞彙表",
     "bulk-edit": "批次編輯",
+    "bulk-edit-all": "批次編輯全部",
+    "bulk-edit-count": "批次編輯（已選擇 {{count}} 項）",
     "bulk-import-entity": "大量匯入{{entity}}",
     "bullet-point": "• {{text}}",
     "bulleted-list": "Bulleted list",

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -853,7 +853,9 @@ const MetricListPage = () => {
                           data-testid="bulk-edit-metric"
                           iconLeading={Edit03}
                           onPress={handleBulkEdit}>
-                          {t('label.edit')}
+                          {t('label.bulk-edit-count', {
+                            count: selectedMetricIds.length,
+                          })}
                         </Button>
                       )}
                       {permission.Delete && (
@@ -883,8 +885,8 @@ const MetricListPage = () => {
                     <div className="metric-list-toolbar-actions">
                       <Dropdown.Root>
                         <Button
-                          className="metric-list-toolbar-link metric-list-status-trigger"
-                          color="link-gray"
+                          className="metric-list-toolbar-link"
+                          color="link-color"
                           iconTrailing={ChevronDown}>
                           {statusFilter
                             ? getMetricStatus(statusFilter).label
@@ -912,12 +914,12 @@ const MetricListPage = () => {
                       </Dropdown.Root>
                       {permission.EditAll && (
                         <Button
-                          className="metric-list-toolbar-link"
+                          className="metric-list-toolbar-link tw:focus-visible:outline-none! tw:focus-visible:bg-brand-primary_alt"
                           color="link-color"
                           data-testid="bulk-edit-metric"
                           iconLeading={Edit03}
                           onPress={handleBulkEdit}>
-                          {t('label.edit')}
+                          {t('label.bulk-edit-all')}
                         </Button>
                       )}
                       <span
@@ -926,7 +928,7 @@ const MetricListPage = () => {
                       />
                       <Dropdown.Root>
                         <Button
-                          className="metric-list-toolbar-link"
+                          className="metric-list-toolbar-link tw:focus-visible:outline-none! tw:focus-visible:bg-brand-primary_alt"
                           color="link-color"
                           iconLeading={Settings01}>
                           {t('label.customize')}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -405,12 +405,9 @@ const MetricListPage = () => {
       // React Aria fires this on row click/Enter (not on the selection checkbox,
       // which only toggles selection). Navigate to the activated metric.
       const metric = metrics.find((item) => item.id === key);
-      if (metric) {
+      if (metric?.fullyQualifiedName) {
         navigate(
-          getEntityDetailsPath(
-            EntityType.METRIC,
-            metric.fullyQualifiedName ?? ''
-          )
+          getEntityDetailsPath(EntityType.METRIC, metric.fullyQualifiedName)
         );
       }
     },

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -63,6 +63,7 @@ import { getGlossaryHomeCrumb } from '../../../components/common/HeaderBreadcrum
 import HeaderShell from '../../../components/common/HeaderShell/HeaderShell.component';
 import Loader from '../../../components/common/Loader/Loader';
 import { PagingHandlerParams } from '../../../components/common/NextPrevious/NextPrevious.interface';
+import RichTextEditorPreviewerV1 from '../../../components/common/RichTextEditor/RichTextEditorPreviewerV1';
 import Table from '../../../components/common/Table/TableV2';
 import { LearningIcon } from '../../../components/Learning/LearningIcon/LearningIcon.component';
 import PageHeader from '../../../components/PageHeader/PageHeader.component';
@@ -399,6 +400,23 @@ const MetricListPage = () => {
     });
   }, [navigate, searchText, selectedMetricIds, selectedMetrics, statusFilter]);
 
+  const handleRowAction = useCallback(
+    (key: Key) => {
+      // React Aria fires this on row click/Enter (not on the selection checkbox,
+      // which only toggles selection). Navigate to the activated metric.
+      const metric = metrics.find((item) => item.id === key);
+      if (metric) {
+        navigate(
+          getEntityDetailsPath(
+            EntityType.METRIC,
+            metric.fullyQualifiedName ?? ''
+          )
+        );
+      }
+    },
+    [metrics, navigate]
+  );
+
   const handleSearchTextChange = useCallback(
     (value: string | ChangeEvent<HTMLInputElement>) => {
       const text = getInputChangeValue(value);
@@ -505,11 +523,17 @@ const MetricListPage = () => {
         dataIndex: 'description',
         key: 'description',
         width: 420,
-        render: (description: string) => (
-          <p className="m-0 metric-list-description">
-            {description || emptyDash}
-          </p>
-        ),
+        render: (description: string) =>
+          description ? (
+            <RichTextEditorPreviewerV1
+              className="metric-list-description"
+              enableSeeMoreVariant={false}
+              markdown={description}
+              showReadMoreBtn={false}
+            />
+          ) : (
+            emptyDash
+          ),
       },
       glossary: {
         title: t('label.glossary-term-plural'),
@@ -818,6 +842,7 @@ const MetricListPage = () => {
                       <Button
                         className="metric-list-selection-clear"
                         color="link-gray"
+                        data-testid="clear-metric-selection"
                         iconLeading={XClose}
                         onPress={() => setSelectedMetricIds([])}>
                         {t('label.clear')}
@@ -993,12 +1018,14 @@ const MetricListPage = () => {
                       ),
                   }}
                   pagination={false}
+                  rowClassName="tw:cursor-pointer"
                   rowKey="id"
                   rowSelection={{
                     selectedRowKeys: selectedMetricIds,
                     onChange: setSelectedMetricIds,
                   }}
                   size="small"
+                  onRowAction={handleRowAction}
                 />
               </>
             )}

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -848,7 +848,7 @@ const MetricListPage = () => {
                     <div className="metric-list-selection-actions">
                       {permission.EditAll && (
                         <Button
-                          className="metric-list-selection-action"
+                          className="metric-list-selection-action tw:text-brand-primary! tw:hover:text-brand-primary! tw:*:data-icon:text-fg-brand-primary!"
                           color="link-color"
                           data-testid="bulk-edit-metric"
                           iconLeading={Edit03}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #31309

Updated the Metrics page interaction to improve navigation and edit selection behavior.

Clicking anywhere on the metric row now navigates to the Metric Details page.
Clicking the checkbox explicitly selects/deselects the metric.


https://github.com/user-attachments/assets/859ba0a9-1e36-4483-a69d-b1e9937acf6b







#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **UI & Navigation:**
    - Added `onRowAction` support to `TableV2` and `MetricListPage` to navigate on row click while keeping checkbox selection separate
    - Render metric descriptions using `RichTextEditorPreviewerV1` for markdown support
- **Testing:**
    - Added Playwright end-to-end tests for metric row navigation and checkbox selection behavior

<sub>This will update automatically on new commits.</sub>