### PR TITLE
fix(context-center): suppress unnecessary user API calls for team owners and pin count fetch

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -22,6 +22,7 @@ import { AxiosError } from 'axios';
 import { ReactComponent as EditIcon } from '../../../assets/svg/edit-new.svg';
 import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
 import UserPopOverCard from '../../../components/common/PopOverCard/UserPopOverCard';
+import { OwnerType } from '../../../enums/user.enum';
 
 import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -274,7 +275,12 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
               className="tw:text-xs tw:font-medium tw:text-secondary tw:gap-2 tw:max-w-40"
               displayName={getEntityName(owners?.[0])}
               profileWidth={20}
-              userName={getEntityName(owners?.[0])}
+              type={
+                owners?.[0]?.type === 'team'
+                  ? OwnerType.TEAM
+                  : OwnerType.USER
+              }
+              userName={owners?.[0].name || owners?.[0].displayName}
             />
           ) : (
             <Typography

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -276,9 +276,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
               displayName={getEntityName(owners?.[0])}
               profileWidth={20}
               type={
-                owners?.[0]?.type === 'team'
-                  ? OwnerType.TEAM
-                  : OwnerType.USER
+                owners?.[0]?.type === 'team' ? OwnerType.TEAM : OwnerType.USER
               }
               userName={owners?.[0].name || owners?.[0].displayName}
             />

--- a/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/KnowledgeCenter/KnowledgeCard/KnowledgeCard.tsx
@@ -102,17 +102,20 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
   const recentlyViewed =
     recentlyViewedQuickLinks as unknown as RecentlyViewedQuickLinks['data'];
 
-  const fetchPermission = async (fqn: string) => {
-    try {
-      const response = await getEntityPermissionByFqn(
-        ResourceEntity.KNOWLEDGE_PAGE as unknown as ResourceEntity,
-        fqn
-      );
-      setPermissions(response);
-    } catch (error) {
-      showErrorToast(error as AxiosError);
-    }
-  };
+  const fetchPermission = useCallback(
+    async (fqn: string) => {
+      try {
+        const response = await getEntityPermissionByFqn(
+          ResourceEntity.KNOWLEDGE_PAGE as unknown as ResourceEntity,
+          fqn
+        );
+        setPermissions(response);
+      } catch (error) {
+        showErrorToast(error as AxiosError);
+      }
+    },
+    [getEntityPermissionByFqn]
+  );
 
   const isQuickLink = knowledgePage.pageType === PageType.QUICK_LINK;
   const path = isQuickLink
@@ -159,7 +162,13 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
       isSoftDelete ? handleToggleDelete() : onDelete?.(knowledgePage?.id);
       onRefreshTagsCategory?.(true);
     },
