### PR TITLE
feat: allow admins to force delete ingestion pipelines (#31203)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -231,6 +231,23 @@ public class IngestionPipelineResourceIT
     return SdkClients.adminClient().ingestionPipelines().getVersionList(id);
   }
 
+  @Test
+  void delete_forceWithoutHardDelete_nonAdminReturnsForbidden(TestNamespace ns) {
+    IngestionPipeline pipeline = createEntity(createMinimalRequest(ns));
+    Map<String, String> params = Map.of("hardDelete", "false", "force", "true");
+
+    OpenMetadataException exception =
+        assertThrows(
+            OpenMetadataException.class,
+            () ->
+                SdkClients.testUserClient()
+                    .ingestionPipelines()
+                    .delete(pipeline.getId().toString(), params));
+
+    assertEquals(403, exception.getStatusCode());
+    assertNotNull(getEntity(pipeline.getId().toString()));
+  }
+
   @Override
   protected IngestionPipeline getVersion(UUID id, Double version) {
     return SdkClients.adminClient().ingestionPipelines().getVersion(id.toString(), version);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -70,6 +70,7 @@ import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.sdk.exception.IngestionRunnerUnavailableException;
 import org.openmetadata.sdk.exception.PipelineServiceClientException;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
@@ -516,20 +517,61 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
 
   @Override
   protected void postDelete(IngestionPipeline entity, boolean hardDelete) {
+    postDelete(entity, hardDelete, false);
+  }
+
+  private boolean postDelete(
+      IngestionPipeline entity, boolean hardDelete, boolean allowUnavailableRunner) {
     super.postDelete(entity, hardDelete);
-    // Delete deployed pipeline in the Pipeline Service Client
+    boolean wasRunnerCleanupSkipped = deleteDeployedPipeline(entity, allowUnavailableRunner);
+    deletePipelineStatuses(entity);
+    return wasRunnerCleanupSkipped;
+  }
+
+  boolean deleteDeployedPipeline(IngestionPipeline entity, boolean allowUnavailableRunner) {
+    boolean wasRunnerCleanupSkipped = false;
     if (pipelineServiceClient != null) {
-      pipelineServiceClient.deletePipeline(entity);
+      try {
+        pipelineServiceClient.deletePipeline(entity);
+      } catch (IngestionRunnerUnavailableException exception) {
+        if (allowUnavailableRunner) {
+          wasRunnerCleanupSkipped = true;
+        } else {
+          throw exception;
+        }
+      }
     } else {
       LOG.debug(
           "Skipping pipeline service delete for '{}' because pipeline service client is not configured.",
           entity.getFullyQualifiedName());
     }
-    // Clean pipeline status
+    return wasRunnerCleanupSkipped;
+  }
+
+  private void deletePipelineStatuses(IngestionPipeline entity) {
     daoCollection
         .entityExtensionTimeSeriesDao()
         .delete(entity.getFullyQualifiedName(), PIPELINE_STATUS_EXTENSION);
   }
+
+  @Transaction
+  public ForcedDeleteResult forceDelete(String deletedBy, UUID id) {
+    RestUtil.DeleteResponse<IngestionPipeline> response =
+        deleteInternal(deletedBy, id, false, true);
+    boolean wasRunnerCleanupSkipped = postDelete(response.entity(), true, true);
+    deleteFromSearch(response.entity(), true);
+    if (wasRunnerCleanupSkipped) {
+      LOG.warn(
+          "Force delete skipped ingestion runner cleanup [user={}, pipelineFqn={}, pipelineId={}]",
+          deletedBy,
+          response.entity().getFullyQualifiedName(),
+          id);
+    }
+    return new ForcedDeleteResult(response, wasRunnerCleanupSkipped);
+  }
+
+  public record ForcedDeleteResult(
+      RestUtil.DeleteResponse<IngestionPipeline> response, boolean wasRunnerCleanupSkipped) {}
 
   @Override
   protected EntityReference getParentReference(IngestionPipeline entity) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -36,6 +36,7 @@ import jakarta.json.JsonPatch;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -85,6 +86,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClientFactory;
 import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository.ForcedDeleteResult;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.limits.Limits;
 import org.openmetadata.service.logstorage.LogStorageFactory;
@@ -104,6 +106,7 @@ import org.openmetadata.service.security.policyevaluator.OperationContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.util.EntityUtil.Fields;
 import org.openmetadata.service.util.OpenMetadataConnectionBuilder;
+import org.openmetadata.service.util.RestUtil;
 
 // TODO merge with workflows
 @Slf4j
@@ -118,6 +121,8 @@ public class IngestionPipelineResource
     extends EntityResource<IngestionPipeline, IngestionPipelineRepository> {
   private IngestionPipelineMapper mapper;
   public static final String COLLECTION_PATH = "/v1/services/ingestionPipelines/";
+  static final String RUNNER_CLEANUP_HEADER = "X-OpenMetadata-Runner-Cleanup";
+  static final String RUNNER_CLEANUP_SKIPPED = "skipped-unavailable";
   private PipelineServiceClientInterface pipelineServiceClient;
   private OpenMetadataApplicationConfig openMetadataApplicationConfig;
   static final String FIELDS = "owners,followers";
@@ -883,6 +888,8 @@ public class IngestionPipelineResource
       description = "Delete an ingestion pipeline by `Id`.",
       responses = {
         @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Force requires hardDelete=true"),
+        @ApiResponse(responseCode = "403", description = "Force requires administrator access"),
         @ApiResponse(responseCode = "404", description = "Ingestion for instance {id} is not found")
       })
   public Response delete(
@@ -892,10 +899,57 @@ public class IngestionPipelineResource
           @QueryParam("hardDelete")
           @DefaultValue("false")
           boolean hardDelete,
+      @Parameter(
+              description =
+                  "Allow an administrator to hard-delete metadata when the ingestion runner is unavailable. "
+                      + "The external workflow might require manual cleanup. (Default = `false`)")
+          @QueryParam("force")
+          @DefaultValue("false")
+          boolean force,
       @Parameter(description = "Id of the ingestion pipeline", schema = @Schema(type = "UUID"))
           @PathParam("id")
           UUID id) {
-    return delete(uriInfo, securityContext, id, false, hardDelete);
+    Response response =
+        force
+            ? forceDelete(uriInfo, securityContext, id, hardDelete)
+            : delete(uriInfo, securityContext, id, false, hardDelete);
+    return response;
+  }
+
+  private Response forceDelete(
+      UriInfo uriInfo, SecurityContext securityContext, UUID id, boolean hardDelete) {
+    authorizeForceDelete(securityContext, id);
+    validateForceDelete(hardDelete);
+    String userName = securityContext.getUserPrincipal().getName();
+    ForcedDeleteResult result = repository.forceDelete(userName, id);
+    limits.invalidateCache(entityType);
+    addHref(uriInfo, result.response().entity());
+    return toForceDeleteResponse(result);
+  }
+
+  private void authorizeForceDelete(SecurityContext securityContext, UUID id) {
+    OperationContext operationContext = new OperationContext(entityType, MetadataOperation.DELETE);
+    authorizer.authorize(
+        securityContext,
+        operationContext,
+        getResourceContextById(id, ResourceContext.Operation.DELETE));
+    authorizer.authorizeAdmin(securityContext);
+  }
+
+  static void validateForceDelete(boolean hardDelete) {
+    if (!hardDelete) {
+      throw new BadRequestException(
+          "Force deleting an ingestion pipeline requires hardDelete=true");
+    }
+  }
+
+  private Response toForceDeleteResponse(ForcedDeleteResult result) {
+    RestUtil.DeleteResponse<IngestionPipeline> deleteResponse = result.response();
+    Response.ResponseBuilder responseBuilder = Response.fromResponse(deleteResponse.toResponse());
+    if (result.wasRunnerCleanupSkipped()) {
+      responseBuilder.header(RUNNER_CLEANUP_HEADER, RUNNER_CLEANUP_SKIPPED);
+    }
+    return responseBuilder.build();
   }
 
   @DELETE

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineRepositoryTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +17,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.metadataIngestion.DatabaseServiceMetadataPipeline;
@@ -23,6 +26,9 @@ import org.openmetadata.schema.metadataIngestion.SourceConfig;
 import org.openmetadata.schema.security.secrets.SecretsManagerConfiguration;
 import org.openmetadata.schema.security.secrets.SecretsManagerProvider;
 import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.sdk.exception.IngestionRunnerUnavailableException;
+import org.openmetadata.sdk.exception.PipelineServiceClientException;
 import org.openmetadata.service.secrets.SecretsManagerFactory;
 
 class IngestionPipelineRepositoryTest {
@@ -44,6 +50,76 @@ class IngestionPipelineRepositoryTest {
     SecretsManagerConfiguration smConfig = new SecretsManagerConfiguration();
     smConfig.setSecretsManager(SecretsManagerProvider.DB);
     SecretsManagerFactory.createSecretsManager(smConfig, "test");
+  }
+
+  @Test
+  void deleteDeployedPipelineReportsSkippedCleanupForUnavailableRunner() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    PipelineServiceClientInterface pipelineServiceClient =
+        mock(PipelineServiceClientInterface.class);
+    doThrow(new IngestionRunnerUnavailableException("runner unavailable"))
+        .when(pipelineServiceClient)
+        .deletePipeline(pipeline);
+    IngestionPipelineRepository cleanupRepository = repositoryWithClient(pipelineServiceClient);
+
+    boolean wasRunnerCleanupSkipped = cleanupRepository.deleteDeployedPipeline(pipeline, true);
+
+    assertTrue(wasRunnerCleanupSkipped);
+  }
+
+  @Test
+  void deleteDeployedPipelinePreservesUnavailableRunnerFailureByDefault() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    PipelineServiceClientInterface pipelineServiceClient =
+        mock(PipelineServiceClientInterface.class);
+    IngestionRunnerUnavailableException unavailable =
+        new IngestionRunnerUnavailableException("runner unavailable");
+    doThrow(unavailable).when(pipelineServiceClient).deletePipeline(pipeline);
+    IngestionPipelineRepository cleanupRepository = repositoryWithClient(pipelineServiceClient);
+
+    IngestionRunnerUnavailableException actual =
+        assertThrows(
+            IngestionRunnerUnavailableException.class,
+            () -> cleanupRepository.deleteDeployedPipeline(pipeline, false));
+
+    assertEquals(unavailable, actual);
+  }
+
+  @Test
+  void deleteDeployedPipelineDoesNotSuppressOtherPipelineFailures() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    PipelineServiceClientInterface pipelineServiceClient =
+        mock(PipelineServiceClientInterface.class);
+    PipelineServiceClientException deploymentFailure =
+        new PipelineServiceClientException("runner rejected deletion");
+    doThrow(deploymentFailure).when(pipelineServiceClient).deletePipeline(pipeline);
+    IngestionPipelineRepository cleanupRepository = repositoryWithClient(pipelineServiceClient);
+
+    PipelineServiceClientException actual =
+        assertThrows(
+            PipelineServiceClientException.class,
+            () -> cleanupRepository.deleteDeployedPipeline(pipeline, true));
+
+    assertEquals(deploymentFailure, actual);
+  }
+
+  @Test
+  void deleteDeployedPipelineReportsCompletedCleanup() {
+    IngestionPipeline pipeline = createBasicPipeline();
+    IngestionPipelineRepository cleanupRepository =
+        repositoryWithClient(mock(PipelineServiceClientInterface.class));
+
+    boolean wasRunnerCleanupSkipped = cleanupRepository.deleteDeployedPipeline(pipeline, true);
+
+    assertFalse(wasRunnerCleanupSkipped);
+  }
+
+  private IngestionPipelineRepository repositoryWithClient(
+      PipelineServiceClientInterface pipelineServiceClient) {
+    IngestionPipelineRepository cleanupRepository =
+        mock(IngestionPipelineRepository.class, Mockito.CALLS_REAL_METHODS);
+    cleanupRepository.setPipelineServiceClient(pipelineServiceClient);
+    return cleanupRepository;
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResourceDeleteTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResourceDeleteTest.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.resources.services.ingestionpipelines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.schema.type.EventType.ENTITY_DELETED;
+
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import java.security.Principal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository;
+import org.openmetadata.service.jdbi3.IngestionPipelineRepository.ForcedDeleteResult;
+import org.openmetadata.service.limits.Limits;
+import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.Authorizer;
+import org.openmetadata.service.util.RestUtil.DeleteResponse;
+
+class IngestionPipelineResourceDeleteTest {
+
+  @Test
+  void forceDeleteAuthorizesBeforeValidatingHardDelete() {
+    IngestionPipelineRepository repository = mock(IngestionPipelineRepository.class);
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = securityContext("operator");
+    UUID pipelineId = UUID.randomUUID();
+    doThrow(new AuthorizationException("administrator access required"))
+        .when(authorizer)
+        .authorizeAdmin(securityContext);
+
+    try (MockedStatic<Entity> entityMock = mockEntityRepository(repository)) {
+      IngestionPipelineResource resource =
+          new IngestionPipelineResource(authorizer, mock(Limits.class));
+
+      assertThrows(
+          AuthorizationException.class,
+          () -> resource.delete(null, securityContext, false, true, pipelineId));
+
+      verify(repository, never()).forceDelete(any(), any());
+    }
+  }
+
+  @Test
+  void forceDeleteRequiresHardDelete() {
+    IngestionPipelineRepository repository = mock(IngestionPipelineRepository.class);
+    SecurityContext securityContext = securityContext("admin");
+    Authorizer authorizer = mock(Authorizer.class);
+
+    try (MockedStatic<Entity> entityMock = mockEntityRepository(repository)) {
+      IngestionPipelineResource resource =
+          new IngestionPipelineResource(authorizer, mock(Limits.class));
+
+      assertThrows(
+          BadRequestException.class,
+          () -> resource.delete(null, securityContext, false, true, UUID.randomUUID()));
+
+      verify(repository, never()).forceDelete(any(), any());
+      verify(authorizer).authorizeAdmin(any(SecurityContext.class));
+    }
+  }
+
+  @Test
+  void forceDeleteReportsSkippedRunnerCleanup() {
+    UUID pipelineId = UUID.randomUUID();
+    IngestionPipeline pipeline = pipeline(pipelineId);
+    IngestionPipelineRepository repository = mock(IngestionPipelineRepository.class);
+    ForcedDeleteResult result =
+        new ForcedDeleteResult(new DeleteResponse<>(pipeline, ENTITY_DELETED), true);
+    when(repository.forceDelete("admin", pipelineId)).thenReturn(result);
+    Limits limits = mock(Limits.class);
+    Authorizer authorizer = mock(Authorizer.class);
+
+    try (MockedStatic<Entity> entityMock = mockEntityRepository(repository)) {
+      IngestionPipelineResource resource = new IngestionPipelineResource(authorizer, limits);
+
+      Response response = resource.delete(null, securityContext("admin"), true, true, pipelineId);
+
+      assertEquals(
+          IngestionPipelineResource.RUNNER_CLEANUP_SKIPPED,
+          response.getHeaderString(IngestionPipelineResource.RUNNER_CLEANUP_HEADER));
+      verify(limits).invalidateCache(Entity.INGESTION_PIPELINE);
+      verify(authorizer).authorizeAdmin(any(SecurityContext.class));
+    }
+  }
+
+  @Test
+  void forceDeleteOmitsCleanupHeaderWhenRunnerCleanupCompletes() {
+    UUID pipelineId = UUID.randomUUID();
+    IngestionPipeline pipeline = pipeline(pipelineId);
+    IngestionPipelineRepository repository = mock(IngestionPipelineRepository.class);
+    ForcedDeleteResult result =
+        new ForcedDeleteResult(new DeleteResponse<>(pipeline, ENTITY_DELETED), false);
+    when(repository.forceDelete("admin", pipelineId)).thenReturn(result);
+
+    try (MockedStatic<Entity> entityMock = mockEntityRepository(repository)) {
+      IngestionPipelineResource resource =
+          new IngestionPipelineResource(mock(Authorizer.class), mock(Limits.class));
+
+      Response response = resource.delete(null, securityContext("admin"), true, true, pipelineId);
+
+      assertNull(response.getHeaderString(IngestionPipelineResource.RUNNER_CLEANUP_HEADER));
+    }
+  }
+
+  @Test
+  void normalDeleteDoesNotRequireAdministratorAccess() {
+    UUID pipelineId = UUID.randomUUID();
+    IngestionPipeline pipeline = pipeline(pipelineId);
+    IngestionPipelineRepository repository = mock(IngestionPipelineRepository.class);
+    when(repository.delete("operator", pipelineId, false, false))
+        .thenReturn(new DeleteResponse<>(pipeline, ENTITY_DELETED));
+    Authorizer authorizer = mock(Authorizer.class);
+
+    try (MockedStatic<Entity> entityMock = mockEntityRepository(repository)) {
+      IngestionPipelineResource resource =
+          new IngestionPipelineResource(authorizer, mock(Limits.class));
+
+      resource.delete(null, securityContext("operator"), false, false, pipelineId);
+
+      verify(authorizer, never()).authorizeAdmin(any(SecurityContext.class));
+      verify(repository, never()).forceDelete(any(), any());
+    }
+  }
+
+  private MockedStatic<Entity> mockEntityRepository(IngestionPipelineRepository repository) {
+    MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+    entityMock
+        .when(() -> Entity.getEntityRepository(Entity.INGESTION_PIPELINE))
+        .thenReturn(repository);
+    return entityMock;
+  }
+
+  private IngestionPipeline pipeline(UUID pipelineId) {
+    return new IngestionPipeline()
+        .withId(pipelineId)
+        .withName("pipeline")
+        .withFullyQualifiedName("service.pipeline");
+  }
+
+  private SecurityContext securityContext(String userName) {
+    SecurityContext securityContext = mock(SecurityContext.class);
+    Principal principal = () -> userName;
+    when(securityContext.getUserPrincipal()).thenReturn(principal);
+    return securityContext;
+  }
+}

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/exception/IngestionRunnerUnavailableException.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/exception/IngestionRunnerUnavailableException.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.sdk.exception;
+
+/** Indicates that an ingestion runner cannot currently receive a pipeline operation. */
+public class IngestionRunnerUnavailableException extends PipelineServiceClientException {
+  public IngestionRunnerUnavailableException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
Cherry-pick of #31203 onto the `2.0` branch.

Clean cherry-pick (`git cherry-pick -x b1e16a1b6591647cceb2400205a3fc4bc7183844`), no conflicts.

## What it does
Adds a `force` query param to the ingestion-pipeline `DELETE` endpoint that lets an **administrator** hard-delete a pipeline's OpenMetadata metadata even when the ingestion runner is unavailable:
- `force=true` requires `hardDelete=true` (else `400`) and admin access (else `403`).
- When the runner is unreachable, the `IngestionRunnerUnavailableException` is swallowed and the response carries `X-OpenMetadata-Runner-Cleanup: skipped-unavailable` so the caller knows external cleanup is still pending.
- `postDelete` is refactored to separate the external runner call (`deleteDeployedPipeline`) from local status cleanup (`deletePipelineStatuses`).

## Verification
- Local build: `mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → **BUILD SUCCESS** (all 11 modules, including integration-tests test-compile).

Upstream PR: https://github.com/open-metadata/OpenMetadata/pull/31203