### PR TITLE
Fixes #31367: prevent path traversal when downloading PowerBI .pbit files

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/file_client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/file_client.py
@@ -19,6 +19,7 @@ import traceback
 import zipfile
 from collections import defaultdict
 from functools import singledispatch
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple  # noqa: UP035
 
 from metadata.clients.aws_client import AWSClient
@@ -85,11 +86,11 @@ def _safe_local_path(extract_dir: str, blob: str) -> str:
     write outside the extract directory (path traversal / arbitrary file write), so
     the resolved path is validated against the resolved extract directory.
     """
-    base = os.path.realpath(extract_dir)
-    target = os.path.realpath(os.path.join(base, blob))  # noqa: PTH118
-    if target != base and not target.startswith(base + os.sep):
+    base = Path(extract_dir).resolve()
+    target = (base / blob).resolve()
+    if not target.is_relative_to(base):
         raise PowerBIFileConfigException(f"Skipping .pbit object key that escapes the extract directory: {blob}")
-    return target
+    return str(target)
 
 
 def download_pbit_files(
@@ -106,16 +107,19 @@ def download_pbit_files(
         kwargs = {}
         if bucket_name:
             kwargs = {"bucket_name": bucket_name}
-        try:
-            for blob in blobs:
-                if blob:
-                    local_file_path = _safe_local_path(extract_dir, blob)
-                    reader = get_reader(config_source=config, client=client)
-                    # create the required dir before downloading
-                    os.makedirs(os.path.dirname(local_file_path), exist_ok=True)  # noqa: PTH103, PTH120
-                    reader.download(path=blob, local_file_path=local_file_path, **kwargs)
-        except PowerBIFileConfigException as exc:
-            logger.warning(exc)
+        for blob in blobs:
+            if not blob:
+                continue
+            try:
+                # validate per blob so one escaping key does not skip the rest
+                local_file_path = _safe_local_path(extract_dir, blob)
+            except PowerBIFileConfigException as exc:
+                logger.warning(exc)
+                continue
+            reader = get_reader(config_source=config, client=client)
+            # create the required dir before downloading
+            os.makedirs(os.path.dirname(local_file_path), exist_ok=True)  # noqa: PTH103, PTH120
+            reader.download(path=blob, local_file_path=local_file_path, **kwargs)
 
 
 def _get_datamodel_schema_list(path: str) -> Optional[List[DataModelSchema]]:  # noqa: UP006, UP045

--- a/ingestion/src/metadata/ingestion/source/dashboard/powerbi/file_client.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/powerbi/file_client.py
@@ -76,6 +76,22 @@ def get_blobs_grouped_by_dir(blobs: List[str]) -> Dict[str, List[str]]:  # noqa:
     return blob_grouped_by_directory
 
 
+def _safe_local_path(extract_dir: str, blob: str) -> str:
+    """Resolve the local download path for a blob and confirm it stays inside
+    ``extract_dir``.
+
+    Blob names come from the cloud storage listing and may contain ``..`` or
+    absolute-path components. Joining them naively would let a crafted object key
+    write outside the extract directory (path traversal / arbitrary file write), so
+    the resolved path is validated against the resolved extract directory.
+    """
+    base = os.path.realpath(extract_dir)
+    target = os.path.realpath(os.path.join(base, blob))  # noqa: PTH118
+    if target != base and not target.startswith(base + os.sep):
+        raise PowerBIFileConfigException(f"Skipping .pbit object key that escapes the extract directory: {blob}")
+    return target
+
+
 def download_pbit_files(
     blob_grouped_by_directory: Dict,  # noqa: UP006
     config,
@@ -86,20 +102,18 @@ def download_pbit_files(
     """
     Method to download the files from sources
     """
-    for (
-        key,
-        blobs,
-    ) in blob_grouped_by_directory.items():
+    for blobs in blob_grouped_by_directory.values():
         kwargs = {}
         if bucket_name:
             kwargs = {"bucket_name": bucket_name}
         try:
             for blob in blobs:
                 if blob:
+                    local_file_path = _safe_local_path(extract_dir, blob)
                     reader = get_reader(config_source=config, client=client)
                     # create the required dir before downloading
-                    os.makedirs(f"{extract_dir}/{key}", exist_ok=True)  # noqa: PTH103
-                    reader.download(path=blob, local_file_path=f"{extract_dir}/{blob}", **kwargs)
+                    os.makedirs(os.path.dirname(local_file_path), exist_ok=True)  # noqa: PTH103, PTH120
+                    reader.download(path=blob, local_file_path=local_file_path, **kwargs)
         except PowerBIFileConfigException as exc:
             logger.warning(exc)
 

--- a/ingestion/tests/unit/source/dashboard/powerbi/test_file_client_path_traversal.py
+++ b/ingestion/tests/unit/source/dashboard/powerbi/test_file_client_path_traversal.py
@@ -110,3 +110,28 @@ class TestDownloadPbitFiles:
         written = extract_dir / "reports" / "sales" / "q1.pbit"
         assert written.exists(), "a legitimate .pbit key should download inside the extract directory"
         assert written.read_bytes() == b"attacker-controlled bytes"
+
+    @patch(
+        "metadata.ingestion.source.dashboard.powerbi.file_client.get_reader",
+        return_value=_FakeReader(),
+    )
+    def test_escaping_key_does_not_skip_other_keys_in_same_group(self, _get_reader, tmp_path):
+        """A traversal key must be skipped individually, without aborting the
+        legitimate keys grouped with it."""
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+
+        # both blobs share the "sub" directory group; one escapes, one is legit
+        grouped = {"sub": ["sub/../../outside/bad.pbit", "sub/good.pbit"]}
+        download_pbit_files(
+            blob_grouped_by_directory=grouped,
+            config=MagicMock(),
+            client=MagicMock(),
+            bucket_name="bucket",
+            extract_dir=str(extract_dir),
+        )
+
+        assert not (outside / "bad.pbit").exists(), "the escaping key must be skipped"
+        assert (extract_dir / "sub" / "good.pbit").exists(), "the legitimate key in the same group must still download"

--- a/ingestion/tests/unit/source/dashboard/powerbi/test_file_client_path_traversal.py
+++ b/ingestion/tests/unit/source/dashboard/powerbi/test_file_client_path_traversal.py
@@ -1,0 +1,112 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""
+Tests that the PowerBI .pbit download path cannot escape the extract directory.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from metadata.ingestion.source.dashboard.powerbi.file_client import (
+    PowerBIFileConfigException,
+    _safe_local_path,
+    download_pbit_files,
+    get_blobs_grouped_by_dir,
+)
+
+MALICIOUS_KEYS = [
+    "reports/../../outside/pwned.pbit",
+    "../../../../etc/cron.d/pwn.pbit",
+    "/etc/cron.d/abs.pbit",
+    "a/b/../../../../../../tmp/x.pbit",
+]
+
+LEGIT_KEYS = [
+    "report.pbit",
+    "reports/sales/q1.pbit",
+    "reports/2026/august/dashboard.pbit",
+]
+
+
+class TestSafeLocalPath:
+    def test_rejects_paths_escaping_extract_dir(self, tmp_path):
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+        for blob in MALICIOUS_KEYS:
+            with pytest.raises(PowerBIFileConfigException, match="escapes the extract directory"):
+                _safe_local_path(str(extract_dir), blob)
+
+    def test_allows_legitimate_keys_and_stays_inside(self, tmp_path):
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+        base = os.path.realpath(str(extract_dir))
+        for blob in LEGIT_KEYS:
+            resolved = _safe_local_path(str(extract_dir), blob)
+            assert resolved.startswith(base + os.sep)
+
+
+class _FakeReader:
+    """Mimics the ADLS reader sink: open(local_file_path, "wb").write(...)."""
+
+    def download(self, path, local_file_path, **__):
+        with Path(local_file_path).open("wb") as fh:
+            fh.write(b"attacker-controlled bytes")
+
+
+class TestDownloadPbitFiles:
+    @patch(
+        "metadata.ingestion.source.dashboard.powerbi.file_client.get_reader",
+        return_value=_FakeReader(),
+    )
+    def test_malicious_key_does_not_write_outside_extract_dir(self, _get_reader, tmp_path):
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        marker = outside / "pwned.pbit"
+
+        malicious_blob = "reports/../../outside/pwned.pbit"
+        grouped = get_blobs_grouped_by_dir([malicious_blob])
+        assert grouped, "the malicious key should still pass the .pbit filter"
+
+        download_pbit_files(
+            blob_grouped_by_directory=grouped,
+            config=MagicMock(),
+            client=MagicMock(),
+            bucket_name="bucket",
+            extract_dir=str(extract_dir),
+        )
+
+        assert not marker.exists(), "path traversal wrote outside the extract directory"
+
+    @patch(
+        "metadata.ingestion.source.dashboard.powerbi.file_client.get_reader",
+        return_value=_FakeReader(),
+    )
+    def test_legitimate_key_writes_inside_extract_dir(self, _get_reader, tmp_path):
+        extract_dir = tmp_path / "extract"
+        extract_dir.mkdir()
+
+        grouped = get_blobs_grouped_by_dir(["reports/sales/q1.pbit"])
+        download_pbit_files(
+            blob_grouped_by_directory=grouped,
+            config=MagicMock(),
+            client=MagicMock(),
+            bucket_name="bucket",
+            extract_dir=str(extract_dir),
+        )
+
+        written = extract_dir / "reports" / "sales" / "q1.pbit"
+        assert written.exists(), "a legitimate .pbit key should download inside the extract directory"
+        assert written.read_bytes() == b"attacker-controlled bytes"


### PR DESCRIPTION
### Describe your changes:

Fixes #31367

The PowerBI file source downloaded .pbit files from cloud storage to a local path built by interpolating the cloud object key directly into `f"{extract_dir}/{blob}"`, and wrote to it without checking the resolved location. Object keys come from the storage listing and can contain `..` or absolute-path components, so a crafted key resolved outside the operator-configured `pbitFilesExtractDir` and the file was written to an unintended location on the ingestion host. The `.pbit` extension filter did not prevent this, because a mid-path `..` still ends in `.pbit`.

This adds a containment guard so downloads cannot escape the extract directory.

### Type of change:

- [X] Bug fix

### High-level design:

The untrusted input is the cloud object key (`blob`) returned by listing the bucket or container. `pbitFilesExtractDir` is trusted operator config. The reader layer writes `local_file_path` verbatim (S3 `download_file`, ADLS `open(...)`, GCS `download_to_filename`), so the containment check belongs where the path is built.

- New helper `_safe_local_path(extract_dir, blob)` resolves the candidate path with `os.path.realpath` and requires it to be within the resolved `extract_dir`, raising `PowerBIFileConfigException` otherwise.
- `download_pbit_files` now uses the validated path for both the directory creation (`os.makedirs`) and the download, so neither can escape. A key that resolves outside the extract directory is skipped and logged, matching the existing warn-and-continue handling.
- Applies to the S3, Azure, and GCS file sources, which all route through `download_pbit_files`. `LocalConfig` reads a local path and is unaffected.

No schema change. No migration needed.

The `zipfile.extractall` call used later to unzip the .pbit archives is not affected, because CPython's `zipfile` already strips `..` and absolute components from archive member names on extraction.

### Tests:

#### Use cases covered

- A cloud object key that resolves outside `pbitFilesExtractDir` is skipped and writes nothing outside the extract directory.
- A legitimate nested key such as `reports/sales/q1.pbit` downloads to the expected location inside the extract directory.

#### Unit tests

- [X] I added unit tests for the new and changed logic.

- Files added or updated:
  - `ingestion/tests/unit/source/dashboard/powerbi/test_file_client_path_traversal.py`: `_safe_local_path` rejects `..` and absolute-path keys and allows legitimate nested keys, and `download_pbit_files` writes nothing outside the extract directory for a traversal key while downloading a legitimate key inside it.
- Result: 4 new tests pass. The existing PowerBI file-client integration test still passes.

#### Backend integration tests

- [X] Not applicable (no backend API changes).

#### Ingestion integration tests

- [X] Not applicable (unit coverage added for the changed logic, existing integration test unaffected).

#### Playwright (UI) tests

- [X] Not applicable (no UI changes).

#### Manual testing performed

1. `ruff check` and `ruff format --check` on the changed files, clean.
2. Ran the PowerBI unit and integration tests in a local venv, all green.

### UI screen recording / screenshots:

Not applicable.

### Checklist:

- [X] I have read the **CONTRIBUTING** document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] For JSON Schema changes: N/A (no schema changes).
- [X] For UI changes: N/A.
- [X] I have added tests and listed them above.

<!-- Bug fix -->

- [X] I have added a test that covers the exact scenario we are fixing.
