### PR TITLE
fix(security): backport io.kubernetes:client-java 25.0.1 (CVE-2026-15687) to 2.0

### DIFF
--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
-      <version>24.0.0</version>
+      <version>${kubernetes-client.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -29,7 +29,8 @@
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>
-    <kubernetes-client.version>24.0.0</kubernetes-client.version>
+    <!-- CVE-2026-15687: Directory Traversal in copyDirectoryFromPod, vulnerable [,25.0.1). -->
+    <kubernetes-client.version>25.0.1</kubernetes-client.version>
     <tika.version>3.2.3</tika.version>
   </properties>
 

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -29,8 +29,6 @@
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>
-    <!-- CVE-2026-15687: Directory Traversal in copyDirectoryFromPod, vulnerable [,25.0.1). -->
-    <kubernetes-client.version>25.0.1</kubernetes-client.version>
     <tika.version>3.2.3</tika.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
     <lombok.version>1.18.36</lombok.version>
     <tomcat-jdbc.version>11.0.11</tomcat-jdbc.version>
     <hikaricp.version>7.0.2</hikaricp.version>
+    <!-- CVE-2026-15687: Directory Traversal in copyDirectoryFromPod, vulnerable [,25.0.1).
+         Lives at the root because two modules consume it — openmetadata-service and
+         openmetadata-integration-tests. Keep it here so a bump cannot miss one of them. -->
+    <kubernetes-client.version>25.0.1</kubernetes-client.version>
     <elasticsearch.version>7.17.25</elasticsearch.version>
     <opensearch.version>2.6.0</opensearch.version>
     <httpasyncclient.version>4.1.5</httpasyncclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,17 @@
         <artifactId>okhttp</artifactId>
         <version>4.12.0</version>
       </dependency>
+      <!-- Held alongside okhttp above. client-java 25.x declares logging-interceptor 5.1.0,
+           which drags in okhttp-jvm 5.1.0 — okhttp 5 moved the okhttp3.* classes into that
+           artifact, so it would sit on the classpath duplicating the pinned okhttp 4.12.0 jar
+           (split package, resolved by classpath order). client-java 25.0.1 references the exact
+           same 118 okhttp/okio members as 24.0.0, so 4.12.0 satisfies it. Drop this pin only as
+           part of a real okhttp 5 migration. -->
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>4.12.0</version>
+      </dependency>
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>


### PR DESCRIPTION
Backport of #31342 to `2.0`. Cherry-picked clean — `2.0` carries the same `kubernetes-client.version` 24.0.0 and the same unpinned `logging-interceptor`.


Bumps `io.kubernetes:client-java` **24.0.0 → 25.0.1** to clear **CVE-2026-15687** (`SNYK-JAVA-IOKUBERNETES-18313175`), and pins `com.squareup.okhttp3:logging-interceptor` to 4.12.0 so the bump does not drag okhttp 5 onto the classpath.

Directory Traversal in `copyDirectoryFromPod` when `enableTarCompressing=false`. CVSS 4.8, vulnerable range `[,25.0.1)`. We never call `Copy`, so this is not exploitable here — but `openmetadata-dist` ships the jar, so the vulnerable version reaches OSS installs and turns up in downstream scans.

**Why our own Snyk report is green on this.** Our scan applies a `high` severity floor, and this finding is medium — so all 20 of our `pom.xml` manifests report `ok: true` while shipping the vulnerable version. It surfaced in the Collate scan, which includes medium.

## Why the logging-interceptor pin

`client-java` 25.x declares `logging-interceptor` 5.1.0, and okhttp 5 **relocated the `okhttp3.*` classes** out of `okhttp` into a new `okhttp-jvm` artifact. Root `dependencyManagement` already pins `okhttp` to 4.12.0, so without a matching pin, `okhttp-jvm:5.1.0` joins `okhttp:4.12.0` on the classpath and `okhttp3.*` ends up split across two jars, resolved by classpath order — a silent, order-dependent hazard in the shipped distribution.

okhttp 4.12.0 satisfies `client-java` 25.0.1: its bytecode references **the exact same 118 `okhttp3`/`okio` members as 24.0.0 does today** — zero added, zero removed. Upstream's move to okhttp 5 is a declared-dependency bump, not an API requirement. The pin should be dropped only as part of a real okhttp 5 migration.

## Verification

- **Resolved classpath is surgical.** Across the 596 artifacts `openmetadata-service` + `openmetadata-k8s-operator` resolve, the only three that move are `client-java`, `client-java-api` and `client-java-proto`. No `okhttp-jvm`; `okhttp` stays 4.12.0, `logging-interceptor` 4.12.0, `kotlin-stdlib` 1.8.21.
- **Only API removal in 25.0.1 is unused.** I diffed the public API of all **43 `io.kubernetes` types we import** — including `CoreV1Api`, `BatchV1Api`, `CustomObjectsApi`, `ApiextensionsV1Api`, `VersionApi`, `ClientBuilder`, `Config` and `Yaml` — between 24.0.0 and 25.0.1. The only removed public members anywhere in that surface are `V1ResourceRequirements.claims*` and the `V1ResourceClaim` type (k8s 1.34 DRA rework). Every `V1ResourceRequirements` call site here (`K8sPipelineClient`, `OMJob`, `K8sJobUtilsTest`) uses only `.requests()`/`.limits()`, and there are zero `V1ResourceClaim` references in the repo.
- `openmetadata-service` and `openmetadata-k8s-operator` build against 25.0.1.

## Related

Collate carries the same bump: open-metadata/openmetadata-collate#5663 (`main`) and #5664 (`2.0`). Collate's root `dependencyManagement` pins `client-java` for its own modules, so it was already covered — this PR fixes it at the source so OSS installs are too, and so the Collate pin stops being a silent override of a vulnerable upstream version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
