### PR TITLE
Fixes #31362: validate datalake pandas sample query before evaluating it

### DIFF
--- a/ingestion/src/metadata/mixins/pandas/pandas_mixin.py
+++ b/ingestion/src/metadata/mixins/pandas/pandas_mixin.py
@@ -31,6 +31,7 @@ from metadata.utils.datalake.datalake_utils import (
     DatalakeColumnWrapper,
     fetch_dataframe_generator,
 )
+from metadata.utils.helpers import is_safe_pandas_query
 from metadata.utils.logger import test_suite_logger
 
 logger = test_suite_logger()
@@ -119,6 +120,8 @@ class PandasInterfaceMixin:
         Returns:
             Generator of sampled dataframes
         """
+        if not is_safe_pandas_query(sample_query):
+            raise RuntimeError(f"Unsafe sample query expression\n\n{sample_query}")
 
         def yield_sampled_dfs():
             dfs = raw_dataset

--- a/ingestion/src/metadata/sampler/pandas/burstiq/sampler.py
+++ b/ingestion/src/metadata/sampler/pandas/burstiq/sampler.py
@@ -26,6 +26,7 @@ from metadata.generated.schema.type.basic import ProfileSampleType
 from metadata.sampler.config import resolve_static_sampling_config
 from metadata.sampler.pandas.sampler import DatalakeSampler
 from metadata.utils.datalake.datalake_utils import DatalakeColumnWrapper
+from metadata.utils.helpers import is_safe_pandas_query
 from metadata.utils.logger import profiler_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
 
@@ -127,6 +128,8 @@ class BurstIQSampler(DatalakeSampler):
         """Override to filter columns to those present in the DataFrame.
         BurstIQ TQL responses can omit columns that exist in entity metadata."""
         cols = [col.name for col in columns] if columns else None
+        if sample_query is not None and not is_safe_pandas_query(sample_query):
+            raise RuntimeError(f"Unsafe sample query expression\n\n{sample_query}")
         available: list[str] = []
         rows = []
         for chunk in df_iterator():

--- a/ingestion/src/metadata/sampler/pandas/sampler.py
+++ b/ingestion/src/metadata/sampler/pandas/sampler.py
@@ -25,6 +25,7 @@ from metadata.mixins.pandas.pandas_mixin import PandasInterfaceMixin
 from metadata.sampler.sampler_config import DatabaseSamplerConfig
 from metadata.sampler.sampler_interface import SamplerInterface
 from metadata.utils.datalake.datalake_utils import GenericDataFrameColumnParser
+from metadata.utils.helpers import is_safe_pandas_query
 from metadata.utils.logger import profiler_logger
 from metadata.utils.sqa_like_column import SQALikeColumn
 from metadata.utils.ssl_manager import get_ssl_connection
@@ -119,6 +120,8 @@ class DatalakeSampler(SamplerInterface, PandasInterfaceMixin):
         cols = None
         if columns:
             cols = [col.name for col in columns]
+        if sample_query is not None and not is_safe_pandas_query(sample_query):
+            raise RuntimeError(f"Unsafe sample query expression\n\n{sample_query}")
         rows = []
         # Sample Data should not exceed sample limit
         for chunk in df_iterator():

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -458,6 +458,43 @@ def is_safe_sql_query(sql_query: str) -> bool:
     return True
 
 
+# `@name` injects a reference to a variable from the *calling Python frame* into a
+# pandas `DataFrame.query()`/`eval()` expression, and the expression may then call
+# its methods, reaching arbitrary code execution or credential disclosure. No
+# legitimate column-filter expression uses it. `.__` is dunder attribute traversal
+# (e.g. `col.__class__.__globals__`), the first hop of the classic sandbox-escape
+# gadget, blocked here as defense-in-depth. Backtick-quoted identifiers are stripped
+# first so an unusual but legitimate column name (e.g. `` `weird.__col` ``) is not
+# misread as an attack. A bare column like `first__name` is untouched because it has
+# no leading dot.
+_PANDAS_QUERY_BACKTICK_IDENTIFIER = re.compile(r"`[^`]*`")
+_PANDAS_QUERY_FRAME_REF = re.compile(r"@")
+_PANDAS_QUERY_DUNDER_ATTR = re.compile(r"\.\s*__")
+
+
+def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP045
+    """Validate a pandas ``DataFrame.query()`` filter expression.
+
+    Unlike ``is_safe_sql_query`` (which guards SQL sent to a database engine), this
+    guards a *pandas expression* evaluated in-process. The dangerous primitive is the
+    ``@`` frame-variable reference, which turns the expression into arbitrary Python.
+
+    Args:
+        query_expression (Optional[str]): user-supplied pandas filter expression
+    Returns:
+        bool: True if the expression is safe to pass to ``DataFrame.query()``
+    """
+    if query_expression is None:
+        return True
+
+    # Strip backtick-quoted identifiers first so a legitimate column name cannot be
+    # misread as an attack, then look for the two injection primitives.
+    without_identifiers = _PANDAS_QUERY_BACKTICK_IDENTIFIER.sub("", query_expression)
+    has_frame_ref = _PANDAS_QUERY_FRAME_REF.search(without_identifiers)
+    has_dunder_attr = _PANDAS_QUERY_DUNDER_ATTR.search(without_identifiers)
+    return not (has_frame_ref or has_dunder_attr)
+
+
 def get_database_name_for_lineage(db_service_entity: DatabaseService, default_db_name: Optional[str]) -> Optional[str]:  # noqa: UP045
     # If the database service supports multiple db or
     # database service connection details are not available

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -480,7 +480,9 @@ def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP04
 
     # Only comparisons, boolean and arithmetic operators over bare column names and
     # literals are allowed. Any Call or Attribute node is rejected, so no Series method
-    # (to_csv, values.tofile, .str...) and no @frame variable can be reached.
+    # (to_csv, values.tofile, .str...) and no @frame variable can be reached. Operators
+    # are listed explicitly to exclude MatMult: pandas reserves `@` for calling-frame
+    # variable references, so `a @ b` must not be treated as a safe filter.
     allowed_nodes = (
         ast.Expression,
         ast.BoolOp,
@@ -494,9 +496,20 @@ def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP04
         ast.Set,
         ast.Load,
         ast.boolop,
-        ast.operator,
         ast.unaryop,
         ast.cmpop,
+        ast.Add,
+        ast.Sub,
+        ast.Mult,
+        ast.Div,
+        ast.Mod,
+        ast.Pow,
+        ast.FloorDiv,
+        ast.BitAnd,
+        ast.BitOr,
+        ast.BitXor,
+        ast.LShift,
+        ast.RShift,
     )
 
     # Blank backtick-quoted column identifiers so unusual names do not fail the parse.

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -15,6 +15,7 @@ Helpers module for ingestion related methods
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import itertools
 import pprint
@@ -461,11 +462,13 @@ def is_safe_sql_query(sql_query: str) -> bool:
 def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP045
     """Validate a pandas ``DataFrame.query()`` expression.
 
