### PR TITLE
fix(api): log async delete failures instead of only notifying a websocket

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/EntityResource.java
@@ -730,6 +730,18 @@ public abstract class EntityResource<T extends EntityInterface, K extends Entity
                 WebsocketNotificationHandler.sendDeleteOperationCompleteNotification(
                     jobId, securityContext, deleteResponse.entity());
               } catch (Exception e) {
+                // Log before notifying. The websocket notification is the ONLY report this path
+                // had, so a failed async delete was invisible to anyone not holding a live socket
+                // — no stack trace, no error line, nothing. A large recursive delete that dies
+                // here then looks exactly like one still grinding.
+                LOG.error(
+                    "Async delete failed for {} {} (jobId {}, recursive={}, hardDelete={})",
+                    entityType,
+                    id,
+                    jobId,
+                    recursive,
+                    hardDelete,
+                    e);
                 WebsocketNotificationHandler.sendDeleteOperationFailedNotification(
                     jobId,
                     securityContext,


### PR DESCRIPTION
Reland of #31288 with **only** the intended change.

## What #31288 got wrong

That PR was raised from a file copied across branches, so it carried `main`'s entire `EntityResource.java` onto `1.13` — **+315/−61** instead of the intended 12 lines. It dragged in a new `@GET` endpoint, CSV import/export rewrites, and `overrideMetadata` plumbing, importing three classes that do not exist on `1.13`:

- `BulkDeleteStaleRequest`
- `AIContextBuilder`
- `RestoreEntityResponse`

That broke the branch. It has been reverted. Apologies — my error, and the cross-branch copy was the cause.

## This PR

**+12/−0, one hunk.** `deleteByIdAsync` caught `Exception` and reported it solely via `WebsocketNotificationHandler.sendDeleteOperationFailedNotification`:

```java
} catch (Exception e) {
  WebsocketNotificationHandler.sendDeleteOperationFailedNotification(
      jobId, securityContext, entity, e.getMessage() == null ? e.toString() : e.getMessage());
}
```

That is the only report the path has. Unless a client happens to be holding a live socket, the failure vanishes — no stack trace, no error line, nothing in the server log.

The consequence is worse than a missing log: a recursive hard delete that dies here is **indistinguishable from one still running**. The caller keeps polling an entity that will never disappear, and the server looks idle. That ambiguity is what made the nightly scale delete failures undiagnosable for several rounds.

Log at `ERROR` with the entity type, id, jobId and the `recursive`/`hardDelete` flags before notifying. Notification behaviour is unchanged.

## Verification

- Diff is one hunk, 12 added lines, no other file touched — checked before pushing this time.
- `mvn compile -pl openmetadata-service` on `1.13`: **BUILD SUCCESS**.

Equivalents for the other branches are #31286 (main) and #31287 (2.0); both were authored in place and are correctly +13/−0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
