### PR TITLE
fix: add MCP appConfiguration cleanup to main's 1.13.4 migration folder

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
@@ -1,12 +1,3 @@
--- Remove page related-entity relationships that point at a column. 'tableColumn' is a
--- search-only pseudo-type with no repository, so resolving such a related-entity row throws
--- "Entity repository for tableColumn not found" and 404s the Context Center list.
--- page relatedEntities are stored as HAS (relation 10).
-DELETE FROM entity_relationship
-WHERE fromEntity = 'tableColumn'
-  AND toEntity = 'page'
-  AND relation = 10;
-
 -- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
 -- no code reads, and hide the now empty configure step.
 UPDATE installed_apps
@@ -21,3 +12,12 @@ UPDATE entity_extension
 SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
 WHERE extension LIKE 'app.version.%'
   AND json->>'$.name' = 'McpApplication';
+
+-- Remove page related-entity relationships that point at a column. 'tableColumn' is a
+-- search-only pseudo-type with no repository, so resolving such a related-entity row throws
+-- "Entity repository for tableColumn not found" and 404s the Context Center list.
+-- page relatedEntities are stored as HAS (relation 10).
+DELETE FROM entity_relationship
+WHERE fromEntity = 'tableColumn'
+  AND toEntity = 'page'
+  AND relation = 10;

--- a/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
@@ -6,3 +6,18 @@ DELETE FROM entity_relationship
 WHERE fromEntity = 'tableColumn'
   AND toEntity = 'page'
   AND relation = 10;
+
+-- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
+-- no code reads, and hide the now empty configure step.
+UPDATE installed_apps
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE name = 'McpApplication';
+
+UPDATE apps_marketplace
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE name = 'McpApplication';
+
+UPDATE entity_extension
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE extension LIKE 'app.version.%'
+  AND json->>'$.name' = 'McpApplication';

--- a/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
@@ -1,12 +1,3 @@
--- Remove page related-entity relationships that point at a column. 'tableColumn' is a
--- search-only pseudo-type with no repository, so resolving such a related-entity row throws
--- "Entity repository for tableColumn not found" and 404s the Context Center list.
--- page relatedEntities are stored as HAS (relation 10).
-DELETE FROM entity_relationship
-WHERE fromEntity = 'tableColumn'
-  AND toEntity = 'page'
-  AND relation = 10;
-
 -- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
 -- no code reads, and hide the now empty configure step.
 UPDATE installed_apps
@@ -21,3 +12,12 @@ UPDATE entity_extension
 SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
 WHERE extension LIKE 'app.version.%'
   AND json::jsonb ->> 'name' = 'McpApplication';
+
+-- Remove page related-entity relationships that point at a column. 'tableColumn' is a
+-- search-only pseudo-type with no repository, so resolving such a related-entity row throws
+-- "Entity repository for tableColumn not found" and 404s the Context Center list.
+-- page relatedEntities are stored as HAS (relation 10).
+DELETE FROM entity_relationship
+WHERE fromEntity = 'tableColumn'
+  AND toEntity = 'page'
+  AND relation = 10;

--- a/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
@@ -6,3 +6,18 @@ DELETE FROM entity_relationship
 WHERE fromEntity = 'tableColumn'
   AND toEntity = 'page'
   AND relation = 10;
+
+-- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
+-- no code reads, and hide the now empty configure step.
+UPDATE installed_apps
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE name = 'McpApplication';
+
+UPDATE apps_marketplace
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE name = 'McpApplication';
+
+UPDATE entity_extension
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE extension LIKE 'app.version.%'
+  AND json::jsonb ->> 'name' = 'McpApplication';


### PR DESCRIPTION
main's own 1.13.4 migration folder (separate from 1.13 branch's) was missing the MCP appConfiguration cleanup from #30620 — it only had the unrelated Context Center fix (#31033). Added the same UPDATE statements so a DB jumping straight from pre-1.13.4 to 2.0.0 via main gets the fix at the right step.