### PR TITLE
fix: add MCP appConfiguration cleanup to 2.0's 1.13.4 migration folder

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
@@ -1,3 +1,18 @@
+-- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
+-- no code reads, and hide the now empty configure step.
+UPDATE installed_apps
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE name = 'McpApplication';
+
+UPDATE apps_marketplace
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE name = 'McpApplication';
+
+UPDATE entity_extension
+SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
+WHERE extension LIKE 'app.version.%'
+  AND json->>'$.name' = 'McpApplication';
+
 -- Remove page related-entity relationships that point at a column. 'tableColumn' is a
 -- search-only pseudo-type with no repository, so resolving such a related-entity row throws
 -- "Entity repository for tableColumn not found" and 404s the Context Center list.

--- a/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
@@ -1,3 +1,18 @@
+-- MCP configuration lives solely in the mcpConfiguration setting. Drop the app-level copy, which
+-- no code reads, and hide the now empty configure step.
+UPDATE installed_apps
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE name = 'McpApplication';
+
+UPDATE apps_marketplace
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE name = 'McpApplication';
+
+UPDATE entity_extension
+SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
+WHERE extension LIKE 'app.version.%'
+  AND json::jsonb ->> 'name' = 'McpApplication';
+
 -- Remove page related-entity relationships that point at a column. 'tableColumn' is a
 -- search-only pseudo-type with no repository, so resolving such a related-entity row throws
 -- "Entity repository for tableColumn not found" and 404s the Context Center list.


### PR DESCRIPTION
Same issue as #31340 but on the 2.0 branch: its own 1.13.4 migration folder was missing the MCP appConfiguration cleanup from #30620, only had the Context Center fix (#31033). Added it on top to match chronological/1.13 ordering.