### PR TITLE
Backport #31356 restore Table Diff on Databricks, Unity Catalog and AzureSQL to 2.0

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -182,7 +182,7 @@ base_requirements = {
     "packaging",  # For version parsing
     "setuptools>=78.1.1",
     "shapely",
-    "collate-data-diff>=0.11.11",
+    "collate-data-diff>=0.11.15",
     # Floor on dbt-extractor (transitive via collate-data-diff -> dbt-core).
     # Pre-0.5 versions ship no cp310-manylinux_2_17_aarch64 wheel, forcing a
     # Rust/Cargo source build on ARM runners. 0.5+ uses cp38-abi3 wheels.

--- a/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
+++ b/ingestion/src/metadata/data_quality/validations/runtime_param_setter/base_diff_params_setter.py
@@ -185,6 +185,8 @@ class BaseTableParameter:
             self._get_service_connection_config(db_service.connection.config) if not override_url else override_url  # noqa: SIM212
         )
         if isinstance(source_url, dict):
+            # Both sides of a same-service diff are handed the same dict
+            source_url = dict(source_url)
             source_url["driver"] = source_url["driver"].split("+")[0]
             return source_url
 

--- a/ingestion/src/metadata/ingestion/source/database/common/data_diff/databricks_base.py
+++ b/ingestion/src/metadata/ingestion/source/database/common/data_diff/databricks_base.py
@@ -5,34 +5,29 @@ from typing import Optional, Union
 from metadata.data_quality.validations.runtime_param_setter.base_diff_params_setter import (
     BaseTableParameter,
 )
+from metadata.generated.schema.entity.services.databaseService import DatabaseService
+from metadata.utils import fqn
 
 
 class DatabricksBaseTableParameter(BaseTableParameter):
-    """Base class for Databricks-based table parameter setters"""
+    """Base class for Databricks-based table parameter setters.
 
-    @classmethod
-    def _get_service_connection_config(
-        cls,
-        service_connection_config,
-    ) -> Optional[Union[str, dict]]:  # noqa: UP007, UP045
-        """Build connection URL for Databricks-based connections"""
-        if not service_connection_config:
-            return None
+    The connection class builds a service-level dict; data_diff resolves a two-part
+    ``schema.table`` path against the connection's catalog, so each side of the diff
+    needs the catalog and schema of its own table.
+    """
 
-        scheme = getattr(service_connection_config, "scheme", "databricks")
-        # Handle enum values properly
-        if hasattr(scheme, "value"):
-            scheme = scheme.value
-
-        host_port = getattr(service_connection_config, "hostPort", "localhost:443")
-        token = getattr(service_connection_config, "token", "")
-        token_value = token.get_secret_value() if hasattr(token, "get_secret_value") else str(token)
-
-        # Include httpPath if available (required for data_diff library)
-        http_path = getattr(service_connection_config, "httpPath", "")
-        if http_path:
-            # Ensure http_path starts with /
-            if not http_path.startswith("/"):
-                http_path = "/" + http_path
-            return f"{scheme}://:{token_value}@{host_port}{http_path}"
-        return f"{scheme}://:{token_value}@{host_port}"
+    def get_data_diff_url(
+        self,
+        db_service: DatabaseService,
+        table_fqn: str,
+        override_url: Optional[Union[str, dict]] = None,  # noqa: UP007, UP045
+    ) -> Union[str, dict]:  # noqa: UP007
+        source_url = super().get_data_diff_url(db_service, table_fqn, override_url)
+        if isinstance(source_url, dict):
+            # Work on a copy to avoid mutating a dict that might be reused
+            source_url = dict(source_url)
+            _, catalog, schema, _ = fqn.split(table_fqn)
+            source_url["catalog"] = catalog
+            source_url["schema"] = schema
+        return source_url

--- a/ingestion/src/metadata/ingestion/source/database/databricks/auth.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/auth.py
@@ -142,3 +142,55 @@ def get_auth_config(connection: DatabricksAuthConnection) -> dict:
         raise ValueError(f"Unsupported authentication type: {type(connection.authType)}")
 
     return auth_method(connection)
