### PR TITLE
Reset test connection badge when form values change

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/TestConnectionModal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/TestConnectionModal.spec.ts
@@ -230,6 +230,51 @@ test.describe(
       await expect(page.getByTestId('retry-test-button')).not.toBeVisible();
     });
 
+    test('changing a form field after a successful test resets the connection badge', async ({
+      page,
+    }) => {
+      const successResponse = {
+        id: MOCK_WORKFLOW_ID,
+        status: 'Successful',
+        response: {
+          status: 'Successful',
+          steps: [
+            { name: 'CheckAccess', passed: true, mandatory: true },
+            { name: 'GetDatabases', passed: true, mandatory: true },
+          ],
+        },
+      };
+
+      await navigateToMysqlConnectionForm(page);
+      await setupWorkflowApiMocks(page, successResponse);
+
+      await page.getByTestId('test-connection-btn').click();
+
+      await expect(page.getByRole('button', { name: /done/i })).toBeVisible({
+        timeout: 30000,
+      });
+      await page.getByRole('button', { name: /done/i }).click();
+
+      await expect(
+        page.getByTestId('test-connection-card-Successful')
+      ).toBeVisible();
+      await expect(page.getByTestId('test-connection-btn')).toHaveText(
+        'Re-test Connection'
+      );
+
+      await page.fill('[id="root\\/hostPort"]', 'localhost:3307');
+
+      await expect(
+        page.getByTestId('test-connection-card-Successful')
+      ).not.toBeVisible();
+      await expect(
+        page.getByTestId('test-connection-card-ready-to-test')
+      ).toBeVisible();
+      await expect(page.getByTestId('test-connection-btn')).toHaveText(
+        'Test Connection'
+      );
+    });
+
     test('failure state shows Edit Connection button and Retry Test button', async ({
       page,
     }) => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TestConnection/TestConnection.tsx
@@ -19,7 +19,7 @@ import {
 import { AlertTriangle, CheckCircle, XCircle, Zap } from '@untitledui/icons';
 import { AxiosError } from 'axios';
 import cx from 'classnames';
-import { isEmpty, toNumber } from 'lodash';
+import { isEmpty, isEqual, toNumber } from 'lodash';
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AIRFLOW_DOCS } from '../../../constants/docs.constants';
@@ -46,6 +46,7 @@ import {
 } from '../../../generated/entity/automations/workflow';
 import { TestConnectionStep } from '../../../generated/entity/services/connections/testConnectionDefinition';
 import useAbortController from '../../../hooks/AbortController/useAbortController';
+import { ConfigData } from '../../../interface/service.interface';
 import {
   addWorkflow,
   deleteWorkflowById,
@@ -167,6 +168,9 @@ const TestConnection: FC<TestConnectionProps> = ({
    * Current workflow reference
    */
   const currentWorkflowRef = useRef(currentWorkflow);
+
+  // Form data as of the last test run, used to detect edits made after a test completed
+  const lastTestedDataRef = useRef<ConfigData | undefined>();
 
   // Timers live in a ref so a new run - or an unmount - can cancel the previous
   // run's callbacks before they write state over a newer result.
@@ -423,7 +427,9 @@ const TestConnection: FC<TestConnectionProps> = ({
     clearTimers();
     const runId = ++runIdRef.current;
 
-    const updatedFormData = formatFormDataForSubmit(getData());
+    const rawFormData = getData();
+    lastTestedDataRef.current = rawFormData;
+    const updatedFormData = formatFormDataForSubmit(rawFormData);
 
     const { ingestionRunner, ...rest } = updatedFormData as ConfigObject & {
       ingestionRunner?: string;
@@ -703,6 +709,16 @@ const TestConnection: FC<TestConnectionProps> = ({
   useEffect(() => {
     currentWorkflowRef.current = currentWorkflow; // update ref with latest value of currentWorkflow state variable
   }, [currentWorkflow]);
+
+  // discard a stale test result once the form data has changed since the last test run
+  useEffect(() => {
+    if (!testStatus || isTestingConnection) {
+      return;
+    }
+    if (!isEqual(getData(), lastTestedDataRef.current)) {
+      handleResetState();
+    }
+  });
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
### Describe your changes:

No linked issue (skipped per maintainer request).

The "Test Connection" success/failure badge in service create/edit forms stayed visible after the user edited connection fields post-test, misleading them into thinking a stale, unverified config had been checked. `TestConnection` now snapshots the form data it actually tested and discards the result (`handleResetState`) once the live form data diverges from that snapshot — badge reverts to "ready to test", button label reverts to "Test Connection", and the parent's `isConnectionVerified` gate re-locks via the existing `onTestConnectionStatusChange(false)` callback.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change, confined to `TestConnection.tsx`:
- Added `lastTestedDataRef` to snapshot `getData()` at the moment a test run starts.
- Added an effect (no dep array, guarded by `!testStatus || isTestingConnection`) that compares the current `getData()` against that snapshot on every render and calls the existing `handleResetState()` reset path on divergence — the same path already used when a retest starts.
- No changes needed in `ConnectionConfigForm.tsx` / `EmbeddedConnectionConfigForm.tsx` — they already pass a fresh `getData` closure each render.

#
### Tests:

#### Use cases covered
- User tests a connection successfully, edits a connection field (e.g. host/port), badge and button label revert to the untested state instead of showing stale "Successful".

#### Unit tests
- [ ] Not applicable — behavior is exercised end-to-end via the Playwright test below; no existing Jest suite for this component to extend.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- Files added/updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/TestConnectionModal.spec.ts` — new test "changing a form field after a successful test resets the connection badge".

#### Manual testing performed
1. Read through `AddServicePage` / `EditConnectionFormPage` wiring to confirm `isConnectionVerified` is correctly re-gated via the existing `onTestConnectionStatusChange(false)` callback path (unchanged call site, reused).
2. `npx tsc --noEmit` — zero new errors introduced by this change (confirmed against baseline via `git stash` diff).
3. `yarn ui-checkstyle` (organize-imports + eslint --fix + prettier) — clean, only pre-existing unrelated warnings.

#
### UI screen recording / screenshots:

TODO: attach recording — no local stack spun up for this change; behavior is covered by the new Playwright test above.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (N/A, no schema changes)
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)