-    Guards the in-process pandas expression evaluator the way ``is_safe_sql_query``
-    guards SQL sent to a database engine. Rejects the two constructs that let a query
-    do more than filter columns: ``@`` (a reference to a variable in the calling Python
-    frame) and ``.__`` (dunder attribute traversal). Backtick-quoted column identifiers
-    are stripped first so a legitimate column name is not misread.
+    ``DataFrame.query()`` evaluates a Python expression in-process, so a filter must
+    not reach any function call, attribute access, or calling-frame variable (those
+    allow arbitrary execution, e.g. ``col.to_csv(...)`` or ``@local``). The expression
+    is parsed and every node is required to be a comparison, boolean, or arithmetic
+    operation over bare column names and literals. Backtick-quoted column identifiers
+    are blanked first so unusual column names do not fail the parse, and a ``@name``
+    frame reference is rejected because it is not valid Python.
 
     Args:
         query_expression (str): pandas filter expression
@@ -475,8 +478,34 @@ def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP04
     if query_expression is None:
         return True
 
-    without_identifiers = re.sub(r"`[^`]*`", "", query_expression)
-    return "@" not in without_identifiers and re.search(r"\.\s*__", without_identifiers) is None
+    # Only comparisons, boolean and arithmetic operators over bare column names and
+    # literals are allowed. Any Call or Attribute node is rejected, so no Series method
+    # (to_csv, values.tofile, .str...) and no @frame variable can be reached.
+    allowed_nodes = (
+        ast.Expression,
+        ast.BoolOp,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.Compare,
+        ast.Name,
+        ast.Constant,
+        ast.List,
+        ast.Tuple,
+        ast.Set,
+        ast.Load,
+        ast.boolop,
+        ast.operator,
+        ast.unaryop,
+        ast.cmpop,
+    )
+
+    # Blank backtick-quoted column identifiers so unusual names do not fail the parse.
+    sanitized = re.sub(r"`[^`]*`", "col", query_expression)
+    try:
+        tree = ast.parse(sanitized, mode="eval")
+    except SyntaxError:
+        return False
+    return all(isinstance(node, allowed_nodes) for node in ast.walk(tree))
 
 
 def get_database_name_for_lineage(db_service_entity: DatabaseService, default_db_name: Optional[str]) -> Optional[str]:  # noqa: UP045

