### PR TITLE
fix(context-center): 1.13.4 migration to drop related-entity rows pointing at a column

### DIFF
--- a/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql
@@ -12,3 +12,12 @@ UPDATE entity_extension
 SET json = JSON_SET(JSON_REMOVE(json, '$.appConfiguration'), '$.allowConfiguration', CAST('false' AS JSON))
 WHERE extension LIKE 'app.version.%'
   AND json->>'$.name' = 'McpApplication';
+
+-- Remove page related-entity relationships that point at a column. 'tableColumn' is a
+-- search-only pseudo-type with no repository, so resolving such a related-entity row throws
+-- "Entity repository for tableColumn not found" and 404s the Context Center list.
+-- page relatedEntities are stored as HAS (relation 10).
+DELETE FROM entity_relationship
+WHERE fromEntity = 'tableColumn'
+  AND toEntity = 'page'
+  AND relation = 10;

--- a/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
+++ b/bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql
@@ -12,3 +12,12 @@ UPDATE entity_extension
 SET json = jsonb_set(json::jsonb - 'appConfiguration', '{allowConfiguration}', 'false'::jsonb)
 WHERE extension LIKE 'app.version.%'
   AND json::jsonb ->> 'name' = 'McpApplication';
+
+-- Remove page related-entity relationships that point at a column. 'tableColumn' is a
+-- search-only pseudo-type with no repository, so resolving such a related-entity row throws
+-- "Entity repository for tableColumn not found" and 404s the Context Center list.
+-- page relatedEntities are stored as HAS (relation 10).
+DELETE FROM entity_relationship
+WHERE fromEntity = 'tableColumn'
+  AND toEntity = 'page'
+  AND relation = 10;


### PR DESCRIPTION
**Backport of:** open-metadata/OpenMetadata#31033 (original fix, merged to `main`)
**Issue:** open-metadata/openmetadata-collate#5249

## What
Backport of the data-cleanup portion of #31033 to the `1.13` branch (target release **1.13.4**).

Context Center pages persist `relatedEntities` as `page --HAS--> <ref>`. When a ref is of type `tableColumn` — a search-only pseudo-type with **no entity repository** — the list resolver calls `getEntityReferencesByIds("tableColumn", ...)` → `getEntityRepository("tableColumn")` throws `EntityNotFoundException: Entity repository for tableColumn not found`, and the **entire Context Center list 404s**.

This migration deletes those stray rows so existing instances recover on upgrade. It is appended **below** the existing 1.13.4 migration (the `McpApplication` config cleanup) to keep migration ordering stable on the branch.

```sql
DELETE FROM entity_relationship
WHERE fromEntity = 'tableColumn'
  AND toEntity = 'page'
  AND relation = 10; -- HAS
```

## Why split from #31033
#31033 also carries the write-strip / read-guard / UI picker exclusion that *prevent* new such rows. Context Center is a **Collate feature at 1.13** (it moved into OSS only on `main`), so those code changes have no target on the OSS `1.13` branch — they land in a separate **Collate 1.13** PR. Only the migration belongs here, because it runs against the shared `entity_relationship` table on every 1.13.4 upgrade (including Collate deployments).

## Scope
- `bootstrap/sql/migrations/native/1.13.4/mysql/postDataMigrationSQLScript.sql`
- `bootstrap/sql/migrations/native/1.13.4/postgres/postDataMigrationSQLScript.sql`

Idempotent, additive-only. No schema change.

## Verification (end-to-end, real Collate 1.13.2 stack)

Pulled the actual `om-1.13.2-cl-1.13.2` release image, migrated a fresh DB to the 1.13.2 baseline (no 1.13.4 yet), then:

1. **Reproduced via the real API** — created a Context Center page and attached a `tableColumn` related entity. The app persisted the row as `fromEntity='tableColumn', toEntity='page', relation=10` (fromId=column, toId=page); the create response returned `404 Entity repository for tableColumn not found`.
2. **Ran the real migration workflow** — built a derived image (`FROM` the 1.13.2 image `+ COPY` this 1.13.4 folder) and ran `./bootstrap/openmetadata-ops.sh migrate`. `MigrationWorkflow` picked up version 1.13.4, ran the post-DDL script, and reported **Success**.

Result: the corrupted `tableColumn → page` row was **removed by the workflow**, `1.13.4` was recorded in `SERVER_CHANGE_LOG`, the statement was logged in `SERVER_MIGRATION_SQL_LOGS` (checksum `e697d37a9eea54b61774…`), and the page entity survived (GET 200). The direction (`fromEntity='tableColumn'`) matches the real persisted rows.

