### PR TITLE
fix(search): inherit domains through multi-level ancestors on batch/reindex path (1.13 backport)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainAssetsColumnExclusionIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainAssetsColumnExclusionIT.java
@@ -265,4 +265,105 @@ public class DomainAssetsColumnExclusionIT {
     assertNotNull(table);
     return table;
   }
+
+  /**
+   * A domain assigned on a database <b>service</b> must be inherited all the way down to a nested
+   * table (service -> database -> schema -> table). Exercised through the batch inheritance path
+   * ({@code setInheritedFields(List, Fields)}) that list endpoints and the search reindex share, so
+   * it guards the regression where the domain reached only the database (one level below the
+   * service) while the single-entity read path still resolved it everywhere.
+   */
+  @Test
+  void serviceLevelDomainInheritedByNestedTable(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+    String shortId = ns.shortPrefix();
+
+    Domain domain = createDomain(client, "svc_inh_domain_" + shortId);
+
+    org.openmetadata.schema.services.connections.database.PostgresConnection conn =
+        DatabaseServices.postgresConnection().hostPort("localhost:5432").username("test").build();
+    DatabaseService service =
+        DatabaseServices.builder()
+            .name("svc_inh_svc_" + shortId)
+            .connection(conn)
+            .description("Test service for service-level domain inheritance")
+            .create();
+
+    CreateDatabase dbReq = new CreateDatabase();
+    dbReq.setName("svc_inh_db_" + shortId);
+    dbReq.setService(service.getFullyQualifiedName());
+    Database database = client.databases().create(dbReq);
+
+    CreateDatabaseSchema schemaReq = new CreateDatabaseSchema();
+    schemaReq.setName("svc_inh_schema_" + shortId);
+    schemaReq.setDatabase(database.getFullyQualifiedName());
+    DatabaseSchema schema = client.databaseSchemas().create(schemaReq);
+
+    CreateTable tableReq = new CreateTable();
+    tableReq.setName(ns.prefix("svc_inh_tbl"));
+    tableReq.setDatabaseSchema(schema.getFullyQualifiedName());
+    tableReq.setColumns(List.of(new Column().withName("c1").withDataType(ColumnDataType.BIGINT)));
+    Table table = client.tables().create(tableReq);
+    assertNotNull(table);
+
+    // Assign the domain on the SERVICE, then confirm the nested table inherits it via a bulk/list
+    // read (the same batch path the reindex uses to build search docs).
+    addServiceToDomain(domain, service.getId().toString());
+
+    Awaitility.await("nested table inherits the service-level domain via the batch/list path")
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(2, TimeUnit.SECONDS)
+        .untilAsserted(() -> assertTrue(listedTableHasDomain(schema, table, domain)));
+  }
+
+  private void addServiceToDomain(Domain domain, String serviceId) throws Exception {
+    String url =
+        String.format(
+            "%s/v1/domains/%s/assets/add",
+            SdkClients.getServerUrl(), domain.getFullyQualifiedName());
+    String body =
+        String.format("{\"assets\":[{\"id\":\"%s\",\"type\":\"databaseService\"}]}", serviceId);
+    java.net.http.HttpRequest request =
+        java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create(url))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json")
+            .PUT(java.net.http.HttpRequest.BodyPublishers.ofString(body))
+            .build();
+    java.net.http.HttpResponse<String> response =
+        java.net.http.HttpClient.newHttpClient()
+            .send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+    assertTrue(
+        response.statusCode() == 200,
+        "assets/add should return 200, got " + response.statusCode() + ": " + response.body());
+  }
+
+  private boolean listedTableHasDomain(DatabaseSchema schema, Table table, Domain domain)
+      throws Exception {
+    String url =
+        String.format(
+            "%s/v1/tables?databaseSchema=%s&fields=domains&limit=100",
+            SdkClients.getServerUrl(), schema.getFullyQualifiedName());
+    java.net.http.HttpRequest request =
+        java.net.http.HttpRequest.newBuilder()
+            .uri(java.net.URI.create(url))
+            .header("Authorization", "Bearer " + SdkClients.getAdminToken())
+            .header("Content-Type", "application/json")
+            .GET()
+            .build();
+    java.net.http.HttpResponse<String> response =
+        java.net.http.HttpClient.newHttpClient()
+            .send(request, java.net.http.HttpResponse.BodyHandlers.ofString());
+    JsonNode root = OBJECT_MAPPER.readTree(response.body());
+    for (JsonNode t : root.path("data")) {
+      if (table.getFullyQualifiedName().equals(t.path("fullyQualifiedName").asText())) {
+        for (JsonNode d : t.path("domains")) {
+          if (domain.getFullyQualifiedName().equals(d.path("fullyQualifiedName").asText())) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -877,7 +877,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   /**
    * Return the parent's EntityReference without loading the parent entity. Subclasses override this
-   * to enable batch parent loading in {@link #setInheritedFields(List, Fields)}.
+   * to enable batch parent loading in {@link #setInheritedFields(List, Fields)}. A type that can
+   * have several CONTAINS parents at once (e.g. a test case, under both a test suite and a test
+   * definition) must override this (or {@link #setInheritedFields(List, Fields)}) to name the one it
+   * inherits from -- otherwise the ancestor fallback resolves an arbitrary CONTAINS parent.
    */
   protected EntityReference getParentReference(T entity) {
     return null;
@@ -1003,7 +1006,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
 
   @SuppressWarnings("unchecked")
   public void setInheritedFieldsUntyped(List<?> entities, Fields fields) {
-    setInheritedFields((List<T>) entities, fields);
+    // Inheritance-ancestor path: these came from find() (getEntitiesForInheritance) with an
+    // un-hydrated getParentReference(), so resolve their parent from the CONTAINS relationship and
+    // pass it in -- that is how multi-level inheritance keeps walking up.
+    List<T> ancestors = (List<T>) entities;
+    setInheritedFields(ancestors, fields, batchFetchInheritanceParents(ancestors));
   }
 
   /** Apply inherited fields from a loaded parent to the entity. Override for custom inheritance logic. */
@@ -1156,38 +1163,51 @@ public abstract class EntityRepository<T extends EntityInterface> {
    * Repos with complex inheritance (e.g. GlossaryTerm, TestCase) can still override this method directly.
    */
   protected void setInheritedFields(List<T> entities, Fields fields) {
+    // Direct list reads: parent references are already hydrated, so there are no un-hydrated
+    // ancestors to resolve. Only the ancestor path (setInheritedFieldsUntyped) passes those in.
+    setInheritedFields(entities, fields, Map.of());
+  }
+
+  private void setInheritedFields(
+      List<T> entities, Fields fields, Map<UUID, EntityReference> unhydratedParentRefs) {
     if (entities.isEmpty()) return;
     String inheritableFields = getInheritableFields();
 
-    var parentRefMap = new HashMap<UUID, EntityReference>();
+    var parentRefsById = new HashMap<UUID, EntityReference>();
     for (var entity : entities) {
       if (!requiresParentForInheritance(entity, fields)) {
         continue;
       }
-      var ref = getParentReference(entity);
-      if (ref != null && ref.getId() != null) {
-        parentRefMap.putIfAbsent(ref.getId(), ref);
+      var parentRef = getParentReference(entity);
+      if (parentRef != null && parentRef.getId() != null) {
+        parentRefsById.putIfAbsent(parentRef.getId(), parentRef);
       }
     }
+    // Parents resolved from CONTAINS for ancestors whose reference wasn't hydrated by find() (empty
+    // on the direct list path) -- lets multi-level inheritance keep walking up.
+    unhydratedParentRefs.values().forEach(ref -> parentRefsById.putIfAbsent(ref.getId(), ref));
 
-    if (parentRefMap.isEmpty()) {
+    if (parentRefsById.isEmpty()) {
       for (var entity : entities) {
         setInheritedFields(entity, fields);
       }
       return;
     }
 
-    var refsByType =
-        parentRefMap.values().stream().collect(Collectors.groupingBy(EntityReference::getType));
+    var parentRefsByType =
+        parentRefsById.values().stream().collect(Collectors.groupingBy(EntityReference::getType));
 
-    var loadedParents = new HashMap<UUID, EntityInterface>();
+    // One bulk load per parent type, served from the thread-local inheritance-parent cache when
+    // present. Parents resolved for un-hydrated ancestors are merged into parentRefsById above, so
+    // they get loaded (and their own inherited fields resolved) here just like hydrated parents.
+    var parentsById = new HashMap<UUID, EntityInterface>();
     var missingRefsByType = new HashMap<String, List<EntityReference>>();
-    for (var entry : refsByType.entrySet()) {
+    for (var entry : parentRefsByType.entrySet()) {
       var missingRefs = new ArrayList<EntityReference>();
       for (var ref : entry.getValue()) {
         var cachedParent = getCachedInheritanceParent(ref, inheritableFields);
         if (cachedParent != null) {
-          loadedParents.put(ref.getId(), cachedParent);
+          parentsById.put(ref.getId(), cachedParent);
         } else {
           missingRefs.add(ref);
         }
@@ -1201,8 +1221,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
       List<? extends EntityInterface> parents =
           Entity.getEntitiesForInheritance(entry.getValue(), inheritableFields, ALL);
       for (var parent : parents) {
-        loadedParents.put(parent.getId(), parent);
-        var parentRef = parentRefMap.get(parent.getId());
+        parentsById.put(parent.getId(), parent);
+        var parentRef = parentRefsById.get(parent.getId());
         if (parentRef != null) {
           cacheInheritanceParent(parentRef, inheritableFields, parent);
         }
@@ -1213,11 +1233,16 @@ public abstract class EntityRepository<T extends EntityInterface> {
       if (!requiresParentForInheritance(entity, fields)) {
         continue;
       }
-      var ref = getParentReference(entity);
-      if (ref != null && loadedParents.get(ref.getId()) instanceof EntityInterface parent) {
+      var parentRef = getParentReference(entity);
+      if (parentRef == null || parentRef.getId() == null) {
+        parentRef = unhydratedParentRefs.get(entity.getId());
+      }
+      if (parentRef != null
+          && parentsById.get(parentRef.getId()) instanceof EntityInterface parent) {
         applyInheritance(entity, fields, parent);
       } else {
-        // Preserve behavior when a parent cannot be resolved via batch loading.
+        // Parent could not be resolved via batch loading (no container, or a concurrently-deleted
+        // parent): fall back to the lenient per-entity path.
         setInheritedFields(entity, fields);
       }
     }
@@ -6684,6 +6709,52 @@ public abstract class EntityRepository<T extends EntityInterface> {
     }
 
     return containerMap;
+  }
+
+  /**
+   * Resolve each entity's inheritance parent from its live CONTAINS relationship. Used for ancestors
+   * loaded via find() whose {@link #getParentReference} is not hydrated (e.g. a schema pulled in to
+   * inherit a database service's domain). Only the parent id and type are taken from the relation
+   * row -- {@link Entity#getEntitiesForInheritance} reloads the full parent -- so no extra reference
+   * lookup is issued. If an entity has several live CONTAINS parents (a corrupt/duplicate edge) the
+   * first is used and a warning logged, matching the single-entity read path
+   * {@link #resolveParentReferenceFromToRecords}.
+   */
+  protected final Map<UUID, EntityReference> batchFetchInheritanceParents(List<T> entities) {
+    Map<UUID, EntityReference> parentByEntityId = new HashMap<>();
+    if (nullOrEmpty(entities)) {
+      return parentByEntityId;
+    }
+    List<CollectionDAO.EntityRelationshipObject> relations =
+        daoCollection
+            .relationshipDAO()
+            .findFromBatch(
+                entityListToStrings(entities),
+                Relationship.CONTAINS.ordinal(),
+                Include.NON_DELETED);
+    Set<UUID> warnedMultipleParents = new HashSet<>();
+    for (var relation : relations) {
+      if (relation.getToId() == null
+          || nullOrEmpty(relation.getFromEntity())
+          || nullOrEmpty(relation.getFromId())) {
+        continue;
+      }
+      UUID entityId = UUID.fromString(relation.getToId());
+      EntityReference parentRef =
+          new EntityReference()
+              .withId(UUID.fromString(relation.getFromId()))
+              .withType(relation.getFromEntity());
+      // putIfAbsent keeps the first parent; warn once per entity if more than one live edge exists.
+      if (parentByEntityId.putIfAbsent(entityId, parentRef) != null
+          && warnedMultipleParents.add(entityId)) {
+        LOG.warn(
+            "{} {} has multiple live CONTAINS parents; inheriting from the first "
+                + "(possible duplicate/stale relationship rows)",
+            entityType,
+            entityId);
+      }
+    }
+    return parentByEntityId;
   }
 
   public final EntityReference getFromEntityRef(


### PR DESCRIPTION
## Summary

Backport of #31246 to the **1.13** branch.

A domain assigned to a **database service** shows as `inherited` on the nested assets' entity pages (database → schema → table), but after a search reindex only the **database** (one level below the service) gets the domain in the search index — the **schema** and **table** beneath it are left without it. The entity page and search become inconsistent, and reindex does not fix it. Same for any hierarchy deeper than one level (e.g. `apiService → apiCollection → apiEndpoint`).

## Root cause

- The single-entity **read path** `getForInheritance` resolves each parent from the `CONTAINS` relationship and recurses up the full chain, so it climbs every level.
- The **batch/reindex path** `getEntitiesForInheritance` → `setInheritedFields(List, Fields)` resolves an ancestor's own parent via `getParentReference()`, which reads a *hydrated* reference (e.g. `database.getService()`). Ancestors are loaded with `find()`, which does **not** hydrate that reference, so an intermediate ancestor can't resolve its own inherited domain and the chain drops after the first hop.

Introduced by the inheritance refactor in #25751 (first shipped in 1.13.0).

## Change (scoped to the inheritance-ancestor path)

- `setInheritedFieldsUntyped` — whose only caller is `getEntitiesForInheritance` (ancestors loaded via `find()` with un-hydrated references) — resolves each ancestor's parent from its live `CONTAINS` relationship via a new `batchFetchInheritanceParents`: **one batched query per level**, building lightweight `id`+`type` references straight from the relation row. The full parent is reloaded by `getEntitiesForInheritance`, so **no extra reference lookup** is issued.
- Those resolved parents are passed into `setInheritedFields` as **data** (a map), not a mode flag. The public `setInheritedFields(List, Fields)` — every direct list-read caller — passes an empty map, so top-level lists keep **exact prior behaviour** (no new inheritance for entities that don't inherit via a parent, matching the single-entity read).
- When an ancestor has several live `CONTAINS` parents, the first is used and a warning logged once — matching the read path (`resolveParentReferenceFromToRecords`).

### 1.13 conflict resolution

Unlike `main`, 1.13 still has the **thread-local inheritance-parent cache** (`getCachedInheritanceParent`/`cacheInheritanceParent`) from #25751. The resolution **keeps that cache** — the per-type bulk load still serves cached parents and populates the cache on miss — and simply feeds the un-hydrated ancestor parents (merged in above) through the same load, so they get resolved just like hydrated parents. No behaviour of the cache changes; the only addition is resolving the un-hydrated ancestor references.

## Build / verification

- `openmetadata-service` and `openmetadata-integration-tests` compile on 1.13 with these changes (verified locally with `-am`).
- The fix was reproduced and verified end-to-end on the equivalent code (see #31246 for the backend + search-index + UI evidence): after a full reindex, the nested table carries the service-level domain in `table_search_index`, versus an unfixed build where it stays empty.
- Adds a `service → database → schema → table` inheritance case to `DomainAssetsColumnExclusionIT`.
