### PR TITLE
fix(workflows): add WorkflowEventConsumer pollInterval 10->1 to the 1.13.4 migration

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
@@ -6,3 +6,13 @@ DELETE FROM entity_relationship
 WHERE fromEntity = 'tableColumn'
   AND toEntity = 'page'
   AND relation = 10;
+
+-- Reduce WorkflowEventConsumer poll interval from 10s to 1s so governance approval workflows
+-- are processed within seconds of the triggering entity change instead of lagging minutes
+-- behind under bulk-event load (e.g. bulk custom-property / entity operations that flood the
+-- change_event stream). The seed WorkflowEvents.json already ships pollInterval=1; this updates
+-- existing installs. Idempotent: only lowers values still above 1.
+UPDATE event_subscription_entity
+SET json = JSON_SET(json, '$.pollInterval', 1)
+WHERE name = 'WorkflowEventConsumer'
+  AND CAST(JSON_EXTRACT(json, '$.pollInterval') AS UNSIGNED) > 1;

--- a/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
@@ -6,3 +6,13 @@ DELETE FROM entity_relationship
 WHERE fromEntity = 'tableColumn'
   AND toEntity = 'page'
   AND relation = 10;
+
+-- Reduce WorkflowEventConsumer poll interval from 10s to 1s so governance approval workflows
+-- are processed within seconds of the triggering entity change instead of lagging minutes
+-- behind under bulk-event load (e.g. bulk custom-property / entity operations that flood the
+-- change_event stream). The seed WorkflowEvents.json already ships pollInterval=1; this updates
+-- existing installs. Idempotent: only lowers values still above 1.
+UPDATE event_subscription_entity
+SET json = jsonb_set(json, '{pollInterval}', '1'::jsonb)
+WHERE name = 'WorkflowEventConsumer'
+  AND (json->>'pollInterval')::int > 1;


### PR DESCRIPTION
## What

Adds the `WorkflowEventConsumer` `pollInterval` `10 → 1` update to the **1.13.4** native migration (MySQL + Postgres).

## Why

The governance event consumer reads the `change_event` stream on its subscription `pollInterval`. Installs seeded before the `pollInterval=1` change keep `pollInterval=10`, so under bulk-event load (bulk custom-property / entity operations that flood `change_event`) the consumer lags **minutes** behind and governance **approval tasks appear too late** (approval / glossary workflows time out).

- The seed `WorkflowEvents.json` already ships `pollInterval:1` (new installs are fine).
- `2.0.0` already carries the same `UPDATE` for the 2.0 upgrade path.
- This adds the idempotent `UPDATE` to **`1.13.4`** so installs upgrading to 1.13.4 — **ahead of 2.0** — also get it. We can't wait for 2.0.

## Change

`bootstrap/sql/migrations/native/1.13.4/{mysql,postgres}/postDataMigrationSQLScript.sql`:

```sql
UPDATE event_subscription_entity
SET json = JSON_SET(json, '$.pollInterval', 1)         -- jsonb_set(..., '{pollInterval}', '1') on postgres
WHERE name = 'WorkflowEventConsumer'
  AND CAST(JSON_EXTRACT(json, '$.pollInterval') AS UNSIGNED) > 1;
```

Idempotent (only lowers values still above 1), append-only, both DB engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
