### PR TITLE
fix(profiler): emit valid Databricks SQL for unquoted identifiers

### DIFF
--- a/ingestion/src/metadata/ingestion/ometa/mixins/progress_mixin.py
+++ b/ingestion/src/metadata/ingestion/ometa/mixins/progress_mixin.py
@@ -25,6 +25,16 @@ from metadata.utils.logger import ometa_logger
 
 logger = ometa_logger()
 
+RESPONSE_BODY_LOG_LIMIT = 500
+
+
+def error_detail(exc: Exception) -> str:
+    """Truncated server response body for a failed request, empty when unavailable."""
+    body = getattr(getattr(exc, "response", None), "text", None)
+    if not body:
+        return ""
+    return f" - response: {body.strip()[:RESPONSE_BODY_LOG_LIMIT]}"
+
 
 class OMetaProgressMixin:
     """
@@ -53,7 +63,7 @@ class OMetaProgressMixin:
                 update.model_dump_json(exclude_none=True),
             )
         except Exception as exc:
-            logger.debug(f"Failed to send progress update: {exc}")
+            logger.debug("Failed to send progress update: %s%s", exc, error_detail(exc))
 
     def send_operation_metrics_batch(self, pipeline_fqn: str, run_id: str, batch: OperationMetricsBatch) -> None:
         """
@@ -71,7 +81,7 @@ class OMetaProgressMixin:
                 batch.model_dump_json(exclude_none=True),
             )
         except Exception as exc:
-            logger.debug(f"Failed to send operation metrics batch: {exc}")
+            logger.debug("Failed to send operation metrics batch: %s%s", exc, error_detail(exc))
 
     def get_progress_state(self, pipeline_fqn: str, run_id: str) -> Optional[ProgressUpdate]:  # noqa: UP045
         """
@@ -94,5 +104,5 @@ class OMetaProgressMixin:
                 return ProgressUpdate.model_validate(response)
             return None  # noqa: TRY300
         except Exception as exc:
-            logger.debug(f"Failed to get progress state: {exc}")
+            logger.debug("Failed to get progress state: %s%s", exc, error_detail(exc))
             return None

--- a/ingestion/src/metadata/profiler/interface/sqlalchemy/databricks/profiler_interface.py
+++ b/ingestion/src/metadata/profiler/interface/sqlalchemy/databricks/profiler_interface.py
@@ -70,6 +70,10 @@ class DatabricksProfilerInterface(SQAProfilerInterface):
         # the `result` here would be `db.schema.table` or `db.schema.table.column`
         # for struct it will be `db.schema.table.column.nestedchild.nestedchild` etc
         # the logic is to add the backticks to nested children.
+        if "`" not in result:
+            # Databricks only quotes identifiers that need it, so an all-lowercase
+            # schema.table.column arrives unquoted with no struct path to repair.
+            return result
         dot_count = result.count(".")
         if dot_count > 1 and "." in result.split("`.`")[-1]:
             splitted_result = result.split("`.")[-1].split(".")

--- a/ingestion/src/metadata/profiler/orm/functions/modulo.py
+++ b/ingestion/src/metadata/profiler/orm/functions/modulo.py
@@ -64,6 +64,7 @@ def _(element, compiler, **kw):
 @compiles(ModuloFn, Dialects.Cockroach)
 @compiles(ModuloFn, Dialects.Teradata)
 @compiles(ModuloFn, Dialects.Exasol)
+@compiles(ModuloFn, Dialects.Databricks)
 def _(element, compiler, **kw):
     """Modulo function for specific dialect"""
     value, base = validate_and_compile(element, compiler, **kw)

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/databricks/test_databricks_profiler_sql.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/databricks/test_databricks_profiler_sql.py
@@ -1,0 +1,76 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Validate the SQL the profiler emits against the real Databricks dialect.
+"""
+
+import pytest
+import sqlalchemy as sa
+from databricks.sqlalchemy import DatabricksDialect
+from sqlalchemy import quoted_name
+
+from metadata.profiler.interface.sqlalchemy.databricks.profiler_interface import (
+    DatabricksProfilerInterface,
+)
+from metadata.profiler.orm.functions.modulo import ModuloFn
+from metadata.profiler.orm.functions.random_num import RandomNumFn
+
+
+@pytest.fixture(scope="module")
+def dialect():
+    """Databricks dialect with the profiler compiler overrides installed."""
+    statement_compiler = DatabricksDialect.statement_compiler
+    original = (statement_compiler.visit_column, statement_compiler.visit_table)
+    DatabricksProfilerInterface._patch_databricks_statement_compiler()
+    yield DatabricksDialect()
+    statement_compiler.visit_column, statement_compiler.visit_table = original
+
+
+def compile_select(dialect, table, column_key):
+    return str(sa.select(table.c[column_key]).compile(dialect=dialect))
+
+
+def test_lowercase_identifiers_are_left_unquoted(dialect):
+    """Databricks does not quote all-lowercase identifiers, and neither should we."""
+    table = sa.Table("my_table", sa.MetaData(), sa.Column("my_col", sa.Boolean), schema="my_schema")
+
+    query = compile_select(dialect, table, "my_col")
+
+    assert "SELECT my_schema.my_table.my_col" in query
+    assert "`" not in query
+
+
+def test_quoted_identifiers_keep_their_backticks(dialect):
+    """Mixed-case identifiers are quoted by the dialect and must stay balanced."""
+    table = sa.Table("MyTable", sa.MetaData(), sa.Column("MyCol", sa.Boolean), schema="MySchema")
+
+    query = compile_select(dialect, table, "MyCol")
+
+    assert "SELECT `MySchema`.`MyTable`.`MyCol`" in query
+    assert query.count("`") % 2 == 0
+
+
+def test_struct_children_are_quoted_individually(dialect):
+    """Struct paths arrive pre-quoted with quoting disabled, mirroring _get_struct_columns."""
+    nested = quoted_name("`addr`.`city`", False)
+    table = sa.Table("MyTable", sa.MetaData(), sa.Column(nested, sa.String), schema="MySchema")
+
+    query = compile_select(dialect, table, nested)
+
+    assert "SELECT `MySchema`.`MyTable`.`addr`.`city`" in query
+
+
+def test_modulo_compiles_to_a_spark_function(dialect):
+    """The generic `%%` escape is only valid for pyformat drivers, not Databricks."""
+    compiled = str(ModuloFn(RandomNumFn(), 100).compile(dialect=dialect, compile_kwargs={"literal_binds": True}))
+
+    assert compiled == "MOD(ABS(RANDOM()) * 100, 100)"
+    assert "%%" not in compiled

