### PR TITLE
fix(appMode): preserve an existing session tuple through the AuthProvider hydrate

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -62,6 +62,7 @@ import {
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import {
   clearAppMode,
+  readAppModeSession,
   resolveEffectiveAppMode,
   resolveInitialAppMode,
   setAppDefaultMode,
@@ -157,6 +158,17 @@ const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
 
   const appDefault = translateWireMode(appConfig?.defaultAppMode ?? null);
   setAppDefaultMode(appDefault);
+
+  // If this tab already has a session tuple (a manual toggle earlier in
+  // this tab, or a reload of one) leave it alone. `useResolvedAppMode`
+  // is the authoritative source and treats the tuple as the highest-
+  // priority signal once persona information is available — writing
+  // here would clobber a valid in-tab choice with the boot-time best-
+  // effort resolve (which cannot yet see persona) and break "toggle to
+  // AI, then reload" for users who did not tick "remember".
+  if (readAppModeSession()?.mode) {
+    return;
+  }
 
   const userPref =
     derivePreferencesFromList(prefsRes.preferences).appMode ?? null;


### PR DESCRIPTION
## Summary

`AuthProvider.hydrateAndResolveAppMode` runs at boot before `useResolvedAppMode` and unconditionally calls `writeAppMode(resolveEffectiveAppMode(userPref, null, appDefault))`. When a tab already has a session tuple — set by a manual toggle earlier in this tab, by \`switchToAiModeViaProfileToggle\` without ticking "remember", or a reload of a previously-active tab — that call clobbers the tuple with the best-effort boot resolve. That resolve is intentionally partial (persona is fetched later by \`useResolvedAppMode\`, as the code comment documents), so with no user preference on the server the write lands on \`DEFAULT_APP_MODE\`.

**Effect on users:**
- "Toggle to AI, then reload" reverts to Classic.
- New tabs opened while a sibling tab is in AI drop the cross-tab hint on their first hydrate.
- Every un-remembered in-tab choice quietly evaporates on any navigation that re-mounts AuthProvider.

**Fix:** skip the boot-time \`writeAppMode\` when a session tuple with a non-empty \`mode\` already exists. \`useResolvedAppMode\` is the authoritative source and its precedence chain already treats the session tuple as the highest-priority signal (compares its \`personaAppMode\` snapshot to the current persona, refines or clears accordingly). Everything else the hydrate does — \`hydrateBackendSyncedPreferences\` and \`setAppDefaultMode\` — still runs, so the tenant default and the store are up-to-date for the resolver.

Fresh boot (no tuple) behavior is unchanged.

## Test plan

- [ ] Fresh login (no session tuple), no server-side \`appMode\` pref, no persona, no tenant default → Classic (unchanged).
- [ ] Fresh login with server \`appMode: ai\` → AI (unchanged; hydrate still sets store; \`useResolvedAppMode\` writes AI).
- [ ] Toggle to AI via profile switcher (no "remember") → hard reload → still AI (was regressing to Classic).
- [ ] Open a new tab while sibling tab is in AI (hint fresh) → new tab boots into AI (was regressing).
- [ ] Cmd+click open a link from an AI tab → destination tab boots into AI.
- [ ] Existing Collate Playwright specs \`AppMode.spec.ts:51\`, \`AppModeResolver.spec.ts:119\`, \`AppModeResolver.spec.ts:137\`, \`AppModeSidebarState.spec.ts:139\` — should turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)