### PR TITLE
Fixes #31348: Keep NLQ disabled in OSS

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataMarketplace/MarketplaceSearchBar/MarketplaceSearchBar.test.tsx
@@ -179,20 +179,26 @@ describe('MarketplaceSearchBar', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('bootstraps isNLPEnabled from API when store is cold (direct marketplace navigation)', async () => {
+  it('keeps NLQ disabled in OSS when store is cold', async () => {
     useSearchStore.setState({
       isNLPEnabled: false,
       isNLPActive: false,
       isNLPInitialized: false,
     });
-    (getNLPEnabledStatus as jest.Mock).mockResolvedValue(true);
-
     renderComponent();
 
     await waitFor(() => {
-      expect(getNLPEnabledStatus).toHaveBeenCalledTimes(1);
-      expect(screen.getByTestId('marketplace-nlq-toggle')).toBeInTheDocument();
+      expect(useSearchStore.getState()).toMatchObject({
+        isNLPEnabled: false,
+        isNLPActive: false,
+        isNLPInitialized: true,
+      });
     });
+
+    expect(getNLPEnabledStatus).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId('marketplace-nlq-toggle')
+    ).not.toBeInTheDocument();
   });
 
   it('skips the API call when store is already initialized', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useSearchStore.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useSearchStore.test.ts
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act } from '@testing-library/react';
+import { getNLPEnabledStatus } from '../rest/searchAPI';
+import searchSettingsClassBase from '../utils/SearchSettingsClassBase';
+import { useSearchStore } from './useSearchStore';
+
+jest.mock('../rest/searchAPI', () => ({
+  getNLPEnabledStatus: jest.fn(),
+}));
+
+const mockGetNLPEnabledStatus = getNLPEnabledStatus as jest.MockedFunction<
+  typeof getNLPEnabledStatus
+>;
+const mockIsNLQSupported = jest.spyOn(
+  searchSettingsClassBase,
+  'isNLQSupported'
+);
+
+describe('useSearchStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsNLQSupported.mockReturnValue(false);
+    useSearchStore.setState({
+      isNLPActive: false,
+      isNLPEnabled: false,
+      isNLPInitialized: false,
+    });
+  });
+
+  it('keeps NLQ disabled in OSS without requesting the server setting', async () => {
+    mockGetNLPEnabledStatus.mockResolvedValue(true);
+    useSearchStore.getState().setNLPActive(true);
+
+    await act(async () => {
+      await useSearchStore.getState().initNLP();
+    });
+
+    expect(mockGetNLPEnabledStatus).not.toHaveBeenCalled();
+    expect(useSearchStore.getState()).toMatchObject({
+      isNLPActive: false,
+      isNLPEnabled: false,
+      isNLPInitialized: true,
+    });
+  });
+
+  it('uses the server setting when the Collate override supports NLQ', async () => {
+    mockIsNLQSupported.mockReturnValue(true);
+    mockGetNLPEnabledStatus.mockResolvedValue(true);
+
+    await act(async () => {
+      await useSearchStore.getState().initNLP();
+    });
+
+    expect(mockGetNLPEnabledStatus).toHaveBeenCalledTimes(1);
+    expect(useSearchStore.getState()).toMatchObject({
+      isNLPEnabled: true,
+      isNLPInitialized: true,
+    });
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useSearchStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useSearchStore.ts
@@ -12,6 +12,7 @@
  */
 import { create } from 'zustand';
 import { getNLPEnabledStatus } from '../rest/searchAPI';
+import searchSettingsClassBase from '../utils/SearchSettingsClassBase';
 
 interface SearchState {
   // NLP flags
@@ -38,6 +39,17 @@ export const useSearchStore = create<SearchState>((set, get) => ({
     if (get().isNLPInitialized) {
       return;
     }
+
+    if (!searchSettingsClassBase.isNLQSupported()) {
+      set({
+        isNLPActive: false,
+        isNLPEnabled: false,
+        isNLPInitialized: true,
+      });
+
+      return;
+    }
+
     const enabled = await getNLPEnabledStatus().catch(() => false);
     set({ isNLPEnabled: enabled, isNLPInitialized: true });
   },

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.test.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2025 Collate.
+ *  Copyright 2026 Collate.
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,18 +11,24 @@
  *  limitations under the License.
  */
 
-class SearchSettingsClassBase {
-  public isNLQSupported(): boolean {
-    return this.showHybridSearchWeights();
-  }
+import { SearchSettingsClassBase } from './SearchSettingsClassBase';
 
+class CollateSearchSettingsClass extends SearchSettingsClassBase {
   public showHybridSearchWeights(): boolean {
-    return false;
+    return true;
   }
 }
 
-const searchSettingsClassBase = new SearchSettingsClassBase();
+describe('SearchSettingsClassBase', () => {
+  it('does not support NLQ in OSS', () => {
+    const searchSettings = new SearchSettingsClassBase();
 
-export default searchSettingsClassBase;
+    expect(searchSettings.isNLQSupported()).toBe(false);
+  });
 
-export { SearchSettingsClassBase };
+  it('supports NLQ through the existing Collate hybrid-search override', () => {
+    const searchSettings = new CollateSearchSettingsClass();
+
+    expect(searchSettings.isNLQSupported()).toBe(true);
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.test.ts
@@ -13,8 +13,14 @@
 
 import { SearchSettingsClassBase } from './SearchSettingsClassBase';
 
-class CollateSearchSettingsClass extends SearchSettingsClassBase {
+class HybridSearchSettingsClass extends SearchSettingsClassBase {
   public showHybridSearchWeights(): boolean {
+    return true;
+  }
+}
+
+class CollateSearchSettingsClass extends SearchSettingsClassBase {
+  public isNLQSupported(): boolean {
     return true;
   }
 }
@@ -26,7 +32,13 @@ describe('SearchSettingsClassBase', () => {
     expect(searchSettings.isNLQSupported()).toBe(false);
   });
 
-  it('supports NLQ through the existing Collate hybrid-search override', () => {
+  it('does not infer NLQ support from hybrid-search weights', () => {
+    const searchSettings = new HybridSearchSettingsClass();
+
+    expect(searchSettings.isNLQSupported()).toBe(false);
+  });
+
+  it('supports NLQ through the dedicated Collate override', () => {
     const searchSettings = new CollateSearchSettingsClass();
 
     expect(searchSettings.isNLQSupported()).toBe(true);

--- a/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/SearchSettingsClassBase.ts
@@ -13,7 +13,7 @@
 
 class SearchSettingsClassBase {
   public isNLQSupported(): boolean {
-    return this.showHybridSearchWeights();
+    return false;
   }
 
   public showHybridSearchWeights(): boolean {


### PR DESCRIPTION
### Describe your changes:

Fixes #31348

NLQ is a Collate-only feature, but the shared UI previously trusted the server deployment flag directly. This change adds an independent deployment-capability guard: OSS always reports NLQ unsupported and skips the NLQ settings request, while Collate explicitly enables the capability through its private override.

Companion Collate change: https://github.com/open-metadata/openmetadata-collate/pull/5671

Issue:
<img width="1511" height="245" alt="Screenshot 2026-08-11 at 9 50 11 PM" src="https://github.com/user-attachments/assets/5acf0cec-cf80-4d3e-9928-ee708cecc03e" />

Fix:
<img width="1474" height="656" alt="Screenshot 2026-08-11 at 9 51 05 PM" src="https://github.com/user-attachments/assets/1c8a9e6f-04fd-4495-9fb6-efb6c855d708" />

#
### Type of change:

- [x] Bug fix

#
### High-level design:

`SearchSettingsClassBase.isNLQSupported()` returns `false` independently from hybrid-search settings. The Collate override returns `true` in the companion private PR, after which the server deployment flag controls runtime enablement.

#
### Tests:

#### Use cases covered

- OSS keeps NLQ inactive and disabled without requesting the server setting.
- Hybrid-search weights do not imply NLQ support.
- Collate-supported deployments continue to read and honor the server setting through a dedicated override.
- Direct Marketplace navigation keeps NLQ disabled in OSS without calling the NLQ settings API.

#### Unit tests

- [x] Added tests for the changed store and search-settings behavior.
- Files: `useSearchStore.test.ts`, `SearchSettingsClassBase.test.ts`, `MarketplaceSearchBar.test.tsx`
- Result: 23 tests passed across 3 focused suites with coverage enabled.

#### Backend integration tests

- [x] Not applicable; no backend changes.

#### Ingestion integration tests

- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests

- [x] Not applicable; behavior is covered at the store and deployment-extension boundary.

#### Manual testing performed

- Ran the focused OSS Jest suites for disabled, independent-capability, and Collate-supported paths.
- Ran the companion Collate override test locally.
- Ran UI ESLint, Prettier, and import organization on all OSS files.

#
### UI screen recording / screenshots:

Screenshots are included above.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #31348` above.
- [x] For UI changes: I attached screenshots above.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario being fixed.