### PR TITLE
fix(logs): Policy agent logs return 400 Invalid request format

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/airflow/AirflowRESTClient.java
@@ -41,6 +41,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipel
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.sdk.exception.PipelineServiceClientException;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClient;
 import org.openmetadata.service.exception.IngestionPipelineDeploymentException;
@@ -654,7 +655,8 @@ public class AirflowRESTClient extends PipelineServiceClient {
   public Map<String, String> getLastIngestionLogs(
       IngestionPipeline ingestionPipeline, String after) {
     HttpResponse<String> response;
-    String taskId = TYPE_TO_TASK.get(ingestionPipeline.getPipelineType().toString());
+    String taskId =
+        PipelineServiceClientInterface.taskKeyOf(ingestionPipeline.getPipelineType().toString());
     // Init empty after query param
 
     URIBuilder uri = buildURI("last_dag_logs");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
@@ -69,6 +69,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServic
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.sdk.exception.PipelineServiceClientException;
 import org.openmetadata.service.clients.pipeline.PipelineServiceClient;
 import org.openmetadata.service.clients.pipeline.config.WorkflowConfigBuilder;
@@ -166,7 +167,6 @@ public class K8sPipelineClient extends PipelineServiceClient {
 
   // Default values
   private static final String DEFAULT_CRON_SCHEDULE = "0 0 * * *";
-  private static final String DEFAULT_TASK_KEY = "ingestion_task";
   private static final String POD_PREFIX = "Pod: ";
   private static final String NAMESPACE_PREFIX = " in namespace: ";
   private static final String KUBERNETES_CLUSTER_PREFIX = "Kubernetes cluster - namespace: ";
@@ -1118,10 +1118,8 @@ public class K8sPipelineClient extends PipelineServiceClient {
         return Map.of("logs", NO_LOGS_MESSAGE + podName);
       }
 
-      String taskKey = TYPE_TO_TASK.get(ingestionPipeline.getPipelineType().value());
-      if (taskKey == null) {
-        taskKey = DEFAULT_TASK_KEY;
-      }
+      String taskKey =
+          PipelineServiceClientInterface.taskKeyOf(ingestionPipeline.getPipelineType().value());
 
       return IngestionLogHandler.buildLogResponse(logs, after, taskKey);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -668,7 +668,7 @@ public class AppResource extends EntityResource<App, AppRepository> {
         Object logs = lastLogs.remove("logs");
         if (logs != null) {
           lastLogs.put(
-              PipelineServiceClientInterface.TYPE_TO_TASK.get(
+              PipelineServiceClientInterface.taskKeyOf(
                   ingestionPipeline.getPipelineType().toString()),
               logs.toString());
         }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -17,7 +17,6 @@ import static org.openmetadata.common.utils.CommonUtil.listOf;
 import static org.openmetadata.common.utils.CommonUtil.listOrEmpty;
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
 import static org.openmetadata.schema.type.MetadataOperation.CREATE;
-import static org.openmetadata.sdk.PipelineServiceClientInterface.TYPE_TO_TASK;
 import static org.openmetadata.service.Entity.FIELD_OWNERS;
 import static org.openmetadata.service.jdbi3.IngestionPipelineRepository.validateProfileSample;
 
@@ -1105,7 +1104,9 @@ public class IngestionPipelineResource
         Object logs = lastIngestionLogs.remove("logs");
         if (logs != null) {
           lastIngestionLogs.put(
-              TYPE_TO_TASK.get(ingestionPipeline.getPipelineType().toString()), logs.toString());
+              PipelineServiceClientInterface.taskKeyOf(
+                  ingestionPipeline.getPipelineType().toString()),
+              logs.toString());
         }
       } else {
         throw new PipelineServiceClientException(
@@ -1197,7 +1198,8 @@ public class IngestionPipelineResource
               Object logs = logChunk.remove("logs");
               if (logs != null) {
                 logChunk.put(
-                    TYPE_TO_TASK.get(ingestionPipeline.getPipelineType().toString()),
+                    PipelineServiceClientInterface.taskKeyOf(
+                        ingestionPipeline.getPipelineType().toString()),
                     logs.toString());
               }
             } else {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/PipelineTaskKeyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/PipelineTaskKeyTest.java
@@ -48,6 +48,34 @@ class PipelineTaskKeyTest {
     assertNotNull(PipelineServiceClientInterface.taskKeyOf(pipelineType.toString()));
   }
 
+  /**
+   * Call sites are split between the two accessors — K8sPipelineClient passes {@code value()} while
+   * the resource layer and AirflowRESTClient pass {@code toString()}. They agree today only because
+   * the generated enum's toString() returns the JSON value; if that ever diverges, K8s log keys
+   * would silently change. Pin the equivalence rather than rely on it.
+   */
+  @ParameterizedTest
+  @EnumSource(PipelineType.class)
+  void bothAccessorFormsResolveToTheSameTaskKey(PipelineType pipelineType) {
+    String fromValue = PipelineServiceClientInterface.taskKeyOf(pipelineType.value());
+    String fromToString = PipelineServiceClientInterface.taskKeyOf(pipelineType.toString());
+
+    assertNotNull(fromValue, "PipelineType." + pipelineType.name() + " unresolved via value()");
+    assertEquals(
+        fromToString,
+        fromValue,
+        "value() and toString() disagree for PipelineType." + pipelineType.name());
+  }
+
+  /** The map is keyed by the JSON value, so value() must hit a real entry, not the fallback. */
+  @ParameterizedTest
+  @EnumSource(PipelineType.class)
+  void everyPipelineTypeHasATaskKeyByValue(PipelineType pipelineType) {
+    assertNotNull(
+        PipelineServiceClientInterface.TYPE_TO_TASK.get(pipelineType.value()),
+        "PipelineType." + pipelineType.name() + " has no TYPE_TO_TASK entry for value()");
+  }
+
   @Test
   void taskKeyOfFallsBackForUnmappedType() {
     assertEquals(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/PipelineTaskKeyTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/PipelineTaskKeyTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.clients.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.sdk.PipelineServiceClientInterface;
+
+/**
+ * Guards the log task key lookup. A pipeline type missing from {@code TYPE_TO_TASK} used to yield a
+ * null map key in the log response, which Jackson rejects — the caller saw an opaque
+ * {@code 400 Invalid request format} instead of their logs.
+ */
+class PipelineTaskKeyTest {
+
+  @ParameterizedTest
+  @EnumSource(PipelineType.class)
+  void everyPipelineTypeHasATaskKey(PipelineType pipelineType) {
+    assertNotNull(
+        PipelineServiceClientInterface.TYPE_TO_TASK.get(pipelineType.toString()),
+        "PipelineType." + pipelineType.name() + " has no TYPE_TO_TASK entry");
+  }
+
+  @ParameterizedTest
+  @EnumSource(PipelineType.class)
+  void taskKeyOfNeverReturnsNull(PipelineType pipelineType) {
+    assertNotNull(PipelineServiceClientInterface.taskKeyOf(pipelineType.toString()));
+  }
+
+  @Test
+  void taskKeyOfFallsBackForUnmappedType() {
+    assertEquals(
+        PipelineServiceClientInterface.DEFAULT_TASK_KEY,
+        PipelineServiceClientInterface.taskKeyOf("someTypeAddedLater"));
+  }
+
+  @Test
+  void policyAgentLogsUseTheKeyTheUiReads() {
+    // agentsDataMapper.ts maps PipelineType.PolicyAgent -> 'ingestion_task'.
+    assertEquals(
+        "ingestion_task",
+        PipelineServiceClientInterface.taskKeyOf(PipelineType.POLICY_AGENT.toString()));
+  }
+
+  /** The failure mode this class guards against, pinned so the regression is unmistakable. */
+  @Test
+  void nullTaskKeyBreaksLogResponseSerialization() {
+    Map<String, String> logResponse = new HashMap<>();
+    logResponse.put(null, "log line");
+
+    assertThrows(
+        JsonMappingException.class, () -> new ObjectMapper().writeValueAsString(logResponse));
+  }
+
+  @Test
+  void logResponseKeyedByPolicyAgentTaskSerializes() throws Exception {
+    Map<String, String> logResponse = new HashMap<>();
+    logResponse.put(
+        PipelineServiceClientInterface.taskKeyOf(PipelineType.POLICY_AGENT.toString()), "log line");
+
+    String json = new ObjectMapper().writeValueAsString(logResponse);
+
+    assertEquals("{\"ingestion_task\":\"log line\"}", json);
+  }
+}

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
@@ -48,16 +48,26 @@ public interface PipelineServiceClientInterface {
   String TRIGGER_ERROR = "TRIGGER_ERROR";
 
   /**
+   * Task key that metadata-style ingestion logs are returned under. Defined once because several
+   * pipeline types deliberately share it and it doubles as {@link #DEFAULT_TASK_KEY}.
+   */
+  String INGESTION_TASK_KEY = "ingestion_task";
+
+  /**
    * Task key used when a pipeline type has no dedicated entry in {@link #TYPE_TO_TASK}. Callers must
    * resolve through {@link #taskKeyOf(String)} rather than reading the map directly: a null task key
    * ends up as a null key in the JSON log response, which Jackson refuses to serialize and which
    * surfaces to the caller as an opaque 400 "Invalid request format".
+   *
+   * <p>Kept separate from {@link #INGESTION_TASK_KEY} even though the values coincide: this one is
+   * fallback policy, and retargeting it must not silently change the response shape of the pipeline
+   * types that map to {@code ingestion_task} as their real, UI-facing contract.
    */
-  String DEFAULT_TASK_KEY = "ingestion_task";
+  String DEFAULT_TASK_KEY = INGESTION_TASK_KEY;
 
   Map<String, String> TYPE_TO_TASK =
       Map.ofEntries(
-          Map.entry(PipelineType.METADATA.toString(), "ingestion_task"),
+          Map.entry(PipelineType.METADATA.toString(), INGESTION_TASK_KEY),
           Map.entry(PipelineType.PROFILER.toString(), "profiler_task"),
           Map.entry(PipelineType.AUTO_CLASSIFICATION.toString(), "auto_classification_task"),
           Map.entry(PipelineType.LINEAGE.toString(), "lineage_task"),
@@ -69,7 +79,7 @@ public interface PipelineServiceClientInterface {
           Map.entry(PipelineType.APPLICATION.toString(), "application_task"),
           // The UI reads policy agent logs from `ingestion_task`
           // (see agentsDataMapper.ts PIPELINE_TYPE_TO_LOG_TASK_FIELD).
-          Map.entry(PipelineType.POLICY_AGENT.toString(), DEFAULT_TASK_KEY));
+          Map.entry(PipelineType.POLICY_AGENT.toString(), INGESTION_TASK_KEY));
 
   /** Resolves the log task key for a pipeline type, falling back to {@link #DEFAULT_TASK_KEY}. */
   static String taskKeyOf(String pipelineType) {

--- a/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
+++ b/openmetadata-spec/src/main/java/org/openmetadata/sdk/PipelineServiceClientInterface.java
@@ -46,26 +46,35 @@ public interface PipelineServiceClientInterface {
 
   String DEPLOYMENT_ERROR = "DEPLOYMENT_ERROR";
   String TRIGGER_ERROR = "TRIGGER_ERROR";
+
+  /**
+   * Task key used when a pipeline type has no dedicated entry in {@link #TYPE_TO_TASK}. Callers must
+   * resolve through {@link #taskKeyOf(String)} rather than reading the map directly: a null task key
+   * ends up as a null key in the JSON log response, which Jackson refuses to serialize and which
+   * surfaces to the caller as an opaque 400 "Invalid request format".
+   */
+  String DEFAULT_TASK_KEY = "ingestion_task";
+
   Map<String, String> TYPE_TO_TASK =
-      Map.of(
-          PipelineType.METADATA.toString(),
-          "ingestion_task",
-          PipelineType.PROFILER.toString(),
-          "profiler_task",
-          PipelineType.AUTO_CLASSIFICATION.toString(),
-          "auto_classification_task",
-          PipelineType.LINEAGE.toString(),
-          "lineage_task",
-          PipelineType.DBT.toString(),
-          "dbt_task",
-          PipelineType.USAGE.toString(),
-          "usage_task",
-          PipelineType.TEST_SUITE.toString(),
-          "test_suite_task",
-          PipelineType.DATA_INSIGHT.toString(),
-          "data_insight_task",
-          PipelineType.APPLICATION.toString(),
-          "application_task");
+      Map.ofEntries(
+          Map.entry(PipelineType.METADATA.toString(), "ingestion_task"),
+          Map.entry(PipelineType.PROFILER.toString(), "profiler_task"),
+          Map.entry(PipelineType.AUTO_CLASSIFICATION.toString(), "auto_classification_task"),
+          Map.entry(PipelineType.LINEAGE.toString(), "lineage_task"),
+          Map.entry(PipelineType.DBT.toString(), "dbt_task"),
+          Map.entry(PipelineType.USAGE.toString(), "usage_task"),
+          Map.entry(PipelineType.TEST_SUITE.toString(), "test_suite_task"),
+          Map.entry(PipelineType.DATA_INSIGHT.toString(), "data_insight_task"),
+          Map.entry(PipelineType.ELASTIC_SEARCH_REINDEX.toString(), "elasticsearch_reindex_task"),
+          Map.entry(PipelineType.APPLICATION.toString(), "application_task"),
+          // The UI reads policy agent logs from `ingestion_task`
+          // (see agentsDataMapper.ts PIPELINE_TYPE_TO_LOG_TASK_FIELD).
+          Map.entry(PipelineType.POLICY_AGENT.toString(), DEFAULT_TASK_KEY));
+
+  /** Resolves the log task key for a pipeline type, falling back to {@link #DEFAULT_TASK_KEY}. */
+  static String taskKeyOf(String pipelineType) {
+    return TYPE_TO_TASK.getOrDefault(pipelineType, DEFAULT_TASK_KEY);
+  }
 
   URL validateServiceURL(String serviceURL);
 


### PR DESCRIPTION
### Describe your changes:

- `GET /v1/services/ingestionPipelines/logs/{id-or-fqn}/last` returns
`400 {"code":400,"message":"Invalid request format"}` for any `policyAgent` pipeline.
Other pipeline types on the same service, with the same ingestion runner, return 200.
The `/last/download` variant is broken the same way.

- `policyAgent` was added to the `PipelineType` enum in #27396 but never added to
`TYPE_TO_TASK`, which maps a pipeline type to the key its logs are returned under.
(`elasticSearchReindex` is missing too.) The lookup returns `null`, that `null` becomes
the key of the log response map, and Jackson refuses to serialize a map with a null key.
`JsonMappingExceptionMapper` converts the resulting `JsonMappingException` into a 400 —
so a server-side serialization bug surfaces as a misleading client error, with no stack
trace logged.

- I added the two missing entries and routed every call site through a new `taskKeyOf()`
helper that falls back to `DEFAULT_TASK_KEY`, so a future pipeline type added without a
mapping degrades gracefully instead of producing a null key.

#
### Manual Verification
<img width="1508" height="602" alt="Screenshot 2026-08-12 at 6 15 06 PM" src="https://github.com/user-attachments/assets/5bd22db7-01d3-413f-bf85-aa37c7784375" />

#
### Type of change:
- [x] Bug fix

#
### High-level design:

- `policyAgent` maps to `ingestion_task` rather than a new `policy_agent_task` key, because
the UI already expects that field for policy agents — see `PIPELINE_TYPE_TO_LOG_TASK_FIELD`
in `agentsDataMapper.ts` and the `*_task` fan-in in the Collate agent log view. Introducing
a new key would have kept the backend from 400-ing while leaving the UI rendering blank
logs. `elasticSearchReindex` maps to `elasticsearch_reindex_task`, which the UI also
already reads.

- `taskKeyOf()` hoists the fallback that `K8sPipelineClient` already had privately
(`DEFAULT_TASK_KEY = "ingestion_task"` plus a null check) into the interface, so all four
call sites share one behaviour instead of one being defensive and three not. Direct reads
of `TYPE_TO_TASK` in production code are replaced; the map stays public for tests.

- `Map.of` was changed to `Map.ofEntries` — with 11 entries the map exceeds `Map.of`'s
10-pair overload limit.

- Alternative considered: making `JsonMappingExceptionMapper` log the exception. Worth doing
separately (the silent swallow is what made this hard to diagnose), but it treats the
symptom, not the missing mapping.

- No schema, API-contract, or migration impact — the response shape for every
already-working pipeline type is unchanged.

#
### Tests:

#### Use cases covered
- Fetching the last run logs for a `policyAgent` pipeline returns 200 with logs under
  `ingestion_task`, by FQN and by Id
- Downloading the last run logs for a `policyAgent` pipeline returns 200 instead of
  failing on a null map key
- Existing pipeline types (`metadata`, `usage`, `profiler`, …) keep their current task
  keys — no response-shape change
- A `PipelineType` added in future without a `TYPE_TO_TASK` entry falls back to
  `ingestion_task` rather than emitting a null key

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added: `openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/PipelineTaskKeyTest.java`
- 26 tests, all passing. `@EnumSource(PipelineType.class)` asserts every enum value has a
  task key, so adding a 12th type without a mapping fails the build. One test pins the
  underlying failure mode — serializing a map with a null key throws `JsonMappingException`
  — so the regression is unmistakable if the fallback is ever removed.

#### Backend integration tests
- [ ] Not applicable — no new or changed API endpoints; this fixes the response
  serialization of an existing one. Covered by unit tests plus manual verification below.

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Against a local stack (MySQL + Elasticsearch + server), on a Snowflake service with a
`policyAgent` pipeline and a `usage` pipeline sharing the same ingestion runner:

1. Before the fix — `GET /logs/snow_check.policy_agent/last` → `400 Invalid request format`;
   `GET /logs/snow_check.<usage-id>/last` → `200`. Same service, same runner, same code
   path; the only difference is the pipeline type.
2. Rebuilt and redeployed, and confirmed the running server's jar exports `taskKeyOf`.
3. After the fix:
   - `/logs/snow_check.policy_agent/last` → **200**, body keyed `ingestion_task`
   - `/logs/snow_check.policy_agent/last/download` → **200**
   - `/logs/snow_check.<usage-id>/last` → **200**, still keyed `usage_task` (no regression)
   - `/logs/snow_check.<usage-id>/last/download` → **200**
4. Verified the logs render in the agent log view in the UI.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [x] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.