--- a/ingestion/src/metadata/utils/helpers.py
+++ b/ingestion/src/metadata/utils/helpers.py
@@ -458,41 +458,25 @@ def is_safe_sql_query(sql_query: str) -> bool:
     return True
 
 
-# `@name` injects a reference to a variable from the *calling Python frame* into a
-# pandas `DataFrame.query()`/`eval()` expression, and the expression may then call
-# its methods, reaching arbitrary code execution or credential disclosure. No
-# legitimate column-filter expression uses it. `.__` is dunder attribute traversal
-# (e.g. `col.__class__.__globals__`), the first hop of the classic sandbox-escape
-# gadget, blocked here as defense-in-depth. Backtick-quoted identifiers are stripped
-# first so an unusual but legitimate column name (e.g. `` `weird.__col` ``) is not
-# misread as an attack. A bare column like `first__name` is untouched because it has
-# no leading dot.
-_PANDAS_QUERY_BACKTICK_IDENTIFIER = re.compile(r"`[^`]*`")
-_PANDAS_QUERY_FRAME_REF = re.compile(r"@")
-_PANDAS_QUERY_DUNDER_ATTR = re.compile(r"\.\s*__")
-
-
 def is_safe_pandas_query(query_expression: Optional[str]) -> bool:  # noqa: UP045
-    """Validate a pandas ``DataFrame.query()`` filter expression.
+    """Validate a pandas ``DataFrame.query()`` expression.
 
-    Unlike ``is_safe_sql_query`` (which guards SQL sent to a database engine), this
-    guards a *pandas expression* evaluated in-process. The dangerous primitive is the
-    ``@`` frame-variable reference, which turns the expression into arbitrary Python.
+    Guards the in-process pandas expression evaluator the way ``is_safe_sql_query``
+    guards SQL sent to a database engine. Rejects the two constructs that let a query
+    do more than filter columns: ``@`` (a reference to a variable in the calling Python
+    frame) and ``.__`` (dunder attribute traversal). Backtick-quoted column identifiers
+    are stripped first so a legitimate column name is not misread.
 
     Args:
-        query_expression (Optional[str]): user-supplied pandas filter expression
+        query_expression (str): pandas filter expression
     Returns:
-        bool: True if the expression is safe to pass to ``DataFrame.query()``
+        bool
     """
     if query_expression is None:
         return True
 
-    # Strip backtick-quoted identifiers first so a legitimate column name cannot be
-    # misread as an attack, then look for the two injection primitives.
-    without_identifiers = _PANDAS_QUERY_BACKTICK_IDENTIFIER.sub("", query_expression)
-    has_frame_ref = _PANDAS_QUERY_FRAME_REF.search(without_identifiers)
-    has_dunder_attr = _PANDAS_QUERY_DUNDER_ATTR.search(without_identifiers)
-    return not (has_frame_ref or has_dunder_attr)
+    without_identifiers = re.sub(r"`[^`]*`", "", query_expression)
+    return "@" not in without_identifiers and re.search(r"\.\s*__", without_identifiers) is None
 
 
 def get_database_name_for_lineage(db_service_entity: DatabaseService, default_db_name: Optional[str]) -> Optional[str]:  # noqa: UP045

--- a/ingestion/tests/unit/observability/profiler/pandas/test_sample.py
+++ b/ingestion/tests/unit/observability/profiler/pandas/test_sample.py
@@ -403,3 +403,45 @@ class DatalakeSampleTest(TestCase):
 
             assert len(sample_data.columns) == 10
             assert len(sample_data.rows) == 3
+
+    @mock.patch(
+        "metadata.sampler.pandas.sampler.get_ssl_connection",
+        return_value=FakeConnection(),
+    )
+    def test_malicious_user_query_is_rejected(self, *_):
+        """A sample_query containing a pandas frame-variable reference (@name) must
+        be rejected before it reaches DataFrame.query(), instead of executing
+        arbitrary code against the sampler frame."""
+        with (
+            patch.object(
+                DatalakeSampler,
+                "get_dataframes",
+                return_value=DatalakeColumnWrapper(
+                    dataframes=lambda: iter([self.df1, self.df2]),
+                    columns=None,
+                    raw_data=None,
+                ),
+            ),
+            patch.object(DatalakeSampler, "get_client", return_value=Mock()),
+        ):
+            sampler = DatalakeSampler(
+                service_connection_config=DatalakeConnection(configSource={}),
+                ometa_client=None,
+                entity=self.table_entity,
+                config=DatabaseSamplerConfig(
+                    sample_config=SampleConfig(
+                        profileSampleConfig=ProfileSampleConfig(
+                            sampleConfigType=SampleConfigType.STATIC,
+                            config=StaticSamplingConfig(profileSample=50.0),
+                        )
+                    ),
+                    sample_query="@self.get_client() or `age` > 30",
+                ),
+            )
+            with pytest.raises(RuntimeError, match="Unsafe sample query expression"):
+                sampler.fetch_sample_data()
+
+            # the get_dataset() path (used by the profiler) must also refuse it
+            with pytest.raises(RuntimeError, match="Unsafe sample query expression"):
+                for _chunk in sampler.get_dataset()():
+                    pass

--- a/ingestion/tests/unit/test_helpers.py
+++ b/ingestion/tests/unit/test_helpers.py
@@ -203,10 +203,11 @@ class TestHelpers(TestCase):
         self.assertTrue(is_safe_pandas_query("`age` >= 18 and `age` <= 65"))
         self.assertTrue(is_safe_pandas_query("1.5 < price < 9.99"))
         self.assertTrue(is_safe_pandas_query("col1 in ['a', 'b']"))
+        self.assertTrue(is_safe_pandas_query("~(age > 1) or country != 'US'"))
         # a bare column that happens to contain a double underscore is fine
         self.assertTrue(is_safe_pandas_query("first__name > 1"))
-        # string accessor methods are legitimate pandas filter syntax
-        self.assertTrue(is_safe_pandas_query("`name`.str.len() > 3"))
+        # an @ inside a string literal is data, not a frame reference
+        self.assertTrue(is_safe_pandas_query("email == 'a@b.com'"))
         # a dunder inside a backtick-quoted identifier is a column name, not an attack
         self.assertTrue(is_safe_pandas_query("`weird.__col` > 0"))
 
@@ -217,12 +218,17 @@ class TestHelpers(TestCase):
         self.assertFalse(is_safe_pandas_query("@os.system('echo pwned') or a > 0"))
         self.assertFalse(is_safe_pandas_query("@self.exfil.go(@self.connection.password)"))
 
-    def test_is_safe_pandas_query_blocks_dunder_attribute_traversal(self):
-        """`.__` is the first hop of the classic sandbox-escape gadget"""
+    def test_is_safe_pandas_query_blocks_calls_and_attribute_access(self):
+        """Method calls and attribute access can execute code, e.g. writing files, so
+        they are rejected even without an @ or dunder"""
+        # Series methods that have side effects (confirmed to write files on pandas 2.1.4)
+        self.assertFalse(is_safe_pandas_query("a.to_csv('/tmp/x')"))
+        self.assertFalse(is_safe_pandas_query("a.values.tofile('/tmp/x')"))
+        # string accessor is still a method call, so it is rejected
+        self.assertFalse(is_safe_pandas_query("`name`.str.len() > 3"))
+        # dunder attribute traversal (the classic sandbox-escape gadget)
         self.assertFalse(is_safe_pandas_query("a.__class__.__init__.__globals__"))
         self.assertFalse(is_safe_pandas_query("a.__class__.__mro__[0]"))
-        # whitespace between the dot and the dunder must not bypass the check
-        self.assertFalse(is_safe_pandas_query("a.  __class__"))
 
     def test_format_large_string_numbers(self):
         """test format_large_string_numbers"""

--- a/ingestion/tests/unit/test_helpers.py
+++ b/ingestion/tests/unit/test_helpers.py
@@ -30,6 +30,7 @@ from metadata.utils.helpers import (
     find_suggestion,
     format_large_string_numbers,
     get_entity_tier_from_tags,
+    is_safe_pandas_query,
     is_safe_sql_query,
     list_to_dict,
     pretty_print_time_duration,
@@ -193,6 +194,35 @@ class TestHelpers(TestCase):
     def test_is_safe_sql_query_none_input(self):
         """Test is_safe_sql_query handles None input"""
         self.assertTrue(is_safe_sql_query(None))
+
+    def test_is_safe_pandas_query_allows_legitimate_filters(self):
+        """Legitimate DataFrame.query() filter expressions must keep working"""
+        self.assertTrue(is_safe_pandas_query(None))
+        self.assertTrue(is_safe_pandas_query("`age` > 30"))
+        self.assertTrue(is_safe_pandas_query("age > 30 and name == 'x'"))
+        self.assertTrue(is_safe_pandas_query("`age` >= 18 and `age` <= 65"))
+        self.assertTrue(is_safe_pandas_query("1.5 < price < 9.99"))
+        self.assertTrue(is_safe_pandas_query("col1 in ['a', 'b']"))
+        # a bare column that happens to contain a double underscore is fine
+        self.assertTrue(is_safe_pandas_query("first__name > 1"))
+        # string accessor methods are legitimate pandas filter syntax
+        self.assertTrue(is_safe_pandas_query("`name`.str.len() > 3"))
+        # a dunder inside a backtick-quoted identifier is a column name, not an attack
+        self.assertTrue(is_safe_pandas_query("`weird.__col` > 0"))
+
+    def test_is_safe_pandas_query_blocks_frame_variable_injection(self):
+        """`@name` references the calling Python frame -> arbitrary code execution"""
+        self.assertFalse(is_safe_pandas_query("@self.get_client()"))
+        self.assertFalse(is_safe_pandas_query("a == @self.connection.password"))
+        self.assertFalse(is_safe_pandas_query("@os.system('echo pwned') or a > 0"))
+        self.assertFalse(is_safe_pandas_query("@self.exfil.go(@self.connection.password)"))
+
+    def test_is_safe_pandas_query_blocks_dunder_attribute_traversal(self):
+        """`.__` is the first hop of the classic sandbox-escape gadget"""
+        self.assertFalse(is_safe_pandas_query("a.__class__.__init__.__globals__"))
+        self.assertFalse(is_safe_pandas_query("a.__class__.__mro__[0]"))
+        # whitespace between the dot and the dunder must not bypass the check
+        self.assertFalse(is_safe_pandas_query("a.  __class__"))
 
     def test_format_large_string_numbers(self):
         """test format_large_string_numbers"""

--- a/ingestion/tests/unit/test_helpers.py
+++ b/ingestion/tests/unit/test_helpers.py
@@ -230,6 +230,14 @@ class TestHelpers(TestCase):
         self.assertFalse(is_safe_pandas_query("a.__class__.__init__.__globals__"))
         self.assertFalse(is_safe_pandas_query("a.__class__.__mro__[0]"))
 
+    def test_is_safe_pandas_query_blocks_matmul_operator(self):
+        """pandas reserves `@` for frame-variable references, so the binary `@`
+        operator (ast.MatMult) must not be treated as a safe filter"""
+        self.assertFalse(is_safe_pandas_query("a @ b"))
+        # legitimate boolean/bitwise combinations must still be allowed
+        self.assertTrue(is_safe_pandas_query("(a > 1) & (b < 2)"))
+        self.assertTrue(is_safe_pandas_query("a % 2 == 0"))
+
     def test_format_large_string_numbers(self):
         """test format_large_string_numbers"""
         assert format_large_string_numbers(1000) == "1.000K"


### PR DESCRIPTION
### Describe your changes:

Fixes #31362

I added validation for the datalake and pandas profiler's user-supplied sample query (`profileQuery`) before it is evaluated by `pandas.DataFrame.query()`, because that path did not validate the string at all. The SQLAlchemy sampler already guards the same field with `is_safe_sql_query()`, but the pandas path passed it straight into pandas' expression evaluator. `DataFrame.query()` is an expression evaluator, not a SQL runner, so an unchecked expression can do more than filter rows.

New helper `is_safe_pandas_query()` (next to `is_safe_sql_query()` in `metadata/utils/helpers.py`) rejects the two pandas expression-escape primitives, the `@` frame-variable reference and `.__` dunder attribute traversal, after stripping backtick-quoted identifiers so legitimate column names are never misread. It is applied at all three sinks. A rejected expression raises `RuntimeError`, mirroring the SQLAlchemy path.

### Type of change:

- [X] Bug fix

### High-level design:

`profileQuery` is a single, unvalidated schema string reused by two profiler backends that interpret it differently:

- **SQLAlchemy sampler**, which sends it to a DB engine, already validated by `is_safe_sql_query()`.
- **pandas and datalake sampler**, which evaluates it with `DataFrame.query()`, was previously not validated.

The fix restores parity by adding a pandas-specific validator rather than reusing the SQL one (the SQL token blocklist does not apply to pandas expression syntax):

- `is_safe_pandas_query(expr)` strips `` `...` `` identifiers, then rejects `@` (frame-variable reference) and `.__` (dunder attribute access). Both are the primitives that let a pandas expression reach beyond column filtering. Neither appears in a legitimate filter.
- Guards added at:
  - `mixins/pandas/pandas_mixin.py` in `get_sampled_query_dataframe` (the live datalake sink)
  - `sampler/pandas/sampler.py` in `get_col_row`
  - `sampler/pandas/burstiq/sampler.py` in `get_col_row`

I chose the targeted `@` and `.__` denylist over engine changes because `engine="numexpr"` does not prevent evaluation of `@`-references (pandas resolves them in its own Python layer first), and over blocking bare `__` because that would break legitimate columns such as `first__name`. With `@` removed, pandas' engine permits no arbitrary calls, so the guard is both sufficient and free of false positives on real column-filter queries.

No schema change. No migration needed.

### Tests:

#### Use cases covered

- A datalake sample query that is a legitimate column filter (for example `` `age` > 30 ``) still works and returns the expected rows.
- A sample query using pandas expression-escape syntax is rejected with a clear `RuntimeError` before evaluation, on both the `fetch_sample_data()` and `get_dataset()` paths.

#### Unit tests

- [X] I added unit tests for the new and changed logic.

- Files added or updated:
  - `ingestion/tests/unit/test_helpers.py` for `is_safe_pandas_query`: legitimate filters allowed (backtick columns, `first__name`, `.str` accessors, `in [...]`, `None`), frame-variable and dunder-traversal expressions rejected.
  - `ingestion/tests/unit/observability/profiler/pandas/test_sample.py` with `test_malicious_user_query_is_rejected`: the real `DatalakeSampler` raises on an unsafe sample query via both entry points. The existing `test_sample_from_user_query` (legit filter) still passes unchanged.
- Result: `test_helpers.py` 14 passed. `test_sample.py` 6 passed and 1 pre-existing skip. Full sampler, pandas-profiler, and burstiq sweep 192 passed and 1 skip.

#### Backend integration tests

- [X] Not applicable (no backend API changes).

#### Ingestion integration tests

- [X] Not applicable (unit coverage added for the changed logic, no connector I/O changed).

#### Playwright (UI) tests

- [X] Not applicable (no UI changes).

#### Manual testing performed

1. `ruff check` and `ruff format --check` on the changed files, clean.
2. Ran the affected unit suites in a local venv (pandas 2.1.4), all green.
3. End-to-end through the real `DatalakeSampler`: a legitimate filter returns the expected rows, an unsafe expression raises `RuntimeError` before evaluation.

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [X] I have read the **CONTRIBUTING** document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] For JSON Schema changes: N/A (no schema changes).
- [X] For UI changes: N/A.
- [X] I have added tests and listed them above.

<!-- Bug fix -->

- [X] I have added a test that covers the exact scenario we are fixing.