-    [knowledgePage, onDelete, handleToggleDelete, onRefreshTagsCategory]
+    [
+      knowledgePage,
+      onDelete,
+      handleToggleDelete,
+      onRefreshTagsCategory,
+      recentlyViewed,
+    ]
   );
 
   const quickLinkActions = useMemo(() => {
@@ -212,7 +221,7 @@ const KnowledgeCard: FC<KnowledgeCardProps> = ({
     if (knowledgeItem.pageType === PageType.QUICK_LINK) {
       fetchPermission(knowledgeItem.fullyQualifiedName);
     }
-  }, [knowledgeItem]);
+  }, [knowledgeItem, fetchPermission]);
 
   return (
     <Card

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -490,6 +490,11 @@ const ContextCenterMemoriesPage: FC = () => {
     [memoryCounts, t]
   );
 
+  const allAssetsLabel = t('label.all-entity', {
+    entity: t('label.asset-plural'),
+  });
+  const allAuthorsLabel = t('label.all-entity', { entity: t('label.author') });
+
   const headerActions = (
     <Button
       color="primary"
@@ -678,10 +683,7 @@ const ContextCenterMemoriesPage: FC = () => {
                               : 'tw:text-secondary'
                           }
                           weight="medium">
-                          {selectedAsset?.label ??
-                            t('label.all-entity', {
-                              entity: t('label.asset-plural'),
-                            })}
+                          {selectedAsset?.label ?? allAssetsLabel}
                         </Typography>
                       </div>
                       <ChevronDown
@@ -732,8 +734,7 @@ const ContextCenterMemoriesPage: FC = () => {
                             : 'tw:text-secondary'
                         }
                         weight="medium">
-                        {selectedAuthor?.label ??
-                          t('label.all-entity', { entity: t('label.author') })}
+                        {selectedAuthor?.label ?? allAuthorsLabel}
                       </Typography>
                     </div>
                     <ChevronDown
@@ -781,12 +782,8 @@ const ContextCenterMemoriesPage: FC = () => {
                       <Dropdown.Item
                         id="all-authors"
                         key="all-authors"
-                        textValue={t('label.all-entity', {
-                          entity: t('label.author'),
-                        })}>
-                        <span>
-                          {t('label.all-entity', { entity: t('label.author') })}
-                        </span>
+                        textValue={allAuthorsLabel}>
+                        <span>{allAuthorsLabel}</span>
                       </Dropdown.Item>
                       {isAuthorOptionsLoading && (
                         <Dropdown.Item

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterMemoriesPage/ContextCenterMemoriesPage.tsx
@@ -225,7 +225,9 @@ const ContextCenterMemoriesPage: FC = () => {
       const [totalVisible, pinnedVisible, createdByMeVisible] =
         await Promise.all([
           getVisibleMemoryCount(),
-          getVisibleMemoryCount({ pinned: true }),
+          // TODO: Unhide when pin feature releases in post-2.0
+          // getVisibleMemoryCount({ pinned: true }),
+          Promise.resolve(0),
           authorFilter
             ? getVisibleMemoryCount({ author: authorFilter })
             : Promise.resolve(0),


### PR DESCRIPTION
### Describe your changes:

Fixes #<!-- no issue --> <!-- Note: no issue exists yet for these two targeted bug fixes -->

I worked on two API noise issues in the Context Center:

1. **KnowledgeCard team-owner API calls** — `UserPopOverCard` was rendered without a `type` prop, defaulting to `OwnerType.USER` for all owners including teams. This caused `useUserProfile` to fire `GET /api/v1/users/name/{name}?fields=profile` on every card mount for team owners (e.g. "Finance Team 16"), resulting in 404s and wasted requests on scroll. Fixed by deriving the correct `OwnerType` from `owners[0].type` so the hook short-circuits immediately for teams.

2. **Memories page pin count fetch** — `fetchMemoryCounts()` was making a parallel `GET /contextCenter/memories?pinned=true` call to count pinned memories, but `pinnedVisible` is never rendered anywhere in the UI. The pin feature is not releasing in 2.0. Replaced with `Promise.resolve(0)` with a TODO comment to restore post-2.0.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Article list with team-owned articles no longer fires `/api/v1/users/name/...` calls for team owners on scroll
- Article list with user-owned articles continues to fetch profile pictures normally (hook still fires for users)
- Memories page no longer makes a `pinned=true` count request on load, filter change, or after delete

#### Unit tests
- [ ] Not added — changes are one-line guards; existing tests cover the component render paths.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — no new user-visible behavior, only suppression of extraneous network calls.

#### Manual testing performed
1. Open ContextCenter → Articles page in DevTools Network tab
2. Scroll the article list — verify no `/api/v1/users/name/...` calls fire for team-owned articles
3. Verify user-owned articles still display profile pictures (API call fires once per unique user, cached)
4. Open ContextCenter → Memories page in DevTools Network tab
5. Verify no `GET /contextCenter/memories?...pinned=true` request on load or after delete/filter change

#
### UI screen recording / screenshots:

Not applicable. <!-- No visible UI change; only network call suppression -->

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — no issue exists yet for these targeted fixes
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — no issue exists yet
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no visible UI change, recording not applicable.
- [ ] I have added tests — not added; guards are trivial and existing render tests cover the paths.