### PR TITLE
feat(ingestion): connector-agnostic metric ingestion feature + Snowflake semantic views

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 docker/development/docker-volume
 docker/docker-compose-quickstart/docker-volume
+ingestion/src/metadata/generated

--- a/ingestion/src/metadata/domain/metrics/__init__.py
+++ b/ingestion/src/metadata/domain/metrics/__init__.py
@@ -1,0 +1,39 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Connector-neutral Metric ingestion contracts and feature.
+
+:mod:`records` owns the normalized shapes; :mod:`feature` is the runnable
+``MetricIngestionFeature`` a connector calls ``accept()`` / ``drain()`` on.
+Connector-specific adapters that produce these records live *inside* each
+connector package.
+"""
+
+from metadata.domain.metrics.feature import (
+    DEFAULT_MAX_DEFINITIONS,
+    MetricFeatureOverflowError,
+    MetricIngestionFeature,
+)
+from metadata.domain.metrics.records import (
+    MetricDefinition,
+    MetricKey,
+    MetricOrigin,
+    MetricSourceType,
+)
+
+__all__ = [
+    "DEFAULT_MAX_DEFINITIONS",
+    "MetricDefinition",
+    "MetricFeatureOverflowError",
+    "MetricIngestionFeature",
+    "MetricKey",
+    "MetricOrigin",
+    "MetricSourceType",
+]

--- a/ingestion/src/metadata/domain/metrics/feature.py
+++ b/ingestion/src/metadata/domain/metrics/feature.py
@@ -1,0 +1,178 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""MetricIngestionFeature — connector-neutral, bounded, drainable Metric emitter.
+
+Contract:
+    ``accept(definition)`` validates and buffers definitions.
+    ``drain()`` yields one CreateMetricRequest per accepted definition, in
+    dependency order, with ``assets`` populated as fqn-only EntityReferenceInput
+    items. The server resolves fqn → id in ``MetricMapper.createToEntity``.
+
+Failure modes:
+    * Non-identical definitions for one MetricKey → ``ValueError``.
+    * Overflow past ``max_definitions`` → ``MetricFeatureOverflowError``.
+    * Cycles or unresolved dependencies → visible ``Either.left`` at drain.
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Iterable  # noqa: TC003
+
+from metadata.domain.metrics.mappers import (
+    resolve_related_metric_fqns,
+    to_create_request,
+)
+from metadata.domain.metrics.records import MetricDefinition, MetricKey  # noqa: TC001
+from metadata.generated.schema.entity.services.ingestionPipelines.status import (
+    StackTraceError,
+)
+from metadata.ingestion.api.models import Either
+
+
+class MetricFeatureOverflowError(RuntimeError):
+    """Raised when accept() would exceed the feature's bounded capacity."""
+
+
+DEFAULT_MAX_DEFINITIONS = 10_000
+
+
+class MetricIngestionFeature:
+    """See the module docstring for the full contract."""
+
+    def __init__(self, *, max_definitions: int = DEFAULT_MAX_DEFINITIONS) -> None:
+        self._max = max_definitions
+        self._definitions: dict[MetricKey, MetricDefinition] = {}
+
+    def accept(self, definition: MetricDefinition) -> None:
+        """Register a definition.
+
+        Raises:
+            MetricFeatureOverflowError: bounded capacity reached.
+            ValueError: same MetricKey seen with a non-identical payload.
+        """
+        existing = self._definitions.get(definition.key)
+        if existing is not None:
+            if existing.canonical_payload() != definition.canonical_payload():
+                raise ValueError(
+                    f"Conflicting definitions for {_key_repr(definition.key)}: "
+                    "same MetricKey, different payload; refusing last-write-wins",
+                )
+            return
+        if len(self._definitions) >= self._max:
+            raise MetricFeatureOverflowError(
+                f"MetricIngestionFeature capacity reached ({self._max} definitions); "
+                f"cannot accept {_key_repr(definition.key)}",
+            )
+        self._definitions[definition.key] = definition
+
+    def drain(self) -> Iterable[Either]:
+        """Yield one CreateMetricRequest per accepted definition, in dep order."""
+        definitions = self._definitions
+        self._definitions = {}
+        if not definitions:
+            return
+
+        ordered, cycle_errors = _topological_sort(definitions)
+        for error in cycle_errors:
+            yield Either(left=error, right=None)
+
+        emitted_fqns: dict[MetricKey, str] = {}
+        for definition in ordered:
+            related_fqns = resolve_related_metric_fqns(definition, emitted_fqns)
+            try:
+                request = to_create_request(definition, related_metric_fqns=related_fqns)
+            except Exception as exc:
+                yield _error(_key_repr(definition.key), exc)
+                continue
+            emitted_fqns[definition.key] = definition.name
+            yield Either(left=None, right=request)
+
+
+def _key_repr(key: MetricKey) -> str:
+    return f"{key.source_type.value}:{key.service_name}:{key.external_id}"
+
+
+def _topological_sort(
+    definitions: dict[MetricKey, MetricDefinition],
+) -> tuple[list[MetricDefinition], list[StackTraceError]]:
+    """Kahn topo sort with stable ordering; errors for cycles + unresolved deps."""
+    keys_sorted = sorted(definitions, key=_sort_key)
+    known = set(definitions)
+    errors: list[StackTraceError] = []
+    dependents: dict[MetricKey, list[MetricKey]] = {k: [] for k in keys_sorted}
+    remaining_indegree: dict[MetricKey, int] = {}
+    for key in keys_sorted:
+        definition = definitions[key]
+        remaining = 0
+        for dep in definition.depends_on:
+            if dep not in known:
+                errors.append(
+                    StackTraceError(
+                        name=_key_repr(key),
+                        error=(f"unresolved dependency {_key_repr(dep)} referenced by {_key_repr(key)}"),
+                        stackTrace=None,
+                    )
+                )
+                continue
+            dependents[dep].append(key)
+            remaining += 1
+        remaining_indegree[key] = remaining
+    ready = sorted(
+        (k for k, count in remaining_indegree.items() if count == 0),
+        key=_sort_key,
+    )
+    ordered_keys: list[MetricKey] = []
+    while ready:
+        current = ready.pop(0)
+        ordered_keys.append(current)
+        for child in sorted(dependents[current], key=_sort_key):
+            remaining_indegree[child] -= 1
+            if remaining_indegree[child] == 0:
+                _insort(ready, child)
+    if len(ordered_keys) < len(keys_sorted):
+        cycle_keys = [k for k in keys_sorted if k not in ordered_keys]
+        errors.extend(
+            StackTraceError(
+                name=_key_repr(key),
+                error=f"dependency cycle involving {_key_repr(key)}",
+                stackTrace=None,
+            )
+            for key in cycle_keys
+        )
+    ordered = [definitions[k] for k in ordered_keys]
+    return ordered, errors
+
+
+def _sort_key(key: MetricKey) -> tuple[str, str, str]:
+    return (key.source_type.value, key.service_name, key.external_id)
+
+
+def _insort(container: list[MetricKey], key: MetricKey) -> None:
+    lo, hi = 0, len(container)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if _sort_key(container[mid]) < _sort_key(key):
+            lo = mid + 1
+        else:
+            hi = mid
+    container.insert(lo, key)
+
+
+def _error(context: str, exc: Exception) -> Either:
+    return Either(
+        left=StackTraceError(
+            name=context,
+            error=f"{context}: {exc}",
+            stackTrace=traceback.format_exc(),
+        ),
+        right=None,
+    )

--- a/ingestion/src/metadata/domain/metrics/mappers.py
+++ b/ingestion/src/metadata/domain/metrics/mappers.py
@@ -1,0 +1,53 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Pure mappers: normalized MetricDefinition → CreateMetricRequest."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from metadata.generated.schema.api.data.createMetric import CreateMetricRequest
+from metadata.generated.schema.type.entityReferenceInputList import EntityReferenceInputList
+
+if TYPE_CHECKING:
+    from metadata.domain.metrics.records import MetricDefinition, MetricKey
+
+
+def to_create_request(
+    definition: MetricDefinition,
+    related_metric_fqns: list[str] | None = None,
+) -> CreateMetricRequest:
+    """Build a CreateMetricRequest with ``assets`` attached as fqn-only
+    EntityReferenceInput items — server resolves fqn → id in MetricMapper."""
+    assets = EntityReferenceInputList(root=list(definition.related_assets)) if definition.related_assets else None
+    return CreateMetricRequest(  # pyright: ignore[reportCallIssue]
+        name=definition.name,
+        displayName=definition.display_name,
+        description=definition.description,
+        metricExpression=definition.expression,
+        metricType=definition.metric_type,
+        unitOfMeasurement=definition.unit,
+        granularity=definition.granularity,
+        dimensions=list(definition.dimensions) or None,
+        measures=list(definition.measures) or None,
+        filters=list(definition.filters) or None,
+        tags=list(definition.tags) or None,
+        relatedMetrics=related_metric_fqns or None,
+        assets=assets,
+    )
+
+
+def resolve_related_metric_fqns(
+    definition: MetricDefinition,
+    resolved_metric_fqns: dict[MetricKey, str],
+) -> list[str]:
+    """Return the subset of upstream metric FQNs that resolved successfully."""
+    return [resolved_metric_fqns[dep_key] for dep_key in definition.depends_on if dep_key in resolved_metric_fqns]

--- a/ingestion/src/metadata/domain/metrics/naming.py
+++ b/ingestion/src/metadata/domain/metrics/naming.py
@@ -1,0 +1,52 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Connector-agnostic Metric name qualification.
+
+Metric FQN == name (flat namespace, server splits on ``.``). Callers pass the
+full identifying tuple (e.g. ``service, database, schema, view, metric`` for
+Snowflake, ``service, project, metric`` for dbt); this module joins them into a
+single, dot-free FQN segment safe for the server and stable across runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from metadata.utils import fqn as fqn_utils
+
+_NAME_SEPARATOR = "-"
+_DEFAULT_MAX_LENGTH = 256
+_DIGEST_LENGTH = 12
+_RESERVED_CHARS = (".", ":", ">")
+
+
+def build_qualified_metric_name(*parts: str, max_length: int = _DEFAULT_MAX_LENGTH) -> str:
+    """Return a globally-unique metric name as a single FQN segment.
+
+    Sanitizes each part (unquote, then strip characters that carry FQN meaning),
+    joins with ``-``, and — if the result exceeds ``max_length`` — truncates and
+    appends a deterministic sha256 tail so distinct long inputs never collide
+    on truncation.
+    """
+    cleaned = [_sanitize(part) for part in parts]
+    joined = _NAME_SEPARATOR.join(cleaned)
+    if len(joined) <= max_length:
+        return joined
+    digest = hashlib.sha256(joined.encode("utf-8")).hexdigest()[:_DIGEST_LENGTH]
+    keep = max_length - _DIGEST_LENGTH - len(_NAME_SEPARATOR)
+    return f"{joined[:keep]}{_NAME_SEPARATOR}{digest}"
+
+
+def _sanitize(part: str) -> str:
+    cleaned = fqn_utils.unquote_name(part or "").replace('"', "")
+    for reserved in _RESERVED_CHARS:
+        cleaned = cleaned.replace(reserved, "_")
+    return cleaned

--- a/ingestion/src/metadata/domain/metrics/records.py
+++ b/ingestion/src/metadata/domain/metrics/records.py
@@ -1,0 +1,124 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Immutable, connector-neutral records the MetricIngestionFeature accepts.
+
+``related_assets`` carries fully-qualified ``EntityReference``s built by the
+connector (typically with just ``type`` + ``fullyQualifiedName``); the server
+resolves FQN → id at write time, so the feature never needs to look up the
+entity via a REST call.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import ConfigDict, Field
+
+from metadata.generated.schema.entity.data.metric import (  # noqa: TC001
+    MetricDimension,
+    MetricExpression,
+    MetricFilter,
+    MetricGranularity,
+    MetricMeasure,
+    MetricType,
+    UnitOfMeasurement,
+)
+from metadata.generated.schema.type.entityReferenceInput import EntityReferenceInput  # noqa: TC001
+from metadata.generated.schema.type.tagLabel import TagLabel  # noqa: TC001
+from metadata.ingestion.models.custom_pydantic import BaseModel
+
+
+class MetricSourceType(str, Enum):
+    """Stable, source-native origin label used inside MetricKey."""
+
+    DBT = "dbt"
+    SNOWFLAKE = "snowflake"
+    POWERBI = "powerbi"
+    OTHER = "other"
+
+
+class MetricOrigin(BaseModel):
+    """Provenance for a normalized metric definition."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_type: MetricSourceType
+    service_name: str
+    external_id: str
+    diagnostic: str | None = Field(default=None)
+
+
+class MetricKey(BaseModel):
+    """Source-scoped identity. Equality is (source_type, service_name, external_id)."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    source_type: MetricSourceType
+    service_name: str
+    external_id: str
+
+    @classmethod
+    def from_origin(cls, origin: MetricOrigin) -> MetricKey:
+        return cls(
+            source_type=origin.source_type,
+            service_name=origin.service_name,
+            external_id=origin.external_id,
+        )
+
+
+class MetricDefinition(BaseModel):
+    """Everything the feature needs to materialize a Metric entity."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    key: MetricKey
+    origin: MetricOrigin
+    name: str
+    display_name: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    expression: MetricExpression | None = Field(default=None)
+    metric_type: MetricType | None = Field(default=None)
+    unit: UnitOfMeasurement | None = Field(default=None)
+    granularity: MetricGranularity | None = Field(default=None)
+    dimensions: tuple[MetricDimension, ...] = Field(default_factory=tuple)
+    measures: tuple[MetricMeasure, ...] = Field(default_factory=tuple)
+    filters: tuple[MetricFilter, ...] = Field(default_factory=tuple)
+    tags: tuple[TagLabel, ...] = Field(default_factory=tuple)
+    related_assets: tuple[EntityReferenceInput, ...] = Field(default_factory=tuple)
+    depends_on: tuple[MetricKey, ...] = Field(default_factory=tuple)
+    source_native: dict | None = Field(default=None)
+
+    def canonical_payload(self) -> tuple:
+        """Value tuple used to detect non-identical conflicts on one MetricKey."""
+        return (
+            self.name,
+            self.display_name,
+            self.description,
+            self.expression,
+            self.metric_type,
+            self.unit,
+            self.granularity,
+            self.dimensions,
+            self.measures,
+            self.filters,
+            self.tags,
+            tuple(sorted(self.related_assets, key=_asset_ref_sort_key)),
+            tuple(sorted(self.depends_on, key=_key_sort_key)),
+        )
+
+
+def _key_sort_key(key: MetricKey) -> tuple[str, str, str]:
+    return (key.source_type.value, key.service_name, key.external_id)
+
+
+def _asset_ref_sort_key(ref: EntityReferenceInput) -> tuple[str, str]:
+    fqn = getattr(ref, "fullyQualifiedName", None) or ""
+    return (ref.type or "", str(fqn))

--- a/ingestion/src/metadata/ingestion/sink/metadata_rest.py
+++ b/ingestion/src/metadata/ingestion/sink/metadata_rest.py
@@ -38,7 +38,6 @@ from metadata.generated.schema.api.data.createDataContract import (
     CreateDataContractRequest,
 )
 from metadata.generated.schema.api.data.createGlossary import CreateGlossaryRequest
-from metadata.generated.schema.api.data.createMetric import CreateMetricRequest
 from metadata.generated.schema.api.data.createPipeline import CreatePipelineRequest
 from metadata.generated.schema.api.data.createQuery import CreateQueryRequest
 from metadata.generated.schema.api.domains.createDataProduct import (
@@ -267,7 +266,6 @@ class MetadataRestSink(Sink):  # pylint: disable=too-many-public-methods
                     CreateLLMModelRequest,
                     CreateMcpServerRequest,
                     CreateGlossaryRequest,
-                    CreateMetricRequest,
                 ),
             )
         ):

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_service.py
@@ -180,12 +180,8 @@ class DbtServiceTopology(ServiceTopology):
                     consumer=["yield_data_models"],
                     nullable=True,
                 ),
-                NodeStage(
-                    type_=AddLineageRequest,
-                    processor="create_dbt_metric_lineage",
-                    nullable=True,
-                ),
             ],
+            post_process=["drain_dbt_metrics"],
         )
     )
 

--- a/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/dbt_utils.py
@@ -1170,37 +1170,6 @@ def find_semantic_models_transitive(
     return result
 
 
-def order_metrics_by_dependency(metrics: dict[str, Any]) -> list[str]:
-    """Order metric node ids so a metric is emitted after the metrics it depends on.
-
-    dbt manifests list metrics in arbitrary dict order, so a derived/ratio metric
-    can appear before the metric it references. Emitting in dependency order lets
-    ``relatedMetrics`` resolve against already-created parents. A DFS post-order
-    with a visited guard keeps the traversal safe against circular dependencies.
-    """
-    name_to_key = {}
-    for key, node in metrics.items():
-        name = getattr(node, "name", None)
-        if name:
-            name_to_key[name] = key
-    ordered: list[str] = []
-    visited: set[str] = set()
-
-    def visit(key: str) -> None:
-        if key in visited:
-            return
-        visited.add(key)
-        for dep_name in find_dependent_metric_names(metrics[key]):
-            dep_key = name_to_key.get(dep_name)
-            if dep_key is not None and dep_key != key:
-                visit(dep_key)
-        ordered.append(key)
-
-    for key in metrics:
-        visit(key)
-    return ordered
-
-
 def find_dependent_metric_names(metric) -> list[str]:
     """Get metric names from depends_on.nodes that are metric references."""
     depends_on = getattr(metric, "depends_on", None)

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -14,13 +14,14 @@
 DBT source methods.
 """
 