--- a/ingestion/tests/unit/observability/profiler/sqlalchemy/databricks/test_visit_column.py
+++ b/ingestion/tests/unit/observability/profiler/sqlalchemy/databricks/test_visit_column.py
@@ -52,6 +52,10 @@ class TestDatabricksProfilerInterface(unittest.TestCase):
         mock_visit_column_super.return_value = "table"
         assert self.profiler.visit_column(MagicMock()) == "table"
 
+        # unquoted schema.table.column: nothing to repair, must pass through untouched
+        mock_visit_column_super.return_value = "my_schema.my_table.my_col"
+        assert self.profiler.visit_column(MagicMock()) == "my_schema.my_table.my_col"
+
     @patch("sqlalchemy.sql.compiler.SQLCompiler.visit_column")
     def test_visit_column_nesting(self, mock_visit_column_super):
         # Mock the response of the super class method

--- a/ingestion/tests/unit/ometa/test_progress_mixin_logging.py
+++ b/ingestion/tests/unit/ometa/test_progress_mixin_logging.py
@@ -1,0 +1,47 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Progress endpoint failures must surface the server's response body.
+"""
+
+from requests import HTTPError, Response
+
+from metadata.ingestion.ometa.mixins.progress_mixin import (
+    RESPONSE_BODY_LOG_LIMIT,
+    error_detail,
+)
+
+
+def http_error(body: str) -> HTTPError:
+    response = Response()
+    response.status_code = 400
+    response._content = body.encode()
+    return HTTPError("400 Client Error: Bad Request", response=response)
+
+
+def test_response_body_is_reported():
+    exc = http_error('{"code":400,"message":"Unable to process JSON"}')
+
+    assert error_detail(exc) == ' - response: {"code":400,"message":"Unable to process JSON"}'
+
+
+def test_long_response_body_is_truncated():
+    exc = http_error("x" * (RESPONSE_BODY_LOG_LIMIT * 2))
+
+    assert error_detail(exc) == f" - response: {'x' * RESPONSE_BODY_LOG_LIMIT}"
+
+
+def test_empty_response_body_adds_nothing():
+    assert error_detail(http_error("")) == ""
+
+
+def test_exception_without_a_response_adds_nothing():
+    assert error_detail(ValueError("boom")) == ""


### PR DESCRIPTION
### Describe your changes:

Profiling a Databricks or Unity Catalog asset fails with `[PARSE_SYNTAX_ERROR] ... SQLSTATE: 42601` on every column, because the generated SQL has unbalanced identifier quoting:

```sql
-- generated
SELECT my_schema`.`my_table`.`my_col FROM my_schema.my_table
-- expected
SELECT my_schema.my_table.my_col FROM my_schema.my_table
```

`DatabricksProfilerInterface.visit_column` is monkeypatched onto `DatabricksDialect.statement_compiler` to re-quote STRUCT children (`` `db`.`sc`.`tbl`.`col.child` `` → `` …`col`.`child` ``). It assumed the compiler always emits backtick-quoted identifiers, but `DatabricksIdentifierPreparer` declares `legal_characters = ^[A-Z0-9_]+$`, so SQLAlchemy quotes an identifier only when it is mixed-case, reserved, or contains illegal characters. An all-lowercase `schema.table.column` therefore arrives **unquoted**, still satisfies the `dot_count > 1` guard, and gets rejoined with `` `.` `` separators while the branch that would supply the leading backtick is skipped — so the outer backticks are lost. Every column-level metric becomes unparseable on any table whose schema, table and column names are all lowercase, which is the common case.

The fix returns early when the compiled reference carries no backticks: there is no struct path to repair, so there is nothing to rewrite.

A second defect sits behind the first on the same code path. `ModuloFn` has no Databricks compiler and falls through to the generic `f"{value} %% {base}"`. The `%%` is an escape for `format`/`pyformat` paramstyle drivers; `databricks-sql-connector` uses `named` paramstyle, so nothing unescapes it and Spark receives a literal `%%`. Registering `Dialects.Databricks` on the existing `MOD(...)` group fixes it — without this the backtick fix alone still leaves profiling broken.

Separately, the progress and operation-metrics mixins logged only `str(exc)`, which reduces a server rejection to `400 Client Error: Bad Request for url: ...` and discards the server's reason. They now report a truncated response body alongside it, so this class of failure is diagnosable from agent logs.

#### Blast radius

This needs no opt-in. It reproduces on the **stock profiler defaults** (`randomizedSample: false`, `profileSampleConfig: DYNAMIC` with `smartSampling`), because that configuration still routes through `get_sample_query` and emits the `_rnd` sample CTE that forces three-part column references.

#### Verified against a live Databricks workspace

A/B on OM `2.0.0-rc1` against a real Unity Catalog service — same pipeline, same data, only these files differing:

| | Profiler records | errors | run state |
|---|---|---|---|
| unpatched | 12 | **90** | failed |
| patched | 102 | **0** | success |

Unpatched, both defects in one line:

```
[PARSE_SYNTAX_ERROR] Syntax error at or near 'customers'. SQLSTATE: 42601 (line 3, pos 16)
(SELECT sales`.`customers`.`ssn AS ssn, ABS(RANDOM()) * 100 %% :`param_3` AS random
FROM sales.customers),
```

Patched: 6/6 tables and 30/30 columns carry profiles, with real values.

New `test_databricks_profiler_sql.py` compiles against the real `DatabricksDialect` instead of a mocked compiler. The pre-existing `test_visit_column.py` only ever fed pre-quoted strings to a mocked `visit_column`, which is why the real preparer's behaviour was never observed; it gains the unquoted case.

#### Backports

Needs cherry-picking to `1.13` and `2.0` after merge. Both branches carry these files unchanged from `main`, so the picks apply clean.

#
### Type of change:
- [x] Bug fix

#
### Manual test steps:
1. Configure a Databricks or Unity Catalog service whose schema, table and column names are all lowercase.
2. Run metadata ingestion, then a profiler pipeline on default settings.
3. Before: every column metric fails with `[PARSE_SYNTAX_ERROR] Syntax error at or near '<table>'. SQLSTATE: 42601`, and only table-level `rowCount` succeeds. After: column metrics compute normally.
