### PR TITLE
fix(ui): resolve --om-z-modal CSS variable missing in 2.0 branch

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Modals/EntityNameModal/EntityNameModal.component.tsx
@@ -110,8 +110,10 @@ const EntityNameModal = <T extends EntityName>({
       isDismissable={false}
       isOpen={visible}
       // The library overlay is `tw:z-50`, which loses to antd `Drawer`/`Modal`
-      // (z-index 1000) — so the dialog renders behind an open column/entity
-      style={{ zIndex: 'var(--om-z-modal)' }}
+      // (z-index 1000) — so the dialog renders behind an open column/entity.
+      // 2.0 does not have tokens.css where --om-z-modal is defined, so use
+      // the value directly.
+      style={{ zIndex: 1500 }}
       onOpenChange={(isOpen) => !isOpen && onCancel()}>
       <Modal>
         <Dialog data-testid="entity-name-modal" width={520}>


### PR DESCRIPTION
## Summary

Cherry-pick of #30608 landed `style={{ zIndex: 'var(--om-z-modal)' }}` on `ModalOverlay` in `EntityNameModal`, but `tokens.css` (where `--om-z-modal: 1500` is defined) does not exist in the 2.0 branch. The variable resolves to nothing, leaving the z-index fix completely inactive — `EntityNameModal` still renders behind antd `Drawer`/`Modal` overlays (z-index 1000) in 2.0.

**Fix:** Use `1500` directly since the token system is not present in 2.0. This is the same effective value as `--om-z-modal` on main.

## Test plan
- [ ] Open an entity with a column drawer → click edit on a column name → `EntityNameModal` should render **above** the drawer, not behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)