### PR TITLE
fix: return ingestion pipeline logs on Argo and stop wiping owners on reindex

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -628,8 +628,11 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
 
   public RestUtil.PutResponse<?> addPipelineStatus(
       UriInfo uriInfo, String fqn, PipelineStatus pipelineStatus) {
-    // Validate the request content
-    IngestionPipeline ingestionPipeline = getByName(uriInfo, fqn, getFields("service"));
+    // Validate the request content. Load owners/domains/followers too: updateEntityIndex below
+    // rebuilds the full search document from this entity, so any field not loaded here would be
+    // wiped from the index on every run status report.
+    IngestionPipeline ingestionPipeline =
+        getByName(uriInfo, fqn, getFields("service,owners,domains,followers"));
     PipelineStatus storedPipelineStatus =
         JsonUtils.readValue(
             daoCollection

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -76,6 +76,7 @@ import org.openmetadata.service.Entity;
 import org.openmetadata.service.OpenMetadataApplicationConfig;
 import org.openmetadata.service.events.lifecycle.EntityLifecycleEventDispatcher;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.logstorage.DefaultLogStorage;
 import org.openmetadata.service.logstorage.LogStorageInterface;
 import org.openmetadata.service.logstorage.S3LogStorage.LogStreamListener;
 import org.openmetadata.service.monitoring.IngestionProgressTracker;
@@ -628,9 +629,8 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
 
   public RestUtil.PutResponse<?> addPipelineStatus(
       UriInfo uriInfo, String fqn, PipelineStatus pipelineStatus) {
-    // Validate the request content. Load owners/domains/followers too: updateEntityIndex below
-    // rebuilds the full search document from this entity, so any field not loaded here would be
-    // wiped from the index on every run status report.
+    // updateEntityIndex below can rebuild the whole search document from this entity, so load
+    // every field it indexes; anything missing here gets wiped from the index on each run.
     IngestionPipeline ingestionPipeline =
         getByName(uriInfo, fqn, getFields("service,owners,domains,followers"));
     PipelineStatus storedPipelineStatus =
@@ -1120,13 +1120,14 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   }
 
   private Map<String, Object> getLogsFromPipelineService(String pipelineFQN, String afterCursor) {
-    // Fall back to traditional pipeline service logs (Airflow/Argo)
+    // Fall back to traditional pipeline service logs (Airflow/Argo). Loads the service and reads
+    // the task-keyed content for the same reasons as DefaultLogStorage.getLogs.
     IngestionPipeline pipeline =
-        Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "", Include.ALL);
+        Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
     Map<String, String> logs = pipelineServiceClient.getLastIngestionLogs(pipeline, afterCursor);
 
     Map<String, Object> result = new HashMap<>();
-    result.put("logs", logs.getOrDefault("logs", ""));
+    result.put("logs", DefaultLogStorage.extractLogContent(logs));
     result.put("after", logs.get("after"));
     result.put("total", logs.getOrDefault("total", "0"));
     return result;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
@@ -23,6 +23,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.UnhandledServerException;
 
 /**
  * Default implementation of LogStorageInterface that delegates to the existing
@@ -64,10 +65,8 @@ public class DefaultLogStorage implements LogStorageInterface {
   @Override
   public Map<String, Object> getLogs(
       String pipelineFQN, UUID runId, String afterCursor, int limit) {
-    // Load the real pipeline: Argo builds its workflow label selector from service.name, so a
-    // name-only stub finds nothing. Airflow needs only the name, which is why a stub sufficed.
-    // Outside the catch below: an unknown pipeline is the caller's error, and reporting it as
-    // "this run has no logs" would send them looking for a runner problem that does not exist.
+    // Load the real pipeline with its service: a runner may locate the run by service, not by
+    // pipeline name alone, so a name-only stub finds nothing.
     IngestionPipeline pipeline =
         Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
     try {
@@ -87,19 +86,11 @@ public class DefaultLogStorage implements LogStorageInterface {
 
       return result;
     } catch (Exception e) {
-      // If pipeline service client is not available (e.g., in tests or when Airflow is down),
-      // return empty logs instead of failing
-      LOG.warn(
-          "Failed to get logs from pipeline service client for pipeline: {}, runId: {}. Returning empty logs.",
-          pipelineFQN,
-          runId,
-          e);
-
-      Map<String, Object> result = new HashMap<>();
-      result.put("logs", "");
-      result.put("after", null);
-      result.put("total", 0L);
-      return result;
+      // Let the failure surface. Returning empty logs here made an unreachable pipeline service
+      // look like a run that simply produced none.
+      LOG.error("Failed to get logs for pipeline: {}, runId: {}", pipelineFQN, runId, e);
+      throw new UnhandledServerException(
+          String.format("Failed to get logs for pipeline %s", pipelineFQN), e);
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
@@ -63,16 +63,16 @@ public class DefaultLogStorage implements LogStorageInterface {
   @Override
   public Map<String, Object> getLogs(
       String pipelineFQN, UUID runId, String afterCursor, int limit) {
+    // Load the real pipeline: Argo builds its workflow label selector from service.name, so a
+    // name-only stub finds nothing. Airflow needs only the name, which is why a stub sufficed.
+    // Outside the catch below: an unknown pipeline is the caller's error, and reporting it as
+    // "this run has no logs" would send them looking for a runner problem that does not exist.
+    IngestionPipeline pipeline =
+        Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
     try {
       // Note: The default implementation through pipeline service client (Airflow/Argo)
       // doesn't support fetching logs by specific runId - it always returns the latest logs
       // The runId parameter is ignored here for backward compatibility
-
-      // Load the real pipeline with its service. A synthesized stub carries only the name, which
-      // is enough for Airflow but not for runners that locate a run by service (Argo builds its
-      // workflow label selector from service.name and fails without it).
-      IngestionPipeline pipeline =
-          Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
 
       // Delegate to pipeline service client (Airflow/Argo)
       Map<String, String> clientLogs =
@@ -103,12 +103,11 @@ public class DefaultLogStorage implements LogStorageInterface {
   }
 
   /**
-   * Pulls the log text out of a pipeline service client response. Runners key the content by task
-   * name (see {@code PipelineServiceClientInterface.TYPE_TO_TASK}), e.g. {@code lineage_task}, so
-   * the only fixed keys are the paging ones. Take the remaining entry rather than guessing the task
-   * name, which depends on the pipeline type.
+   * Pulls the log text out of a client response. Runners key it by task name (see {@code
+   * PipelineServiceClientInterface.TYPE_TO_TASK}), e.g. {@code lineage_task}, so only the paging
+   * keys are fixed. Take the remaining entry instead of guessing the task name.
    */
-  private static String extractLogContent(Map<String, String> clientLogs) {
+  public static String extractLogContent(Map<String, String> clientLogs) {
     if (clientLogs == null) {
       return "";
     }
@@ -136,7 +135,7 @@ public class DefaultLogStorage implements LogStorageInterface {
         }
       }
     } catch (Exception e) {
-      LOG.warn("Failed to get latest run ID from pipeline status", e);
+      LOG.warn("Failed to get latest run ID for pipeline: {}", pipelineFQN, e);
     }
 
     // If no run ID found, generate a new one

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
@@ -16,6 +16,7 @@ package org.openmetadata.service.logstorage;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
@@ -105,7 +106,8 @@ public class DefaultLogStorage implements LogStorageInterface {
   /**
    * Pulls the log text out of a client response. Runners key it by task name (see {@code
    * PipelineServiceClientInterface.TYPE_TO_TASK}), e.g. {@code lineage_task}, so only the paging
-   * keys are fixed. Take the remaining entry instead of guessing the task name.
+   * keys are fixed. Take the remaining entries instead of guessing the task name. Today a response
+   * carries exactly one task, but iterate in key order so more than one stays deterministic.
    */
   public static String extractLogContent(Map<String, String> clientLogs) {
     if (clientLogs == null) {
@@ -113,9 +115,9 @@ public class DefaultLogStorage implements LogStorageInterface {
     }
     return clientLogs.entrySet().stream()
         .filter(e -> !PAGING_KEYS.contains(e.getKey()) && e.getValue() != null)
+        .sorted(Map.Entry.comparingByKey())
         .map(Map.Entry::getValue)
-        .findFirst()
-        .orElse("");
+        .collect(Collectors.joining("\n"));
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/logstorage/DefaultLogStorage.java
@@ -19,8 +19,9 @@ import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.service.Entity;
 
 /**
  * Default implementation of LogStorageInterface that delegates to the existing
@@ -28,6 +29,8 @@ import org.openmetadata.sdk.PipelineServiceClientInterface;
  */
 @Slf4j
 public class DefaultLogStorage implements LogStorageInterface {
+
+  private static final Set<String> PAGING_KEYS = Set.of("total", "after");
 
   private PipelineServiceClientInterface pipelineServiceClient;
 
@@ -65,12 +68,11 @@ public class DefaultLogStorage implements LogStorageInterface {
       // doesn't support fetching logs by specific runId - it always returns the latest logs
       // The runId parameter is ignored here for backward compatibility
 
-      // Create a minimal IngestionPipeline object with just the FQN
-      IngestionPipeline pipeline = new IngestionPipeline();
-      pipeline.setFullyQualifiedName(pipelineFQN);
-      pipeline.setName(extractPipelineName(pipelineFQN));
-      // Set a default pipeline type to avoid NPE in AirflowRESTClient
-      pipeline.setPipelineType(PipelineType.METADATA);
+      // Load the real pipeline with its service. A synthesized stub carries only the name, which
+      // is enough for Airflow but not for runners that locate a run by service (Argo builds its
+      // workflow label selector from service.name and fails without it).
+      IngestionPipeline pipeline =
+          Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
 
       // Delegate to pipeline service client (Airflow/Argo)
       Map<String, String> clientLogs =
@@ -78,7 +80,7 @@ public class DefaultLogStorage implements LogStorageInterface {
 
       // Convert the response to match our interface
       Map<String, Object> result = new HashMap<>();
-      result.put("logs", clientLogs.getOrDefault("logs", ""));
+      result.put("logs", extractLogContent(clientLogs));
       result.put("after", clientLogs.get("after"));
       result.put("total", clientLogs.getOrDefault("total", "0"));
 
@@ -100,13 +102,30 @@ public class DefaultLogStorage implements LogStorageInterface {
     }
   }
 
+  /**
+   * Pulls the log text out of a pipeline service client response. Runners key the content by task
+   * name (see {@code PipelineServiceClientInterface.TYPE_TO_TASK}), e.g. {@code lineage_task}, so
+   * the only fixed keys are the paging ones. Take the remaining entry rather than guessing the task
+   * name, which depends on the pipeline type.
+   */
+  private static String extractLogContent(Map<String, String> clientLogs) {
+    if (clientLogs == null) {
+      return "";
+    }
+    return clientLogs.entrySet().stream()
+        .filter(e -> !PAGING_KEYS.contains(e.getKey()) && e.getValue() != null)
+        .map(Map.Entry::getValue)
+        .findFirst()
+        .orElse("");
+  }
+
   @Override
   public UUID getLatestRunId(String pipelineFQN) {
     // Try to get the latest run ID from pipeline status
     try {
-      IngestionPipeline pipeline = new IngestionPipeline();
-      pipeline.setFullyQualifiedName(pipelineFQN);
-      pipeline.setName(extractPipelineName(pipelineFQN));
+      // Same reason as getLogs above: the runner needs the pipeline's service to find its runs.
+      IngestionPipeline pipeline =
+          Entity.getEntityByName(Entity.INGESTION_PIPELINE, pipelineFQN, "service", Include.ALL);
 
       List<PipelineStatus> statuses = pipelineServiceClient.getQueuedPipelineStatus(pipeline);
       if (!statuses.isEmpty()) {
@@ -174,11 +193,5 @@ public class DefaultLogStorage implements LogStorageInterface {
   @Override
   public void close() {
     // Nothing to close for default implementation
-  }
-
-  private String extractPipelineName(String pipelineFQN) {
-    // Extract pipeline name from FQN (last part after the last dot)
-    int lastDotIndex = pipelineFQN.lastIndexOf('.');
-    return lastDotIndex >= 0 ? pipelineFQN.substring(lastDotIndex + 1) : pipelineFQN;
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStatusIndexTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStatusIndexTest.java
@@ -52,6 +52,8 @@ class IngestionPipelineStatusIndexTest {
       new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER).withName("data-eng");
   private static final EntityReference DOMAIN =
       new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN).withName("analytics");
+  private static final EntityReference FOLLOWER =
+      new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER).withName("watcher");
 
   @Test
   void addPipelineStatusKeepsOwnersAndDomainsOnTheIndexedPipeline() {
@@ -80,6 +82,7 @@ class IngestionPipelineStatusIndexTest {
       verify(searchRepository).updateEntityIndex(indexed.capture());
       assertEquals(List.of(OWNER), indexed.getValue().getOwners());
       assertEquals(List.of(DOMAIN), indexed.getValue().getDomains());
+      assertEquals(List.of(FOLLOWER), indexed.getValue().getFollowers());
     }
   }
 
@@ -101,6 +104,9 @@ class IngestionPipelineStatusIndexTest {
     }
     if (fields.contains(Entity.FIELD_DOMAINS)) {
       pipeline.withDomains(List.of(DOMAIN));
+    }
+    if (fields.contains(Entity.FIELD_FOLLOWERS)) {
+      pipeline.withFollowers(List.of(FOLLOWER));
     }
     return pipeline;
   }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStatusIndexTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStatusIndexTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.search.SearchRepository;
+import org.openmetadata.service.util.EntityUtil.Fields;
+
+/**
+ * Regression test for #31334. addPipelineStatus hands its pipeline to
+ * searchRepository.updateEntityIndex, which may rebuild the whole search document from it. Any field
+ * the method did not load would be written to the index as empty.
+ */
+class IngestionPipelineStatusIndexTest {
+
+  private static final String SERVICE_FQN = "mysqlService";
+  private static final String PIPELINE_NAME = "metadataPipeline";
+  private static final String PIPELINE_FQN = SERVICE_FQN + "." + PIPELINE_NAME;
+  private static final EntityReference OWNER =
+      new EntityReference().withId(UUID.randomUUID()).withType(Entity.USER).withName("data-eng");
+  private static final EntityReference DOMAIN =
+      new EntityReference().withId(UUID.randomUUID()).withType(Entity.DOMAIN).withName("analytics");
+
+  @Test
+  void addPipelineStatusKeepsOwnersAndDomainsOnTheIndexedPipeline() {
+    SearchRepository searchRepository = mock(SearchRepository.class);
+
+    // Only the two lookups the repository constructor needs are stubbed; the rest of Entity stays
+    // real so the repository is built with its actual allowed fields.
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class, CALLS_REAL_METHODS)) {
+      entityMock
+          .when(Entity::getCollectionDAO)
+          .thenReturn(mock(CollectionDAO.class, RETURNS_DEEP_STUBS));
+      entityMock.when(Entity::getSearchRepository).thenReturn(searchRepository);
+
+      IngestionPipelineRepository repository =
+          spy(new IngestionPipelineRepository(new OpenMetadataApplicationConfig()));
+      // A read only populates the fields it was asked for, so answer the same way: owners and
+      // domains come back only if addPipelineStatus actually requested them.
+      doAnswer(invocation -> pipelineFor(invocation.getArgument(2, Fields.class)))
+          .when(repository)
+          .getByName(any(), anyString(), any(Fields.class));
+      doReturn(List.of()).when(repository).getRecentPipelineStatuses(anyString());
+
+      repository.addPipelineStatus(null, PIPELINE_FQN, new PipelineStatus().withRunId("run-1"));
+
+      ArgumentCaptor<IngestionPipeline> indexed = ArgumentCaptor.forClass(IngestionPipeline.class);
+      verify(searchRepository).updateEntityIndex(indexed.capture());
+      assertEquals(List.of(OWNER), indexed.getValue().getOwners());
+      assertEquals(List.of(DOMAIN), indexed.getValue().getDomains());
+    }
+  }
+
+  private static IngestionPipeline pipelineFor(Fields fields) {
+    IngestionPipeline pipeline =
+        new IngestionPipeline()
+            .withId(UUID.randomUUID())
+            .withName(PIPELINE_NAME)
+            .withFullyQualifiedName(PIPELINE_FQN)
+            .withVersion(0.1)
+            .withService(
+                new EntityReference()
+                    .withId(UUID.randomUUID())
+                    .withType(Entity.DATABASE_SERVICE)
+                    .withName(SERVICE_FQN)
+                    .withFullyQualifiedName(SERVICE_FQN));
+    if (fields.contains(Entity.FIELD_OWNERS)) {
+      pipeline.withOwners(List.of(OWNER));
+    }
+    if (fields.contains(Entity.FIELD_DOMAINS)) {
+      pipeline.withDomains(List.of(DOMAIN));
+    }
+    return pipeline;
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
@@ -19,14 +19,20 @@ import static org.mockito.Mockito.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
+import org.openmetadata.schema.type.EntityReference;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
+import org.openmetadata.service.Entity;
 
 @ExtendWith(MockitoExtension.class)
 public class LogStorageTest {
@@ -34,6 +40,7 @@ public class LogStorageTest {
   @Mock private PipelineServiceClientInterface mockPipelineServiceClient;
 
   private DefaultLogStorage defaultLogStorage;
+  private MockedStatic<Entity> entityMock;
   private final String testPipelineFQN = "service.database.pipeline";
   private final UUID testRunId = UUID.randomUUID();
 
@@ -43,6 +50,75 @@ public class LogStorageTest {
     Map<String, Object> config = new HashMap<>();
     config.put("pipelineServiceClient", mockPipelineServiceClient);
     defaultLogStorage.initialize(config);
+    // The storage loads the real pipeline so the runner can locate its run by service.
+    entityMock = mockStatic(Entity.class);
+    entityMock
+        .when(
+            () ->
+                Entity.getEntityByName(
+                    eq(Entity.INGESTION_PIPELINE),
+                    eq(testPipelineFQN),
+                    anyString(),
+                    any(Include.class)))
+        .thenReturn(new IngestionPipeline().withFullyQualifiedName(testPipelineFQN));
+  }
+
+  @AfterEach
+  void tearDown() {
+    entityMock.close();
+  }
+
+  @Test
+  void getLogsPassesThePipelineServiceToTheRunner() {
+    // Regression: the storage used to synthesize a name-only pipeline. Argo builds its workflow
+    // label selector from service.name and threw a NullPointerException, which the catch below
+    // turned into "no logs", so log fetches silently returned empty on every Argo deployment.
+    IngestionPipeline withService =
+        new IngestionPipeline()
+            .withFullyQualifiedName(testPipelineFQN)
+            .withService(
+                new EntityReference().withName("service").withType(Entity.DATABASE_SERVICE));
+    entityMock
+        .when(
+            () ->
+                Entity.getEntityByName(
+                    eq(Entity.INGESTION_PIPELINE),
+                    eq(testPipelineFQN),
+                    anyString(),
+                    any(Include.class)))
+        .thenReturn(withService);
+    when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
+        .thenReturn(Map.of("ingestion_task", "content", "total", "1"));
+
+    defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10);
+
+    ArgumentCaptor<IngestionPipeline> sent = ArgumentCaptor.forClass(IngestionPipeline.class);
+    verify(mockPipelineServiceClient).getLastIngestionLogs(sent.capture(), isNull());
+    assertNotNull(sent.getValue().getService(), "runner cannot locate the run without the service");
+    assertEquals("service", sent.getValue().getService().getName());
+  }
+
+  @Test
+  void getLogsReadsContentKeyedByTaskName() {
+    // Runners key log content by task name (TYPE_TO_TASK), e.g. "lineage_task"; only "total" and
+    // "after" are fixed. Reading a literal "logs" key returned empty for every real response.
+    when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
+        .thenReturn(Map.of("lineage_task", "InvalidPrivateKeyException: bad PEM", "total", "1"));
+
+    Map<String, Object> result = defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10);
+
+    assertEquals("InvalidPrivateKeyException: bad PEM", result.get("logs"));
+    assertEquals("1", result.get("total"));
+  }
+
+  @Test
+  void getLogsReturnsEmptyStringWhenTheRunnerSendsOnlyPagingKeys() {
+    when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
+        .thenReturn(Map.of("total", "0"));
+
+    Map<String, Object> result = defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10);
+
+    assertEquals("", result.get("logs"));
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
@@ -33,6 +33,7 @@ import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.exception.EntityNotFoundException;
 
 @ExtendWith(MockitoExtension.class)
 public class LogStorageTest {
@@ -70,9 +71,8 @@ public class LogStorageTest {
 
   @Test
   void getLogsPassesThePipelineServiceToTheRunner() {
-    // Regression: the storage used to synthesize a name-only pipeline. Argo builds its workflow
-    // label selector from service.name and threw a NullPointerException, which the catch below
-    // turned into "no logs", so log fetches silently returned empty on every Argo deployment.
+    // Regression: a name-only pipeline made Argo's label selector NPE, and the catch in getLogs
+    // turned that into "no logs", so every Argo log fetch silently returned empty.
     IngestionPipeline withService =
         new IngestionPipeline()
             .withFullyQualifiedName(testPipelineFQN)
@@ -99,9 +99,28 @@ public class LogStorageTest {
   }
 
   @Test
+  void getLogsSurfacesAnUnknownPipelineInsteadOfReportingNoLogs() {
+    // A wrong FQN is the caller's error. Swallowing it into empty logs sends the user hunting a
+    // runner outage that is not there.
+    entityMock
+        .when(
+            () ->
+                Entity.getEntityByName(
+                    eq(Entity.INGESTION_PIPELINE),
+                    eq(testPipelineFQN),
+                    anyString(),
+                    any(Include.class)))
+        .thenThrow(new EntityNotFoundException("pipeline not found"));
+
+    assertThrows(
+        EntityNotFoundException.class,
+        () -> defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10));
+  }
+
+  @Test
   void getLogsReadsContentKeyedByTaskName() {
-    // Runners key log content by task name (TYPE_TO_TASK), e.g. "lineage_task"; only "total" and
-    // "after" are fixed. Reading a literal "logs" key returned empty for every real response.
+    // Runners key content by task name (TYPE_TO_TASK); only "total" and "after" are fixed, so a
+    // literal "logs" key came back empty for every real response.
     when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
         .thenReturn(Map.of("lineage_task", "InvalidPrivateKeyException: bad PEM", "total", "1"));
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
@@ -131,6 +131,18 @@ public class LogStorageTest {
   }
 
   @Test
+  void getLogsIsDeterministicWhenTheRunnerSendsMoreThanOneTask() {
+    // A response carries one task today, so map order never mattered. Order by key anyway: picking
+    // an arbitrary entry would make the log text change between identical calls.
+    when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
+        .thenReturn(Map.of("lineage_task", "second", "ingestion_task", "first", "total", "2"));
+
+    Map<String, Object> result = defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10);
+
+    assertEquals("first\nsecond", result.get("logs"));
+  }
+
+  @Test
   void getLogsReturnsEmptyStringWhenTheRunnerSendsOnlyPagingKeys() {
     when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
         .thenReturn(Map.of("total", "0"));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/logstorage/LogStorageTest.java
@@ -34,6 +34,7 @@ import org.openmetadata.schema.type.Include;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.exception.EntityNotFoundException;
+import org.openmetadata.service.exception.UnhandledServerException;
 
 @ExtendWith(MockitoExtension.class)
 public class LogStorageTest {
@@ -128,6 +129,18 @@ public class LogStorageTest {
 
     assertEquals("InvalidPrivateKeyException: bad PEM", result.get("logs"));
     assertEquals("1", result.get("total"));
+  }
+
+  @Test
+  void getLogsSurfacesAPipelineServiceFailure() {
+    // An unreachable pipeline service used to be reported as a run with no logs, which reads as
+    // "this run produced nothing" rather than "we could not reach the runner".
+    when(mockPipelineServiceClient.getLastIngestionLogs(any(IngestionPipeline.class), isNull()))
+        .thenThrow(new RuntimeException("pipeline service unreachable"));
+
+    assertThrows(
+        UnhandledServerException.class,
+        () -> defaultLogStorage.getLogs(testPipelineFQN, testRunId, null, 10));
   }
 
   @Test


### PR DESCRIPTION
Fixes #31411
Fixes #31334

- Loads the pipeline together with its `service` before asking the runner for logs. Argo locates a workflow by `service.name`, so a name-only stub found nothing and the failure was swallowed into an empty result.
- Reads log content from the task-keyed field the runners actually return (`ingestion_task`, `lineage_task`, ...) instead of a literal `"logs"` key that is never written.
- Loads `owners`, `domains` and `followers` before reindexing a pipeline on a run status report, so they are not wiped from the search index when the full document is rebuilt.
- An unknown pipeline FQN now surfaces as not-found rather than as a pipeline with no logs.
