### PR TITLE
fix(delete): dispatch recursive delete to the bulk subtree path

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4362,26 +4362,34 @@ public abstract class EntityRepository<T extends EntityInterface> {
         return;
       }
     }
-    // Use batch deletion only for hard deletes with large numbers of children
-    // For soft deletes, we must maintain the correct order for restoration to work properly
-    if (hardDelete && children.size() > 100) {
-      LOG.info("Using batch deletion for {} children entities", children.size());
-      batchDeleteChildren(children, hardDelete, updatedBy);
-    } else {
-      // For soft deletes or small numbers, use original sequential deletion
-      // This ensures proper parent-child relationships are maintained for restoration
-      for (EntityRelationshipRecord entityRelationshipRecord : children) {
-        LOG.info(
-            "Recursively {} deleting {} {}",
-            hardDelete ? "hard" : "soft",
-            entityRelationshipRecord.getType(),
-            entityRelationshipRecord.getId());
-        Entity.deleteEntity(
-            updatedBy,
-            entityRelationshipRecord.getType(),
-            entityRelationshipRecord.getId(),
-            true,
-            hardDelete);
+    // Both soft-delete and hard-delete dispatch to the per-type bulk path. One batched DB write
+    // plus one batched change-event insert per type, regardless of descendant count. For hard
+    // delete, bulkHardDeleteSubtree replaces the legacy batchDeleteChildren / Entity.deleteEntity
+    // loop that opened an independent JDBI transaction per descendant.
+    //
+    // Both bulk methods, and the two EntityRepositoryRestoreTest cases asserting this dispatch,
+    // were already on this branch — only the wiring here was missing, so those tests have been
+    // failing and every recursive delete stayed on the per-entity path. At service scale that is
+    // one cascade versus 100k of them: a 100k-table hard delete ran >20 minutes without
+    // finishing here, while the same delete on 2.0 completes in ~14 minutes.
+    //
+    // Time-series children are intentionally skipped — see dispatchToContainedChildren for the
+    // rationale (millions-of-rows lock risk, orphans cleaned offline by DataRetention).
+    Map<String, List<UUID>> idsByType =
+        children.stream()
+            .collect(
+                Collectors.groupingBy(
+                    EntityRelationshipRecord::getType,
+                    Collectors.mapping(EntityRelationshipRecord::getId, Collectors.toList())));
+    for (var entry : idsByType.entrySet()) {
+      String childType = entry.getKey();
+      if (!Entity.isTimeSeriesEntity(childType)) {
+        EntityRepository<?> repo = Entity.getEntityRepository(childType);
+        if (hardDelete) {
+          repo.bulkHardDeleteSubtree(entry.getValue(), updatedBy);
+        } else {
+          repo.bulkSoftDeleteSubtree(entry.getValue(), updatedBy);
+        }
       }
     }
   }
@@ -4431,9 +4439,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   /**
    * Process a batch of entities for hard deletion. Entered only via
-   * {@link #batchDeleteChildren}, which only fires for {@code hardDelete=true} and
-   * {@code children.size() > 100}; the soft-delete and small-batch paths stay on the
-   * sequential {@link Entity#deleteEntity} flow.
+   * {@link #batchDeleteChildren}, which {@link #deleteChildren} no longer calls — the recursive
+   * hard delete now dispatches per child type to {@link #bulkHardDeleteSubtree}. Both this method
+   * and {@code batchDeleteChildren} remain because they are {@code protected} and a subclass may
+   * still route through them; nothing in this class does.
    *
    * <p>Each child is removed via {@link #cleanup}, which deletes the entity row, all
    * {@code (id, *)} and {@code (*, id)} entity_relationship rows, extensions, tag usage,


### PR DESCRIPTION
This is why `ServiceDeleteSearchCleanupScaleIT` is red on `1.13` while `2.0` passes.

## The bug

`deleteChildren` still walked children **one at a time** — `batchDeleteChildren` for >100 hard deletes, `Entity.deleteEntity` otherwise — each descendant opening its own JDBI transaction.

`bulkHardDeleteSubtree` and `bulkSoftDeleteSubtree` were **already on this branch**. So were the two tests asserting this exact dispatch:

```
EntityRepositoryRestoreTest.deleteChildren_hardDelete_groupsByTypeAndDispatchesToBulkHardDelete
EntityRepositoryRestoreTest.deleteChildren_softDelete_groupsByTypeAndDispatchesToBulkSoftDelete
```

**Both have been failing on `1.13`.** I confirmed it on a clean checkout of the branch before touching anything — 15 tests, 2 failures, `Wanted but not invoked`. The backport brought the methods and the tests but not the wiring, so every recursive delete stayed on the per-entity path and both bulk methods were dead code.

## Why it matters at scale

One cascade versus 100k of them. From the nightly Java IT scale suite:

| delete | 2.0 (dispatches) | 1.13 (per-entity) |
|---|---|---|
| 50k cleanup | **6–8 min** | ✗ never finished in 15 min |
| 100k service | **~14.7 min** | ✗ never finished in 20 min |

Create throughput is *identical* between the branches — `EntityLoader` does 100k in 27–28 min on both. Only deletes diverge.

It also compounds: because 1.13's cleanups never complete, undeleted rows accumulate, and the next test's seed goes from ~63 min to **300 min**.

## The change

Group children by type and hand each type's ids to the bulk subtree path, matching `2.0`. Time-series children stay excluded for the reason `dispatchToContainedChildren` documents.

`batchDeleteChildren` and `processDeletionBatch` are **left in place** — both are `protected` and a subclass may still route through them. This removes the call, not the capability.

## Verification

`EntityRepositoryRestoreTest` + `EntityRepositoryCertificationTest` + `SoftDeleteScriptTest`: **46 tests, 0 failures** — including the two that were failing before this change. `mvn compile -pl openmetadata-service` BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