+
+
+class DataDiffConnectionError(Exception):
+    """Raised when a connection cannot be described to data-diff.
+
+    Not a ValueError: the data-diff param setter swallows those and falls back to a
+    credential-less URL, which parks the driver on an interactive OAuth flow.
+    """
+
+
+def get_data_diff_auth(connection: DatabricksAuthConnection) -> dict:
+    """Credential fields for a data-diff connection dict.
+
+    Every value is a plain string: data-diff caches connections on ``json.dumps``
+    of the dict, so credential providers are built on its side, not passed in.
+
+    Raises:
+        DataDiffConnectionError: on an unsupported authentication type.
+    """
+    auth_type = connection.authType
+    if isinstance(auth_type, PersonalAccessToken):
+        return {"auth_method": "pat", "access_token": auth_type.token.get_secret_value()}
+    if isinstance(auth_type, DatabricksOauth):
+        return {
+            "auth_method": "oauth-m2m",
+            "databricks_client_id": auth_type.clientId,
+            "databricks_client_secret": auth_type.clientSecret.get_secret_value(),
+        }
+    if isinstance(auth_type, AzureAdSetup):
+        return {
+            "auth_method": "azure-sp-m2m",
+            "azure_client_id": auth_type.azureClientId,
+            "azure_client_secret": auth_type.azureClientSecret.get_secret_value(),
+            "azure_tenant_id": auth_type.azureTenantId,
+        }
+    raise DataDiffConnectionError(f"Unsupported authentication type for Data Diff: {type(auth_type).__name__}")
+
+
+def get_data_diff_connection_dict(connection: DatabricksAuthConnection) -> dict:
+    """Service-level data-diff connection dict, without the table's catalog and schema.
+
+    Raises:
+        DataDiffConnectionError: when the connection cannot be expressed to data-diff.
+    """
+    if not connection.httpPath:
+        raise DataDiffConnectionError("Data Diff requires the connection's HTTP Path to be set")
+    return {
+        "driver": DEFAULT_SCHEME,
+        "server_hostname": _host(connection),
+        "http_path": connection.httpPath,
+        **get_data_diff_auth(connection),
+    }

--- a/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/databricks/connection.py
@@ -57,6 +57,7 @@ from metadata.ingestion.connections.test_connections import SourceConnectionExce
 from metadata.ingestion.source.database.databricks.auth import (
     catalog_url,
     get_auth_config,
+    get_data_diff_connection_dict,
     probe_target,
 )
 from metadata.ingestion.source.database.databricks.client import DatabricksClient
@@ -414,6 +415,10 @@ class DatabricksConnection(BaseConnection[DatabricksConnectionConfig, Engine]):
         engine = get_connection(self.service_connection)
         self._on_close(engine.dispose)
         return engine
+
+    def get_connection_dict(self) -> dict:
+        """Return the connection parameters for data-diff."""
+        return get_data_diff_connection_dict(self.service_connection)
 
     def close(self) -> None:
         # Not _on_close: that registry is reset by close(), so a sub-owner

--- a/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
+++ b/ingestion/src/metadata/ingestion/source/database/unitycatalog/connection.py
@@ -64,6 +64,7 @@ from metadata.ingestion.connections.test_connections import SourceConnectionExce
 from metadata.ingestion.source.database.databricks.auth import (
     catalog_url,
     get_auth_config,
+    get_data_diff_connection_dict,
     normalize_host_port,
     probe_target,
 )