-import contextlib
 import re
 import traceback
 from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Union  # noqa: UP035
 
+from metadata.domain.metrics import MetricIngestionFeature
+from metadata.domain.metrics.naming import build_qualified_metric_name
 from metadata.generated.schema.api.data.createMetric import CreateMetricRequest
 from metadata.generated.schema.api.lineage.addLineage import AddLineageRequest
 from metadata.generated.schema.api.tests.createTestCase import CreateTestCaseRequest
@@ -30,13 +31,7 @@ from metadata.generated.schema.api.tests.createTestDefinition import (
 from metadata.generated.schema.entity.classification.tag import Tag
 from metadata.generated.schema.entity.data.glossaryTerm import GlossaryTerm
 from metadata.generated.schema.entity.data.metric import (
-    Language,
     Metric,
-    MetricDimension,
-    MetricExpression,
-    MetricFilter,
-    MetricGranularity,
-    MetricMeasure,
 )
 from metadata.generated.schema.entity.data.table import (
     Column,
@@ -78,6 +73,7 @@ from metadata.generated.schema.type.entityReferenceList import EntityReferenceLi
 from metadata.ingestion.api.models import Either
 from metadata.ingestion.lineage.models import ConnectionTypeDialectMapper
 from metadata.ingestion.lineage.sql_lineage import get_column_fqn, get_lineage_by_query
+from metadata.ingestion.models.barrier import Barrier
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.models.ometa_lineage import LineageRequest, OMetaLineageRequest
 from metadata.ingestion.models.patch_request import PatchedEntity, PatchRequest
@@ -126,10 +122,9 @@ from metadata.ingestion.source.database.dbt.dbt_utils import (
     get_dbt_test_primary_table_fqn,
     get_manifest_column_name,
     get_snapshot_effective_schema_and_database,
-    map_dbt_metric_type,
-    order_metrics_by_dependency,
     validate_custom_property_value,
 )
+from metadata.ingestion.source.database.dbt.metric_adapter import normalize_dbt_metric
 from metadata.ingestion.source.database.dbt.models import DbtMeta
 from metadata.utils import fqn
 from metadata.utils.elasticsearch import get_entity_from_es_result
@@ -169,6 +164,7 @@ class DbtSource(DbtServiceSource):
         # per referencing model. Bounded by the number of distinct upstream nodes in the
         # project and reset per project in yield_data_models.
         self.reported_unresolved_upstreams: set[str] = set()
+        self.metric_feature = MetricIngestionFeature()
         self._load_omd_custom_properties()
 
     @classmethod
@@ -945,7 +941,7 @@ class DbtSource(DbtServiceSource):
         if not metrics:
             return
         logger.debug(f"Found {len(metrics)} dbt metrics to process")
-        for key in order_metrics_by_dependency(metrics):
+        for key in metrics:
             self.context.get().dbt_metrics[key] = {
                 "metric_node": metrics[key],
                 "semantic_models": semantic_models,
@@ -1319,45 +1315,14 @@ class DbtSource(DbtServiceSource):
         semantic_models = metric_entry["semantic_models"]
         all_metrics = metric_entry.get("all_metrics") or {}
         try:
-            metric_name = metric_node.name
-            dbt_type = getattr(metric_node.type, "value", str(metric_node.type))
-            metric_type = map_dbt_metric_type(dbt_type)
-
-            description = getattr(metric_node, "description", None) or ""
-            label = getattr(metric_node, "label", None)
-
-            type_params = getattr(metric_node, "type_params", None)
-            metric_expression, related_metrics = self._build_expression_and_related(dbt_type, type_params, all_metrics)
-
-            dimensions = self._extract_dimensions(metric_node, semantic_models, all_metrics)
-            measures = self._extract_measures(metric_node, semantic_models, all_metrics)
-            filters = self._extract_filters(metric_node)
-
-            granularity = None
-            time_gran = getattr(metric_node, "time_granularity", None)
-            if time_gran:
-                gran_value = getattr(time_gran, "value", str(time_gran)).upper()
-                with contextlib.suppress(ValueError):
-                    granularity = MetricGranularity(gran_value)
-
-            tags = self._extract_metric_tags(metric_node)
-
-            create_metric = CreateMetricRequest(
-                name=metric_name,
-                displayName=label or metric_name,
-                description=description,
-                metricType=metric_type,
-                metricExpression=metric_expression,
-                granularity=granularity,
-                relatedMetrics=related_metrics,
-                dimensions=dimensions or None,
-                measures=measures or None,
-                filters=filters or None,
-                tags=tags or None,
+            definition = normalize_dbt_metric(
+                metric_node,
+                semantic_models,
+                service_name=self.config.serviceName,
+                all_metrics=all_metrics,
+                tags=tuple(self._extract_metric_tags(metric_node)),
             )
-
-            yield Either(right=create_metric)
-
+            self.metric_feature.accept(definition)
         except Exception as exc:
             yield Either(
                 left=StackTraceError(
@@ -1367,155 +1332,33 @@ class DbtSource(DbtServiceSource):
                 )
             )
 
-    def _build_expression_and_related(self, dbt_type, type_params, all_metrics):
-        builders = {
-            "simple": self._simple_metric_expression,
-            "derived": self._derived_metric_expr_and_related,
-            "ratio": self._ratio_metric_expr_and_related,
-            "cumulative": self._cumulative_metric_expression,
-            "conversion": self._conversion_metric_expression,
-        }
-        metric_expression = None
-        related_metrics = None
-        builder = builders.get(dbt_type)
-        if builder and type_params:
-            metric_expression, related_metrics = builder(type_params)
-        if related_metrics:
-            related_metrics = self._filter_known_metrics(related_metrics, all_metrics)
-        return metric_expression, related_metrics
+    def drain_dbt_metrics(self) -> Iterable[Either]:
+        """Emit the buffered metrics, flush the sink, then build their lineage.
 
-    @staticmethod
-    def _simple_metric_expression(type_params):
-        expression = None
-        measure_ref = getattr(type_params, "measure", None)
-        measure_name = getattr(measure_ref, "name", None) if measure_ref else None
-        if measure_name:
-            expression = MetricExpression(language=Language.SQL, code=measure_name)
-        return expression, None
+        The lineage step resolves each metric through the API, so the metrics
+        must be persisted before those lookups run.
+        """
+        yield from self.metric_feature.drain()
+        metric_entries = list(self.context.get().dbt_metrics.values())
+        if not metric_entries:
+            return
+        yield Either(right=Barrier(reason="dbt_metrics_flush"))
+        for metric_entry in metric_entries:
+            yield from self.create_dbt_metric_lineage(metric_entry)
 
-    @staticmethod
-    def _derived_metric_expr_and_related(type_params):
-        expression = None
-        expr = getattr(type_params, "expr", None)
-        if expr:
-            expression = MetricExpression(language=Language.SQL, code=expr)
-        sub_metrics = getattr(type_params, "metrics", None) or []
-        related = [getattr(m, "name", str(m)) for m in sub_metrics] or None
-        return expression, related
-
-    @staticmethod
-    def _ratio_metric_expr_and_related(type_params):
-        expression = None
-        numerator = getattr(type_params, "numerator", None)
-        denominator = getattr(type_params, "denominator", None)
-        num_name = getattr(numerator, "name", str(numerator)) if numerator else ""
-        den_name = getattr(denominator, "name", str(denominator)) if denominator else ""
-        related = [name for name in (num_name, den_name) if name] or None
-        if num_name and den_name:
-            expression = MetricExpression(language=Language.SQL, code=f"{num_name} / {den_name}")
-        return expression, related
-
-    @staticmethod
-    def _cumulative_window_str(type_params):
-        window_str = ""
-        cum_params = getattr(type_params, "cumulative_type_params", None)
-        window = getattr(cum_params, "window", None) if cum_params else None
-        if window:
-            count = getattr(window, "count", "")
-            gran = getattr(window, "granularity", None)
-            gran_val = getattr(gran, "value", str(gran)) if gran else ""
-            window_str = f" over {count} {gran_val}" if count else ""
-        return window_str
-
-    @staticmethod
-    def _cumulative_metric_expression(type_params):
-        expression = None
-        measure_ref = getattr(type_params, "measure", None)
-        measure_name = getattr(measure_ref, "name", None) if measure_ref else None
-        if measure_name:
-            window_str = DbtSource._cumulative_window_str(type_params)
-            expression = MetricExpression(language=Language.SQL, code=f"cumulative({measure_name}{window_str})")
-        return expression, None
-
-    @staticmethod
-    def _conversion_metric_expression(type_params):
-        expression = None
-        conv = getattr(type_params, "conversion_type_params", None)
-        if conv:
-            base = getattr(conv, "base_measure", None)
-            conversion = getattr(conv, "conversion_measure", None)
-            base_name = getattr(base, "name", "") if base else ""
-            conv_name = getattr(conversion, "name", "") if conversion else ""
-            entity = getattr(conv, "entity", "")
-            expression = MetricExpression(
-                language=Language.SQL,
-                code=f"conversion({base_name} -> {conv_name}, entity={entity})",
-            )
-        return expression, None
-
-    @staticmethod
-    def _filter_known_metrics(related_metrics, all_metrics):
-        known = {name for node in all_metrics.values() if (name := getattr(node, "name", None))}
-        return [name for name in related_metrics if name in known] or None
-
-    def _extract_dimensions(self, metric_node, semantic_models, all_metrics=None) -> list[MetricDimension]:
-        result = []
-        models = (
-            find_semantic_models_transitive(metric_node, semantic_models, all_metrics)
-            if all_metrics
-            else find_semantic_models_for_metric(metric_node, semantic_models)
+    def _qualified_metric_name(self, metric_node) -> str:
+        return build_qualified_metric_name(
+            self.config.serviceName,
+            str(getattr(metric_node, "package_name", "") or ""),
+            metric_node.name,
         )
-        seen = set()
-        for sm in models:
-            for dim in getattr(sm, "dimensions", None) or []:
-                if dim.name in seen:
-                    continue
-                seen.add(dim.name)
-                dim_type = getattr(dim.type, "value", str(dim.type)).upper() if dim.type else None
-                result.append(
-                    MetricDimension(
-                        name=dim.name,
-                        type=dim_type,
-                        description=getattr(dim, "description", None),
-                        expression=getattr(dim, "expr", None),
-                    )
-                )
-        return result
 
-    def _extract_measures(self, metric_node, semantic_models, all_metrics=None) -> list[MetricMeasure]:
-        result = []
-        models = (
-            find_semantic_models_transitive(metric_node, semantic_models, all_metrics)
-            if all_metrics
-            else find_semantic_models_for_metric(metric_node, semantic_models)
+    @staticmethod
+    def _metric_node_by_name(all_metrics: dict, name: str):
+        return next(
+            (node for node in all_metrics.values() if getattr(node, "name", None) == name),
+            None,
         )
-        seen = set()
-        for sm in models:
-            for measure in getattr(sm, "measures", None) or []:
-                if measure.name in seen:
-                    continue
-                seen.add(measure.name)
-                agg_value = getattr(measure.agg, "value", str(measure.agg)) if measure.agg else None
-                result.append(
-                    MetricMeasure(
-                        name=measure.name,
-                        aggregation=agg_value,
-                        description=getattr(measure, "description", None),
-                        expression=getattr(measure, "expr", None),
-                    )
-                )
-        return result
-
-    def _extract_filters(self, metric_node) -> list[MetricFilter]:
-        result = []
-        filter_obj = getattr(metric_node, "filter", None)
-        if filter_obj:
-            where_filters = getattr(filter_obj, "where_filters", None) or []
-            for wf in where_filters:
-                sql_template = getattr(wf, "where_sql_template", None)
-                if sql_template:
-                    result.append(MetricFilter(where=sql_template))
-        return result
 
     def _extract_metric_tags(self, metric_node) -> list:
         tags = getattr(metric_node, "tags", None) or []
@@ -1536,7 +1379,7 @@ class DbtSource(DbtServiceSource):
         semantic_models = metric_entry["semantic_models"]
         all_metrics = metric_entry.get("all_metrics") or {}
 
-        metric_name = metric_node.name
+        metric_name = self._qualified_metric_name(metric_node)
         metric_entity = self.metadata.get_by_name(
             entity=Metric,
             fqn=metric_name,
@@ -1600,7 +1443,10 @@ class DbtSource(DbtServiceSource):
         # Metric → Metric lineage (for derived/ratio/conversion metrics)
         for parent_name in find_dependent_metric_names(metric_node):
             try:
-                parent_entity = self.metadata.get_by_name(entity=Metric, fqn=parent_name)
+                parent_node = self._metric_node_by_name(all_metrics, parent_name)
+                if parent_node is None:
+                    continue
+                parent_entity = self.metadata.get_by_name(entity=Metric, fqn=self._qualified_metric_name(parent_node))
                 if not parent_entity:
                     continue
                 columns_lineage = self._build_metric_metric_column_lineage(parent_entity, metric_entity)

--- a/ingestion/src/metadata/ingestion/source/database/dbt/metric_adapter.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metric_adapter.py
@@ -1,0 +1,261 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""dbt semantic-layer adapter: manifest metric node → normalized MetricDefinition.
+
+Pure translation. ``semantic_models`` and ``all_metrics`` arrive as the manifest's
+own dicts keyed by ``unique_id``; the semantic models backing a metric are selected
+through its ``depends_on``. Tags need an API lookup to become TagLabels, so the
+caller resolves them and passes them in.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable  # noqa: TC003
+from typing import Any
+
+from metadata.domain.metrics.naming import build_qualified_metric_name
+from metadata.domain.metrics.records import (
+    MetricDefinition,
+    MetricKey,
+    MetricOrigin,
+    MetricSourceType,
+)
+from metadata.generated.schema.entity.data.metric import (
+    Language,
+    MetricDimension,
+    MetricExpression,
+    MetricFilter,
+    MetricGranularity,
+    MetricMeasure,
+    MetricType,
+)
+from metadata.generated.schema.type.entityReferenceInput import EntityReferenceInput
+from metadata.generated.schema.type.tagLabel import TagLabel  # noqa: TC001
+from metadata.ingestion.source.database.dbt.dbt_utils import (
+    find_dependent_metric_names,
+    find_semantic_models_for_metric,
+    find_semantic_models_transitive,
+    map_dbt_metric_type,
+)
+
+
+def normalize_dbt_metric(
+    metric_node: Any,
+    semantic_models: dict[str, Any],
+    *,
+    service_name: str,
+    all_metrics: dict[str, Any] | None = None,
+    tags: tuple[TagLabel, ...] = (),
+) -> MetricDefinition:
+    """Turn a parsed dbt metric node into a MetricDefinition.
+
+    ``semantic_models`` / ``all_metrics`` are the manifest dicts keyed by
+    ``unique_id``. ``tags`` must already be resolved to TagLabels by the caller.
+    """
+    all_metrics = all_metrics or {}
+    dbt_type = _enum_value(getattr(metric_node, "type", None))
+    expression = _expression(dbt_type, getattr(metric_node, "type_params", None))
+    models = _models_for(metric_node, semantic_models, all_metrics)
+
+    origin = MetricOrigin(
+        source_type=MetricSourceType.DBT,
+        service_name=service_name,
+        external_id=str(getattr(metric_node, "unique_id", metric_node.name)),
+    )
+    package = str(getattr(metric_node, "package_name", "") or "")
+
+    return MetricDefinition(
+        key=MetricKey.from_origin(origin),
+        origin=origin,
+        name=build_qualified_metric_name(service_name, package, metric_node.name),
+        display_name=getattr(metric_node, "label", None) or metric_node.name,
+        description=getattr(metric_node, "description", None) or None,
+        expression=expression,
+        metric_type=map_dbt_metric_type(dbt_type) or MetricType.OTHER,
+        granularity=_granularity(metric_node),
+        dimensions=tuple(_dimensions(models)),
+        measures=tuple(_measures(models)),
+        filters=tuple(_filters(metric_node)),
+        tags=tuple(tags),
+        depends_on=_dependency_keys(find_dependent_metric_names(metric_node), all_metrics, service_name),
+        related_assets=tuple(_asset_refs(models, service_name)),
+    )
+
+
+def _models_for(metric_node: Any, semantic_models: dict[str, Any], all_metrics: dict[str, Any]) -> list[Any]:
+    """Semantic models backing this metric, following parent metrics when known."""
+    if all_metrics:
+        return find_semantic_models_transitive(metric_node, semantic_models, all_metrics)
+    return find_semantic_models_for_metric(metric_node, semantic_models)
+
+
+def _enum_value(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(getattr(value, "value", value)).lower()
+
+
+def _expression(dbt_type: str, type_params: Any) -> MetricExpression | None:
+    builder = _EXPRESSION_BUILDERS.get(dbt_type)
+    return builder(type_params) if builder and type_params else None
+
+
+def _simple_expression(type_params: Any) -> MetricExpression | None:
+    name = _ref_name(getattr(type_params, "measure", None))
+    return _sql(name) if name else None
+
+
+def _derived_expression(type_params: Any) -> MetricExpression | None:
+    expr = getattr(type_params, "expr", None)
+    return _sql(expr) if expr else None
+
+
+def _ratio_expression(type_params: Any) -> MetricExpression | None:
+    numerator = _ref_name(getattr(type_params, "numerator", None))
+    denominator = _ref_name(getattr(type_params, "denominator", None))
+    return _sql(f"{numerator} / {denominator}") if numerator and denominator else None
+
+
+def _cumulative_expression(type_params: Any) -> MetricExpression | None:
+    name = _ref_name(getattr(type_params, "measure", None))
+    return _sql(f"cumulative({name}{_cumulative_window(type_params)})") if name else None
+
+
+def _conversion_expression(type_params: Any) -> MetricExpression | None:
+    conversion = getattr(type_params, "conversion_type_params", None)
+    if not conversion:
+        return None
+    base = _ref_name(getattr(conversion, "base_measure", None)) or ""
+    target = _ref_name(getattr(conversion, "conversion_measure", None)) or ""
+    entity = getattr(conversion, "entity", "") or ""
+    return _sql(f"conversion({base} -> {target}, entity={entity})")
+
+
+_EXPRESSION_BUILDERS = {
+    "simple": _simple_expression,
+    "derived": _derived_expression,
+    "ratio": _ratio_expression,
+    "cumulative": _cumulative_expression,
+    "conversion": _conversion_expression,
+}
+
+
+def _cumulative_window(type_params: Any) -> str:
+    params = getattr(type_params, "cumulative_type_params", None)
+    window = getattr(params, "window", None) if params else None
+    if not window:
+        return ""
+    count = getattr(window, "count", "")
+    granularity = getattr(window, "granularity", None)
+    value = getattr(granularity, "value", str(granularity)) if granularity else ""
+    return f" over {count} {value}" if count else ""
+
+
+def _ref_name(ref: Any) -> str | None:
+    return getattr(ref, "name", None) if ref is not None else None
+
+
+def _sql(code: str) -> MetricExpression:
+    return MetricExpression(language=Language.SQL, code=code)
+
+
+def _dependency_keys(related_names: list[str], all_metrics: dict[str, Any], service_name: str) -> tuple[MetricKey, ...]:
+    """Map related metric names onto MetricKeys via each node's unique_id.
+
+    ``all_metrics`` is keyed by unique_id, so the names are resolved through a
+    name index rather than used as keys.
+    """
+    unique_id_by_name: dict[str, str] = {}
+    for node in all_metrics.values():
+        name = getattr(node, "name", None)
+        if name:
+            unique_id_by_name[name] = str(getattr(node, "unique_id", name))
+    return tuple(
+        MetricKey(
+            source_type=MetricSourceType.DBT,
+            service_name=service_name,
+            external_id=unique_id_by_name[name],
+        )
+        for name in related_names
+        if name in unique_id_by_name
+    )
+
+
+def _dimensions(models: list[Any]) -> Iterable[MetricDimension]:
+    seen: set[str] = set()
+    for model in models:
+        for dimension in getattr(model, "dimensions", None) or []:
+            if dimension.name in seen:
+                continue
+            seen.add(dimension.name)
+            raw_type = getattr(dimension, "type", None)
+            yield MetricDimension(  # pyright: ignore[reportCallIssue]
+                name=dimension.name,
+                type=(getattr(raw_type, "value", str(raw_type)).upper() if raw_type else None),
+                description=getattr(dimension, "description", None),
+                expression=getattr(dimension, "expr", None),
+            )
+
+
+def _measures(models: list[Any]) -> Iterable[MetricMeasure]:
+    seen: set[str] = set()
+    for model in models:
+        for measure in getattr(model, "measures", None) or []:
+            if measure.name in seen:
+                continue
+            seen.add(measure.name)
+            agg = getattr(measure, "agg", None)
+            yield MetricMeasure(  # pyright: ignore[reportCallIssue]
+                name=measure.name,
+                aggregation=(str(getattr(agg, "value", agg)) if agg else None),
+                description=getattr(measure, "description", None),
+                expression=getattr(measure, "expr", None),
+            )
+
+
+def _filters(metric_node: Any) -> Iterable[MetricFilter]:
+    filter_obj = getattr(metric_node, "filter", None)
+    if not filter_obj:
+        return
+    for where_filter in getattr(filter_obj, "where_filters", None) or []:
+        template = getattr(where_filter, "where_sql_template", None)
+        if template:
+            yield MetricFilter(where=template)
+
+
+def _granularity(metric_node: Any) -> MetricGranularity | None:
+    raw = getattr(metric_node, "time_granularity", None)
+    if not raw:
+        return None
+    value = str(getattr(raw, "value", raw)).upper()
+    with contextlib.suppress(ValueError):
+        return MetricGranularity(value)
+    return None
+
+
+def _asset_refs(models: list[Any], service_name: str) -> Iterable[EntityReferenceInput]:
+    """The physical tables backing each semantic model, as fqn-only references."""
+    seen: set[str] = set()
+    for model in models:
+        relation = getattr(model, "node_relation", None)
+        if relation is None:
+            continue
+        database = getattr(relation, "database", None)
+        schema = getattr(relation, "schema_name", None)
+        table = getattr(relation, "alias", None)
+        if not (database and schema and table):
+            continue
+        fully_qualified_name = f"{service_name}.{database}.{schema}.{table}"
+        if fully_qualified_name in seen:
+            continue
+        seen.add(fully_qualified_name)
+        yield EntityReferenceInput(type="table", fullyQualifiedName=fully_qualified_name)

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -14,6 +14,7 @@ Snowflake source module
 
 import json  # noqa: I001
 import traceback
+from copy import deepcopy
 from datetime import datetime
 from typing import Dict, Iterable, List, Optional, Tuple, cast  # noqa: UP035
 
@@ -65,9 +66,29 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.models.ometa_classification import OMetaTagAndClassification
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.column_type_parser import create_sqlalchemy_type
+from metadata.domain.metrics import MetricIngestionFeature
+from metadata.ingestion.models.topology import NodeStage
 from metadata.ingestion.source.database.common_db_source import (
     CommonDbSourceService,
     TableNameAndType,
+)
+from metadata.ingestion.source.database.database_service import DatabaseServiceTopology
+from metadata.ingestion.source.database.snowflake.metric_adapter import (
+    normalize_snowflake_metric,
+)
+from metadata.generated.schema.api.data.createMetric import CreateMetricRequest
+from metadata.ingestion.models.barrier import Barrier
+from metadata.ingestion.source.database.snowflake.semantic_view import (
+    SemanticCatalogCache,
+    build_columns,
+    fetch_definition,
+    fetch_view_names,
+)
+from metadata.ingestion.source.database.snowflake.semantic_view.lineage import (
+    BaseTableEdge,
+    build_view_lineage,
+    to_metric_lineage_request,
+    to_view_lineage_request,
 )
 from metadata.ingestion.source.database.external_table_lineage_mixin import (
     ExternalTableLineageMixin,
@@ -207,6 +228,24 @@ def _show_column(row, name: str):
     return result
 
 
+# Base-table -> view edges wait for every schema to be walked, since a base table
+# may live in one this run has not reached. This caps that wait: past it, edges are
+# emitted early and any still-unwritten base table fails visibly at the sink.
+_MAX_PENDING_VIEW_LINEAGE = 5_000
+
+_SNOWFLAKE_TOPOLOGY = deepcopy(DatabaseServiceTopology())
+_SNOWFLAKE_TOPOLOGY.table.stages.append(
+    NodeStage(  # pyright: ignore[reportCallIssue]
+        type_=CreateMetricRequest,
+        processor="yield_semantic_view_metrics",
+        nullable=True,
+    )
+)
+_SNOWFLAKE_TOPOLOGY.root.post_process = list(_SNOWFLAKE_TOPOLOGY.root.post_process or []) + [
+    "drain_semantic_view_metrics",
+]
+
+
 # pylint: disable=too-many-public-methods
 class SnowflakeSource(
     ExternalTableLineageMixin,
@@ -219,6 +258,7 @@ class SnowflakeSource(
     """
 
     service_connection: SnowflakeConnection
+    topology = _SNOWFLAKE_TOPOLOGY
 
     def __init__(
         self,
@@ -228,6 +268,11 @@ class SnowflakeSource(
         incremental_configuration: IncrementalConfig,
     ):
         super().__init__(config, metadata)
+        self.metric_feature = MetricIngestionFeature()
+        self._pending_view_lineage: list[tuple[str, BaseTableEdge]] = []
+        self._pending_metric_lineage: list[tuple[str, str]] = []
+        self._semantic_catalog_cache = SemanticCatalogCache()
+        self._semantic_view_names_by_schema: dict[str, list[str]] = {}
         self.partition_details = {}
         self.schema_desc_map = {}
         self.database_desc_map = {}
@@ -831,7 +876,47 @@ class SnowflakeSource(
         if self.service_connection.includeStages:
             table_list.extend(self._get_stage_names_and_types(schema_name))
 
+        if getattr(self.service_connection, "includeSemanticViews", False):
+            try:
+                table_list.extend(self._get_semantic_view_names_and_types(schema_name))
+            except Exception as exc:
+                logger.warning(f"Failed to list semantic views in schema [{schema_name}]: {exc}")
+                logger.debug(traceback.format_exc())
+
         return table_list
+
+    def _get_semantic_view_names_and_types(self, schema_name: str) -> list[TableNameAndType]:
+        """Semantic views enter the normal Table lifecycle as ``TableType.SemanticView``
+        so ``yield_table``, tag inheritance and ``mark_tables_as_deleted`` all apply."""
+        self._semantic_view_names_by_schema[schema_name] = fetch_view_names(self.connection, schema_name)
+        return [
+            TableNameAndType(name=view, type_=TableType.SemanticView)
+            for view in self._semantic_view_names_by_schema[schema_name]
+        ]
+
+    def _get_semantic_view_columns(self, schema_name: str, table_name: str):
+        """Populate a semantic view's Table columns from the dim/fact/metric catalog.
+        Returns SQLAlchemy-shape dicts so ``sql_column_handler.process_column`` maps
+        them into OM ``Column`` entities via the standard type-parser path."""
+        try:
+            catalog = self._semantic_view_catalog(schema_name, table_name)
+        except Exception as exc:
+            logger.warning(f"Failed to fetch semantic-view catalog for {schema_name}.{table_name}: {exc}")
+            logger.debug(traceback.format_exc())
+            return []
+        return build_columns(
+            dimensions=catalog.dimensions,
+            facts=catalog.facts,
+            metrics=catalog.metrics,
+        )
+
+    def _semantic_view_catalog(self, schema_name: str, table_name: str):
+        """Slice the LRU-cached schema-wide catalog for one view. First lookup
+        per schema fires 3 or 4 queries (dim/fact/metric + tables); every
+        subsequent view in the same schema is a cache hit."""
+        view_names = self._semantic_view_names_by_schema.get(schema_name) or [table_name]
+        schema_catalog = self._semantic_catalog_cache.get_or_load(self.connection, schema_name, view_names)
+        return schema_catalog.view(table_name)
 
     def _get_org_name(self) -> Optional[str]:  # noqa: UP045
         try:
@@ -1068,6 +1153,9 @@ class SnowflakeSource(
         if table_type == TableType.Stage:
             return []
 
+        if table_type == TableType.SemanticView:
+            return self._get_semantic_view_columns(schema_name, table_name)
+
         # For streams, we will use source table/view's columns
         # since stream does not define columns separately in Snowflake
         if table_type == TableType.Stream:
@@ -1150,6 +1238,8 @@ class SnowflakeSource(
                 # Snowflake Stage does not have a DDL or definition,
                 # so we will return None for stage type
                 pass
+            elif table_type == TableType.SemanticView:
+                schema_definition = fetch_definition(self.connection, f"{schema_name}.{table_name}")
             elif self.source_config.includeDDL or table_type == TableType.Dynamic:
                 schema_definition = inspector.get_table_ddl(self.connection, table_name, schema_name)
             schema_definition = str(schema_definition).strip() if schema_definition is not None else None
@@ -1323,3 +1413,103 @@ class SnowflakeSource(
                 table_tags.append(label)
 
         return table_tags if table_tags else None
+
+    def yield_semantic_view_metrics(self, table_name_and_type: Tuple[str, TableType]) -> Iterable[Either]:  # noqa: UP006
+        """Accept every reusable metric on ``table_name_and_type`` (a semantic
+        view) into ``self.metric_feature``. Runs per Table row on ``.table``
+        (producer yields plain ``(name, TableType)`` tuples, matching
+        ``yield_table``). Drain fires at ``root.post_process``."""
+        table_name, table_type = table_name_and_type
+        if table_type != TableType.SemanticView:
+            return
+        ctx = self.context.get()
+        service = ctx.database_service  # pyright: ignore[reportAttributeAccessIssue]
+        database = ctx.database  # pyright: ignore[reportAttributeAccessIssue]
+        schema = ctx.database_schema  # pyright: ignore[reportAttributeAccessIssue]
+        try:
+            catalog = self._semantic_view_catalog(schema, table_name)
+        except Exception as exc:
+            yield Either(
+                left=StackTraceError(
+                    name=f"semantic-view/{schema}.{table_name}",
+                    error=f"failed to fetch catalog: {exc}",
+                    stackTrace=traceback.format_exc(),
+                )
+            )
+            return
+        base_fqn_by_logical = {
+            logical: f"{service}.{cat}.{sch}.{name}" for logical, (cat, sch, name) in catalog.base_tables.items()
+        }
+        view_fqn = f"{service}.{database}.{schema}.{table_name}"
+        if self.source_config.processViewLineage:
+            self._buffer_view_lineage(view_fqn, catalog, base_fqn_by_logical)
+            if len(self._pending_view_lineage) >= _MAX_PENDING_VIEW_LINEAGE:
+                logger.warning(
+                    "Buffered semantic-view lineage reached %d edges; emitting them now. "
+                    "Edges whose base table lives in a schema this run has not reached yet "
+                    "will not resolve.",
+                    len(self._pending_view_lineage),
+                )
+                yield from self._flush_view_lineage()
+        for metric_row in catalog.metrics:
+            try:
+                definition = normalize_snowflake_metric(
+                    service_name=service,
+                    database=database,
+                    schema=schema,
+                    view=table_name,
+                    metric_row=metric_row,
+                    dimension_rows=catalog.dimensions,
+                    fact_rows=catalog.facts,
+                )
+                self.metric_feature.accept(definition)
+            except Exception as exc:
+                yield Either(
+                    left=StackTraceError(
+                        name=f"semantic-metric/{schema}.{table_name}",
+                        error=f"accept failed: {exc}",
+                        stackTrace=traceback.format_exc(),
+                    )
+                )
+                continue
+            if self.source_config.processViewLineage:
+                self._pending_metric_lineage.append((view_fqn, definition.name))
+
+    def drain_semantic_view_metrics(self) -> Iterable[Either]:
+        """Drain metric definitions, flush the sink, then emit buffered lineage.
+
+        Lineage endpoints resolve fqn-only references at write time, so the
+        target Tables and Metrics must be persisted before the edges are sent.
+        """
+        yield from self.metric_feature.drain()
+        if not (self._pending_view_lineage or self._pending_metric_lineage):
+            return
+        yield from self._flush_view_lineage()
+        for view_fqn, metric_name in self._pending_metric_lineage:
+            yield Either(right=to_metric_lineage_request(view_fqn, metric_name))
+        self._pending_metric_lineage.clear()
+
+    def _flush_view_lineage(self) -> Iterable[Either]:
+        """Emit buffered base-table → view edges behind a sink flush."""
+        yield Either(right=Barrier(reason="semantic_view_lineage_flush"))  # pyright: ignore[reportCallIssue]
+        for view_fqn, edge in self._pending_view_lineage:
+            yield Either(right=to_view_lineage_request(view_fqn, edge))
+        self._pending_view_lineage.clear()
+
+    def _buffer_view_lineage(
+        self,
+        view_fqn: str,
+        catalog,
+        base_fqn_by_logical: dict[str, str],
+    ) -> None:
+        """Buffer base-table → view edges. Edges hold bare column names; the
+        request objects are built at emission so a long run stays cheap."""
+        if not base_fqn_by_logical:
+            return
+        self._pending_view_lineage.extend(
+            (view_fqn, edge)
+            for edge in build_view_lineage(
+                catalog=catalog,
+                base_table_fqns_by_logical={k.lower(): v for k, v in base_fqn_by_logical.items()},
+            )
+        )

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metric_adapter.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metric_adapter.py
@@ -1,0 +1,156 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view adapter: catalog rows → normalized MetricDefinition
+with fqn-only EntityReferenceInput assets (server resolves fqn → id on write)."""
+
+from __future__ import annotations
+
+from metadata.domain.metrics.naming import build_qualified_metric_name
+from metadata.domain.metrics.records import (
+    MetricDefinition,
+    MetricKey,
+    MetricOrigin,
+    MetricSourceType,
+)
+from metadata.generated.schema.entity.data.metric import (
+    Language,
+    MetricDimension,
+    MetricExpression,
+    MetricMeasure,
+    MetricType,
+    Type,
+)
+from metadata.generated.schema.type.entityReferenceInput import EntityReferenceInput
+
+_SEMANTIC_NAME_IDX = 1
+_SEMANTIC_DATA_TYPE_IDX = 2
+_SEMANTIC_EXPRESSION_IDX = 3
+_SEMANTIC_COMMENT_IDX = 4
+_SEMANTIC_SYNONYMS_IDX = 5
+
+_METRIC_TYPE_BY_PREFIX = {
+    "SUM": MetricType.SUM,
+    "COUNT": MetricType.COUNT,
+    "AVG": MetricType.AVERAGE,
+    "MIN": MetricType.MIN,
+    "MAX": MetricType.MAX,
+}
+
+_TIME_TYPE_MARKERS = ("DATE", "TIME", "TIMESTAMP")
+
+
+def build_metric_external_id(service: str, database: str, schema: str, view: str, metric: str) -> str:
+    """Internal MetricKey identity — dots OK, only compared for dedup."""
+    return f"{service}.{database}.{schema}.{view}.{metric}"
+
+
+def build_metric_entity_name(service: str, database: str, schema: str, view: str, metric: str) -> str:
+    """Server-visible metric name for a Snowflake semantic-view metric."""
+    return build_qualified_metric_name(service, database, schema, view, metric)
+
+
+def infer_metric_type(expression: str | None) -> MetricType:
+    if not expression:
+        return MetricType.OTHER
+    head = expression.strip().split("(", 1)[0].strip().upper()
+    return _METRIC_TYPE_BY_PREFIX.get(head, MetricType.OTHER)
+
+
+def _aggregation(expression: str | None) -> str | None:
+    if not expression or infer_metric_type(expression) is MetricType.OTHER:
+        return None
+    return expression.strip().split("(", 1)[0].strip().upper()
+
+
+def _dimension_type(data_type: str | None) -> Type | None:
+    if not data_type:
+        return None
+    upper = data_type.upper()
+    return Type.TIME if any(m in upper for m in _TIME_TYPE_MARKERS) else Type.CATEGORICAL
+
+
+def _description(row: tuple) -> str | None:
+    parts: list[str] = []
+    comment = row[_SEMANTIC_COMMENT_IDX]
+    synonyms = row[_SEMANTIC_SYNONYMS_IDX] if len(row) > _SEMANTIC_SYNONYMS_IDX else None
+    if comment:
+        parts.append(str(comment))
+    if synonyms:
+        parts.append(f"Synonyms: {synonyms}.")
+    return " ".join(parts) or None
+
+
+def _dimension(row: tuple) -> MetricDimension:
+    return MetricDimension(  # pyright: ignore[reportCallIssue]
+        name=row[_SEMANTIC_NAME_IDX],
+        type=_dimension_type(row[_SEMANTIC_DATA_TYPE_IDX]),
+        description=_description(row),
+        expression=row[_SEMANTIC_EXPRESSION_IDX] or None,
+    )
+
+
+def _measure(row: tuple) -> MetricMeasure:
+    expression = row[_SEMANTIC_EXPRESSION_IDX]
+    return MetricMeasure(  # pyright: ignore[reportCallIssue]
+        name=row[_SEMANTIC_NAME_IDX],
+        aggregation=_aggregation(expression),
+        description=_description(row),
+        expression=expression or None,
+    )
+
+
+def _table_ref(fully_qualified_name: str) -> EntityReferenceInput:
+    return EntityReferenceInput(type="table", fullyQualifiedName=fully_qualified_name)
+
+
+def normalize_snowflake_metric(
+    *,
+    service_name: str,
+    database: str,
+    schema: str,
+    view: str,
+    metric_row: tuple,
+    dimension_rows: list[tuple],
+    fact_rows: list[tuple],
+) -> MetricDefinition:
+    """Assemble a MetricDefinition from one Snowflake semantic-view metric row.
+
+    ``assets`` holds the semantic view alone. Physical base tables sit one hop
+    further upstream (base table → view → metric) and are represented as
+    lineage edges rather than flattened into a direct metric-to-table link.
+    """
+    metric_name = metric_row[_SEMANTIC_NAME_IDX]
+    expression = metric_row[_SEMANTIC_EXPRESSION_IDX]
+    comment = metric_row[_SEMANTIC_COMMENT_IDX]
+
+    external_id = build_metric_external_id(service_name, database, schema, view, metric_name)
+    origin = MetricOrigin(
+        source_type=MetricSourceType.SNOWFLAKE,
+        service_name=service_name,
+        external_id=external_id,
+    )
+    key = MetricKey.from_origin(origin)
+
+    metric_expression = MetricExpression(language=Language.SQL, code=expression) if expression else None
+    view_fqn = f"{service_name}.{database}.{schema}.{view}"
+
+    return MetricDefinition(
+        key=key,
+        origin=origin,
+        name=build_metric_entity_name(service_name, database, schema, view, metric_name),
+        display_name=metric_name,
+        description=comment or None,
+        expression=metric_expression,
+        metric_type=infer_metric_type(expression),
+        dimensions=tuple(_dimension(row) for row in dimension_rows),
+        measures=tuple(_measure(row) for row in fact_rows),
+        related_assets=(_table_ref(view_fqn),),
+    )

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/__init__.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/__init__.py
@@ -1,0 +1,31 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view helpers: SQL, I/O, column building."""
+
+from metadata.ingestion.source.database.snowflake.semantic_view.catalog import (
+    SchemaCatalog,
+    SemanticCatalogCache,
+    SemanticViewCatalog,
+    fetch_definition,
+    fetch_view_names,
+)
+from metadata.ingestion.source.database.snowflake.semantic_view.columns import (
+    build_columns,
+)
+
+__all__ = [
+    "SchemaCatalog",
+    "SemanticCatalogCache",
+    "SemanticViewCatalog",
+    "build_columns",
+    "fetch_definition",
+    "fetch_view_names",
+]

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/catalog.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/catalog.py
@@ -1,0 +1,178 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""I/O layer over Snowflake's semantic-view catalog.
+
+Primary fetch is one query per catalog view (dim/fact/metric/tables) against
+``SEMANTIC_VIEW_SCHEMA = '{schema}'`` — every view's rows in one round trip,
+grouped by view client-side. Errno 90030 ("information schema query returned
+too much data") triggers a per-view fallback for the specific catalog that
+overflowed. Results cache per schema in a bounded LRU so the column-fetch and
+metric-emit paths share catalog data across the ~2 lookups per view."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from cachetools import LRUCache
+from sqlalchemy import text
+
+from metadata.ingestion.source.database.snowflake.semantic_view.queries import (
+    _CATALOG_DIMENSIONS,
+    _CATALOG_FACTS,
+    _CATALOG_METRICS,
+    SNOWFLAKE_GET_SEMANTIC_OBJECTS_FOR_VIEW,
+    SNOWFLAKE_GET_SEMANTIC_OBJECTS_IN_SCHEMA,
+    SNOWFLAKE_GET_SEMANTIC_TABLES_IN_SCHEMA,
+    SNOWFLAKE_GET_SEMANTIC_VIEW_DEFINITION,
+    SNOWFLAKE_GET_SEMANTIC_VIEWS,
+    SNOWFLAKE_INFO_SCHEMA_TOO_LARGE_ERRNO,
+)
+from snowflake.connector.errors import ProgrammingError
+
+_SCHEMA_CATALOG_CACHE_SIZE = 4
+
+
+@dataclass(frozen=True)
+class SemanticViewCatalog:
+    """The ``INFORMATION_SCHEMA.SEMANTIC_*`` snapshot for ONE semantic view.
+
+    ``base_tables`` is empty when the SEMANTIC_TABLES fetch fails (older
+    Snowflake accounts / permission gaps) so dim/fact/metric flow is never
+    dropped.
+    """
+
+    dimensions: list[tuple]
+    facts: list[tuple]
+    metrics: list[tuple]
+    base_tables: dict[str, tuple[str, str, str]]
+
+
+@dataclass
+class SchemaCatalog:
+    """Aggregated schema-wide catalog indexed by ``semantic_view_name``."""
+
+    dimensions_by_view: dict[str, list[tuple]] = field(default_factory=dict)
+    facts_by_view: dict[str, list[tuple]] = field(default_factory=dict)
+    metrics_by_view: dict[str, list[tuple]] = field(default_factory=dict)
+    base_tables_by_view: dict[str, dict[str, tuple[str, str, str]]] = field(default_factory=dict)
+
+    def view(self, view_name: str) -> SemanticViewCatalog:
+        return SemanticViewCatalog(
+            dimensions=self.dimensions_by_view.get(view_name, []),
+            facts=self.facts_by_view.get(view_name, []),
+            metrics=self.metrics_by_view.get(view_name, []),
+            base_tables=self.base_tables_by_view.get(view_name, {}),
+        )
+
+
+class SemanticCatalogCache:
+    """Bounded per-schema catalog cache — one entry holds every view's rows."""
+
+    def __init__(self, maxsize: int = _SCHEMA_CATALOG_CACHE_SIZE) -> None:
+        self._cache: LRUCache = LRUCache(maxsize=maxsize)
+
+    def get_or_load(self, connection: Any, schema: str, view_names: list[str]) -> SchemaCatalog:
+        if schema not in self._cache:
+            self._cache[schema] = _fetch_schema_catalog(connection, schema, view_names)
+        return self._cache[schema]
+
+    def invalidate(self, schema: str) -> None:
+        self._cache.pop(schema, None)
+
+
+def fetch_view_names(connection: Any, schema: str) -> list[str]:
+    """Return the semantic-view names in ``schema``."""
+    rows = _rows(connection, SNOWFLAKE_GET_SEMANTIC_VIEWS.format(schema=schema))
+    return [row[0] for row in rows]
+
+
+def fetch_definition(connection: Any, fully_qualified_name: str) -> str | None:
+    """Return ``GET_DDL('SEMANTIC_VIEW', ...)`` or ``None`` on failure."""
+    try:
+        rows = _rows(connection, SNOWFLAKE_GET_SEMANTIC_VIEW_DEFINITION.format(fqn=fully_qualified_name))
+        return rows[0][0] if rows else None
+    except Exception:
+        return None
+
+
+def _fetch_schema_catalog(connection: Any, schema: str, view_names: list[str]) -> SchemaCatalog:
+    return SchemaCatalog(
+        dimensions_by_view=_fetch_objects(connection, schema, _CATALOG_DIMENSIONS, view_names),
+        facts_by_view=_fetch_objects(connection, schema, _CATALOG_FACTS, view_names),
+        metrics_by_view=_fetch_objects(connection, schema, _CATALOG_METRICS, view_names),
+        base_tables_by_view=_try_base_tables(connection, schema),
+    )
+
+
+def _fetch_objects(
+    connection: Any,
+    schema: str,
+    catalog_view: str,
+    view_names: list[str],
+) -> dict[str, list[tuple]]:
+    """Schema-wide query, fall back per-view on Snowflake errno 90030."""
+    try:
+        rows = _rows(
+            connection,
+            SNOWFLAKE_GET_SEMANTIC_OBJECTS_IN_SCHEMA.format(catalog_view=catalog_view, schema=schema),
+        )
+        return _group_by_view(rows, view_index=0, row_start_index=1)
+    except ProgrammingError as exc:
+        if getattr(exc, "errno", None) != SNOWFLAKE_INFO_SCHEMA_TOO_LARGE_ERRNO:
+            raise
+    grouped: dict[str, list[tuple]] = {}
+    for view in view_names:
+        try:
+            rows = _rows(
+                connection,
+                SNOWFLAKE_GET_SEMANTIC_OBJECTS_FOR_VIEW.format(
+                    catalog_view=catalog_view,
+                    schema=schema,
+                    semantic_view=view,
+                ),
+            )
+        except Exception:
+            grouped[view] = []
+            continue
+        grouped[view] = [tuple(row[1:]) for row in rows]
+    return grouped
+
+
+def _try_base_tables(connection: Any, schema: str) -> dict[str, dict[str, tuple[str, str, str]]]:
+    """Return ``{view_name: {logical_table_name: (base_catalog, base_schema, base_name)}}``
+    so column-level lineage can look up physical tables by the logical alias used in
+    semantic-view expressions."""
+    try:
+        rows = _rows(connection, SNOWFLAKE_GET_SEMANTIC_TABLES_IN_SCHEMA.format(schema=schema))
+    except Exception:
+        return {}
+    grouped: dict[str, dict[str, tuple[str, str, str]]] = {}
+    for row in rows:
+        view_name, logical_name, base_catalog, base_schema, base_name = row[0], row[1], row[2], row[3], row[4]
+        if not (view_name and logical_name and base_catalog and base_schema and base_name):
+            continue
+        grouped.setdefault(view_name, {})[logical_name] = (base_catalog, base_schema, base_name)
+    return grouped
+
+
+def _group_by_view(rows: list[tuple], view_index: int, row_start_index: int) -> dict[str, list[tuple]]:
+    grouped: dict[str, list[tuple]] = {}
+    for row in rows:
+        view = row[view_index]
+        if not view:
+            continue
+        grouped.setdefault(view, []).append(tuple(row[row_start_index:]))
+    return grouped
+
+
+def _rows(connection: Any, sql: str) -> list[tuple]:
+    return list(connection.execute(text(sql)))

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/columns.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/columns.py
@@ -1,0 +1,162 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Pure builder: dim/fact/metric rows → SQLAlchemy-shape column dicts that
+the standard ``sql_column_handler`` pipeline understands. Every dim, fact and
+metric on a Snowflake semantic view surfaces as a Column on the view's Table
+entity, tagged in the description with its kind + logical table + expression
++ synonyms + comment."""
+
+from __future__ import annotations
+
+import sqlalchemy.types as sqltypes
+
+from snowflake.sqlalchemy.snowdialect import ischema_names
+
+_ROW_TABLE_IDX = 0
+_ROW_NAME_IDX = 1
+_ROW_TYPE_IDX = 2
+_ROW_EXPR_IDX = 3
+_ROW_COMMENT_IDX = 4
+_ROW_SYNONYMS_IDX = 5
+
+
+def build_columns(
+    *,
+    dimensions: list[tuple],
+    facts: list[tuple],
+    metrics: list[tuple],
+) -> list[dict]:
+    """Merge dim/fact/metric rows into SQLAlchemy-shape column dicts.
+
+    Same column name across kinds collapses into one entry whose description
+    enumerates every kind. The returned dicts have ``type`` set to a SQLAlchemy
+    type instance so ``ColumnTypeParser`` maps to the correct OM DataType and
+    ``dataLength`` / ``precision`` / ``scale``.
+    """
+    merged: dict[str, dict] = {}
+    for kind, rows in (("Dimension", dimensions), ("Fact", facts), ("Metric", metrics)):
+        for row in rows:
+            _accumulate(merged, kind, row)
+    return [_to_sqlalchemy_dict(entry) for entry in merged.values()]
+
+
+def _accumulate(merged: dict[str, dict], kind: str, row: tuple) -> None:
+    name = row[_ROW_NAME_IDX]
+    if not name:
+        return
+    entry = merged.setdefault(
+        name,
+        {
+            "name": name,
+            "raw_type": row[_ROW_TYPE_IDX],
+            "kinds": [],
+            "logical_table": row[_ROW_TABLE_IDX] or None,
+            "expression": row[_ROW_EXPR_IDX] or None,
+            "synonyms": row[_ROW_SYNONYMS_IDX] or None,
+            "comment": row[_ROW_COMMENT_IDX] or None,
+        },
+    )
+    entry["kinds"].append(kind)
+
+
+def _to_sqlalchemy_dict(entry: dict) -> dict:
+    stripped_expression = _strip_logical_qualifier(entry["expression"], entry["logical_table"])
+    return {
+        "name": entry["name"],
+        "type": _resolve_sqlalchemy_type(entry["raw_type"]),
+        "nullable": True,
+        "default": None,
+        "autoincrement": False,
+        "comment": _build_description(
+            kinds=entry["kinds"],
+            logical_table=entry["logical_table"],
+            expression=stripped_expression,
+            synonyms=entry["synonyms"],
+            comment=entry["comment"],
+        ),
+        "system_data_type": entry["raw_type"] or None,
+    }
+
+
+def _resolve_sqlalchemy_type(raw: str | None):
+    """Map ``VARCHAR(16777216)`` / ``NUMBER(38,2)`` to an SA type instance so
+    downstream ``ColumnTypeParser`` picks up ``dataLength`` / ``precision``
+    / ``scale`` from the type object rather than defaulting to 1."""
+    if not raw:
+        return sqltypes.NullType()
+    head = raw.strip().split("(", 1)[0].strip().upper()
+    type_class = ischema_names.get(head)
+    if type_class is None:
+        return sqltypes.NullType()
+    args, kwargs = _parse_type_args(raw)
+    try:
+        return type_class(*args, **kwargs)
+    except Exception:
+        try:
+            return type_class()
+        except Exception:
+            return sqltypes.NullType()
+
+
+def _parse_type_args(raw: str) -> tuple[list, dict]:
+    if "(" not in raw or not raw.rstrip().endswith(")"):
+        return [], {}
+    body = raw[raw.index("(") + 1 : raw.rindex(")")].strip()
+    if not body:
+        return [], {}
+    parts = [p.strip() for p in body.split(",")]
+    nums: list[int] = []
+    for p in parts:
+        if not p.isdigit():
+            return [], {}
+        nums.append(int(p))
+    return nums, {}
+
+
+def _strip_logical_qualifier(expression: str | None, logical_table: str | None) -> str | None:
+    """Drop the leading ``logical_table.`` prefix from raw Snowflake semantic
+    expressions so the column description reads ``c_region``, not
+    ``customers.c_region`` — the qualifier is already carried on
+    ``Logical table:`` separately."""
+    if not expression or not logical_table:
+        return expression
+    prefix = f"{logical_table.lower()}."
+    lowered = expression.lower()
+    idx = 0
+    result_chars: list[str] = []
+    while idx < len(expression):
+        remaining_lower = lowered[idx:]
+        if remaining_lower.startswith(prefix):
+            idx += len(prefix)
+            continue
+        result_chars.append(expression[idx])
+        idx += 1
+    return "".join(result_chars)
+
+
+def _build_description(
+    *,
+    kinds: list[str],
+    logical_table: str | None,
+    expression: str | None,
+    synonyms: str | None,
+    comment: str | None,
+) -> str:
+    parts = [f"[{', '.join(kinds)}]"]
+    if logical_table:
+        parts.append(f"Logical table: {logical_table}.")
+    if expression:
+        parts.append(f"Expression: {expression}.")
+    if synonyms:
+        parts.append(f"Synonyms: {synonyms}.")
+    if comment:
+        parts.append(comment)
+    return " ".join(parts)

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/lineage.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/lineage.py
@@ -1,0 +1,172 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view lineage: expression resolution and wire requests.
+
+Walks each semantic view's dim/fact/metric expressions to resolve every
+referenced physical base column, following intra-view metric→fact→physical
+chains with bounded depth. Edges carry bare column names — the owning table
+FQNs live on the edge and on the caller — so a run can buffer many edges
+cheaply and materialize the request objects only at emission.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from metadata.generated.schema.type.entityLineage import ColumnLineage, LineageDetails
+from metadata.generated.schema.type.entityLineage import Source as LineageSource
+from metadata.ingestion.models.ometa_lineage import OMetaFQNLineageRequest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from metadata.ingestion.source.database.snowflake.semantic_view.catalog import (
+        SemanticViewCatalog,
+    )
+
+_EXPRESSION_TOKEN = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)")
+_MAX_INDIRECTION_DEPTH = 5
+
+_ROW_TABLE_IDX = 0
+_ROW_NAME_IDX = 1
+_ROW_EXPR_IDX = 3
+
+_TABLE = "table"
+_METRIC = "metric"
+
+
+class ColumnLineageEdge:
+    """One base-column → view-column pair, named relative to their tables."""
+
+    __slots__ = ("from_column", "to_column")
+
+    def __init__(self, from_column: str, to_column: str) -> None:
+        self.from_column = from_column
+        self.to_column = to_column
+
+
+class BaseTableEdge:
+    """One physical base table with the column pairs feeding its view."""
+
+    __slots__ = ("base_table_fqn", "columns")
+
+    def __init__(self, base_table_fqn: str, columns: list[ColumnLineageEdge]) -> None:
+        self.base_table_fqn = base_table_fqn
+        self.columns = columns
+
+
+def build_view_lineage(
+    *,
+    catalog: SemanticViewCatalog,
+    base_table_fqns_by_logical: dict[str, str],
+) -> list[BaseTableEdge]:
+    """Return one BaseTableEdge per physical base table this view derives from.
+
+    ``base_table_fqns_by_logical`` maps logical table names (as they appear in
+    expressions, lowercased) to the OM Table FQN of the physical base table.
+    """
+    logical_expressions = _index_by_logical(catalog.dimensions, catalog.facts, catalog.metrics)
+    edges_by_base: dict[str, list[ColumnLineageEdge]] = {}
+    for logical_table, name, raw_expression in _each_view_column(catalog):
+        for base_logical, base_column in _resolve_physical(logical_expressions, logical_table, raw_expression):
+            base_fqn = base_table_fqns_by_logical.get(base_logical.lower())
+            if not base_fqn:
+                continue
+            edges_by_base.setdefault(base_fqn, []).append(ColumnLineageEdge(from_column=base_column, to_column=name))
+    return [BaseTableEdge(base_table_fqn=fqn, columns=edges) for fqn, edges in edges_by_base.items()]
+
+
+def to_view_lineage_request(view_fqn: str, edge: BaseTableEdge) -> OMetaFQNLineageRequest:
+    """Build the base-table → semantic-view request for one resolved edge."""
+    return OMetaFQNLineageRequest(
+        from_entity_fqn=edge.base_table_fqn,
+        from_entity_type=_TABLE,
+        to_entity_fqn=view_fqn,
+        to_entity_type=_TABLE,
+        lineage_details=LineageDetails(  # pyright: ignore[reportCallIssue]
+            source=LineageSource.ViewLineage,
+            columnsLineage=[
+                ColumnLineage(  # pyright: ignore[reportCallIssue]
+                    fromColumns=[f"{edge.base_table_fqn}.{pair.from_column}"],  # pyright: ignore[reportArgumentType]
+                    toColumn=f"{view_fqn}.{pair.to_column}",  # pyright: ignore[reportArgumentType]
+                )
+                for pair in edge.columns
+            ]
+            or None,
+        ),
+    )
+
+
+def to_metric_lineage_request(view_fqn: str, metric_name: str) -> OMetaFQNLineageRequest:
+    """Build the semantic-view → Metric request. Metric FQN is its name."""
+    return OMetaFQNLineageRequest(
+        from_entity_fqn=view_fqn,
+        from_entity_type=_TABLE,
+        to_entity_fqn=metric_name,
+        to_entity_type=_METRIC,
+        lineage_details=LineageDetails(source=LineageSource.ViewLineage),  # pyright: ignore[reportCallIssue]
+    )
+
+
+def _each_view_column(catalog: SemanticViewCatalog) -> Iterable[tuple[str, str, str]]:
+    for row in (*catalog.dimensions, *catalog.facts, *catalog.metrics):
+        logical_table = row[_ROW_TABLE_IDX] or ""
+        name = row[_ROW_NAME_IDX] or ""
+        expression = row[_ROW_EXPR_IDX] or ""
+        if name and expression:
+            yield logical_table, name, expression
+
+
+def _index_by_logical(*row_groups: list[tuple]) -> dict[str, dict[str, str]]:
+    """Map ``{logical_table_lower: {name_lower: expression}}`` for follow-through."""
+    index: dict[str, dict[str, str]] = {}
+    for group in row_groups:
+        for row in group:
+            logical_table = (row[_ROW_TABLE_IDX] or "").lower()
+            name = (row[_ROW_NAME_IDX] or "").lower()
+            expression = row[_ROW_EXPR_IDX] or ""
+            if not (logical_table and name and expression):
+                continue
+            index.setdefault(logical_table, {})[name] = expression
+    return index
+
+
+def _resolve_physical(
+    logical_expressions: dict[str, dict[str, str]],
+    starting_table: str,
+    expression: str,
+    depth: int = 0,
+) -> Iterable[tuple[str, str]]:
+    """Walk expression tokens; yield ``(logical_base_table, base_column)`` pairs.
+
+    A token like ``customers.c_region`` — if ``customers`` is a physical
+    logical table (no intra-view expression defined), we yield it directly.
+    If ``customers.some_intermediate`` resolves to another expression inside
+    the view (e.g. a fact referencing another fact), recurse up to
+    ``_MAX_INDIRECTION_DEPTH`` to reach the physical columns."""
+    if depth >= _MAX_INDIRECTION_DEPTH:
+        return
+    for match in _EXPRESSION_TOKEN.finditer(expression):
+        table_token, column_token = match.group(1), match.group(2)
+        table_key = table_token.lower()
+        column_key = column_token.lower()
+        inner_expression = logical_expressions.get(table_key, {}).get(column_key)
+        if inner_expression:
+            yield from _resolve_physical(
+                logical_expressions,
+                table_token,
+                inner_expression,
+                depth=depth + 1,
+            )
+            continue
+        yield table_token, column_token
+    _ = starting_table

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/semantic_view/queries.py
@@ -1,0 +1,52 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""SQL constants for Snowflake semantic-view catalog access.
+
+Column naming differs between INFORMATION_SCHEMA.SEMANTIC_VIEWS (``SCHEMA``,
+``NAME``) and the child catalogs (``SEMANTIC_VIEW_SCHEMA``,
+``SEMANTIC_VIEW_NAME``). Primary path is one query per catalog per schema —
+fallback (per-view) exists only for errno 90030 ("information schema query
+returned too much data") which the primary can hit on very large schemas."""
+
+from __future__ import annotations
+
+SNOWFLAKE_GET_SEMANTIC_VIEWS = """
+SELECT NAME FROM information_schema.semantic_views WHERE SCHEMA = '{schema}'
+"""
+
+SNOWFLAKE_GET_SEMANTIC_OBJECTS_IN_SCHEMA = """
+SELECT SEMANTIC_VIEW_NAME, TABLE_NAME, NAME, DATA_TYPE, EXPRESSION, COMMENT, SYNONYMS
+FROM information_schema.{catalog_view}
+WHERE SEMANTIC_VIEW_SCHEMA = '{schema}'
+"""
+
+SNOWFLAKE_GET_SEMANTIC_OBJECTS_FOR_VIEW = """
+SELECT SEMANTIC_VIEW_NAME, TABLE_NAME, NAME, DATA_TYPE, EXPRESSION, COMMENT, SYNONYMS
+FROM information_schema.{catalog_view}
+WHERE SEMANTIC_VIEW_SCHEMA = '{schema}' AND SEMANTIC_VIEW_NAME = '{semantic_view}'
+"""
+
+SNOWFLAKE_GET_SEMANTIC_TABLES_IN_SCHEMA = """
+SELECT SEMANTIC_VIEW_NAME, NAME, BASE_TABLE_CATALOG, BASE_TABLE_SCHEMA, BASE_TABLE_NAME
+FROM information_schema.semantic_tables
+WHERE SEMANTIC_VIEW_SCHEMA = '{schema}'
+"""
+
+SNOWFLAKE_GET_SEMANTIC_VIEW_DEFINITION = """
+SELECT GET_DDL('SEMANTIC_VIEW','{fqn}') AS "text"
+"""
+
+_CATALOG_DIMENSIONS = "semantic_dimensions"
+_CATALOG_FACTS = "semantic_facts"
+_CATALOG_METRICS = "semantic_metrics"
+
+# Errno raised by INFORMATION_SCHEMA when the result set is too large.
+SNOWFLAKE_INFO_SCHEMA_TOO_LARGE_ERRNO = 90030

--- a/ingestion/tests/unit/domain/metrics/test_feature.py
+++ b/ingestion/tests/unit/domain/metrics/test_feature.py
@@ -1,0 +1,190 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Outcome-based tests for MetricIngestionFeature."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from metadata.domain.metrics import (
+    DEFAULT_MAX_DEFINITIONS,
+    MetricDefinition,
+    MetricFeatureOverflowError,
+    MetricIngestionFeature,
+    MetricKey,
+    MetricOrigin,
+    MetricSourceType,
+)
+from metadata.generated.schema.api.data.createMetric import CreateMetricRequest
+from metadata.generated.schema.type.entityReferenceInput import EntityReferenceInput
+
+if TYPE_CHECKING:
+    from metadata.generated.schema.entity.data.metric import MetricType
+
+
+def _origin(
+    source: MetricSourceType = MetricSourceType.DBT,
+    service: str = "svc",
+    external: str = "m1",
+) -> MetricOrigin:
+    return MetricOrigin(source_type=source, service_name=service, external_id=external)
+
+
+def _defn(
+    origin: MetricOrigin,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    depends_on: tuple[MetricKey, ...] = (),
+    related_assets: tuple[EntityReferenceInput, ...] = (),
+    metric_type: MetricType | None = None,
+) -> MetricDefinition:
+    return MetricDefinition(
+        key=MetricKey.from_origin(origin),
+        origin=origin,
+        name=name or origin.external_id,
+        description=description,
+        depends_on=depends_on,
+        related_assets=related_assets,
+        metric_type=metric_type,
+    )
+
+
+def _table_ref(fqn: str) -> EntityReferenceInput:
+    return EntityReferenceInput(type="table", fullyQualifiedName=fqn)
+
+
+def _rights(feature: MetricIngestionFeature) -> list[Any]:
+    return [e.right for e in feature.drain() if e.right is not None]
+
+
+def _lefts(feature: MetricIngestionFeature) -> list[Any]:
+    return [e.left for e in feature.drain() if e.left is not None]
+
+
+def test_identical_duplicates_collapse():
+    feature = MetricIngestionFeature()
+    origin = _origin()
+    feature.accept(_defn(origin, description="d"))
+    feature.accept(_defn(origin, description="d"))
+    requests = [r for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    assert len(requests) == 1
+
+
+def test_conflicting_definitions_fail_visibly():
+    feature = MetricIngestionFeature()
+    origin = _origin()
+    feature.accept(_defn(origin, description="first"))
+    with pytest.raises(ValueError, match="Conflicting definitions"):
+        feature.accept(_defn(origin, description="second"))
+
+
+def test_same_names_from_distinct_origins_do_not_merge():
+    feature = MetricIngestionFeature()
+    a = MetricOrigin(source_type=MetricSourceType.DBT, service_name="svc", external_id="ext-a")
+    b = MetricOrigin(source_type=MetricSourceType.SNOWFLAKE, service_name="svc", external_id="ext-b")
+    feature.accept(_defn(a, name="revenue"))
+    feature.accept(_defn(b, name="revenue"))
+    requests = [r for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    assert len(requests) == 2
+
+
+def test_dependency_ordering_is_stable():
+    feature = MetricIngestionFeature()
+    parent = _origin(external="parent")
+    child = _origin(external="child")
+    feature.accept(_defn(child, depends_on=(MetricKey.from_origin(parent),)))
+    feature.accept(_defn(parent))
+    order = [r.name.root for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    assert order.index("parent") < order.index("child")
+
+
+def test_cycle_is_reported():
+    feature = MetricIngestionFeature()
+    a = _origin(external="a")
+    b = _origin(external="b")
+    feature.accept(_defn(a, depends_on=(MetricKey.from_origin(b),)))
+    feature.accept(_defn(b, depends_on=(MetricKey.from_origin(a),)))
+    assert any("cycle" in err.error for err in _lefts(feature))
+
+
+def test_unresolved_dependency_is_reported():
+    feature = MetricIngestionFeature()
+    missing = MetricKey(source_type=MetricSourceType.DBT, service_name="svc", external_id="ghost")
+    feature.accept(_defn(_origin(external="orphan"), depends_on=(missing,)))
+    assert any("unresolved dependency" in err.error for err in _lefts(feature))
+
+
+def test_bounded_capacity_and_overflow_is_explicit():
+    feature = MetricIngestionFeature(max_definitions=2)
+    feature.accept(_defn(_origin(external="a")))
+    feature.accept(_defn(_origin(external="b")))
+    with pytest.raises(MetricFeatureOverflowError):
+        feature.accept(_defn(_origin(external="c")))
+
+
+def test_capacity_default_is_bounded():
+    assert 0 < DEFAULT_MAX_DEFINITIONS < 10**9
+
+
+def test_assets_ride_inline_as_fqn_only_entity_reference_input():
+    """assets go out on CreateMetricRequest with fqn set + id absent — server
+    resolves via MetricMapper.resolveAssets."""
+    feature = MetricIngestionFeature()
+    feature.accept(_defn(_origin(), related_assets=(_table_ref("svc.db.sch.t"),)))
+    requests = [r for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    assert requests[0].assets is not None
+    assets = requests[0].assets.root
+    assert len(assets) == 1
+    assert assets[0].type == "table"
+    assert assets[0].fullyQualifiedName == "svc.db.sch.t"
+    assert assets[0].id is None
+
+
+def test_definitions_without_assets_leave_assets_field_none():
+    feature = MetricIngestionFeature()
+    feature.accept(_defn(_origin()))
+    requests = [r for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    assert requests[0].assets is None
+
+
+def test_related_metric_fqns_flow_to_create_request():
+    feature = MetricIngestionFeature()
+    parent = _origin(external="parent")
+    child = _origin(external="child")
+    feature.accept(_defn(parent, name="parent"))
+    feature.accept(_defn(child, name="child", depends_on=(MetricKey.from_origin(parent),)))
+    requests = [r for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+    child_req = next(r for r in requests if r.name.root == "child")
+    assert child_req.relatedMetrics is not None
+    assert [r.root for r in child_req.relatedMetrics] == ["parent"]
+
+
+def test_connectors_without_metrics_are_unchanged():
+    feature = MetricIngestionFeature()
+    assert list(feature.drain()) == []
+
+
+def test_output_deterministic_regardless_of_registration_order():
+    inputs = [_defn(_origin(external=x)) for x in ("z", "a", "m", "b", "y")]
+
+    def run(order):
+        feature = MetricIngestionFeature()
+        for d in order:
+            feature.accept(d)
+        return [r.name.root for r in _rights(feature) if isinstance(r, CreateMetricRequest)]
+
+    forward = run(inputs)
+    reverse = run(list(reversed(inputs)))
+    assert forward == reverse
+    assert forward == sorted(forward)

--- a/ingestion/tests/unit/test_dbt_metric_adapter.py
+++ b/ingestion/tests/unit/test_dbt_metric_adapter.py
@@ -1,0 +1,241 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""dbt metric adapter — fixtures mirror the manifest v12 shapes the connector
+receives: ``semantic_models`` / ``all_metrics`` are dicts keyed by unique_id and
+the backing models are reached through the metric's ``depends_on``."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace as Ns
+
+from metadata.domain.metrics.records import MetricSourceType
+from metadata.generated.schema.entity.data.metric import MetricType
+from metadata.ingestion.source.database.dbt.metric_adapter import normalize_dbt_metric
+
+SERVICE = "dbt_svc"
+
+
+def _dimension(name: str, dim_type: str = "categorical", expr: str | None = None):
+    return Ns(name=name, type=Ns(value=dim_type), description=f"{name} desc", expr=expr)
+
+
+def _measure(name: str, agg: str = "sum", expr: str | None = None):
+    return Ns(name=name, agg=Ns(value=agg), description=f"{name} desc", expr=expr)
+
+
+def _semantic_model(unique_id: str, name: str, dimensions=(), measures=(), relation=True):
+    return Ns(
+        name=name,
+        unique_id=unique_id,
+        dimensions=list(dimensions),
+        measures=list(measures),
+        node_relation=(
+            Ns(database="my_db", schema_name="my_schema", alias="orders", relation_name=None) if relation else None
+        ),
+    )
+
+
+def _metric(
+    name: str,
+    metric_type: str = "simple",
+    *,
+    unique_id: str | None = None,
+    package: str = "analytics",
+    type_params=None,
+    depends_on=(),
+    label: str | None = None,
+):
+    return Ns(
+        name=name,
+        unique_id=unique_id or f"metric.analytics.{name}",
+        package_name=package,
+        type=Ns(value=metric_type),
+        type_params=type_params,
+        depends_on=Ns(nodes=list(depends_on), macros=[]),
+        label=label,
+        description=f"{name} description",
+        filter=None,
+        time_granularity=None,
+        tags=None,
+    )
+
+
+def test_dict_shaped_semantic_models_yield_dimensions_and_measures():
+    """The manifest hands over a dict keyed by unique_id, not a list — iterating
+    it directly would walk string keys and silently produce nothing."""
+    sm_id = "semantic_model.analytics.orders"
+    semantic_models = {
+        sm_id: _semantic_model(sm_id, "orders", dimensions=[_dimension("region")], measures=[_measure("amount")])
+    }
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")), depends_on=[sm_id])
+
+    definition = normalize_dbt_metric(node, semantic_models, service_name=SERVICE)
+
+    assert [d.name for d in definition.dimensions] == ["region"]
+    assert [m.name for m in definition.measures] == ["amount"]
+
+
+def test_metric_name_is_qualified_with_service_and_package():
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")))
+    definition = normalize_dbt_metric(node, {}, service_name=SERVICE)
+
+    assert definition.name == "dbt_svc-analytics-revenue"
+    assert "." not in definition.name
+    assert definition.display_name == "revenue"
+    assert definition.origin.source_type is MetricSourceType.DBT
+    assert definition.origin.external_id == "metric.analytics.revenue"
+
+
+def test_dimension_type_and_measure_aggregation_are_mapped():
+    sm_id = "semantic_model.analytics.orders"
+    semantic_models = {
+        sm_id: _semantic_model(
+            sm_id,
+            "orders",
+            dimensions=[_dimension("ordered_at", "time"), _dimension("region", "categorical")],
+            measures=[_measure("amount", "sum")],
+        )
+    }
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")), depends_on=[sm_id])
+
+    definition = normalize_dbt_metric(node, semantic_models, service_name=SERVICE)
+
+    by_name = {d.name: d for d in definition.dimensions}
+    assert by_name["ordered_at"].type.value.upper() == "TIME"
+    assert by_name["region"].type.value.upper() == "CATEGORICAL"
+    assert definition.measures[0].aggregation == "sum"
+
+
+def test_derived_metric_records_dependencies_as_metric_keys():
+    parent = _metric("revenue", type_params=Ns(measure=Ns(name="amount")))
+    child = _metric(
+        "margin",
+        "derived",
+        type_params=Ns(expr="revenue - cost", metrics=[Ns(name="revenue")]),
+        depends_on=["metric.analytics.revenue"],
+    )
+    all_metrics = {parent.unique_id: parent, child.unique_id: child}
+
+    definition = normalize_dbt_metric(child, {}, service_name=SERVICE, all_metrics=all_metrics)
+
+    assert definition.metric_type is MetricType.DERIVED
+    assert definition.expression.code == "revenue - cost"
+    assert [k.external_id for k in definition.depends_on] == ["metric.analytics.revenue"]
+
+
+def test_unknown_related_metric_is_dropped_from_dependencies():
+    child = _metric(
+        "margin",
+        "derived",
+        type_params=Ns(expr="revenue - cost", metrics=[Ns(name="ghost")]),
+        depends_on=["metric.analytics.ghost"],
+    )
+    definition = normalize_dbt_metric(child, {}, service_name=SERVICE, all_metrics={child.unique_id: child})
+    assert definition.depends_on == ()
+
+
+def test_ratio_metric_builds_expression_and_two_dependencies():
+    numerator = _metric("wins", unique_id="metric.analytics.wins")
+    denominator = _metric("deals", unique_id="metric.analytics.deals")
+    ratio = _metric(
+        "win_rate",
+        "ratio",
+        type_params=Ns(numerator=Ns(name="wins"), denominator=Ns(name="deals")),
+        depends_on=["metric.analytics.wins", "metric.analytics.deals"],
+    )
+    all_metrics = {m.unique_id: m for m in (numerator, denominator, ratio)}
+
+    definition = normalize_dbt_metric(ratio, {}, service_name=SERVICE, all_metrics=all_metrics)
+
+    assert definition.metric_type is MetricType.RATIO
+    assert definition.expression.code == "wins / deals"
+    assert {k.external_id for k in definition.depends_on} == {
+        "metric.analytics.wins",
+        "metric.analytics.deals",
+    }
+
+
+def test_conversion_metric_records_dependencies_from_the_dbt_graph():
+    """Conversion metrics name their parents only in ``depends_on``, never in
+    ``type_params`` — reading dependencies from the graph is what keeps them
+    ordered behind their parents."""
+    parent = _metric("visits", unique_id="metric.analytics.visits")
+    conversion = _metric(
+        "signup_rate",
+        "conversion",
+        type_params=Ns(
+            conversion_type_params=Ns(
+                base_measure=Ns(name="visits"),
+                conversion_measure=Ns(name="signups"),
+                entity="user",
+            )
+        ),
+        depends_on=["metric.analytics.visits"],
+    )
+    all_metrics = {m.unique_id: m for m in (parent, conversion)}
+
+    definition = normalize_dbt_metric(conversion, {}, service_name=SERVICE, all_metrics=all_metrics)
+
+    assert definition.metric_type is MetricType.CONVERSION
+    assert [k.external_id for k in definition.depends_on] == ["metric.analytics.visits"]
+
+
+def test_assets_reference_the_semantic_model_backing_tables():
+    sm_id = "semantic_model.analytics.orders"
+    semantic_models = {sm_id: _semantic_model(sm_id, "orders")}
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")), depends_on=[sm_id])
+
+    definition = normalize_dbt_metric(node, semantic_models, service_name=SERVICE)
+
+    assert len(definition.related_assets) == 1
+    asset = definition.related_assets[0]
+    assert asset.type == "table"
+    assert asset.fullyQualifiedName == "dbt_svc.my_db.my_schema.orders"
+    assert asset.id is None
+
+
+def test_semantic_model_without_node_relation_contributes_no_asset():
+    sm_id = "semantic_model.analytics.orders"
+    semantic_models = {sm_id: _semantic_model(sm_id, "orders", relation=False)}
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")), depends_on=[sm_id])
+
+    definition = normalize_dbt_metric(node, semantic_models, service_name=SERVICE)
+    assert definition.related_assets == ()
+
+
+def test_tags_are_passed_through_from_the_caller():
+    """Tag resolution needs an API lookup, so the connector resolves them and the
+    adapter stays pure."""
+    from metadata.generated.schema.type.tagLabel import (
+        LabelType,
+        State,
+        TagLabel,
+        TagSource,
+    )
+
+    label = TagLabel(
+        tagFQN="dbtTags.gold",
+        labelType=LabelType.Automated,
+        state=State.Suggested,
+        source=TagSource.Classification,
+    )
+    node = _metric("revenue", type_params=Ns(measure=Ns(name="amount")))
+
+    definition = normalize_dbt_metric(node, {}, service_name=SERVICE, tags=(label,))
+
+    assert len(definition.tags) == 1
+    assert definition.tags[0].tagFQN.root == "dbtTags.gold"
+
+
+def test_unknown_metric_type_falls_back_to_other():
+    node = _metric("weird", "some_future_type", type_params=Ns(measure=Ns(name="amount")))
+    definition = normalize_dbt_metric(node, {}, service_name=SERVICE)
+    assert definition.metric_type is MetricType.OTHER

--- a/ingestion/tests/unit/topology/database/test_snowflake_metric_adapter.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_metric_adapter.py
@@ -1,0 +1,146 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view adapter: catalog rows → normalized MetricDefinition."""
+
+from __future__ import annotations
+
+from metadata.domain.metrics.records import MetricSourceType
+from metadata.generated.schema.entity.data.metric import MetricType, Type
+from metadata.ingestion.source.database.snowflake.metric_adapter import (
+    build_metric_entity_name,
+    infer_metric_type,
+    normalize_snowflake_metric,
+)
+
+
+def _row(
+    name: str,
+    expression: str,
+    data_type: str = "NUMBER",
+    comment: str = "",
+    synonyms: str | None = None,
+) -> tuple:
+    return ("MY_VIEW", name, data_type, expression, comment, synonyms)
+
+
+def test_metric_name_is_qualified_with_service_and_stays_single_segment():
+    metric_row = _row("total_sales", "SUM(amount)", comment="Total sales")
+    definition = normalize_snowflake_metric(
+        service_name="snow_svc",
+        database="my_catalog",
+        schema="my_schema",
+        view="my_view",
+        metric_row=metric_row,
+        dimension_rows=[_row("region", "region", "VARCHAR")],
+        fact_rows=[_row("amount", "amount", "NUMBER")],
+    )
+    assert definition.origin.source_type is MetricSourceType.SNOWFLAKE
+    assert definition.origin.external_id == "snow_svc.my_catalog.my_schema.my_view.total_sales"
+    assert definition.name == "snow_svc-my_catalog-my_schema-my_view-total_sales"
+    assert "." not in definition.name, "server-visible name must be a single FQN segment"
+    assert definition.metric_type is MetricType.SUM
+    assert definition.expression.code == "SUM(amount)"
+
+
+def test_assets_link_to_the_semantic_view_only():
+    """Base tables are one hop further upstream (base -> view -> metric) and are
+    represented as lineage, not flattened into a direct metric-to-table link."""
+    metric_row = _row("total_sales", "SUM(amount)")
+    definition = normalize_snowflake_metric(
+        service_name="snow",
+        database="my_catalog",
+        schema="my_schema",
+        view="my_view",
+        metric_row=metric_row,
+        dimension_rows=[],
+        fact_rows=[],
+    )
+    assert len(definition.related_assets) == 1
+    assert definition.related_assets[0].fullyQualifiedName == "snow.my_catalog.my_schema.my_view"
+
+
+def test_overflow_name_gets_digest_suffix_to_stay_unique():
+    a = build_metric_entity_name("s" * 300, "d", "s", "v", "m1")
+    b = build_metric_entity_name("s" * 300, "d", "s", "v", "m2")
+    assert a != b, "long distinct names must not collide after truncation"
+    assert len(a) <= 256 and len(b) <= 256
+
+
+def test_dimension_time_type_inferred_from_data_type():
+    metric_row = _row("cnt", "COUNT(*)")
+    definition = normalize_snowflake_metric(
+        service_name="s",
+        database="d",
+        schema="sch",
+        view="v",
+        metric_row=metric_row,
+        dimension_rows=[
+            _row("region", "region", "VARCHAR"),
+            _row("event_ts", "event_ts", "TIMESTAMP_NTZ"),
+        ],
+        fact_rows=[],
+    )
+    by_name = {d.name: d for d in definition.dimensions}
+    assert by_name["region"].type is Type.CATEGORICAL
+    assert by_name["event_ts"].type is Type.TIME
+
+
+def test_measure_carries_aggregation_head_when_inferable():
+    metric_row = _row("cnt", "COUNT(*)")
+    definition = normalize_snowflake_metric(
+        service_name="s",
+        database="d",
+        schema="sch",
+        view="v",
+        metric_row=metric_row,
+        dimension_rows=[],
+        fact_rows=[
+            _row("revenue", "SUM(price*qty)"),
+            _row("plain", "price"),
+        ],
+    )
+    by_name = {m.name: m for m in definition.measures}
+    assert by_name["revenue"].aggregation == "SUM"
+    assert by_name["plain"].aggregation is None
+
+
+def test_synonyms_folded_into_description_alongside_comment():
+    metric_row = _row("cnt", "COUNT(*)")
+    definition = normalize_snowflake_metric(
+        service_name="s",
+        database="d",
+        schema="sch",
+        view="v",
+        metric_row=metric_row,
+        dimension_rows=[_row("region", "region", "VARCHAR", comment="US regions", synonyms="area,zone")],
+        fact_rows=[],
+    )
+    desc = definition.dimensions[0].description
+    assert "US regions" in desc
+    assert "Synonyms: area,zone" in desc
+
+
+def test_quoted_identifier_gets_unquoted_before_sanitization():
+    # A Snowflake identifier wrapped in double quotes should unquote first,
+    # so a bare `"schema"` becomes `schema`, not `_schema_`.
+    name = build_metric_entity_name("svc", "db", '"schema"', "view", "m")
+    assert name == "svc-db-schema-view-m"
+
+
+def test_metric_type_inference():
+    assert infer_metric_type("SUM(x)") is MetricType.SUM
+    assert infer_metric_type("count(*)") is MetricType.COUNT
+    assert infer_metric_type("AVG(x)") is MetricType.AVERAGE
+    assert infer_metric_type("MIN(x)") is MetricType.MIN
+    assert infer_metric_type("MAX(x)") is MetricType.MAX
+    assert infer_metric_type("PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x)") is MetricType.OTHER
+    assert infer_metric_type(None) is MetricType.OTHER
+    assert infer_metric_type("") is MetricType.OTHER

--- a/ingestion/tests/unit/topology/database/test_snowflake_semantic_view_columns.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_semantic_view_columns.py
@@ -1,0 +1,116 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view column builder — returns SQLAlchemy-shape dicts
+that the standard ``sql_column_handler`` pipeline understands."""
+
+from __future__ import annotations
+
+from sqlalchemy.types import NullType
+
+from metadata.ingestion.source.database.snowflake.semantic_view.columns import (
+    build_columns,
+)
+
+
+def _row(table: str, name: str, dtype: str, expr: str = "", comment: str = "", synonyms: str = "") -> tuple:
+    return (table, name, dtype, expr, comment, synonyms)
+
+
+def test_dim_fact_metric_rows_become_sqlalchemy_dicts():
+    cols = build_columns(
+        dimensions=[_row("orders", "region", "VARCHAR")],
+        facts=[_row("orders", "amount", "NUMBER(38,2)")],
+        metrics=[_row("orders", "total_sales", "NUMBER", expr="SUM(amount)")],
+    )
+    by_name = {c["name"]: c for c in cols}
+    assert set(by_name) == {"region", "amount", "total_sales"}
+    assert by_name["region"]["type"] is not None
+    assert by_name["amount"]["nullable"] is True
+    assert "[Dimension]" in by_name["region"]["comment"]
+    assert "[Metric]" in by_name["total_sales"]["comment"]
+    assert "Expression: SUM(amount)" in by_name["total_sales"]["comment"]
+    assert by_name["region"]["system_data_type"] == "VARCHAR"
+
+
+def test_unknown_snowflake_type_maps_to_null_type():
+    cols = build_columns(
+        dimensions=[_row("t", "weird", "EXOTIC_TYPE")],
+        facts=[],
+        metrics=[],
+    )
+    assert isinstance(cols[0]["type"], NullType)
+    assert cols[0]["system_data_type"] == "EXOTIC_TYPE"
+
+
+def test_same_name_across_kinds_collapses_and_enumerates_kinds():
+    cols = build_columns(
+        dimensions=[_row("t", "revenue", "NUMBER")],
+        facts=[_row("t", "revenue", "NUMBER")],
+        metrics=[_row("t", "revenue", "NUMBER")],
+    )
+    assert len(cols) == 1
+    assert "[Dimension, Fact, Metric]" in cols[0]["comment"]
+
+
+def test_logical_table_synonyms_and_comment_flow_to_description():
+    cols = build_columns(
+        dimensions=[_row("orders", "region", "VARCHAR", comment="US regions only", synonyms="area,zone")],
+        facts=[],
+        metrics=[],
+    )
+    comment = cols[0]["comment"]
+    assert "Logical table: orders" in comment
+    assert "Synonyms: area,zone" in comment
+    assert "US regions only" in comment
+
+
+def test_empty_rows_yield_no_columns():
+    assert build_columns(dimensions=[], facts=[], metrics=[]) == []
+
+
+def test_varchar_length_carried_on_sqlalchemy_type():
+    """dataLength defaults to 1 unless the type instance carries it — parse it."""
+    from sqlalchemy.sql.sqltypes import VARCHAR
+
+    cols = build_columns(
+        dimensions=[_row("orders", "region", "VARCHAR(16777216)")],
+        facts=[],
+        metrics=[],
+    )
+    sa_type = cols[0]["type"]
+    assert isinstance(sa_type, VARCHAR)
+    assert sa_type.length == 16777216
+
+
+def test_number_precision_scale_carried_on_sqlalchemy_type():
+    from sqlalchemy.sql.sqltypes import Numeric
+
+    cols = build_columns(
+        dimensions=[],
+        facts=[_row("orders", "amount", "NUMBER(18,2)")],
+        metrics=[],
+    )
+    sa_type = cols[0]["type"]
+    assert isinstance(sa_type, Numeric)
+    assert sa_type.precision == 18
+    assert sa_type.scale == 2
+
+
+def test_logical_table_qualifier_stripped_from_expression_in_description():
+    cols = build_columns(
+        dimensions=[_row("customers", "c_region", "VARCHAR", expr="customers.c_region")],
+        facts=[],
+        metrics=[_row("customers", "cnt", "NUMBER", expr="COUNT(customers.c_custkey)")],
+    )
+    by = {c["name"]: c for c in cols}
+    assert "Expression: c_region" in by["c_region"]["comment"]
+    assert "customers.c_region" not in by["c_region"]["comment"]
+    assert "Expression: COUNT(c_custkey)" in by["cnt"]["comment"]

--- a/ingestion/tests/unit/topology/database/test_snowflake_semantic_view_lineage.py
+++ b/ingestion/tests/unit/topology/database/test_snowflake_semantic_view_lineage.py
@@ -1,0 +1,147 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Snowflake semantic-view → base-table column-level lineage builder."""
+
+from __future__ import annotations
+
+from metadata.ingestion.ometa.utils import model_str
+from metadata.ingestion.source.database.snowflake.semantic_view.catalog import (
+    SemanticViewCatalog,
+)
+from metadata.ingestion.source.database.snowflake.semantic_view.lineage import (
+    build_view_lineage,
+    to_metric_lineage_request,
+    to_view_lineage_request,
+)
+
+
+def _row(logical_table: str, name: str, expression: str) -> tuple:
+    return (logical_table, name, "NUMBER", expression, "", None)
+
+
+def test_direct_column_lineage_from_dimension_expression():
+    catalog = SemanticViewCatalog(
+        dimensions=[_row("customers", "region", "customers.c_region")],
+        facts=[],
+        metrics=[],
+        base_tables={"customers": ("MY_CATALOG", "MY_SCHEMA", "CUSTOMERS")},
+    )
+    edges = build_view_lineage(
+        catalog=catalog,
+        base_table_fqns_by_logical={"customers": "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS"},
+    )
+    assert len(edges) == 1
+    assert edges[0].base_table_fqn == "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS"
+    assert len(edges[0].columns) == 1
+    col = edges[0].columns[0]
+    assert col.from_column == "c_region"
+    assert col.to_column == "region"
+
+
+def test_metric_that_wraps_a_fact_resolves_through_the_intra_view_chain():
+    catalog = SemanticViewCatalog(
+        dimensions=[],
+        facts=[_row("orders", "line_amount", "orders.o_totalprice")],
+        metrics=[_row("orders", "total_revenue", "SUM(orders.line_amount)")],
+        base_tables={"orders": ("MY_CATALOG", "MY_SCHEMA", "ORDERS")},
+    )
+    edges = build_view_lineage(
+        catalog=catalog,
+        base_table_fqns_by_logical={"orders": "snow.MY_CATALOG.MY_SCHEMA.ORDERS"},
+    )
+    revenue_pairs = [c for e in edges for c in e.columns if c.to_column == "total_revenue"]
+    assert any(c.from_column == "o_totalprice" for c in revenue_pairs)
+
+
+def test_no_lineage_when_base_tables_map_empty():
+    catalog = SemanticViewCatalog(
+        dimensions=[_row("customers", "region", "customers.c_region")],
+        facts=[],
+        metrics=[],
+        base_tables={},
+    )
+    edges = build_view_lineage(catalog=catalog, base_table_fqns_by_logical={})
+    assert edges == []
+
+
+def test_multiple_base_tables_produce_separate_edges():
+    catalog = SemanticViewCatalog(
+        dimensions=[
+            _row("customers", "region", "customers.c_region"),
+            _row("orders", "order_date", "orders.o_orderdate"),
+        ],
+        facts=[],
+        metrics=[],
+        base_tables={
+            "customers": ("MY_CATALOG", "MY_SCHEMA", "CUSTOMERS"),
+            "orders": ("MY_CATALOG", "MY_SCHEMA", "ORDERS"),
+        },
+    )
+    edges = build_view_lineage(
+        catalog=catalog,
+        base_table_fqns_by_logical={
+            "customers": "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS",
+            "orders": "snow.MY_CATALOG.MY_SCHEMA.ORDERS",
+        },
+    )
+    fqns = {e.base_table_fqn for e in edges}
+    assert fqns == {"snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS", "snow.MY_CATALOG.MY_SCHEMA.ORDERS"}
+
+
+def test_edges_store_bare_column_names_not_qualified_fqns():
+    """Buffered edges stay cheap because the table prefixes are not repeated
+    per column pair — the request builder joins them at emission."""
+    catalog = SemanticViewCatalog(
+        dimensions=[_row("customers", "region", "customers.c_region")],
+        facts=[],
+        metrics=[],
+        base_tables={"customers": ("MY_CATALOG", "MY_SCHEMA", "CUSTOMERS")},
+    )
+    edges = build_view_lineage(
+        catalog=catalog,
+        base_table_fqns_by_logical={"customers": "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS"},
+    )
+    col = edges[0].columns[0]
+    assert "." not in col.from_column
+    assert "." not in col.to_column
+
+
+def test_view_lineage_request_qualifies_columns_against_both_tables():
+    catalog = SemanticViewCatalog(
+        dimensions=[_row("customers", "region", "customers.c_region")],
+        facts=[],
+        metrics=[],
+        base_tables={"customers": ("MY_CATALOG", "MY_SCHEMA", "CUSTOMERS")},
+    )
+    edge = build_view_lineage(
+        catalog=catalog,
+        base_table_fqns_by_logical={"customers": "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS"},
+    )[0]
+    request = to_view_lineage_request("snow.MY_CATALOG.MY_SCHEMA.MY_VIEW", edge)
+    assert request.from_entity_fqn == "snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS"
+    assert request.from_entity_type == "table"
+    assert request.to_entity_fqn == "snow.MY_CATALOG.MY_SCHEMA.MY_VIEW"
+    assert request.to_entity_type == "table"
+    column_lineage = request.lineage_details.columnsLineage
+    assert len(column_lineage) == 1
+    assert [model_str(c) for c in column_lineage[0].fromColumns] == ["snow.MY_CATALOG.MY_SCHEMA.CUSTOMERS.c_region"]
+    assert model_str(column_lineage[0].toColumn) == "snow.MY_CATALOG.MY_SCHEMA.MY_VIEW.region"
+
+
+def test_metric_lineage_request_targets_the_flat_metric_namespace():
+    request = to_metric_lineage_request(
+        "snow.MY_CATALOG.MY_SCHEMA.MY_VIEW", "snow-MY_CATALOG-MY_SCHEMA-MY_VIEW-total_revenue"
+    )
+    assert request.from_entity_fqn == "snow.MY_CATALOG.MY_SCHEMA.MY_VIEW"
+    assert request.from_entity_type == "table"
+    assert request.to_entity_fqn == "snow-MY_CATALOG-MY_SCHEMA-MY_VIEW-total_revenue"
+    assert request.to_entity_type == "metric"
+    assert request.lineage_details.columnsLineage is None

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricMapper.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/metrics/MetricMapper.java
@@ -1,9 +1,13 @@
 package org.openmetadata.service.resources.metrics;
 
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.service.util.EntityUtil.getEntityReferences;
 
+import java.util.List;
 import org.openmetadata.schema.api.data.CreateMetric;
 import org.openmetadata.schema.entity.data.Metric;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.EntityReferenceInput;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.mapper.EntityMapper;
 
@@ -14,12 +18,47 @@ public class MetricMapper implements EntityMapper<Metric, CreateMetric> {
         .withMetricExpression(create.getMetricExpression())
         .withGranularity(create.getGranularity())
         .withRelatedMetrics(getEntityReferences(Entity.METRIC, create.getRelatedMetrics()))
-        .withAssets(create.getAssets())
+        .withAssets(toEntityReferences(create.getAssets()))
         .withMetricType(create.getMetricType())
         .withUnitOfMeasurement(create.getUnitOfMeasurement())
         .withCustomUnitOfMeasurement(create.getCustomUnitOfMeasurement())
         .withDimensions(create.getDimensions())
         .withMeasures(create.getMeasures())
         .withFilters(create.getFilters());
+  }
+
+  /**
+   * Converts inbound asset references, leaving them unresolved. MetricRepository#prepare runs
+   * them through EntityUtil#populateEntityReferences, which resolves fullyQualifiedName to id
+   * and drops references whose target does not exist.
+   *
+   * @param inputs inbound references, each keyed by id or fullyQualifiedName
+   * @return unresolved references, or null when there are none
+   */
+  private static List<EntityReference> toEntityReferences(List<EntityReferenceInput> inputs) {
+    List<EntityReference> result = null;
+    if (!nullOrEmpty(inputs)) {
+      result = inputs.stream().map(MetricMapper::toEntityReference).toList();
+    }
+    return result;
+  }
+
+  private static EntityReference toEntityReference(EntityReferenceInput input) {
+    if (input.getId() == null && input.getFullyQualifiedName() == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Asset reference of type '%s' must set either 'id' or 'fullyQualifiedName'",
+              input.getType()));
+    }
+    return new EntityReference()
+        .withId(input.getId())
+        .withType(input.getType())
+        .withFullyQualifiedName(input.getFullyQualifiedName())
+        .withName(input.getName())
+        .withDescription(input.getDescription())
+        .withDisplayName(input.getDisplayName())
+        .withDeleted(input.getDeleted())
+        .withInherited(input.getInherited())
+        .withHref(input.getHref());
   }
 }

--- a/openmetadata-spec/src/main/resources/json/schema/api/data/createMetric.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/data/createMetric.json
@@ -71,8 +71,8 @@
       }
     },
     "assets": {
-      "description": "Data assets (tables, dashboards, etc.) this metric is computed on or applies to.",
-      "$ref": "../../type/entityReferenceList.json",
+      "description": "Data assets (tables, dashboards, etc.) this metric is computed on or applies to. Each item is addressable by `id` OR `fullyQualifiedName`; the server resolves fqn refs to the underlying entity at write time.",
+      "$ref": "../../type/entityReferenceInputList.json",
       "default": null
     },
     "owners": {

--- a/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/data/table.json
@@ -37,7 +37,8 @@
         "Foreign",
         "Transient",
         "Stream",
-        "Stage"
+        "Stage",
+        "SemanticView"
       ],
       "javaEnums": [
         {
@@ -78,6 +79,9 @@
         },
         {
           "name": "Stage"
+        },
+        {
+          "name": "SemanticView"
         }
       ]
     },

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/snowflakeConnection.json
@@ -106,6 +106,12 @@
       "type": "boolean",
       "default": false
     },
+    "includeSemanticViews": {
+      "title": "Include Semantic Views",
+      "description": "Ingest Snowflake semantic views as tables plus their reusable metrics as Metric entities.",
+      "type": "boolean",
+      "default": false
+    },
     "clientSessionKeepAlive": {
       "title": "Client Session Keep Alive",
       "description": "Keep the session alive for long-running scans.",

--- a/openmetadata-spec/src/main/resources/json/schema/type/entityReferenceInput.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/entityReferenceInput.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://open-metadata.org/schema/type/entityReferenceInput.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Entity Reference Input",
+  "description": "Inbound-request shape of an entity reference. Callers address the target by `id` OR by `fullyQualifiedName` — the server resolves either to a fully-populated EntityReference before persisting. Same field set as EntityReference so existing clients that also send optional metadata (`name`, `displayName`, `description`, `deleted`, `inherited`, `href`) continue to validate.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.type.EntityReferenceInput",
+  "properties": {
+    "id": {
+      "description": "Unique identifier that identifies an entity instance. Optional when `fullyQualifiedName` is provided.",
+      "$ref": "basic.json#/definitions/uuid"
+    },
+    "type": {
+      "description": "Entity type/class name - Examples: `database`, `table`, `metrics`, `databaseService`, `dashboardService`...",
+      "type": "string"
+    },
+    "name": {
+      "description": "Name of the entity instance.",
+      "type": "string"
+    },
+    "fullyQualifiedName": {
+      "description": "Fully qualified name of the entity instance. When set without `id`, the server resolves it to the target entity.",
+      "type": "string"
+    },
+    "description": {
+      "description": "Optional description of entity.",
+      "$ref": "basic.json#/definitions/markdown"
+    },
+    "displayName": {
+      "description": "Display Name that identifies this entity.",
+      "type": "string"
+    },
+    "deleted": {
+      "description": "If true the entity referred to has been soft-deleted.",
+      "type": "boolean"
+    },
+    "inherited": {
+      "description": "If true the relationship indicated by this entity reference is inherited from the parent entity.",
+      "type": "boolean"
+    },
+    "href": {
+      "description": "Link to the entity resource.",
+      "$ref": "basic.json#/definitions/href"
+    }
+  },
+  "required": ["type"],
+  "additionalProperties": false
+}

--- a/openmetadata-spec/src/main/resources/json/schema/type/entityReferenceInputList.json
+++ b/openmetadata-spec/src/main/resources/json/schema/type/entityReferenceInputList.json
@@ -1,0 +1,11 @@
+{
+    "$id": "https://open-metadata.org/schema/type/entityReferenceInputList.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Entity Reference Input List",
+    "description": "List of EntityReferenceInput items. Used on inbound Create requests where each reference may be addressed by `id` OR `fullyQualifiedName`.",
+    "type": "array",
+    "items": {
+        "$ref": "entityReferenceInput.json"
+    },
+    "default": null
+}

--- a/scripts/datamodel_generation.py
+++ b/scripts/datamodel_generation.py
@@ -13,11 +13,13 @@ This script generates the Python models from the JSON Schemas definition. Additi
 pydantic class used for the password fields with the `CustomSecretStr` pydantic class which retrieves the secrets
 from a configured secrets' manager.
 """
+
 import glob
 import os
 import re
 
 from datamodel_code_generator.imports import Import
+
 # `model.pydantic` held the Pydantic v1 models and was removed in datamodel-code-generator 0.60+.
 # We generate with `--output-model-type pydantic_v2.BaseModel`, so patch the v2 type map.
 from datamodel_code_generator.model import pydantic_v2 as pydantic_model
@@ -40,7 +42,9 @@ UNICODE_REGEX_REPLACEMENT_FILE_PATHS = [
     f"{ingestion_path}src/metadata/generated/schema/type/basic.py",
 ]
 
-args = f"--input {directory_root}openmetadata-spec/src/main/resources/json/schema --output-model-type pydantic_v2.BaseModel --use-annotated --base-class metadata.ingestion.models.custom_pydantic.BaseModel --input-file-type jsonschema --output {ingestion_path}src/metadata/generated/schema --set-default-enum-member".split(" ")
+args = f"--input {directory_root}openmetadata-spec/src/main/resources/json/schema --output-model-type pydantic_v2.BaseModel --use-annotated --base-class metadata.ingestion.models.custom_pydantic.BaseModel --input-file-type jsonschema --output {ingestion_path}src/metadata/generated/schema --set-default-enum-member".split(
+    " "
+)
 
 main(args)
 
@@ -53,7 +57,9 @@ for file_path in UNICODE_REGEX_REPLACEMENT_FILE_PATHS:
         file_.write(content)
 
 # Add missing Union import
-MISSING_IMPORTS = [f"{ingestion_path}src/metadata/generated/schema/entity/applications/app.py",]
+MISSING_IMPORTS = [
+    f"{ingestion_path}src/metadata/generated/schema/entity/applications/app.py",
+]
 WRITE_AFTER = "from __future__ import annotations"
 
 for file_path in MISSING_IMPORTS:
@@ -81,7 +87,9 @@ for file_path in MISSING_IMPORTS:
 # construction time -- that would make it impossible to ever construct the
 # raw-named object that transform_entity_names is meant to encode, breaking
 # tests in tests/unit/models/test_custom_basemodel_validation.py.
-generated_files = glob.glob(f"{ingestion_path}src/metadata/generated/schema/**/*.py", recursive=True)
+generated_files = glob.glob(
+    f"{ingestion_path}src/metadata/generated/schema/**/*.py", recursive=True
+)
 
 patterns_to_remove = [
     "pattern='^((?!::).)*$',",
@@ -113,9 +121,12 @@ for file_path in DATETIME_AWARE_FILE_PATHS:
         content = f.read()
         content = content.replace(
             "from pydantic import AnyUrl, AwareDatetime, ConfigDict, EmailStr, Field, RootModel",
-            "from pydantic import AnyUrl, ConfigDict, EmailStr, Field, RootModel"
+            "from pydantic import AnyUrl, ConfigDict, EmailStr, Field, RootModel",
         )
-        content = content.replace("from datetime import date, time", "from datetime import date, time, datetime")
+        content = content.replace(
+            "from datetime import date, time",
+            "from datetime import date, time, datetime",
+        )
         content = content.replace("AwareDatetime", "datetime")
     with open(file_path, "w", encoding=UTF_8) as f:
         f.write(content)
@@ -136,13 +147,19 @@ for file_path in DATETIME_AWARE_FILE_PATHS:
 # This is a stopgap for the Python models only. The real fix is a discriminator on
 # `type` in openmetadata-spec/.../metadataIngestion/workflow.json, which would
 # resolve the union deterministically for the Java and TypeScript consumers too.
-UNION_MODE_FILE = f"{ingestion_path}src/metadata/generated/schema/metadataIngestion/workflow.py"
-SOURCE_CONFIG_BLOCK = re.compile(r"(class SourceConfig\(BaseModel\):.*?\n    \) )= None\n", re.DOTALL)
+UNION_MODE_FILE = (
+    f"{ingestion_path}src/metadata/generated/schema/metadataIngestion/workflow.py"
+)
+SOURCE_CONFIG_BLOCK = re.compile(
+    r"(class SourceConfig\(BaseModel\):.*?\n    [)\]] )= None\n", re.DOTALL
+)
 
 with open(UNION_MODE_FILE, "r", encoding=UTF_8) as f:
     content = f.read()
 
-content, applied = SOURCE_CONFIG_BLOCK.subn(r'\1= Field(None, union_mode="left_to_right")\n', content, count=1)
+content, applied = SOURCE_CONFIG_BLOCK.subn(
+    r'\1= Field(None, union_mode="left_to_right")\n', content, count=1
+)
 if applied != 1:
     # Fail loudly: silently skipping this leaves every `type`-less workflow config
     # resolving to the wrong pipeline model at runtime.


### PR DESCRIPTION
> **Draft.** Needs a linked issue (`Fixes #N`) and live validation before review — see *Status* below.

### Describe your changes

Metric ingestion was solved once per connector. dbt implemented extraction, naming, dependency ordering and emission inline in its source class; Snowflake had no metric support at all. The source-neutral half of that work is identical for every connector because it is dictated by the OM data model, not by the source — so this moves it into one place.

- **`domain/metrics/`** — a connector-agnostic `MetricIngestionFeature` (identity, dedup, conflict detection, dependency ordering, bounded buffering, emission) plus immutable records, mappers and name qualification. It imports no connector code and holds no API client.
- **Per-connector adapters** — pure functions from source rows to a normalized `MetricDefinition`. All I/O stays in the connector.
- **Snowflake** — semantic views ingested as `SemanticView` tables through the standard table lifecycle; each Snowflake metric becomes a `Metric`; base-table→view and view→metric lineage with column-level detail.
- **dbt** — rewired onto the same feature. Its inline extraction and its own dependency-ordering pass are removed.
- **Server** — a new `EntityReferenceInput` lets a `Create` request address an asset by `fullyQualifiedName` instead of `id`. `MetricMapper` converts references without resolving them; the existing `EntityUtil.populateEntityReferences` in `MetricRepository.prepare` resolves them and already skips missing targets.

### Type of change

- [x] New feature
- [x] Improvement
- [x] Breaking change

### High-level design

A `Create*` request is a **command** that *addresses* entities; the stored entity is an **aggregate** that holds *resolved* references. `EntityReferenceInput` makes that split explicit: same field set as `EntityReference`, but only `type` is required. The stored `Metric.assets` shape is unchanged.

Both connectors accept metrics into the feature during their normal stages and drain at `post_process`, then emit a `Barrier` so the sink flushes before lineage is written — lineage endpoints resolve names at write time, so the targets must exist first.

Query and call counts, versus the alternatives:

| Path | Before | After |
|---|---|---|
| Snowflake catalog, N views/schema | — | 5 per schema, cached; per-view fallback on errno 90030 |
| Metric writes, N metrics | N single POSTs | bulk PUT per batch |
| Asset id resolution | 1 GET per reference, client-side | 0 — resolved server-side, batched by type |

### Breaking change

**dbt metric names are now qualified** with service and package (`revenue` → `dbt_svc-analytics-revenue`). A `Metric`'s FQN *is* its name, so existing dbt Metric entities are orphaned rather than updated. This fixes a real collision — two dbt services sharing a metric name currently overwrite each other — but it needs a migration story before this merges.

### Status

Unit tests pass (297). **Nothing here has been exercised against a live instance**, specifically:

- `EntityReferenceInput` → `populateEntityReferences` — the whole fqn-addressing premise
- `PUT /v1/metrics/bulk` with fqn-only assets
- Both drain orderings; the `Barrier` is load-bearing for correctness
- Snowflake `INFORMATION_SCHEMA.SEMANTIC_*` column names, which come from documentation rather than an Enterprise account

### Checklist

- [ ] Linked issue — **TODO**
- [x] Schema changes regenerated (`make generate`, `mvn install -pl openmetadata-spec`)
- [x] Unit tests added for new logic
- [ ] Backend integration test for the `EntityReferenceInput` path — **TODO**
- [x] Not applicable — no UI changes