### PR TITLE
Backport to 2.0: search index field search, template parse noise, and service href collection paths

### DIFF
--- a/ingestion/src/metadata/ingestion/source/search/elasticsearch/parser.py
+++ b/ingestion/src/metadata/ingestion/source/search/elasticsearch/parser.py
@@ -14,7 +14,6 @@ Utils module to parse the jsonschema
 """
 
 import traceback
-from typing import List, Optional  # noqa: UP035
 
 from metadata.generated.schema.entity.data.searchIndex import DataType, SearchIndexField
 from metadata.utils.logger import ingestion_logger
@@ -32,11 +31,14 @@ def _missing_(cls, value):
 DataType._missing_ = _missing_
 
 
-def parse_es_index_mapping(mapping: dict) -> Optional[List[SearchIndexField]]:  # noqa: UP006, UP045
+def parse_es_index_mapping(mapping: dict | None) -> list[SearchIndexField]:
     """
     Recursively convert the parsed schema into required models
     """
     field_models = []
+    if not mapping:
+        logger.debug("No mappings to parse: the index or template declares none")
+        return field_models
     try:
         properties = mapping.get("properties", {})
         for key, value in properties.items():

--- a/ingestion/src/metadata/ingestion/source/search/opensearch/parser.py
+++ b/ingestion/src/metadata/ingestion/source/search/opensearch/parser.py
@@ -14,7 +14,6 @@ Utils module to parse the OpenSearch mapping json schema.
 """
 
 import traceback
-from typing import List, Optional  # noqa: UP035
 
 from metadata.generated.schema.entity.data.searchIndex import DataType, SearchIndexField
 from metadata.utils.logger import ingestion_logger
@@ -32,18 +31,21 @@ def _missing_(cls, value):
 DataType._missing_ = _missing_
 
 
-def parse_os_index_mapping(mapping: dict) -> Optional[List[SearchIndexField]]:  # noqa: UP006, UP045
+def parse_os_index_mapping(mapping: dict | None) -> list[SearchIndexField]:
     """
     Recursively convert the OpenSearch mapping into the required models.
 
     Args:
-        mapping (dict): The OpenSearch mapping dictionary.
+        mapping (dict | None): The OpenSearch mapping dictionary, or None when the index
+            or template declares no mappings.
 
     Returns:
-        Optional[List[SearchIndexField]]: A list of SearchIndexField objects if parsing is successful,
-        otherwise None.
+        list[SearchIndexField]: The parsed fields; empty when there is nothing to parse.
     """
     field_models = []
+    if not mapping:
+        logger.debug("No mappings to parse: the index or template declares none")
+        return field_models
     try:
         properties = mapping.get("properties", {})
         for key, value in properties.items():

