### PR TITLE
fix: correct stale truncation-notice assertion in status.py tests

### DIFF
--- a/ingestion/tests/unit/test_status.py
+++ b/ingestion/tests/unit/test_status.py
@@ -41,7 +41,7 @@ class TestStatus(TestCase):
         output = self.status.as_string()
         for item in items:
             self.assertIn(item, output)
-        self.assertNotIn("total items", output)
+        self.assertNotIn("_total_items", output)
 
     def test_as_string_large_list_is_truncated(self):
         """Lists exceeding MAX_STATUS_DISPLAY_ITEMS should be truncated."""
@@ -58,7 +58,7 @@ class TestStatus(TestCase):
         self.status.records = [f"record_{i}" for i in range(MAX_STATUS_DISPLAY_ITEMS)]
 
         output = self.status.as_string()
-        self.assertNotIn("total items", output)
+        self.assertNotIn("_total_items", output)
         self.assertIn("record_0", output)
         self.assertIn(f"record_{MAX_STATUS_DISPLAY_ITEMS - 1}", output)
 


### PR DESCRIPTION
## Summary
Follow-up to #31297. Two assertions in `test_status.py` were checking for `"total items"`, a phrase left over from an earlier draft of the truncation fix. The shipped code actually writes `_total_items` (underscore) as the truncation marker, so that old phrase never shows up in the output — meaning the checks passed no matter what, even if truncation-suppression was broken. Updated both to check for the phrase the code actually produces.

## Test plan
- [x] `pytest tests/unit/test_status.py -v` — 15/15 passed
- [x] `ruff check tests/unit/test_status.py` — clean