### PR TITLE
chore(release): bump version to 1.13.4

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <properties>

--- a/docker/docker-compose-ingestion/docker-compose-ingestion.yml
+++ b/docker/docker-compose-ingestion/docker-compose-ingestion.yml
@@ -18,7 +18,7 @@ volumes:
 services:  
   ingestion:
     container_name: openmetadata_ingestion
-    image: docker.getcollate.io/openmetadata/ingestion:1.13.0
+    image: docker.getcollate.io/openmetadata/ingestion:1.13.4
     environment:
       AIRFLOW__API__AUTH_BACKENDS: "airflow.api.auth.backend.basic_auth,airflow.api.auth.backend.session"
       AIRFLOW__CORE__EXECUTOR: LocalExecutor

--- a/docker/docker-compose-openmetadata/docker-compose-openmetadata.yml
+++ b/docker/docker-compose-openmetadata/docker-compose-openmetadata.yml
@@ -14,7 +14,7 @@ services:
   execute-migrate-all:
     container_name: execute_migrate_all
     command: "./bootstrap/openmetadata-ops.sh migrate"
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -238,7 +238,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}

--- a/docker/docker-compose-quickstart/Dockerfile
+++ b/docker/docker-compose-quickstart/Dockerfile
@@ -11,7 +11,7 @@
 
 # Build stage
 FROM alpine:3 AS build
-ARG RI_VERSION="1.13.0"
+ARG RI_VERSION="1.13.4"
 ENV RELEASE_URL="https://github.com/open-metadata/OpenMetadata/releases/download/${RI_VERSION}-release/openmetadata-${RI_VERSION}.tar.gz"
 
 RUN mkdir -p /opt/openmetadata && \
@@ -21,7 +21,7 @@ RUN mkdir -p /opt/openmetadata && \
 
 # Final stage
 FROM alpine:3
-ARG RI_VERSION="1.13.0"
+ARG RI_VERSION="1.13.4"
 ARG BUILD_DATE
 ARG COMMIT_ID
 LABEL maintainer="OpenMetadata"

--- a/docker/docker-compose-quickstart/docker-compose-postgres.yml
+++ b/docker/docker-compose-quickstart/docker-compose-postgres.yml
@@ -18,7 +18,7 @@ volumes:
 services:
   postgresql:
     container_name: openmetadata_postgresql
-    image: docker.getcollate.io/openmetadata/postgresql:1.13.0
+    image: docker.getcollate.io/openmetadata/postgresql:1.13.4
     restart: always
     command: "--work_mem=10MB"
     environment:
@@ -61,7 +61,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -286,7 +286,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -505,7 +505,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: docker.getcollate.io/openmetadata/ingestion:1.13.0
+    image: docker.getcollate.io/openmetadata/ingestion:1.13.4
     depends_on:
       elasticsearch:
         condition: service_started

--- a/docker/docker-compose-quickstart/docker-compose.yml
+++ b/docker/docker-compose-quickstart/docker-compose.yml
@@ -18,7 +18,7 @@ volumes:
 services:
   mysql:
     container_name: openmetadata_mysql
-    image: docker.getcollate.io/openmetadata/db:1.13.0
+    image: docker.getcollate.io/openmetadata/db:1.13.4
     command: "--sort_buffer_size=10M"
     restart: always
     environment:
@@ -59,7 +59,7 @@ services:
 
   execute-migrate-all:
     container_name: execute_migrate_all
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     command: "./bootstrap/openmetadata-ops.sh migrate"
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
@@ -284,7 +284,7 @@ services:
   openmetadata-server:
     container_name: openmetadata_server
     restart: always
-    image: docker.getcollate.io/openmetadata/server:1.13.0
+    image: docker.getcollate.io/openmetadata/server:1.13.4
     environment:
       OPENMETADATA_CLUSTER_NAME: ${OPENMETADATA_CLUSTER_NAME:-openmetadata}
       SERVER_PORT: ${SERVER_PORT:-8585}
@@ -504,7 +504,7 @@ services:
 
   ingestion:
     container_name: openmetadata_ingestion
-    image: docker.getcollate.io/openmetadata/ingestion:1.13.0
+    image: docker.getcollate.io/openmetadata/ingestion:1.13.4
     depends_on:
       elasticsearch:
         condition: service_started

--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -109,7 +109,7 @@ ARG INGESTION_DEPENDENCY="all"
 ENV PIP_NO_CACHE_DIR=1
 # Make pip silent
 ENV PIP_QUIET=1
-ARG RI_VERSION="1.13.0.0"
+ARG RI_VERSION="1.13.4.0"
 # Pin setuptools<81 as pkg_resources was removed in setuptools 81.0.0+
 # cx-Oracle's setup.py still uses pkg_resources
 RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -134,7 +134,7 @@ RUN pip install --upgrade "pip>=26.2,<27" "setuptools<81"
 RUN pip install --no-build-isolation "cx_Oracle>=8.3.0,<9"
 
 ARG INGESTION_DEPENDENCY="all"
