### PR TITLE
feat(security-scan): show fixable Snyk count in Slack header, gate icon on it

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -342,13 +342,24 @@ jobs:
 
           retire_counts = load_counts("retire-report/_retire_counts.json")
           snyk_counts = load_counts("security-report/_counts.json")
+          snyk_fixable = (snyk_counts or {}).get("fixable", 0)
 
-          if retire == "success" and snyk == "success":
-              overall = "🟢"
-          elif retire == "failure" or snyk == "failure":
+          # The Snyk icon reflects whether there's anything to act on, not merely
+          # whether vulnerabilities exist. High/critical findings with no upstream
+          # fix are nothing we can do, so they stay 🟢; only a fixable Snyk finding
+          # (or a Snyk run that broke before producing a report) turns it red. The
+          # "Fail on high/critical" gate below still fails CI independently, so the
+          # run can read ❌ while this icon reads 🟢.
+          if retire == "cancelled" or snyk == "cancelled":
+              overall = "⚠️"
+          elif retire == "failure":
+              overall = "🚨"
+          elif snyk == "failure" and not snyk_counts:
+              overall = "🚨"
+          elif snyk_fixable > 0:
               overall = "🚨"
           else:
-              overall = "⚠️"
+              overall = "🟢"
 
           header = (
               f"{overall}  *Security scan* — *OpenMetadata Repo*\n"
@@ -356,6 +367,7 @@ jobs:
               f"• Vulnerability scan (Retire.js): {status_icon(retire)}"
               f"{totals_line(retire_counts)}\n"
               f"• Security scan (Snyk): {status_icon(snyk)}"
+              f"  ·  {snyk_fixable} fix{'es' if snyk_fixable != 1 else ''} available"
               f"{totals_line(snyk_counts)}"
           )
           fallback = f"{overall} Security scan — OpenMetadata Repo on {ref_name}. {run_url}"

--- a/scripts/snyk_summary.py
+++ b/scripts/snyk_summary.py
@@ -170,6 +170,13 @@ def count_severities(libs, by_rule=None):
     return counts
 
 
+def count_fixable(libs):
+    """Number of vulnerable libraries Snyk has a fix for — one per
+    (package, version) with a non-empty `fixedIn`. Mirrors the per-library
+    `fix: X` / `no fix` label rendered in the Slack detail rows."""
+    return sum(1 for info in libs.values() if info["fixedIn"])
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("src", nargs="?", default="security-report")
@@ -181,6 +188,7 @@ def main():
     md_parts = ["## 🛡️ Snyk Security Scan\n"]
     slack_parts = ["*🛡️ Snyk Security Scan*"]
     totals = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    fixable = 0
 
     files = sorted(glob.glob(os.path.join(args.src, "*.json")))
     # exclude our own output files if present
@@ -191,7 +199,7 @@ def main():
         sys.stdout.write("\n".join(md_parts) + "\n")
         if args.counts_file:
             with open(args.counts_file, "w") as f:
-                json.dump({**totals, "total": 0}, f)
+                json.dump({**totals, "total": 0, "fixable": 0}, f)
         if args.slack_file:
             with open(args.slack_file, "w") as f:
                 f.write("*🛡️ Snyk Security Scan*\n> No JSON reports found.")
@@ -214,6 +222,7 @@ def main():
             md_parts.append(render_deps_md(name, libs, total))
             slack_parts.append(render_deps_slack(name, libs, total, args.top))
             sub = count_severities(libs, {})
+            fixable += count_fixable(libs)
         for k in totals:
             totals[k] += sub[k]
 
@@ -221,7 +230,7 @@ def main():
 
     if args.counts_file:
         with open(args.counts_file, "w") as f:
-            json.dump({**totals, "total": sum(totals.values())}, f)
+            json.dump({**totals, "total": sum(totals.values()), "fixable": fixable}, f)
 
     if args.slack_file:
         header = (


### PR DESCRIPTION
## What

Ports [collate-hybrid-ingestion-runner#170](https://github.com/open-metadata/collate-hybrid-ingestion-runner/pull/170) to this repo. Adds a **fixes-available** count to the Snyk security scan and surfaces it in the Slack notification.

### Header
```
🟢  *Security scan* — *OpenMetadata Repo*
• Security scan (Snyk): ✅  ·  0 fixes available
```
- Appends `N fix(es) available` on the Snyk line (correct singular/plural).
- **Icon reflects actionability, not mere existence of findings.** Snyk high/critical findings with *no upstream fix* are nothing we can act on, so they stay 🟢. Only a fixable finding (or a Snyk run that broke before producing a report) turns it 🚨. Retire.js failure and cancelled runs are unchanged.

## Changes

- `scripts/snyk_summary.py` — new `count_fixable()` counts vulnerable libraries with a non-empty `fixedIn` (mirrors the per-row fix/no-fix label). Written into `_counts.json` as `"fixable"`.
- `.github/workflows/security-scan.yml` — reads `fixable`, renders it on the Snyk line, and recomputes the overall status icon from it.

## Scope

Retire.js is intentionally left out — this change only covers Snyk.

## Note

The `Fail on high/critical` / `Force failure` CI steps are **unchanged** — the run still fails on any high/critical Snyk finding even when no fix exists. So the Slack icon can read 🟢 while the run shows ❌. Left strict on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)