### PR TITLE
fix(redshift): Exclude internal materialized view tables by default

### DIFF
--- a/ingestion/tests/unit/topology/database/test_redshift.py
+++ b/ingestion/tests/unit/topology/database/test_redshift.py
@@ -28,6 +28,7 @@ from metadata.ingestion.source.database.redshift.models import RedshiftInstanceT
 from metadata.ingestion.source.database.redshift.queries import (
     REDSHIFT_SQL_STATEMENT_MAP,
 )
+from metadata.utils.filters import filter_by_table
 
 mock_redshift_config = {
     "source": {
@@ -78,6 +79,19 @@ class RedshiftUnitTest(unittest.TestCase):
         """Test connection closing"""
         mock_connection.return_value = True
         self.redshift_source.close()
+
+    def test_connection_defaults_filter_internal_materialized_view_tables(self):
+        table_filter = self.redshift_source.service_connection.tableFilterPattern
+        assert table_filter is not None
+
+        self.assertTrue(filter_by_table(table_filter, "mv_tbl__orders_rollup__0"))
+        self.assertTrue(
+            filter_by_table(
+                table_filter,
+                "redshift_service.database.schema.mv_tbl__orders_rollup__0",
+            )
+        )
+        self.assertFalse(filter_by_table(table_filter, "orders_rollup"))
 
     def test_detect_provisioned_when_stl_accessible(self):
         """Test detection of Provisioned cluster when STL tables are accessible"""

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
@@ -92,7 +92,11 @@
     "tableFilterPattern": {
       "title": "Default Table Filter Pattern",
       "description": "Regex to only include/exclude tables that matches the pattern.",
-      "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern"
+      "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern",
+      "default": {
+        "includes": [],
+        "excludes": ["^(?:.*\\.)?mv_tbl__.*__\\d+$"]
+      }
     },
     "databaseFilterPattern": {
       "title": "Default Database Filter Pattern",


### PR DESCRIPTION
## Summary

- Adds a Redshift service-level table filter default for internal mv_tbl__...__N backing tables.
- Keeps user-facing materialized views available while preventing metadata and profiler pipelines from targeting their internal storage tables.

## Testing

- make generate
- mvn clean install -pl openmetadata-spec -DskipTests
- yarn parse-schema
- pytest -q ingestion/tests/unit/topology/database/test_redshift.py ingestion/tests/unit/source/database/test_redshift_progress_count.py (13 passed)