--- a/ingestion/tests/unit/topology/search/test_search_index_mapping_parser.py
+++ b/ingestion/tests/unit/topology/search/test_search_index_mapping_parser.py
@@ -1,0 +1,80 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Test the Elasticsearch and OpenSearch index mapping parsers
+"""
+
+import logging
+
+import pytest
+
+from metadata.generated.schema.entity.data.searchIndex import DataType
+from metadata.ingestion.source.search.elasticsearch.parser import parse_es_index_mapping
+from metadata.ingestion.source.search.opensearch.parser import parse_os_index_mapping
+
+PARSERS = [parse_es_index_mapping, parse_os_index_mapping]
+
+MAPPING_WITH_PROPERTIES = {
+    "properties": {
+        "customer_id": {"type": "keyword"},
+        "address": {
+            "properties": {
+                "city": {"type": "text", "description": "City name"},
+            }
+        },
+    }
+}
+
+
+class TestIndexMappingParser:
+    """Behaviour shared by the Elasticsearch and OpenSearch mapping parsers."""
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    @pytest.mark.parametrize("mapping", [None, {}])
+    def test_missing_mapping_yields_no_fields(self, parse, mapping):
+        assert parse(mapping) == []
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    @pytest.mark.parametrize("mapping", [None, {}])
+    def test_missing_mapping_logs_no_error(self, parse, mapping, caplog):
+        with caplog.at_level(logging.DEBUG):
+            parse(mapping)
+
+        assert not [record for record in caplog.records if record.levelno >= logging.WARNING]
+        assert "No mappings to parse" in caplog.text
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    def test_mapping_without_properties_yields_no_fields(self, parse):
+        assert parse({"_meta": {"managed": True}}) == []
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    def test_properties_are_parsed_into_fields(self, parse):
+        fields = parse(MAPPING_WITH_PROPERTIES)
+
+        assert [field.name.root for field in fields] == ["customer_id", "address"]
+        assert fields[0].dataType == DataType.KEYWORD
+        assert fields[0].children is None
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    def test_nested_properties_become_children(self, parse):
+        address = parse(MAPPING_WITH_PROPERTIES)[1]
+
+        assert address.dataType == DataType.OBJECT
+        assert [child.name.root for child in address.children] == ["city"]
+        assert address.children[0].description.root == "City name"
+
+    @pytest.mark.parametrize("parse", PARSERS)
+    def test_unknown_data_type_falls_back_to_unknown(self, parse):
+        fields = parse({"properties": {"weird": {"type": "not_a_real_es_type"}}})
+
+        assert fields[0].dataType == DataType.UNKNOWN
+        assert fields[0].dataTypeDisplay == "not_a_real_es_type"

--- a/ingestion/tests/unit/topology/search/test_search_index_mapping_parser.py
+++ b/ingestion/tests/unit/topology/search/test_search_index_mapping_parser.py
@@ -18,10 +18,17 @@ import logging
 import pytest
 
 from metadata.generated.schema.entity.data.searchIndex import DataType
-from metadata.ingestion.source.search.elasticsearch.parser import parse_es_index_mapping
-from metadata.ingestion.source.search.opensearch.parser import parse_os_index_mapping
+from metadata.ingestion.source.search.elasticsearch import parser as es_parser
+from metadata.ingestion.source.search.opensearch import parser as os_parser
+
+parse_es_index_mapping = es_parser.parse_es_index_mapping
+parse_os_index_mapping = os_parser.parse_os_index_mapping
 
 PARSERS = [parse_es_index_mapping, parse_os_index_mapping]
+
+# caplog.at_level() must name this logger: other suites pin "metadata" to INFO via
+# set_loggers_level, and raising only the root logger leaves the debug record filtered.
+PARSER_LOGGER = es_parser.logger.name
 
 MAPPING_WITH_PROPERTIES = {
     "properties": {
@@ -46,7 +53,7 @@ class TestIndexMappingParser:
     @pytest.mark.parametrize("parse", PARSERS)
     @pytest.mark.parametrize("mapping", [None, {}])
     def test_missing_mapping_logs_no_error(self, parse, mapping, caplog):
-        with caplog.at_level(logging.DEBUG):
+        with caplog.at_level(logging.DEBUG, logger=PARSER_LOGGER):
             parse(mapping)
 
         assert not [record for record in caplog.records if record.levelno >= logging.WARNING]

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseServiceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseServiceIT.java
@@ -52,6 +52,18 @@ public abstract class BaseServiceIT<T extends EntityInterface, K extends CreateE
   }
 
   @Test
+  void test_hrefUsesOwnCollectionPath(TestNamespace ns) {
+    T service = createEntity(createMinimalRequest(ns));
+
+    assertNotNull(service.getHref(), "Service href must be set");
+    assertTrue(
+        service.getHref().getPath().startsWith(getResourcePath()),
+        String.format(
+            "%s href '%s' must live under '%s'",
+            getEntityType(), service.getHref(), getResourcePath()));
+  }
+
+  @Test
   void test_listWithDomainFilter(TestNamespace ns) throws Exception {
     OpenMetadataClient client = SdkClients.adminClient();
     String typePrefix = getEntityType().replace("Service", "").toLowerCase();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseServiceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/BaseServiceIT.java
@@ -57,7 +57,7 @@ public abstract class BaseServiceIT<T extends EntityInterface, K extends CreateE
 
     assertNotNull(service.getHref(), "Service href must be set");
     assertTrue(
-        service.getHref().getPath().startsWith(getResourcePath()),
+        service.getHref().getPath().endsWith(getResourcePath() + service.getId()),
         String.format(
             "%s href '%s' must live under '%s'",
             getEntityType(), service.getHref(), getResourcePath()));

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetadataServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/MetadataServiceRepository.java
@@ -4,7 +4,7 @@ import org.openmetadata.schema.entity.services.MetadataConnection;
 import org.openmetadata.schema.entity.services.MetadataService;
 import org.openmetadata.schema.entity.services.ServiceType;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.resources.services.database.DatabaseServiceResource;
+import org.openmetadata.service.resources.services.metadata.MetadataServiceResource;
 
 public class MetadataServiceRepository
     extends ServiceEntityRepository<MetadataService, MetadataConnection> {
@@ -12,7 +12,7 @@ public class MetadataServiceRepository
 
   public MetadataServiceRepository() {
     super(
-        DatabaseServiceResource.COLLECTION_PATH,
+        MetadataServiceResource.COLLECTION_PATH,
         Entity.METADATA_SERVICE,
         Entity.getCollectionDAO().metadataServiceDAO(),
         MetadataConnection.class,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchServiceRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/SearchServiceRepository.java
@@ -4,13 +4,13 @@ import org.openmetadata.schema.entity.services.SearchService;
 import org.openmetadata.schema.entity.services.ServiceType;
 import org.openmetadata.schema.type.SearchConnection;
 import org.openmetadata.service.Entity;
-import org.openmetadata.service.resources.services.storage.StorageServiceResource;
+import org.openmetadata.service.resources.services.searchIndexes.SearchServiceResource;
 
 public class SearchServiceRepository
     extends ServiceEntityRepository<SearchService, SearchConnection> {
   public SearchServiceRepository() {
     super(
-        StorageServiceResource.COLLECTION_PATH,
+        SearchServiceResource.COLLECTION_PATH,
         Entity.SEARCH_SERVICE,
         Entity.getCollectionDAO().searchServiceDAO(),
         SearchConnection.class,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/mysql/v200/Migration.java
@@ -12,6 +12,7 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrat
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateRdfIndexAppScheduleToWeekly;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
+import static org.openmetadata.service.migration.utils.v200.SearchIndexSettingsRepair.repairSearchIndexFieldSearchSettings;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class Migration extends MigrationProcessImpl {
     // runDataMigration() per PR #26571, so this dual-invoke is required to
     // close that path. The helper is idempotent — safe on every run.
     backfillSearchRankingSettings();
+    repairSearchIndexFieldSearchSettings();
     migrateRdfIndexAppScheduleToWeekly(collectionDAO);
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, MYSQL);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/postgres/v200/Migration.java
@@ -12,6 +12,7 @@ import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrat
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateRdfIndexAppScheduleToWeekly;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateSuggestionsToTaskEntity;
 import static org.openmetadata.service.migration.utils.v200.MigrationUtil.migrateThreadTasksToTaskEntity;
+import static org.openmetadata.service.migration.utils.v200.SearchIndexSettingsRepair.repairSearchIndexFieldSearchSettings;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ public class Migration extends MigrationProcessImpl {
     // runDataMigration() per PR #26571, so this dual-invoke is required to
     // close that path. The helper is idempotent — safe on every run.
     backfillSearchRankingSettings();
+    repairSearchIndexFieldSearchSettings();
     migrateRdfIndexAppScheduleToWeekly(collectionDAO);
     addTableColumnSearchSettings();
     migrateSuggestionsToTaskEntity(handle, POSTGRES);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/SearchIndexSettingsRepair.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/SearchIndexSettingsRepair.java
@@ -1,0 +1,194 @@
+package org.openmetadata.service.migration.utils.v200;
+
+import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.ArrayList;
+import lombok.extern.slf4j.Slf4j;
+import org.openmetadata.schema.api.search.Aggregation;
+import org.openmetadata.schema.api.search.AllowedSearchFields;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.FieldBoost;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.service.migration.utils.SearchSettingsMergeUtil;
+
+/** Migration utility for 2.0.0 repair of the searchIndex asset search configuration. */
+@Slf4j
+public class SearchIndexSettingsRepair {
+  private SearchIndexSettingsRepair() {}
+
+  private static final String SEARCH_INDEX_ASSET_TYPE = "searchIndex";
+  private static final String ML_FEATURE_PREFIX = "mlFeatures.";
+  private static final String RESPONSE_SCHEMA_PREFIX = "searchIndex.responseSchema.";
+  private static final String INDEX_FIELD_PREFIX = "fields.";
+
+  /**
+   * Repairs the {@code searchIndex} search configuration so that a search index can be found by the
+   * name of one of its fields. The shipped seed pointed the asset at {@code mlFeatures.*} and the
+   * allowedFields catalog at {@code searchIndex.responseSchema.*}; neither path exists in the
+   * searchIndex mapping, whose fields live under {@code fields.*}. The settings merge is additive
+   * and never rewrites an asset type it already knows, so correcting the seed alone leaves upgraded
+   * clusters on the dead configuration. Idempotent; safe on every reprocessing pass.
+   */
+  public static void repairSearchIndexFieldSearchSettings() {
+    try {
+      Settings storedSettings = SearchSettingsMergeUtil.getSearchSettingsFromDatabase();
+      SearchSettings seedSettings = SearchSettingsMergeUtil.loadSearchSettingsFromFile();
+      if (storedSettings == null || seedSettings == null) {
+        LOG.warn("Search settings unavailable; skipping searchIndex field-search repair");
+      } else {
+        SearchSettings currentSettings = SearchSettingsMergeUtil.loadSearchSettings(storedSettings);
+        if (repairSearchIndexSettings(currentSettings, seedSettings)) {
+          SearchSettingsMergeUtil.saveSearchSettings(storedSettings, currentSettings);
+          LOG.info("Repaired searchIndex search settings to target indexed field names");
+        } else {
+          LOG.info("searchIndex search settings already target indexed field names");
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error repairing searchIndex field search settings", e);
+    }
+  }
+
+  public static boolean repairSearchIndexSettings(
+      SearchSettings currentSettings, SearchSettings seedSettings) {
+    boolean changed = repairAllowedFields(currentSettings, seedSettings);
+    AssetTypeConfiguration currentAsset = findSearchIndexAsset(currentSettings);
+    AssetTypeConfiguration seedAsset = findSearchIndexAsset(seedSettings);
+    if (currentAsset != null && seedAsset != null) {
+      changed |= removeStaleAssetEntries(currentAsset);
+      changed |= addSeedSearchFields(currentAsset, seedAsset);
+      changed |= addSeedAggregations(currentAsset, seedAsset);
+      changed |= addSeedHighlightFields(currentAsset, seedAsset);
+    }
+    return changed;
+  }
+
+  private static AssetTypeConfiguration findSearchIndexAsset(SearchSettings settings) {
+    AssetTypeConfiguration result = null;
+    for (AssetTypeConfiguration config : listOrEmpty(settings.getAssetTypeConfigurations())) {
+      if (SEARCH_INDEX_ASSET_TYPE.equalsIgnoreCase(config.getAssetType())) {
+        result = config;
+        break;
+      }
+    }
+    return result;
+  }
+
+  private static boolean removeStaleAssetEntries(AssetTypeConfiguration asset) {
+    boolean changed = false;
+    if (!nullOrEmpty(asset.getSearchFields())) {
+      changed = asset.getSearchFields().removeIf(field -> isMlFeature(field.getField()));
+    }
+    if (!nullOrEmpty(asset.getAggregations())) {
+      changed |= asset.getAggregations().removeIf(agg -> isMlFeature(agg.getField()));
+    }
+    if (!nullOrEmpty(asset.getHighlightFields())) {
+      changed |= asset.getHighlightFields().removeIf(SearchIndexSettingsRepair::isMlFeature);
+    }
+    return changed;
+  }
+
+  private static boolean addSeedSearchFields(
+      AssetTypeConfiguration currentAsset, AssetTypeConfiguration seedAsset) {
+    boolean changed = false;
+    if (currentAsset.getSearchFields() == null) {
+      currentAsset.setSearchFields(new ArrayList<>());
+    }
+    for (FieldBoost seedField : listOrEmpty(seedAsset.getSearchFields())) {
+      if (isIndexField(seedField.getField()) && !hasSearchField(currentAsset, seedField)) {
+        currentAsset.getSearchFields().add(seedField);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private static boolean addSeedAggregations(
+      AssetTypeConfiguration currentAsset, AssetTypeConfiguration seedAsset) {
+    boolean changed = false;
+    if (currentAsset.getAggregations() == null) {
+      currentAsset.setAggregations(new ArrayList<>());
+    }
+    for (Aggregation seedAggregation : listOrEmpty(seedAsset.getAggregations())) {
+      if (isIndexField(seedAggregation.getField())
+          && !hasAggregation(currentAsset, seedAggregation)) {
+        currentAsset.getAggregations().add(seedAggregation);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private static boolean addSeedHighlightFields(
+      AssetTypeConfiguration currentAsset, AssetTypeConfiguration seedAsset) {
+    boolean changed = false;
+    if (currentAsset.getHighlightFields() == null) {
+      currentAsset.setHighlightFields(new ArrayList<>());
+    }
+    for (String seedField : listOrEmpty(seedAsset.getHighlightFields())) {
+      if (isIndexField(seedField) && !currentAsset.getHighlightFields().contains(seedField)) {
+        currentAsset.getHighlightFields().add(seedField);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  private static boolean repairAllowedFields(
+      SearchSettings currentSettings, SearchSettings seedSettings) {
+    AllowedSearchFields currentAllowed = findSearchIndexAllowedFields(currentSettings);
+    AllowedSearchFields seedAllowed = findSearchIndexAllowedFields(seedSettings);
+    boolean changed = false;
+    if (currentAllowed != null && seedAllowed != null && !nullOrEmpty(currentAllowed.getFields())) {
+      changed = currentAllowed.getFields().removeIf(field -> isResponseSchema(field.getName()));
+      for (var seedField : listOrEmpty(seedAllowed.getFields())) {
+        if (isIndexField(seedField.getName())
+            && !hasAllowedField(currentAllowed, seedField.getName())) {
+          currentAllowed.getFields().add(seedField);
+          changed = true;
+        }
+      }
+    }
+    return changed;
+  }
+
+  private static AllowedSearchFields findSearchIndexAllowedFields(SearchSettings settings) {
+    AllowedSearchFields result = null;
+    for (AllowedSearchFields allowedFields : listOrEmpty(settings.getAllowedFields())) {
+      if (SEARCH_INDEX_ASSET_TYPE.equalsIgnoreCase(allowedFields.getEntityType())) {
+        result = allowedFields;
+        break;
+      }
+    }
+    return result;
+  }
+
+  private static boolean hasSearchField(AssetTypeConfiguration asset, FieldBoost seedField) {
+    return listOrEmpty(asset.getSearchFields()).stream()
+        .anyMatch(field -> seedField.getField().equals(field.getField()));
+  }
+
+  private static boolean hasAggregation(AssetTypeConfiguration asset, Aggregation seedAggregation) {
+    return listOrEmpty(asset.getAggregations()).stream()
+        .anyMatch(agg -> seedAggregation.getName().equals(agg.getName()));
+  }
+
+  private static boolean hasAllowedField(AllowedSearchFields allowedFields, String seedName) {
+    return listOrEmpty(allowedFields.getFields()).stream()
+        .anyMatch(field -> seedName.equals(field.getName()));
+  }
+
+  private static boolean isMlFeature(String fieldName) {
+    return fieldName != null && fieldName.startsWith(ML_FEATURE_PREFIX);
+  }
+
+  private static boolean isResponseSchema(String fieldName) {
+    return fieldName != null && fieldName.startsWith(RESPONSE_SCHEMA_PREFIX);
+  }
+
+  private static boolean isIndexField(String fieldName) {
+    return fieldName != null && fieldName.startsWith(INDEX_FIELD_PREFIX);
+  }
+}

--- a/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
+++ b/openmetadata-service/src/main/resources/json/data/settings/searchSettings.json
@@ -1204,21 +1204,26 @@
           "matchType": "standard"
         },
         {
-          "field": "mlFeatures.name",
+          "field": "fields.name",
           "boost": 8.0,
           "matchType": "standard"
         },
         {
-          "field": "mlFeatures.description",
+          "field": "fields.name.keyword",
+          "boost": 2.0,
+          "matchType": "exact"
+        },
+        {
+          "field": "fields.description",
           "boost": 1.0,
           "matchType": "standard"
         }
       ],
       "aggregations": [
         {
-          "name": "mlFeatures.name.keyword",
+          "name": "fields.name.keyword",
           "type": "terms",
-          "field": "mlFeatures.name.keyword"
+          "field": "fields.name.keyword"
         }
       ],
       "scoreMode": "sum",
@@ -1227,8 +1232,8 @@
         "name",
         "displayName",
         "description",
-        "mlFeatures.name",
-        "mlFeatures.description"
+        "fields.name",
+        "fields.description"
       ],
       "matchTypeBoostMultipliers": {
         "exactMatchMultiplier": 2.0,
@@ -3370,11 +3375,15 @@
           "description": "Search on parts of the hierarchical name for flexible matching."
         },
         {
-          "name": "searchIndex.responseSchema.name",
+          "name": "fields.name",
           "description": "Search on the names of fields indexed in the search index."
         },
         {
-          "name": "searchIndex.responseSchema.description",
+          "name": "fields.name.keyword",
+          "description": "Exact match on a search index field name for precise lookups."
+        },
+        {
+          "name": "fields.description",
           "description": "Search on field descriptions to find search indexes with fields serving specific purposes."
         },
         {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/SearchIndexSettingsRepairTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/SearchIndexSettingsRepairTest.java
@@ -1,0 +1,164 @@
+package org.openmetadata.service.migration.utils.v200;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.api.search.AllowedSearchFields;
+import org.openmetadata.schema.api.search.AssetTypeConfiguration;
+import org.openmetadata.schema.api.search.SearchSettings;
+import org.openmetadata.schema.utils.JsonUtils;
+
+class SearchIndexSettingsRepairTest {
+
+  private static final String STORED_SETTINGS =
+      """
+      {
+        "assetTypeConfigurations": [
+          {
+            "assetType": "mlmodel",
+            "searchFields": [
+              {"field": "mlFeatures.name", "boost": 8.0, "matchType": "standard"}
+            ],
+            "aggregations": [
+              {"name": "mlFeatures.name.keyword", "type": "terms", "field": "mlFeatures.name.keyword"}
+            ],
+            "highlightFields": ["name", "mlFeatures.name"]
+          },
+          {
+            "assetType": "searchIndex",
+            "searchFields": [
+              {"field": "name", "boost": 10.0, "matchType": "phrase"},
+              {"field": "mlFeatures.name", "boost": 8.0, "matchType": "standard"},
+              {"field": "mlFeatures.description", "boost": 1.0, "matchType": "standard"}
+            ],
+            "aggregations": [
+              {"name": "mlFeatures.name.keyword", "type": "terms", "field": "mlFeatures.name.keyword"}
+            ],
+            "highlightFields": ["name", "description", "mlFeatures.name", "mlFeatures.description"]
+          }
+        ],
+        "allowedFields": [
+          {
+            "entityType": "searchIndex",
+            "fields": [
+              {"name": "name"},
+              {"name": "searchIndex.responseSchema.name"},
+              {"name": "searchIndex.responseSchema.description"}
+            ]
+          }
+        ]
+      }
+      """;
+
+  private static final String SEED_SETTINGS =
+      """
+      {
+        "assetTypeConfigurations": [
+          {
+            "assetType": "searchIndex",
+            "searchFields": [
+              {"field": "name", "boost": 10.0, "matchType": "phrase"},
+              {"field": "fields.name", "boost": 8.0, "matchType": "standard"},
+              {"field": "fields.name.keyword", "boost": 2.0, "matchType": "exact"},
+              {"field": "fields.description", "boost": 1.0, "matchType": "standard"}
+            ],
+            "aggregations": [
+              {"name": "fields.name.keyword", "type": "terms", "field": "fields.name.keyword"}
+            ],
+            "highlightFields": ["name", "description", "fields.name", "fields.description"]
+          }
+        ],
+        "allowedFields": [
+          {
+            "entityType": "searchIndex",
+            "fields": [
+              {"name": "name"},
+              {"name": "fields.name"},
+              {"name": "fields.name.keyword"},
+              {"name": "fields.description"}
+            ]
+          }
+        ]
+      }
+      """;
+
+  private SearchSettings stored() {
+    return JsonUtils.readValue(STORED_SETTINGS, SearchSettings.class);
+  }
+
+  private SearchSettings seed() {
+    return JsonUtils.readValue(SEED_SETTINGS, SearchSettings.class);
+  }
+
+  private AssetTypeConfiguration asset(SearchSettings settings, String assetType) {
+    return settings.getAssetTypeConfigurations().stream()
+        .filter(config -> assetType.equals(config.getAssetType()))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private List<String> searchFieldNames(AssetTypeConfiguration asset) {
+    return asset.getSearchFields().stream().map(field -> field.getField()).toList();
+  }
+
+  @Test
+  void repairReplacesMlFeatureSearchFieldsWithIndexedFields() {
+    SearchSettings settings = stored();
+
+    assertTrue(SearchIndexSettingsRepair.repairSearchIndexSettings(settings, seed()));
+
+    AssetTypeConfiguration searchIndex = asset(settings, "searchIndex");
+    assertEquals(
+        List.of("name", "fields.name", "fields.name.keyword", "fields.description"),
+        searchFieldNames(searchIndex));
+    assertEquals(
+        List.of("fields.name.keyword"),
+        searchIndex.getAggregations().stream().map(agg -> agg.getField()).toList());
+    assertEquals(
+        List.of("name", "description", "fields.name", "fields.description"),
+        searchIndex.getHighlightFields());
+  }
+
+  @Test
+  void repairReplacesResponseSchemaAllowedFieldsWithIndexedFields() {
+    SearchSettings settings = stored();
+
+    assertTrue(SearchIndexSettingsRepair.repairSearchIndexSettings(settings, seed()));
+
+    AllowedSearchFields allowed =
+        settings.getAllowedFields().stream()
+            .filter(entry -> "searchIndex".equals(entry.getEntityType()))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(
+        List.of("name", "fields.name", "fields.name.keyword", "fields.description"),
+        allowed.getFields().stream().map(field -> field.getName()).toList());
+  }
+
+  @Test
+  void repairLeavesMlModelConfigurationUntouched() {
+    SearchSettings settings = stored();
+
+    SearchIndexSettingsRepair.repairSearchIndexSettings(settings, seed());
+
+    AssetTypeConfiguration mlmodel = asset(settings, "mlmodel");
+    assertEquals(List.of("mlFeatures.name"), searchFieldNames(mlmodel));
+    assertEquals(List.of("name", "mlFeatures.name"), mlmodel.getHighlightFields());
+  }
+
+  @Test
+  void repairIsIdempotent() {
+    SearchSettings settings = stored();
+    SearchIndexSettingsRepair.repairSearchIndexSettings(settings, seed());
+
+    assertFalse(SearchIndexSettingsRepair.repairSearchIndexSettings(settings, seed()));
+  }
+
+  @Test
+  void repairSkipsSettingsWithoutSearchIndexConfiguration() {
+    assertFalse(SearchIndexSettingsRepair.repairSearchIndexSettings(new SearchSettings(), seed()));
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #<!-- TODO: link the same issue as #31308 before marking this ready -->

> **Draft:** backport of #31308. Needs the issue number and a `Fixes <issue-number>: …` title, same as the parent.

Backport to `2.0` of **#31308** — three fixes from the 2.0.0 ElasticSearch connector test review:

1. **A search index could not be found by the name of one of its fields.** The shipped `searchIndex` asset config pointed `searchFields`, `aggregations` and `highlightFields` at `mlFeatures.*`, and `allowedFields` at `searchIndex.responseSchema.*`. Neither path exists in the searchIndex mapping, whose fields live under `fields.*`.
2. **Index templates without mappings logged an error per template.** A template declaring only `settings` or `aliases` is legal and reached the parser as `None`, where the broad `except` turned an expected case into an error log.
3. **Search and metadata services reported an `href` under the wrong collection** (`storageServices` / `databaseServices`).

The five cherry-picked commits apply to `2.0` with **no conflicts**, and the resulting diff is byte-identical to the parent PR (687 diff lines on both). Every file the change touches — and every file it depends on (`SearchSettingsMergeUtil`, `SearchSettingsHandler`, `v200/MigrationUtil`, `BaseEntityIT`, `logger.py`, the searchSettings schema and the searchIndex ES mapping) — is identical between `main` and `2.0`, so there is no behavioural divergence to reconcile.

Design rationale, including why the seed change needs the v200 data migration, is in #31308.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Unchanged from #31308 — see that PR. No 2.0-specific adaptation was required.

#
### Tests:

#### Use cases covered
- Searching a search index by one of its field names returns that index
- A cluster upgraded with the old `searchIndex` settings has them repaired on migration
- An index template that declares only settings or aliases ingests with zero fields and no error log
- Every service type reports an `href` under its own collection path

#### Unit tests
- `ingestion/tests/unit/topology/search/test_search_index_mapping_parser.py`
- `openmetadata-service/.../migration/utils/v200/SearchIndexSettingsRepairTest.java`

#### Backend integration tests
- `openmetadata-integration-tests/.../BaseServiceIT.java` — `test_hrefUsesOwnCollectionPath`, inherited by every service IT.

#### Ingestion integration tests
- Not applicable — covered by the unit tests above.

#### Playwright (UI) tests
- Not applicable — no UI changes.

#### Manual testing performed
Verified on this branch, built from `2.0`:

1. `SearchIndexSettingsRepairTest` — 5/5 pass.
2. `tests/unit/topology/search/` — 24/24 pass.
3. `openmetadata-integration-tests` compiles; `test_hrefUsesOwnCollectionPath` passes on `SearchServiceResourceIT`, `MetadataServiceResourceIT` and `StorageServiceResourceIT`.

The parent PR additionally verified the behaviour end-to-end on a local stack against a real Elasticsearch cluster (84 indices, 131 templates, 13 without mappings): zero parse errors, field-name search returning the right index, and a full red→green cycle on the settings migration.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — pending the issue number
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — pending
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: no schema change; the seed-data change ships with a data migration.
- [x] For UI changes: N/A.
- [x] I have added tests (unit / integration as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
