### PR TITLE
feat(login): support a configurable full-screen login video

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Layout/CarouselLayout/CarouselLayout.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Layout/CarouselLayout/CarouselLayout.tsx
@@ -14,6 +14,7 @@ import { Col, Grid, Layout, Row } from 'antd';
 import { Content } from 'antd/lib/layout/layout';
 import classNames from 'classnames';
 import { lazy, ReactNode } from 'react';
+import loginClassBase from '../../../constants/LoginClassBase';
 import withSuspenseFallback from '../../AppRouter/withSuspenseFallback';
 import DocumentTitle from '../../common/DocumentTitle/DocumentTitle';
 import './carousel-layout.less';
@@ -32,25 +33,38 @@ export const CarouselLayout = ({
   carouselClassName?: string;
 }) => {
   const { xl } = Grid.useBreakpoint();
+  const hasLoginVideo = Boolean(loginClassBase.getLoginVideo());
+
+  const formColumn = (
+    <Col className="carousel-left-side-container" span={xl ? 10 : 24}>
+      {children}
+    </Col>
+  );
+
+  const mediaColumn = xl && (
+    <Col span={14}>
+      <div
+        className={classNames('form-carousel-container', carouselClassName)}>
+        <LoginCarousel />
+      </div>
+    </Col>
+  );
 
   return (
     <Layout>
       <DocumentTitle title={pageTitle} />
       <Content className="p-md">
         <Row data-testid="signin-page" gutter={[48, 0]} wrap={false}>
-          <Col className="carousel-left-side-container" span={xl ? 10 : 24}>
-            {children}
-          </Col>
-          {xl && (
-            <Col span={14}>
-              <div
-                className={classNames(
-                  'form-carousel-container',
-                  carouselClassName
-                )}>
-                <LoginCarousel />
-              </div>
-            </Col>
+          {hasLoginVideo ? (
+            <>
+              {mediaColumn}
+              {formColumn}
+            </>
+          ) : (
+            <>
+              {formColumn}
+              {mediaColumn}
+            </>
           )}
         </Row>
       </Content>

--- a/openmetadata-ui/src/main/resources/ui/src/constants/LoginClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/LoginClassBase.ts
@@ -44,6 +44,10 @@ class LoginClassBase {
 
     return carouselContent;
   }
+
+  public getLoginVideo(): string | undefined {
+    return undefined;
+  }
 }
 
 const loginClassBase = new LoginClassBase();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/LoginPage/LoginCarousel.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/LoginPage/LoginCarousel.tsx
@@ -13,14 +13,39 @@
 
 import { Carousel, Typography } from 'antd';
 import { uniqueId } from 'lodash';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import loginClassBase from '../../constants/LoginClassBase';
 
 const LoginCarousel = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const carouselContent = loginClassBase.getLoginCarouselContent();
+  const loginVideo = loginClassBase.getLoginVideo();
   const { t } = useTranslation();
+
+  const prefersReducedMotion = useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      Boolean(
+        window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+      ),
+    []
+  );
+
+  if (loginVideo) {
+    return (
+      <video
+        aria-hidden
+        muted
+        playsInline
+        autoPlay={!prefersReducedMotion}
+        className="tw:absolute tw:inset-0 tw:h-full tw:w-full tw:object-cover"
+        data-testid="login-video"
+        loop={!prefersReducedMotion}
+        src={loginVideo}
+      />
+    );
+  }
 
   return (
     <Carousel


### PR DESCRIPTION
## Describe your changes

Adds an **optional full-screen login video** to the sign-in page. This is an opt-in extension point — default behavior is unchanged.

- `LoginClassBase.getLoginVideo(): string | undefined` — new hook, returns `undefined` by default. Deployments that don't override it keep the existing image carousel with zero change.
- `LoginCarousel` — when a video URL is provided, renders a `muted`, `loop`, `playsInline`, `autoPlay` `<video>` in place of the carousel. Autoplay and loop are disabled when the user has `prefers-reduced-motion: reduce`.
- `CarouselLayout` — when a login video is present, moves the media column to the leading position (video-left, form-right); otherwise the existing order is preserved.

### Styling

The video is styled entirely with Tailwind utilities on the element itself:

```
tw:absolute tw:inset-0 tw:h-full tw:w-full tw:object-cover
```

`tw:absolute tw:inset-0` fills the container's padding box, so the video sits edge-to-edge and its corners are clipped by the container's existing `overflow: hidden` + `border-radius` — **no new LESS rules** were introduced.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How was this tested?

- Verified default path is untouched: `getLoginVideo()` returns `undefined` → image carousel renders as before.
- Verified the video path renders full-bleed, muted autoplay, and respects `prefers-reduced-motion`.
- `eslint` clean on all three changed files.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) doc
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] No breaking change; default behavior preserved via the `undefined` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)
