### PR TITLE
fix(ingestion): wrap Snowflake session tag and SHOW TABLES queries with text() for SQLAlchemy 2.x (2.0 backport)

### DIFF
--- a/ingestion/.basedpyright/baseline.json
+++ b/ingestion/.basedpyright/baseline.json
@@ -71606,14 +71606,6 @@
                 }
             },
             {
-                "code": "reportAttributeAccessIssue",
-                "range": {
-                    "startColumn": 78,
-                    "endColumn": 103,
-                    "lineCount": 1
-                }
-            },
-            {
                 "code": "reportMissingParameterType",
                 "range": {
                     "startColumn": 26,

--- a/ingestion/src/metadata/mixins/sqalchemy/sqa_mixin.py
+++ b/ingestion/src/metadata/mixins/sqalchemy/sqa_mixin.py
@@ -76,7 +76,8 @@ class SQAInterfaceMixin(Root):
             and hasattr(self.service_connection_config, "queryTag")
             and self.service_connection_config.queryTag
         ):
-            session.execute(SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=self.service_connection_config.queryTag))
+            query_tag = self.service_connection_config.queryTag  # pyright: ignore[reportAttributeAccessIssue]
+            session.execute(text(SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag)))
 
     def set_catalog(self, session) -> None:
         """Set the catalog or database for the session.

--- a/ingestion/src/metadata/profiler/metrics/system/snowflake/system.py
+++ b/ingestion/src/metadata/profiler/metrics/system/snowflake/system.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Tuple  # noqa: UP035
 
 import sqlalchemy.orm
 from pydantic import TypeAdapter
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from metadata.generated.schema.entity.data.table import (
@@ -38,6 +39,7 @@ from metadata.utils.profiler_utils import get_identifiers_from_string
 from metadata.utils.time_utils import datetime_to_timestamp
 
 PUBLIC_SCHEMA = "PUBLIC"
+SHOW_TABLES_MATCH_LIMIT = 100
 logger = profiler_logger()
 RESULT_SCAN = """
     SELECT *
@@ -98,7 +100,13 @@ class SnowflakeTableResovler:
         self.session = session
 
     def show_tables(self, db, schema, table):