@@ -474,6 +475,10 @@ class UnityCatalogConnection(BaseConnection[UnityCatalogConnectionConfig, Worksp
 
     def _get_client(self) -> WorkspaceClient:
         return get_connection(self.service_connection)
+
+    def get_connection_dict(self) -> dict:
+        """Return the connection parameters for data-diff."""
+        return get_data_diff_connection_dict(self.service_connection)
 
     def close(self) -> None:
         # Not _on_close: that registry is reset by close(), so a sub-owner

--- a/ingestion/tests/unit/metadata/data_quality/test_databricks_data_diff.py
+++ b/ingestion/tests/unit/metadata/data_quality/test_databricks_data_diff.py
@@ -1,0 +1,152 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Data diff connection parameters for Databricks and Unity Catalog"""
+
+import pytest
+
+from metadata.generated.schema.entity.services.connections.database.databricks.azureAdSetup import (
+    AzureAdSetup,
+)
+from metadata.generated.schema.entity.services.connections.database.databricks.databricksOAuth import (
+    DatabricksOauth,
+)
+from metadata.generated.schema.entity.services.connections.database.databricks.personalAccessToken import (
+    PersonalAccessToken,
+)
+from metadata.generated.schema.entity.services.connections.database.databricksConnection import (
+    DatabricksConnection as DatabricksConnectionConfig,
+)
+from metadata.generated.schema.entity.services.connections.database.unityCatalogConnection import (
+    UnityCatalogConnection as UnityCatalogConnectionConfig,
+)
+from metadata.generated.schema.entity.services.databaseService import (
+    DatabaseConnection,
+    DatabaseService,
+    DatabaseServiceType,
+)
+from metadata.ingestion.source.database.databricks.auth import (
+    DataDiffConnectionError,
+    get_data_diff_connection_dict,
+)
+from metadata.ingestion.source.database.unitycatalog.data_diff.data_diff import (
+    UnityCatalogTableParameter,
+)
+
+HOST_PORT = "my-workspace.cloud.databricks.com:443"
+HTTP_PATH = "/sql/1.0/warehouses/abc123"
+
+PERSONAL_ACCESS_TOKEN = PersonalAccessToken(token="dapi-token")
+DATABRICKS_OAUTH = DatabricksOauth(clientId="client-id", clientSecret="client-secret")
+AZURE_AD = AzureAdSetup(
+    azureClientId="azure-client-id",
+    azureClientSecret="azure-client-secret",
+    azureTenantId="azure-tenant-id",
+)
+
+
+def unity_catalog_config(auth_type=PERSONAL_ACCESS_TOKEN, **kwargs) -> UnityCatalogConnectionConfig:
+    return UnityCatalogConnectionConfig(
+        **{"hostPort": HOST_PORT, "httpPath": HTTP_PATH, "authType": auth_type, **kwargs}
+    )
+
+
+def databricks_config(auth_type=PERSONAL_ACCESS_TOKEN, **kwargs) -> DatabricksConnectionConfig:
+    return DatabricksConnectionConfig(**{"hostPort": HOST_PORT, "httpPath": HTTP_PATH, "authType": auth_type, **kwargs})
+
+
+def unity_catalog_service(config: UnityCatalogConnectionConfig) -> DatabaseService:
+    return DatabaseService.model_construct(
+        name="my_service",
+        serviceType=DatabaseServiceType.UnityCatalog,
+        connection=DatabaseConnection(config=config),
+    )
+
+
+@pytest.mark.parametrize("builder", [unity_catalog_config, databricks_config])
+class TestDataDiffConnectionDict:
+    """Both connectors share the connection dict builder."""
+
+    def test_personal_access_token(self, builder):
+        connection_dict = get_data_diff_connection_dict(builder(PERSONAL_ACCESS_TOKEN))
+
+        assert connection_dict == {
+            "driver": "databricks",
+            "server_hostname": "my-workspace.cloud.databricks.com",
+            "http_path": HTTP_PATH,
+            "auth_method": "pat",
+            "access_token": "dapi-token",
+        }
+
+    def test_databricks_oauth(self, builder):
+        connection_dict = get_data_diff_connection_dict(builder(DATABRICKS_OAUTH))
+
+        assert connection_dict["auth_method"] == "oauth-m2m"
+        assert connection_dict["databricks_client_id"] == "client-id"
+        assert connection_dict["databricks_client_secret"] == "client-secret"
+        assert "access_token" not in connection_dict
+
+    def test_azure_ad(self, builder):
+        connection_dict = get_data_diff_connection_dict(builder(AZURE_AD))
+
+        assert connection_dict["auth_method"] == "azure-sp-m2m"
+        assert connection_dict["azure_client_id"] == "azure-client-id"
+        assert connection_dict["azure_client_secret"] == "azure-client-secret"
+        assert connection_dict["azure_tenant_id"] == "azure-tenant-id"
+        assert "access_token" not in connection_dict
+
+    def test_every_value_is_json_serializable(self, builder):
+        """data_diff caches connections on json.dumps of the dict."""
+        for auth_type in (PERSONAL_ACCESS_TOKEN, DATABRICKS_OAUTH, AZURE_AD):
+            connection_dict = get_data_diff_connection_dict(builder(auth_type))
+            assert all(isinstance(value, str) for value in connection_dict.values())
+
+    def test_pasted_workspace_url_is_normalized(self, builder):
+        connection_dict = get_data_diff_connection_dict(builder(hostPort="https://my-workspace.cloud.databricks.com"))
+
+        assert connection_dict["server_hostname"] == "my-workspace.cloud.databricks.com"
+
+
+def test_missing_http_path_is_rejected():
+    """Only Unity Catalog can reach this: the Databricks schema requires httpPath."""
+    with pytest.raises(DataDiffConnectionError, match="HTTP Path"):
+        get_data_diff_connection_dict(unity_catalog_config(httpPath=None))
+
+
+class TestDataDiffTableScope:
+    """data_diff resolves a two-part schema.table path against the connection's catalog."""
+
+    def test_catalog_and_schema_come_from_the_table(self):
+        service = unity_catalog_service(unity_catalog_config())
+
+        connection_dict = UnityCatalogTableParameter().get_data_diff_url(service, "my_service.my_catalog.my_schema.t")
+
+        assert connection_dict["catalog"] == "my_catalog"
+        assert connection_dict["schema"] == "my_schema"
+        assert connection_dict["access_token"] == "dapi-token"
+
+    def test_service_level_catalog_does_not_win(self):
+        service = unity_catalog_service(unity_catalog_config(catalog="configured_catalog"))
+
+        connection_dict = UnityCatalogTableParameter().get_data_diff_url(service, "my_service.my_catalog.my_schema.t")
+
+        assert connection_dict["catalog"] == "my_catalog"
+
+    def test_both_sides_of_a_same_service_diff_keep_their_own_catalog(self):
+        service = unity_catalog_service(unity_catalog_config())
+        setter = UnityCatalogTableParameter()
+
+        table1 = setter.get_data_diff_url(service, "my_service.catalog_one.schema_one.t")
+        table2 = setter.get_data_diff_url(service, "my_service.catalog_two.schema_two.t", override_url=table1)
+
+        assert table1["catalog"] == "catalog_one"
+        assert table1["schema"] == "schema_one"
+        assert table2["catalog"] == "catalog_two"
+        assert table2["schema"] == "schema_two"

--- a/ingestion/tests/unit/topology/database/test_databricks_migration.py
+++ b/ingestion/tests/unit/topology/database/test_databricks_migration.py
@@ -75,20 +75,26 @@ class TestTypeMap:
 
 
 class TestDatabricksBaseDefaultScheme:
-    """Verify DatabricksBaseTableParameter uses the new default scheme"""
+    """Verify the data diff connection uses the new default scheme"""
 
     def test_default_scheme(self):
-        from metadata.ingestion.source.database.common.data_diff.databricks_base import (
-            DatabricksBaseTableParameter,
+        from metadata.generated.schema.entity.services.connections.database.databricks.personalAccessToken import (
+            PersonalAccessToken,
+        )
+        from metadata.generated.schema.entity.services.connections.database.databricksConnection import (
+            DatabricksConnection,
+        )
+        from metadata.ingestion.source.database.databricks.auth import (
+            get_data_diff_connection_dict,
         )
 
-        class FakeConfig:
-            hostPort = "host:443"  # noqa: N815
-            token = "secret"
+        connection = DatabricksConnection(
+            hostPort="workspace.cloud.databricks.com:443",
+            httpPath="/sql/1.0/warehouses/abc123",
+            authType=PersonalAccessToken(token="dapi123"),
+        )
 
-        result = DatabricksBaseTableParameter._get_service_connection_config(FakeConfig())
-        assert result is not None
-        assert "databricks+connector" not in result
+        assert get_data_diff_connection_dict(connection)["driver"] == "databricks"
 
 
 class TestDatabricksPipelineConnectionUrl:

--- a/openmetadata-service/src/main/resources/json/data/tests/tableDiff.json
+++ b/openmetadata-service/src/main/resources/json/data/tests/tableDiff.json
@@ -71,7 +71,10 @@
     "Mssql",
     "Oracle",
     "Trino",
-    "SapHana"
+    "SapHana",
+    "Databricks",
+    "UnityCatalog",
+    "AzureSQL"
   ],
   "validatorClass": "TableDiffValidator"
 }


### PR DESCRIPTION
### Describe your changes:

Backport of #31356.

Table Diff has been broken on Databricks and Unity Catalog since #23561 moved `token` under `authType` on both connection schemas without updating the data-diff consumer, and unreachable from the UI on all three connectors since #24706 introduced a `supportedServices` allowlist that omitted them.

`DatabricksBaseTableParameter` read `getattr(config, "token", "")`, so the URL carried an empty password. data-diff maps that to `access_token`, `databricks-sql-connector` drops a falsy one, and auth selection falls through to the interactive OAuth provider — a headless agent then parks on a browser redirect that never arrives.

The connection is now described to data-diff as a dict built by the connection class from `authType`, carrying an `auth_method` discriminator so personal access token, Databricks OAuth M2M and Azure AD service principal are each expressed in full. The parameter setter injects the catalog and schema of each table, which the URL form used to supply.

Requires `collate-data-diff>=0.11.15` (open-metadata/collate-data-diff#33), already released.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — clean cherry-pick of `d302bfab6ce`, no conflicts.