-ARG RI_VERSION="1.13.0.0"
+ARG RI_VERSION="1.13.4.0"
 RUN pip install "openmetadata-ingestion[airflow]~=${RI_VERSION}"
 RUN pip install "openmetadata-ingestion[${INGESTION_DEPENDENCY}]~=${RI_VERSION}"
 

--- a/ingestion/pyproject.toml
+++ b/ingestion/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # since it helps us organize and isolate version management
 [project]
 name = "openmetadata-ingestion"
-version = "1.13.0.0"
+version = "1.13.4.0"
 dynamic = ["readme", "dependencies", "optional-dependencies"]
 authors = [
     { name = "OpenMetadata Committers" }

--- a/openmetadata-airflow-apis/pyproject.toml
+++ b/openmetadata-airflow-apis/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 # since it helps us organize and isolate version management
 [project]
 name = "openmetadata_managed_apis"
-version = "1.13.0.0"
+version = "1.13.4.0"
 readme = "README.md"
 authors = [
     {name = "OpenMetadata Committers"}

--- a/openmetadata-clients/openmetadata-java-client/pom.xml
+++ b/openmetadata-clients/openmetadata-java-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-clients</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-clients/pom.xml
+++ b/openmetadata-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-dist/pom.xml
+++ b/openmetadata-dist/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
 
   <artifactId>openmetadata-dist</artifactId>

--- a/openmetadata-integration-tests/pom.xml
+++ b/openmetadata-integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openmetadata-integration-tests</artifactId>

--- a/openmetadata-k8s-operator/pom.xml
+++ b/openmetadata-k8s-operator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     

--- a/openmetadata-mcp/pom.xml
+++ b/openmetadata-mcp/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.open-metadata</groupId>
         <artifactId>platform</artifactId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     
     <artifactId>openmetadata-mcp</artifactId>

--- a/openmetadata-sdk/pom.xml
+++ b/openmetadata-sdk/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.open-metadata</groupId>
         <artifactId>platform</artifactId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
 
     <artifactId>openmetadata-sdk</artifactId>

--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>openmetadata-service</artifactId>

--- a/openmetadata-shaded-deps/elasticsearch-dep/pom.xml
+++ b/openmetadata-shaded-deps/elasticsearch-dep/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-shaded-deps</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>elasticsearch-deps</artifactId>

--- a/openmetadata-shaded-deps/opensearch-dep/pom.xml
+++ b/openmetadata-shaded-deps/opensearch-dep/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>openmetadata-shaded-deps</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>opensearch-deps</artifactId>

--- a/openmetadata-shaded-deps/pom.xml
+++ b/openmetadata-shaded-deps/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>openmetadata-shaded-deps</artifactId>

--- a/openmetadata-spec/pom.xml
+++ b/openmetadata-spec/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>platform</artifactId>
         <groupId>org.open-metadata</groupId>
-        <version>1.13.1</version>
+        <version>1.13.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-ui-core-components/pom.xml
+++ b/openmetadata-ui-core-components/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/openmetadata-ui/pom.xml
+++ b/openmetadata-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>platform</artifactId>
     <groupId>org.open-metadata</groupId>
-    <version>1.13.1</version>
+    <version>1.13.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     based on Open Metadata Standards/APIs, supporting connectors to a wide range of data services,
     OpenMetadata enables end-to-end metadata management, giving you the freedom to unlock the value of your data assets.
   </description>
-  <version>1.13.1</version>
+  <version>1.13.4</version>
   <url>https://github.com/open-metadata/OpenMetadata</url>
   <modules>
     <module>openmetadata-spec</module>


### PR DESCRIPTION
## What

Bumps the `1.13` branch to `1.13.4`, generated with:

```
make update_all RELEASE_VERSION=1.13.4
```

## Changes

| Files | From | To |
|---|---|---|
| 16 `pom.xml` (Maven reactor) | `1.13.1` | `1.13.4` |
| `ingestion/pyproject.toml`, `openmetadata-airflow-apis/pyproject.toml` | `1.13.0.0` | `1.13.4.0` |
| 4 `docker-compose*.yml` image tags | `1.13.0` | `1.13.4` |
| `ingestion/Dockerfile`, `ingestion/operators/docker/Dockerfile` `RI_VERSION` | `1.13.0.0` | `1.13.4.0` |
| `docker/docker-compose-quickstart/Dockerfile` `RI_VERSION` | `1.13.0` | `1.13.4` |

## Notes

The Python and Docker release files were still at `1.13.0` — the `1.13.0 -> 1.13.1` bump (7f65203f88) only touched the poms. Since `python-packages-publish.yml` builds straight from the checked-out branch with no version override, `ingestion/pyproject.toml` is what gets published to PyPI, so this realigns them with the Maven artifacts.

`update_openapi_version` is a no-op here: the `@Info` annotation in `OpenMetadataApplication.java` holds `"1.13"`, and the script's regex only matches a three-part version. Left as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)