### PR TITLE
fix(tasks): apply column-level tag suggestions to the column, not the parent (backport #31361 to 2.0)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/migration/utils/v200/MigrationUtil.java
@@ -552,10 +552,13 @@ public class MigrationUtil {
         ObjectNode payload = JsonUtils.getObjectNode();
         payload.put("suggestionType", mappedSuggestionType);
 
-        String fieldPath =
-            "Tag".equals(mappedSuggestionType)
-                ? Entity.FIELD_TAGS
-                : extractFieldPathFromEntityLink(entityLink);
+        // Keep the field path the entityLink points at (e.g. columns.<col>.tags) so a tag
+        // suggestion lands on the suggested column, not the parent entity; fall back to
+        // entity-level tags only when the link carries no tags field.
+        String fieldPath = extractFieldPathFromEntityLink(entityLink);
+        if ("Tag".equals(mappedSuggestionType) && !fieldPath.endsWith(Entity.FIELD_TAGS)) {
+          fieldPath = Entity.FIELD_TAGS;
+        }
         payload.put("fieldPath", fieldPath);
 
         if ("Tag".equals(mappedSuggestionType)) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -1061,21 +1061,12 @@ public class TaskWorkflowHandler {
         List<TagLabel> tags =
             JsonUtils.readValue(suggestedValue, new TypeReference<List<TagLabel>>() {});
         if (tags != null && !tags.isEmpty()) {
-          boolean isEntityLevel =
-              fieldPath == null
-                  || fieldPath.isEmpty()
-                  || fieldPath.equals("description")
-                  || !fieldPath.contains("::");
-
-          if (isEntityLevel) {
+          // Reuse the same field-path resolution as applyTagUpdate so both "::" and dot-form
+          // paths (e.g. columns.customer_id.tags) land on the suggested field, not the parent.
+          if (isEntityLevelTagPath(fieldPath)) {
             applyEntityLevelTags(entity, repository, user, tags);
-          } else {
-            String[] parts = fieldPath.split("::");
-            String targetFqn = entity.getFullyQualifiedName();
-            if (parts.length >= 2) {
-              targetFqn = entity.getFullyQualifiedName() + "." + parts[1];
-            }
-            repository.applyTags(tags, targetFqn);
+          } else if (!patchFieldTags(entity, repository, user, fieldPath, tags, null)) {
+            repository.applyTags(tags, resolveTagTargetFqn(entity, fieldPath));
           }
           LOG.info(
               "[TaskWorkflowHandler] Applied tag suggestion: {} tags for entity '{}'",

--- a/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/migration/utils/v200/MigrationUtilTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.Update;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -281,6 +283,68 @@ class MigrationUtilTest {
         entityRelationshipInserts >= 2,
         "Expected at least 2 entity_relationship inserts (CREATED + MENTIONED_IN), got "
             + entityRelationshipInserts);
+  }
+
+  @Test
+  void migrateColumnTagSuggestionKeepsColumnInFieldPath() {
+    JsonNode payload =
+        migrateTagSuggestionAndCapturePayload(
+            "dead-beef-0000-0004", "<#E::table::sample.shop.orders::columns::customer_id::tags>");
+    assertEquals("Tag", payload.get("suggestionType").asText());
+    assertEquals("columns.customer_id.tags", payload.get("fieldPath").asText());
+  }
+
+  @Test
+  void migrateTableLevelTagSuggestionUsesEntityLevelFieldPath() {
+    JsonNode payload =
+        migrateTagSuggestionAndCapturePayload(
+            "dead-beef-0000-0005", "<#E::table::sample.shop.orders::tags>");
+    assertEquals("tags", payload.get("fieldPath").asText());
+  }
+
+  private JsonNode migrateTagSuggestionAndCapturePayload(String suggestionId, String entityLink) {
+    when(handle.createQuery("SELECT 1 FROM suggestions LIMIT 1").mapToMap().list())
+        .thenReturn(List.of(Map.of("1", 1)));
+    String suggestionJson =
+        """
+        {
+          "id": "%s",
+          "type": "SuggestTagLabel",
+          "status": "Open",
+          "entityLink": "%s",
+          "tagLabels": [{"tagFQN": "PII.Sensitive", "source": "Classification", "labelType": "Manual", "state": "Suggested"}],
+          "createdBy": { "id": "cccc-dddd-eeee-ffff", "type": "user" },
+          "createdAt": 1700000000000,
+          "updatedAt": 1700000000000,
+          "updatedBy": "system"
+        }
+        """
+            .formatted(suggestionId, entityLink);
+    when(handle
+            .createQuery("SELECT json FROM suggestions ORDER BY updatedAt ASC")
+            .mapToMap()
+            .list())
+        .thenReturn(List.of(Map.of("json", suggestionJson)));
+    when(handle
+            .createQuery("SELECT COUNT(*) FROM task_entity WHERE id = :id")
+            .bind("id", suggestionId)
+            .mapTo(Long.class)
+            .one())
+        .thenReturn(0L);
+    when(handle.createQuery(anyString()).mapTo(Long.class).findOne())
+        .thenReturn(java.util.Optional.of(0L));
+    when(handle.createQuery(contains("entity_relationship")).mapToMap().list())
+        .thenReturn(Collections.emptyList());
+
+    Update taskInsert = mock(Update.class);
+    when(taskInsert.bind(anyString(), anyString())).thenReturn(taskInsert);
+    when(handle.createUpdate(contains("INSERT INTO task_entity"))).thenReturn(taskInsert);
+
+    MigrationUtil.migrateSuggestionsToTaskEntity(handle, MYSQL);
+
+    ArgumentCaptor<String> jsonCaptor = ArgumentCaptor.forClass(String.class);
+    verify(taskInsert).bind(eq("json"), jsonCaptor.capture());
+    return JsonUtilsHolder.readTree(jsonCaptor.getValue()).get("payload");
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskWorkflowHandlerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/tasks/TaskWorkflowHandlerTest.java
@@ -37,6 +37,7 @@ import org.openmetadata.schema.entity.tasks.Task;
 import org.openmetadata.schema.type.Column;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
+import org.openmetadata.schema.type.TagLabel;
 import org.openmetadata.schema.type.TaskEntityStatus;
 import org.openmetadata.schema.type.TaskEntityType;
 import org.openmetadata.schema.type.TaskResolution;
@@ -341,5 +342,46 @@ class TaskWorkflowHandlerTest {
     assertEquals("Customer profile block", resultProfile.getDescription());
     assertEquals(
         "Phone", resultProfile.getChildren().getLast().getChildren().getFirst().getDescription());
+  }
+
+  @Test
+  void testApplySuggestion_columnTag_appliesToColumnNotParent() throws Exception {
+    Column customerId = new Column().withName("customer_id");
+    Table table =
+        new Table()
+            .withId(UUID.randomUUID())
+            .withName("orders")
+            .withFullyQualifiedName("svc.db.schema.orders")
+            .withColumns(List.of(customerId));
+
+    Task task = new Task().withId(UUID.randomUUID());
+    Map<String, String> payload =
+        Map.of(
+            "suggestionType", "Tag",
+            "fieldPath", "columns.customer_id.tags",
+            "suggestedValue",
+                "[{\"tagFQN\":\"PII.Sensitive\",\"source\":\"Classification\",\"labelType\":\"Manual\",\"state\":\"Suggested\"}]");
+    EntityRepository<?> repository = mock(EntityRepository.class);
+
+    Method applySuggestion =
+        TaskWorkflowHandler.class.getDeclaredMethod(
+            "applySuggestion",
+            Task.class,
+            Object.class,
+            EntityInterface.class,
+            EntityRepository.class,
+            String.class);
+    applySuggestion.setAccessible(true);
+    applySuggestion.invoke(
+        TaskWorkflowHandler.getInstance(), task, payload, table, repository, "admin");
+
+    Column resultColumn = table.getColumns().getFirst();
+    assertNotNull(resultColumn.getTags(), "Column tags should be set");
+    assertEquals(1, resultColumn.getTags().size());
+    assertEquals("PII.Sensitive", resultColumn.getTags().getFirst().getTagFQN());
+    List<TagLabel> parentTags = table.getTags();
+    assertTrue(
+        parentTags == null || parentTags.isEmpty(),
+        "Column tag suggestion must not tag the parent table");
   }
 }


### PR DESCRIPTION
Backport of #31361 to the `2.0` release branch (clean cherry-pick, no conflicts).

### Describe your changes:

Accepting a column-level **tag** suggestion applied the tag to the **parent entity** instead of the suggested column. Column *descriptions* were unaffected. Two independent defects:

**1. Migration — `MigrationUtil.migrateSuggestionsToTaskEntity` (v200)**
Hardcoded `payload.fieldPath = Entity.FIELD_TAGS` (`"tags"`) for every tag suggestion, discarding the `columns::<col>` segment of the `entityLink`. Now derives the field path from the entityLink so a column tag keeps `columns.<col>.tags`, falling back to entity-level `"tags"` only when the link carries no tags field.

**2. Apply — `TaskWorkflowHandler.applySuggestion` (tag branch)**
Decided entity-vs-field level with `!fieldPath.contains("::")` and extracted the column with `split("::")`, so dot-form paths (`columns.<col>.tags`, which the migration produces) were treated as entity-level and applied to the parent. Now reuses the same helpers as the sibling `applyTagUpdate` — `isEntityLevelTagPath` / `patchFieldTags` (via `FieldPathUtils`) / `resolveTagTargetFqn` — which handle both `::` and dot-form paths.

Both fixes are needed together; the apply fix also benefits native column-tag suggestions, not only migrated ones.

### How tested:
- `MigrationUtilTest`: a column tag suggestion migrates to `fieldPath = columns.customer_id.tags` (not `tags`); a table-level tag migrates to `tags`.
- `TaskWorkflowHandlerTest`: applying a column-tag Suggestion task tags the column and leaves the parent untagged.
- Full `openmetadata-service` unit suite green on `2.0` (154 tests).
- Manually validated end-to-end on a 1.13.3 → 2.0 in-place upgrade: column-tag accept lands on the column for both `table` and `dashboardDataModel`.

### Type of change:
- [x] Bug fix
