### PR TITLE
Fixes #31407: isolate persona and user per test in CustomizeWidgets Playwright spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts
@@ -48,7 +48,6 @@ import {
 } from '../../utils/widgetFilters';
 
 let adminUser: UserClass;
-let persona: PersonaClass;
 
 // Test domain and data products for comprehensive testing
 let testDomain: Domain;
@@ -61,10 +60,75 @@ let activitySeedTable: TableClass;
 const FEED_WIDGET_PAGE_SIZE = 15;
 const SEEDED_ACTIVITY_COUNT = FEED_WIDGET_PAGE_SIZE + 1;
 
-const test = base.extend<{ page: Page }>({
-  page: async ({ browser }, use) => {
+type WidgetTestFixtures = {
+  page: Page;
+  testUser: UserClass;
+  persona: PersonaClass;
+};
+
+// Issue #31407. Every test here rewrites the whole `persona.<name>` layout document
+// (remove widget -> save -> add widget -> save). Those saves are last-write-wins,
+// so under `fullyParallel` two tests sharing a persona silently drop each other's
+// widgets and a later test finds its widget missing from the landing page. The
+// user has to be per test as well: the layout is resolved from
+// `currentUser.defaultPersona`, which is a single field on the user.
+const test = base.extend<WidgetTestFixtures>({
+  testUser: async ({ browser }, use) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    const user = new UserClass();
+    await user.create(apiContext);
+    await user.setAdminRole(apiContext);
+    await afterAction();
+
+    await use(user);
+
+    const { apiContext: cleanupContext, afterAction: cleanupAfterAction } =
+      await performAdminLogin(browser);
+    await user.delete(cleanupContext);
+    await cleanupAfterAction();
+  },
+
+  persona: async ({ browser, testUser }, use) => {
+    const { apiContext, afterAction } = await performAdminLogin(browser);
+    const testPersona = new PersonaClass();
+    await testPersona.create(apiContext, [testUser.responseData.id]);
+
+    const personaReference = {
+      id: testPersona.responseData.id,
+      type: 'persona',
+      name: testPersona.responseData.name,
+      fullyQualifiedName: testPersona.responseData.fullyQualifiedName,
+      description: testPersona.responseData.description,
+      displayName: testPersona.responseData.displayName,
+    };
+
+    await apiContext.patch(`/api/v1/users/${testUser.responseData.id}`, {
+      data: [
+        { op: 'add', path: '/personas/0', value: personaReference },
+        { op: 'add', path: '/defaultPersona', value: personaReference },
+      ],
+      headers: {
+        'Content-Type': 'application/json-patch+json',
+      },
+    });
+    await afterAction();
+
+    await use(testPersona);
+
+    const { apiContext: cleanupContext, afterAction: cleanupAfterAction } =
+      await performAdminLogin(browser);
+    await testPersona.delete(cleanupContext);
+    await cleanupAfterAction();
+  },
+
+  page: async ({ browser, testUser, persona }, use) => {
+    // `persona` is depended on for its side effect - the default persona has to
+    // be attached to the user before login, otherwise the session starts with
+    // the stock layout instead of the persona's customizable one.
+    void persona;
+
     const page = await browser.newPage();
-    await adminUser.login(page);
+    await testUser.login(page);
     await use(page);
     await page.close();
   },
@@ -74,7 +138,6 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   test.slow(true);
 
   adminUser = new UserClass();
-  persona = new PersonaClass();
   testDomain = new Domain();
   testDataProducts = [
     new DataProduct([testDomain]),
@@ -85,7 +148,6 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   const { afterAction, apiContext } = await performAdminLogin(browser);
   await adminUser.create(apiContext);
   await adminUser.setAdminRole(apiContext);
-  await persona.create(apiContext, [adminUser.responseData.id]);
 
   // Set adminUser as owner for entities created by entityDetails config
   // Only domains and glossaries from entityDetails typically support owners
@@ -158,39 +220,6 @@ test.beforeAll('Setup pre-requests', async ({ browser }) => {
   // Delete all existing KPIs before running the test
   await deleteKpiRequest(apiContext);
 
-  // Set default persona for admin user
-  await apiContext.patch(`/api/v1/users/${adminUser.responseData.id}`, {
-    data: [
-      {
-        op: 'add',
-        path: '/personas/0',
-        value: {
-          id: persona.responseData.id,
-          type: 'persona',
-          name: persona.responseData.name,
-          fullyQualifiedName: persona.responseData.fullyQualifiedName,
-          description: persona.responseData.description,
-          displayName: persona.responseData.displayName,
-        },
-      },
-      {
-        op: 'add',
-        path: '/defaultPersona',
-        value: {
-          id: persona.responseData.id,
-          type: 'persona',
-          name: persona.responseData.name,
-          fullyQualifiedName: persona.responseData.fullyQualifiedName,
-          description: persona.responseData.description,
-          displayName: persona.responseData.displayName,
-        },
-      },
-    ],
-    headers: {
-      'Content-Type': 'application/json-patch+json',
-    },
-  });
-
   await afterAction();
 });
 
@@ -214,7 +243,7 @@ test.beforeEach(async ({ page }) => {
   await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
 });
 
-test('Activity Feed Widget', async ({ page }) => {
+test('Activity Feed Widget', async ({ page, persona, testUser }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.ActivityFeed';
@@ -229,7 +258,7 @@ test('Activity Feed Widget', async ({ page }) => {
       page,
       widgetKey,
       'Activity Feed',
-      `/users/${adminUser.responseData.name}/activity_feed/all`
+      `/users/${testUser.responseData.name}/activity_feed/all`
     );
   });
 
@@ -244,7 +273,7 @@ test('Activity Feed Widget', async ({ page }) => {
     await waitForAllLoadersToDisappear(page, 'entity-list-skeleton');
     await verifyWidgetFooterViewMore(page, {
       widgetKey,
-      link: `/users/${adminUser.responseData.name}/activity_feed/all`,
+      link: `/users/${testUser.responseData.name}/activity_feed/all`,
       requireViewMore: true,
     });
 
@@ -258,7 +287,7 @@ test('Activity Feed Widget', async ({ page }) => {
   });
 });
 
-test('Data Assets Widget', async ({ page }) => {
+test('Data Assets Widget', async ({ page, persona }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.DataAssets';
@@ -311,7 +340,7 @@ test('Data Assets Widget', async ({ page }) => {
   });
 });
 
-test('My Data Widget', async ({ page }) => {
+test('My Data Widget', async ({ page, persona, testUser }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.MyData';
@@ -326,7 +355,7 @@ test('My Data Widget', async ({ page }) => {
       page,
       widgetKey,
       'My Data',
-      `/users/${adminUser.responseData.name}/mydata`
+      `/users/${testUser.responseData.name}/mydata`
     );
   });
 
@@ -367,7 +396,7 @@ test('My Data Widget', async ({ page }) => {
   });
 });
 
-test('KPI Widget', async ({ page }) => {
+test('KPI Widget', async ({ page, persona }) => {
   test.slow(true);
 
   await test.step('Add KPI', async () => {
@@ -469,7 +498,7 @@ test('KPI Widget', async ({ page }) => {
   });
 });
 
-test('Total Data Assets Widget', async ({ page }) => {
+test('Total Data Assets Widget', async ({ page, persona }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.TotalAssets';
@@ -518,7 +547,7 @@ test('Total Data Assets Widget', async ({ page }) => {
   });
 });
 
-test('Following Assets Widget', async ({ page }) => {
+test('Following Assets Widget', async ({ page, persona, testUser }) => {
   test.slow(true);
 
   await testDomain.visitEntityPage(page);
@@ -543,7 +572,7 @@ test('Following Assets Widget', async ({ page }) => {
       page,
       widgetKey,
       'Following',
-      `/users/${adminUser.responseData.name}/following`
+      `/users/${testUser.responseData.name}/following`
     );
   });
 
@@ -586,7 +615,7 @@ test('Following Assets Widget', async ({ page }) => {
   });
 });
 
-test('Domains Widget', async ({ page }) => {
+test('Domains Widget', async ({ page, persona }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.Domains';
@@ -639,7 +668,7 @@ test('Domains Widget', async ({ page }) => {
   });
 });
 
-test('My Tasks Widget', async ({ page }) => {
+test('My Tasks Widget', async ({ page, persona, testUser }) => {
   test.slow(true);
 
   await test.step('Create a task', async () => {
@@ -653,7 +682,7 @@ test('My Tasks Widget', async ({ page }) => {
         about: `<#E::glossary::${glossary1.responseData.fullyQualifiedName}>`,
         type: 'DescriptionUpdate',
         category: 'MetadataUpdate',
-        assignees: [adminUser.responseData.name],
+        assignees: [testUser.responseData.name],
         payload: {
           suggestedValue: 'Test task description for My Tasks widget test',
           currentValue: '',
@@ -685,7 +714,7 @@ test('My Tasks Widget', async ({ page }) => {
       page,
       widgetKey,
       'My Tasks',
-      `/users/${adminUser.responseData.name}/task`
+      `/users/${testUser.responseData.name}/task`
     );
   });
 
@@ -717,7 +746,7 @@ test('My Tasks Widget', async ({ page }) => {
   });
 });
 
-test('Data Products Widget', async ({ page }) => {
+test('Data Products Widget', async ({ page, persona }) => {
   test.slow(true);
 
   const widgetKey = 'KnowledgePanel.DataProducts';


### PR DESCRIPTION
### Describe your changes:

Fixes #31407

`playwright/e2e/Flow/CustomizeWidgets.spec.ts` was flaky, failing with a widget that is simply absent from the landing page:

```
Flow/CustomizeWidgets.spec.ts:472 › Total Data Assets Widget

Error: expect(locator).toBeVisible() failed
Locator: getByTestId('KnowledgePanel.TotalAssets')
Expected: visible
Timeout: 15000ms
Error: element(s) not found
```

The page snapshot at failure time showed only 4 of the 7 default widgets — `MyData`, `KPI` and `TotalAssets` were missing from the layout entirely, not scrolled out of view and not loading.

**Root cause.** Every test in the file ended with a `Test widget customization` step running `removeAndVerifyWidget()` → save → `addAndVerifyWidget()` → save. Each save is a full rewrite of the `persona.<name>` docStore document, i.e. last-write-wins over the whole widget layout. The spec shared a single `persona` and a single `adminUser` created in `beforeAll`, and `playwright.config.ts` sets `fullyParallel: true`, so those tests ran concurrently. Two workers each read the layout, each dropped their own widget from their own stale copy, and each wrote the whole document back — permanently losing the other test's widget. Any test that later expected one of those widgets failed with "element(s) not found".

**Fix.** Replace the shared module-level state with per-test `testUser` and `persona` fixtures, so each test owns its own layout document. A fresh persona has no docStore document, so the customize page falls back to `DEFAULT_LANDING_PAGE_LAYOUT` — exactly the widget set these tests assert on.

The user has to be per test as well as the persona: the landing page resolves its layout from `currentUser.defaultPersona` (`src/hooks/useApplicationStore.ts`), which is a single field on the user, so keeping a shared user would just move the race onto that field. Tests asserting on user-scoped URLs (`/users/<name>/activity_feed/all`, `/mydata`, `/following`, `/task`) and the `My Tasks` assignee now use the per-test user.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — single test file, no product code changed.

#
### Tests:

#### Use cases covered
- All 9 landing-page widget tests in `CustomizeWidgets.spec.ts` can add/remove widgets concurrently without one test's layout save dropping another test's widget.

#### Unit tests
Not applicable — this PR only changes Playwright test setup; no product code.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Files updated: `openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/CustomizeWidgets.spec.ts`

#### Manual testing performed
Ran the spec locally against a running server on `:8585`, 5 parallel workers:

```bash
cd openmetadata-ui/src/main/resources/ui
npx playwright test playwright/e2e/Flow/CustomizeWidgets.spec.ts --project=chromium
```

Result: **10 passed, 2 failed** (5.1m). Every widget-presence failure is gone, including the original `Total Data Assets Widget` failure.

The 2 remaining failures are data-dependent, not layout-related, and I believe they are environment gaps in a local run rather than regressions from this change — leaving CI to confirm:

1. `KPI Widget › Test widget loads KPI data correctly` — `KnowledgePanel.KPI .recharts-area` not found. The chart container renders but has no series, because KPI results require the Data Insight app to have run; the `chromium` project `grepInvert`s `@data-insight` so it never runs it.
2. `Activity Feed Widget › Test widget filters` — 180s timeout in `playwright/utils/widgetFilters.ts:49` waiting for `GET /api/v1/activity/my-feed` after selecting the "My Data" filter.

Neither failure involves a widget missing from the layout.

#
### UI screen recording / screenshots:

Not applicable — test-only change, no UI behaviour changed.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [x] For UI changes: I attached a screen recording and/or screenshots above. (Test-only change.)
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. The fixed spec *is* the test; issue #31407 is referenced in the fixture comment for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
