### PR TITLE
fix(glossary): raise WORKFLOW_POLL timeout to survive WorkflowEventConsumer lag in AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -65,9 +65,11 @@ const AUTO_APPROVED_BY_REVIEWER_STAGE = 'Auto-Approved by Reviewer';
 // always misses. A coarse interval therefore charges a whole interval per miss against the caller's
 // budget, and every caller here is a `test.slow()` (180s) or `test.setTimeout(5m)` test that polls
 // up to twice - which is how waiting for a one-second event produced a 180s test timeout.
+// AUT upgrade environments produce a large change-event backlog that delays
+// WorkflowEventConsumer by up to ~8 minutes. Raise the poll window to match.
 const WORKFLOW_POLL = {
-  timeout: 60_000,
-  intervals: [1_000, 2_000, 5_000],
+  timeout: 600_000,
+  intervals: [60_000, 40_000, 20_000],
 };
 
 type WorkflowInstanceStateRow = {


### PR DESCRIPTION
## Why

The AUT upgrade test (1.11.13 → 1.13, EKS/RDS PostgreSQL) generates a ~3,300-event change-event backlog. `WorkflowEventConsumer` is `@DisallowConcurrentExecution` and processes events serially, so it falls **8+ minutes behind** before it reaches Glossary-term creation events.

`WORKFLOW_POLL` in `glossary.ts` was set to `60 s` — the `verifyTaskCreated` and `verifyWorkflowInstanceExists` polls timed out every time in AUT environments.

Failing tests (AUT run [31345075677](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31345075677)):
- `GlossaryApprovalAfterMove > Approval on parent after child move`
- `GlossaryApprovalFlow > Approval workflow on glossary creation`
- `GlossaryApprovalFlow > Approval workflow on updating reviewers`

## What

Raise `WORKFLOW_POLL` from `{ timeout: 60_000, intervals: [1_000, 2_000, 5_000] }` to `{ timeout: 600_000, intervals: [60_000, 40_000, 20_000] }` in `playwright/utils/glossary.ts`.

- Matches the 600 s budget already used for entity/service approval workflow tests (PR #5623 / `GOVERNANCE_TRIGGER_TIMEOUT_MS`).
- Slower intervals avoid hammering the server while the consumer is catching up.

## Test plan

- [ ] AUT run with this change shows Glossary approval tests passing.
- [ ] No impact on non-upgrade CI runs (the consumer is fast there; tests complete on the first or second poll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)