### PR TITLE
test(e2e): verify glossary description with a web-first assertion

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/glossary.ts
@@ -461,11 +461,13 @@ export const verifyGlossaryDetails = async (
 
   await checkName(page, glossaryDetails.name);
 
-  const viewerContainerText = await page.textContent(
-    '[data-testid="viewer-container"]'
+  // The description renders through a lazily-imported BlockEditor whose Suspense
+  // fallback is null, so viewer-container is attached with an empty subtree until
+  // that chunk resolves. A one-shot page.textContent() read wins that race under
+  // CI load and returns ''; only a web-first assertion retries until it renders.
+  await expect(page.getByTestId('viewer-container')).toContainText(
+    glossaryDetails.description
   );
-
-  expect(viewerContainerText).toContain(glossaryDetails.description);
 
   // Owner
   if (glossaryDetails.owners.length > 0) {


### PR DESCRIPTION
### Describe your changes:

Fixes #31384

`verifyGlossaryDetails` read the glossary description with a single, non-retrying DOM read:

```ts
const viewerContainerText = await page.textContent('[data-testid="viewer-container"]');

expect(viewerContainerText).toContain(glossaryDetails.description);
```

`page.textContent()` resolves as soon as the element is **attached** and reads its text exactly once. The description renders through `RichTextEditorPreviewNew`, whose `BlockEditor` is `withSuspenseFallback(lazy(() => import(...)))` with the **default `null` fallback** — so `viewer-container` is attached with a literally empty subtree until that chunk resolves. Under CI load the read wins that race and returns `""`.

`waitForAllLoadersToDisappear` doesn't cover it either: it waits for `[data-testid="loader"]`, and this Suspense fallback renders **no loader**.

I switched to the retrying web-first assertion already used everywhere else in the suite (e.g. `playwright/utils/tag.ts`), so the check waits for the editor to actually mount.

**The data was never wrong.** The screenshot Playwright captures *after* the assertion fails shows the description rendered correctly — this was purely a test-side race.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- `Glossary.spec.ts` › "Approve and reject glossary term from Glossary Listing" — the test that was hard-failing and blocking the merge queue
- `Glossary.spec.ts` › "Glossary & terms creation for reviewer as user" / "as team" — same helper, same failure signature

#### Unit tests
N/A — this is a change to a Playwright helper; the E2E tests above are the coverage.

#### Verification performed

I reproduced the exact failure and proved the fix against it, modelling `viewer-container` the way `RichTextEditorPreviewNew` behaves (attached immediately with an empty subtree, filled once the lazy chunk resolves):

```
BEFORE — one-shot read (glossary.ts:464 as it was):
  RED    page.textContent() + toContain  (failed after 14ms)
         expect(received).toContain(expected) // indexOf
         Expected substring: "Glossary terms that describe general conceptual terms. …"
         Received string:    ""

AFTER — web-first assertion (this change):
  GREEN  expect(locator).toContainText()  (passed after 1866ms)
```

The RED output reproduces the CI error verbatim.

Checks run locally on the changed file:
- `organize-imports-cli` → `eslint --fix` → `prettier --write` (the exact UI Checkstyle sequence): **0 errors**, idempotent on re-run. The single remaining warning (`playwright/no-wait-for-selector` at line 2085) is pre-existing and unrelated.
- `yarn tsc:playwright` before vs after: **164 errors both ways, identical** apart from two pre-existing `glossary.ts` errors shifting by exactly the 2 lines this diff adds (1411→1413, 1465→1467). No new type errors.

#### Playwright / UI screen recording
N/A — no UI change; this only touches a Playwright helper.

#
### Notes for reviewers

**Scope.** This fixes the dominant failure mode only — the empty-description read, which accounts for 4 of the 5 recent failures and a 56% first-attempt failure rate for this test.

The run that prompted this ([31566736080](https://github.com/open-metadata/OpenMetadata/actions/runs/31566736080/job/94024735824)) also failed its *retry* a second, unrelated way, which this PR deliberately does **not** touch:

> Worker 0 deleted a glossary through the UI. The backend's `sendToOne(userId, DELETE_ENTITY_CHANNEL, …)` fans that completion out to **every socket belonging to that user**, and all Playwright workers share one admin login — so worker 3's unrelated page popped a `"… deleted successfully!"` toast. `<ToastProvider />` defaults to `bottom-center`, landing on the Add Glossary **Save** button, and react-aria pauses a toast's auto-dismiss while the pointer is over it (`useToastRegion`: `onHoverStart → pauseAll()`). With the cursor resting under the toast, the 3s timer never elapses and the click can never land — Playwright retried until the 180s test timeout.

That one is a product issue, not a test issue, and fixing it means touching `openmetadata-ui-core-components` (making non-interactive toast variants `pointer-events: none`) and/or scoping `AsyncDeleteProvider`'s success toast to jobs the session actually started. It's also user-visible: rest your cursor at the bottom-centre of the screen and a success toast will sit there indefinitely, blocking whatever is underneath. Happy to raise that separately if you'd like it pursued.