-        return self.session.execute(f'SHOW TABLES LIKE \'{table}\' IN SCHEMA "{db}"."{schema}" LIMIT 1;').fetchone()
+        # SHOW ... LIKE treats _ and % as wildcards and has no ESCAPE clause, so the
+        # match is narrowed server-side and the name column is compared here instead.
+        rows = self.session.execute(
+            text(f'SHOW TABLES LIKE \'{table}\' IN SCHEMA "{db}"."{schema}" LIMIT {SHOW_TABLES_MATCH_LIMIT}')
+        ).fetchall()
+        target = CaseInsensitiveString(table)
+        return next((row for row in rows if target == row[1]), None)
 
     def table_exists(self, db, schema, table):
         """Return True if the table exists in Snowflake. Uses cache to store the results.

--- a/ingestion/tests/unit/metadata/ingestion/source/database/snowflake/profiler/test_system_metrics.py
+++ b/ingestion/tests/unit/metadata/ingestion/source/database/snowflake/profiler/test_system_metrics.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, create_autospec, patch
 import pytest
 from sqlalchemy.engine.result import IteratorResult, SimpleResultMetaData
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import coercions, roles
 
 from metadata.generated.schema.entity.data.table import (
     DmlOperationType,
@@ -121,6 +122,47 @@ def test_get_identifiers(
             resolver.resolve_snowflake_fqn(context_database, context_schema, identifier)
     else:
         assert expected_value == resolver.resolve_snowflake_fqn(context_database, context_schema, identifier)
+
+
+def show_tables_session(rows):
+    """Build a session double that applies SQLAlchemy 2.x statement coercion and yields rows."""
+
+    class _Session:
+        def execute(self, statement):
+            coercions.expect(roles.StatementRole, statement)
+            metadata = SimpleResultMetaData(["created_on", "name", "database_name", "schema_name"])
+            return IteratorResult(metadata, iter(rows))
+
+    return _Session()
+
+
+def show_tables_row(name):
+    return ("2026-07-20 00:00:00", name, "MY_DB", "MY_SCHEMA")
+
+
+def test_show_tables_statement_is_accepted_by_sqlalchemy_2x():
+    resolver = SnowflakeTableResovler(show_tables_session([show_tables_row("MY_TABLE")]))
+
+    assert resolver.show_tables("MY_DB", "MY_SCHEMA", "MY_TABLE")[1] == "MY_TABLE"
+
+
+def test_show_tables_matches_uppercase_stored_identifiers():
+    resolver = SnowflakeTableResovler(show_tables_session([show_tables_row("MY_TABLE")]))
+
+    assert resolver.show_tables("my_db", "my_schema", "my_table")[1] == "MY_TABLE"
+
+
+def test_show_tables_skips_rows_matched_only_by_like_wildcards():
+    rows = [show_tables_row("MYATABLE"), show_tables_row("MY_TABLE")]
+    resolver = SnowflakeTableResovler(show_tables_session(rows))
+
+    assert resolver.show_tables("my_db", "my_schema", "my_table")[1] == "MY_TABLE"
+
+
+def test_show_tables_returns_none_when_only_wildcard_matches_exist():
+    resolver = SnowflakeTableResovler(show_tables_session([show_tables_row("MYATABLE")]))
+
+    assert resolver.show_tables("my_db", "my_schema", "my_table") is None
 
 
 class TestSnowflakeSystemMetricsComputerDynamicTable:

--- a/ingestion/tests/unit/metadata/mixins/sqalchemy/test_sqa_mixin.py
+++ b/ingestion/tests/unit/metadata/mixins/sqalchemy/test_sqa_mixin.py
@@ -1,0 +1,57 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for the SQLAlchemy interface mixin"""
+
+from sqlalchemy.sql import coercions, roles
+
+from metadata.generated.schema.entity.services.connections.database.snowflakeConnection import (
+    SnowflakeConnection,
+)
+from metadata.mixins.sqalchemy.sqa_mixin import SQAInterfaceMixin
+
+
+class RecordingSession:
+    """Session double that applies SQLAlchemy 2.x statement coercion and records statements."""
+
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, statement):
+        coercions.expect(roles.StatementRole, statement)
+        self.statements.append(statement)
+
+
+class SnowflakeInterface(SQAInterfaceMixin):
+    def __init__(self, service_connection_config):
+        self.service_connection_config = service_connection_config
+
+
+def snowflake_interface(query_tag=None):
+    return SnowflakeInterface(
+        SnowflakeConnection(username="user", account="account", warehouse="warehouse", queryTag=query_tag)
+    )
+
+
+def test_set_session_tag_statement_is_accepted_by_sqlalchemy_2x():
+    session = RecordingSession()
+
+    snowflake_interface(query_tag="my_tag").set_session_tag(session)
+
+    assert [str(statement) for statement in session.statements] == ['ALTER SESSION SET QUERY_TAG="my_tag"']
+
+
+def test_set_session_tag_is_skipped_without_a_query_tag():
+    session = RecordingSession()
+
+    snowflake_interface().set_session_tag(session)
+
+    assert session.statements == []


### PR DESCRIPTION
### Describe your changes:

Backport of #29847 (`fff4dcf`) to 2.0.

Snowflake profiler ingestion fails for every table under SQLAlchemy 2.x because `set_session_tag` (`sqa_mixin.py`) and `show_tables` (`snowflake/system.py`) pass bare SQL strings to `session.execute()`, which SA 2.x rejects:

```
Textual SQL expression 'ALTER SESSION SET QUERY_T...' should be explicitly declared as text('ALTER SESSION SET QUERY_T...')
```

Both files are identical on 2.0 and 2.0 pins `sqlalchemy>=2.0.0,<3`, so the bug is live on this branch.

Alongside the `text()` wrapping, `show_tables` matches the returned name column case-insensitively — `SHOW ... LIKE` has no `ESCAPE` clause, so `_` and `%` stay wildcards and Snowflake returns identifiers uppercased.

Cherry-picked with `-x`; applied without conflicts and the diff matches main exactly.

### Type of change:

- [x] Bug fix