### PR TITLE
Backport #31137 to 1.13: propagate inherited domain to descendants in search on asset move

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DataProductResourceIT.java
@@ -721,6 +721,34 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
     return SdkClients.adminClient().tables().create(createTable);
   }
 
+  private org.openmetadata.schema.entity.data.DatabaseSchema createSchemaWithDomain(
+      TestNamespace ns, String suffix, Domain domain) {
+    DatabaseService service = getOrCreateDatabaseService(ns);
+    org.openmetadata.schema.entity.data.Database database =
+        getOrCreateDatabase(ns, service.getFullyQualifiedName());
+    org.openmetadata.schema.api.data.CreateDatabaseSchema create =
+        new org.openmetadata.schema.api.data.CreateDatabaseSchema()
+            .withName(ns.prefix(suffix))
+            .withDatabase(database.getFullyQualifiedName())
+            .withDomains(List.of(domain.getFullyQualifiedName()));
+    return SdkClients.adminClient().databaseSchemas().create(create);
+  }
+
+  private Table createChildTable(
+      TestNamespace ns,
+      String suffix,
+      org.openmetadata.schema.entity.data.DatabaseSchema schema,
+      Domain domain) {
+    CreateTable createTable =
+        new CreateTable()
+            .withName(ns.prefix(suffix))
+            .withDatabaseSchema(schema.getFullyQualifiedName());
+    if (domain != null) {
+      createTable.withDomains(List.of(domain.getFullyQualifiedName()));
+    }
+    return SdkClients.adminClient().tables().create(createTable);
+  }
+
   private Dashboard createTestDashboard(TestNamespace ns, String suffix, Domain domain) {
     DashboardService service = DashboardServiceTestFactory.createMetabase(ns);
 
@@ -856,6 +884,40 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
     }
 
     return JsonUtils.readObjects(fieldNode.toString(), EntityReference.class);
+  }
+
+  private void assertSingleSearchDomain(UUID tableId, Domain expected, String message)
+      throws Exception {
+    assertSingleSearchDomain(tableId, expected, message, "table_search_index");
+  }
+
+  private void assertSingleSearchDomain(
+      UUID entityId, Domain expected, String message, String indexName) throws Exception {
+    List<EntityReference> searchDomains =
+        getEntityReferencesFromSearchIndex(entityId, indexName, "domains");
+    assertNotNull(searchDomains, message);
+    assertEquals(1, searchDomains.size(), message);
+    assertEquals(expected.getId(), searchDomains.getFirst().getId(), message);
+  }
+
+  private org.openmetadata.schema.entity.data.Database createDatabaseWithDomain(
+      TestNamespace ns, String suffix, Domain domain) {
+    DatabaseService service = getOrCreateDatabaseService(ns);
+    org.openmetadata.schema.api.data.CreateDatabase create =
+        new org.openmetadata.schema.api.data.CreateDatabase()
+            .withName(ns.prefix(suffix))
+            .withService(service.getFullyQualifiedName())
+            .withDomains(List.of(domain.getFullyQualifiedName()));
+    return SdkClients.adminClient().databases().create(create);
+  }
+
+  private org.openmetadata.schema.entity.data.DatabaseSchema createSchemaUnderDatabase(
+      TestNamespace ns, String suffix, org.openmetadata.schema.entity.data.Database database) {
+    org.openmetadata.schema.api.data.CreateDatabaseSchema create =
+        new org.openmetadata.schema.api.data.CreateDatabaseSchema()
+            .withName(ns.prefix(suffix))
+            .withDatabase(database.getFullyQualifiedName());
+    return SdkClients.adminClient().databaseSchemas().create(create);
   }
 
   // ===================================================================
@@ -1388,6 +1450,124 @@ public class DataProductResourceIT extends BaseEntityIT<DataProduct, CreateDataP
                   domain2.getId(),
                   searchIndexDomains.getFirst().getId(),
                   "Search index should show the migrated domain2");
+            });
+  }
+
+  @Test
+  void test_changeDataProductDomain_propagatesInheritedDomainToChildTablesInSearch(TestNamespace ns)
+      throws Exception {
+    Domain finance = createTestDomain(ns, "dp_inherit_finance");
+    Domain hr = createTestDomain(ns, "dp_inherit_hr");
+    Domain marketing = createTestDomain(ns, "dp_inherit_marketing");
+
+    // Schema with an explicit Finance domain, assigned as the data product's only asset
+    org.openmetadata.schema.entity.data.DatabaseSchema schema =
+        createSchemaWithDomain(ns, "dp_inherit_schema", finance);
+
+    // Children under the schema: t1 inherits Finance, t2 is explicitly Finance, t3 is Marketing
+    Table inheritedChild = createChildTable(ns, "dp_inherit_t1", schema, null);
+    Table explicitSameDomainChild = createChildTable(ns, "dp_inherit_t2", schema, finance);
+    Table explicitOtherDomainChild = createChildTable(ns, "dp_inherit_t3", schema, marketing);
+
+    CreateDataProduct create =
+        new CreateDataProduct()
+            .withName(ns.prefix("dp_inherit"))
+            .withDescription("Data product for inherited-domain search propagation test")
+            .withDomains(List.of(finance.getFullyQualifiedName()));
+    DataProduct dataProduct = createEntity(create);
+
+    bulkAddAssets(
+        dataProduct.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(schema.getEntityReference())));
+
+    Awaitility.await("Wait for schema asset to be linked")
+        .pollInterval(Duration.ofSeconds(1))
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> assertEquals(1, getAssets(dataProduct.getId(), 10, 0).getPaging().getTotal()));
+
+    // Move the data product, and with it the schema asset, from Finance to HR
+    dataProduct.setDomains(List.of(hr.getEntityReference()));
+    patchEntity(dataProduct.getId().toString(), dataProduct);
+
+    Awaitility.await("Wait for inherited-domain search propagation to child tables")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertSingleSearchDomain(
+                  inheritedChild.getId(),
+                  hr,
+                  "Child table that inherits its domain should follow the data product to HR in search");
+              assertSingleSearchDomain(
+                  explicitSameDomainChild.getId(),
+                  finance,
+                  "Child table with an explicit Finance domain should stay in Finance in search");
+              assertSingleSearchDomain(
+                  explicitOtherDomainChild.getId(),
+                  marketing,
+                  "Child table with an explicit Marketing domain should keep it in search");
+            });
+  }
+
+  @Test
+  void test_changeDataProductDomain_multiLevelDescendantsFollowInSearch(TestNamespace ns)
+      throws Exception {
+    Domain finance = createTestDomain(ns, "dp_ml_finance");
+    Domain hr = createTestDomain(ns, "dp_ml_hr");
+    Domain marketing = createTestDomain(ns, "dp_ml_marketing");
+
+    // Database (explicit Finance) is the asset; the schema and one table inherit through it, two
+    // levels down, so the move must reach descendants keyed on database.id in search.
+    org.openmetadata.schema.entity.data.Database database =
+        createDatabaseWithDomain(ns, "dp_ml_db", finance);
+    org.openmetadata.schema.entity.data.DatabaseSchema schema =
+        createSchemaUnderDatabase(ns, "dp_ml_schema", database);
+    Table inheritedTable = createChildTable(ns, "dp_ml_t1", schema, null);
+    Table explicitTable = createChildTable(ns, "dp_ml_t2", schema, marketing);
+
+    CreateDataProduct create =
+        new CreateDataProduct()
+            .withName(ns.prefix("dp_ml"))
+            .withDescription("Data product for multi-level domain propagation test")
+            .withDomains(List.of(finance.getFullyQualifiedName()));
+    DataProduct dataProduct = createEntity(create);
+
+    bulkAddAssets(
+        dataProduct.getFullyQualifiedName(),
+        new BulkAssets().withAssets(List.of(database.getEntityReference())));
+
+    Awaitility.await("Wait for database asset to be linked")
+        .pollInterval(Duration.ofSeconds(1))
+        .atMost(Duration.ofSeconds(15))
+        .untilAsserted(
+            () -> assertEquals(1, getAssets(dataProduct.getId(), 10, 0).getPaging().getTotal()));
+
+    dataProduct.setDomains(List.of(hr.getEntityReference()));
+    patchEntity(dataProduct.getId().toString(), dataProduct);
+
+    Awaitility.await("Wait for multi-level inherited-domain search propagation")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertSingleSearchDomain(
+                  schema.getId(),
+                  hr,
+                  "Inheriting schema (child of the moved database) should follow to HR in search",
+                  "database_schema_search_index");
+              assertSingleSearchDomain(
+                  inheritedTable.getId(),
+                  hr,
+                  "Inheriting grandchild table should follow to HR in search");
+              assertSingleSearchDomain(
+                  explicitTable.getId(),
+                  marketing,
+                  "Grandchild table with an explicit domain should keep it in search");
             });
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/DomainResourceIT.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
@@ -27,22 +28,34 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DatabaseServiceTestFactory;
 import org.openmetadata.it.util.SdkClients;
 import org.openmetadata.it.util.TestNamespace;
 import org.openmetadata.schema.api.VoteRequest;
+import org.openmetadata.schema.api.data.CreateDatabaseSchema;
+import org.openmetadata.schema.api.data.CreateTable;
 import org.openmetadata.schema.api.domains.CreateDomain;
 import org.openmetadata.schema.api.domains.CreateDomain.DomainType;
 import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.entity.data.Database;
+import org.openmetadata.schema.entity.data.DatabaseSchema;
+import org.openmetadata.schema.entity.data.Table;
 import org.openmetadata.schema.entity.domains.Domain;
+import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.ChangeEvent;
+import org.openmetadata.schema.type.Column;
+import org.openmetadata.schema.type.ColumnDataType;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.Votes;
+import org.openmetadata.schema.type.api.BulkAssets;
+import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.models.ListParams;
 import org.openmetadata.sdk.models.ListResponse;
 import org.openmetadata.sdk.network.HttpMethod;
+import org.openmetadata.sdk.network.RequestOptions;
 
 /**
  * Integration tests for Domain entity operations.
@@ -1358,5 +1371,246 @@ public class DomainResourceIT extends BaseEntityIT<Domain, CreateDomain> {
             && votes.getUpVoters().stream()
                 .anyMatch(ref -> ref != null && voter.getId().equals(ref.getId()));
     assertFalse(voterInUpVotes, "Soft-deleted voter must not appear in list endpoint votes");
+  }
+
+  @Test
+  void test_domainAssetAdd_propagatesInheritedDomainToChildTablesInSearch(TestNamespace ns)
+      throws Exception {
+    Domain hr = createDomainForTest(ns, "dom_add_hr");
+    Domain marketing = createDomainForTest(ns, "dom_add_marketing");
+
+    // Schema not yet in any domain, with an inheriting child and an explicit-domain child.
+    DatabaseSchema schema = createDomainTestSchema(ns, "add", null, null);
+    Table inheritedChild = createDomainChildTable(ns, "add_t1", schema, null);
+    Table explicitChild =
+        createDomainChildTable(ns, "add_t2", schema, marketing.getFullyQualifiedName());
+
+    addAssetsToDomain(hr.getFullyQualifiedName(), List.of(schema.getEntityReference()));
+
+    Awaitility.await("Wait for domain-page asset add to propagate inherited domain in search")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertSingleSearchDomain(
+                  schema.getId(),
+                  hr,
+                  "database_schema_search_index",
+                  "Schema added to HR should show HR in search");
+              assertSingleSearchDomain(
+                  inheritedChild.getId(),
+                  hr,
+                  "table_search_index",
+                  "Child inheriting from the schema should follow to HR in search");
+              assertSingleSearchDomain(
+                  explicitChild.getId(),
+                  marketing,
+                  "table_search_index",
+                  "Child with an explicit domain should keep it in search");
+            });
+  }
+
+  @Test
+  void test_domainAssetRemove_descendantReinheritsFromAncestryInSearch(TestNamespace ns)
+      throws Exception {
+    Domain finance = createDomainForTest(ns, "dom_rm_finance");
+    Domain removeDomain = createDomainForTest(ns, "dom_rm_target");
+
+    // Database in Finance; schema explicitly in removeDomain; child inherits removeDomain.
+    DatabaseSchema schema =
+        createDomainTestSchema(
+            ns, "rm", finance.getFullyQualifiedName(), removeDomain.getFullyQualifiedName());
+    Table inheritedChild = createDomainChildTable(ns, "rm_t1", schema, null);
+
+    Awaitility.await("Wait for child to inherit removeDomain in search")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertSingleSearchDomain(
+                    inheritedChild.getId(),
+                    removeDomain,
+                    "table_search_index",
+                    "Child should inherit removeDomain before removal"));
+
+    removeAssetsFromDomain(
+        removeDomain.getFullyQualifiedName(), List.of(schema.getEntityReference()));
+
+    // After detaching removeDomain, the schema re-derives its domain from its database (Finance),
+    // and its inheriting descendants must follow to Finance in search — not stay stale on
+    // removeDomain and not be blanked out. Polled so the assertion holds across the full async
+    // propagation window (guards against a regression that clears/mis-sets the child late).
+    Awaitility.await("Wait for schema and inheriting child to re-inherit Finance after removal")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertSingleSearchDomain(
+                  schema.getId(),
+                  finance,
+                  "database_schema_search_index",
+                  "Schema should re-inherit Finance from its database after removal");
+              assertSingleSearchDomain(
+                  inheritedChild.getId(),
+                  finance,
+                  "table_search_index",
+                  "Inheriting child should re-inherit Finance from the schema's ancestry after removal, not stay on removeDomain or be cleared");
+            });
+  }
+
+  private Domain createDomainForTest(TestNamespace ns, String suffix) {
+    return createEntity(
+        new CreateDomain()
+            .withName(ns.prefix(suffix))
+            .withDescription("Test domain " + suffix)
+            .withDomainType(DomainType.AGGREGATE));
+  }
+
+  private DatabaseSchema createDomainTestSchema(
+      TestNamespace ns, String suffix, String databaseDomainFqn, String schemaDomainFqn) {
+    OpenMetadataClient client = SdkClients.adminClient();
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+    org.openmetadata.schema.api.data.CreateDatabase createDb =
+        new org.openmetadata.schema.api.data.CreateDatabase()
+            .withName(ns.shortPrefix("dom_db_" + suffix))
+            .withService(service.getFullyQualifiedName());
+    if (databaseDomainFqn != null) {
+      createDb.withDomains(List.of(databaseDomainFqn));
+    }
+    Database database = client.databases().create(createDb);
+    CreateDatabaseSchema createSchema =
+        new CreateDatabaseSchema()
+            .withName(ns.shortPrefix("dom_sc_" + suffix))
+            .withDatabase(database.getFullyQualifiedName());
+    if (schemaDomainFqn != null) {
+      createSchema.withDomains(List.of(schemaDomainFqn));
+    }
+    return client.databaseSchemas().create(createSchema);
+  }
+
+  private Table createDomainChildTable(
+      TestNamespace ns, String suffix, DatabaseSchema schema, String domainFqn) {
+    CreateTable createTable =
+        new CreateTable()
+            .withName(ns.shortPrefix("dom_t_" + suffix))
+            .withDatabaseSchema(schema.getFullyQualifiedName())
+            .withColumns(List.of(new Column().withName("id").withDataType(ColumnDataType.BIGINT)));
+    if (domainFqn != null) {
+      createTable.withDomains(List.of(domainFqn));
+    }
+    return SdkClients.adminClient().tables().create(createTable);
+  }
+
+  private void addAssetsToDomain(String domainFqn, List<EntityReference> assets) throws Exception {
+    BulkAssets request = new BulkAssets().withAssets(assets).withDryRun(false);
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(HttpMethod.PUT, "/v1/domains/" + domainFqn + "/assets/add", request, Void.class);
+  }
+
+  private void removeAssetsFromDomain(String domainFqn, List<EntityReference> assets)
+      throws Exception {
+    BulkAssets request = new BulkAssets().withAssets(assets).withDryRun(false);
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.PUT, "/v1/domains/" + domainFqn + "/assets/remove", request, Void.class);
+  }
+
+  private List<EntityReference> searchDomains(UUID entityId, String indexName) throws Exception {
+    String searchResponse =
+        SdkClients.adminClient().search().query("id:" + entityId).index(indexName).execute();
+    JsonNode fieldNode =
+        JsonUtils.readTree(searchResponse)
+            .path("hits")
+            .path("hits")
+            .path(0)
+            .path("_source")
+            .path("domains");
+    if (fieldNode.isMissingNode() || !fieldNode.isArray()) {
+      return null;
+    }
+    return JsonUtils.readObjects(fieldNode.toString(), EntityReference.class);
+  }
+
+  private void assertSingleSearchDomain(
+      UUID entityId, Domain expected, String indexName, String message) throws Exception {
+    List<EntityReference> domains = searchDomains(entityId, indexName);
+    assertNotNull(domains, message);
+    assertEquals(1, domains.size(), message);
+    assertEquals(expected.getId(), domains.get(0).getId(), message);
+  }
+
+  @Test
+  void test_entityDomainChange_doesNotOverAppendToExplicitDescendantInSearch(TestNamespace ns)
+      throws Exception {
+    Domain a = createDomainForTest(ns, "ovr_a");
+    Domain bDom = createDomainForTest(ns, "ovr_b");
+    Domain cDom = createDomainForTest(ns, "ovr_c");
+
+    // Schema explicitly in A, with an inheriting child and an explicit-domain (C) child.
+    DatabaseSchema schema = createDomainTestSchema(ns, "ovr", null, a.getFullyQualifiedName());
+    Table inheritedChild = createDomainChildTable(ns, "ovr_inh", schema, null);
+    Table explicitChild =
+        createDomainChildTable(ns, "ovr_expl", schema, cDom.getFullyQualifiedName());
+
+    Awaitility.await("baseline domains in search")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              assertSingleSearchDomain(
+                  inheritedChild.getId(), a, "table_search_index", "inherited child starts in A");
+              assertSingleSearchDomain(
+                  explicitChild.getId(), cDom, "table_search_index", "explicit child starts in C");
+            });
+
+    // Change the schema's own domain A -> B (the entity-update path, recorded as delete+add).
+    String patch =
+        String.format(
+            "[{\"op\":\"replace\",\"path\":\"/domains\",\"value\":[{\"id\":\"%s\",\"type\":\"domain\",\"fullyQualifiedName\":\"%s\"}]}]",
+            bDom.getId(), bDom.getFullyQualifiedName());
+    SdkClients.adminClient()
+        .getHttpClient()
+        .executeForString(
+            HttpMethod.PATCH,
+            "/v1/databaseSchemas/" + schema.getId(),
+            patch,
+            RequestOptions.builder().header("Content-Type", "application/json-patch+json").build());
+
+    Awaitility.await("after schema domain change A -> B")
+        .atMost(Duration.ofSeconds(30))
+        .pollDelay(Duration.ofMillis(500))
+        .pollInterval(Duration.ofSeconds(2))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              // inherited child follows the parent to B
+              assertSingleSearchDomain(
+                  inheritedChild.getId(),
+                  bDom,
+                  "table_search_index",
+                  "inheriting child should follow the schema to B in search");
+              // explicit child keeps ONLY C — the parent's new domain must NOT be appended
+              List<EntityReference> explDomains =
+                  searchDomains(explicitChild.getId(), "table_search_index");
+              assertNotNull(explDomains, "explicit child should be indexed");
+              assertEquals(
+                  1,
+                  explDomains.size(),
+                  "explicit-domain child must not get the parent's changed domain appended in search");
+              assertEquals(
+                  cDom.getId(),
+                  explDomains.get(0).getId(),
+                  "explicit-domain child keeps its own domain C");
+            });
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataProductRepository.java
@@ -1013,6 +1013,13 @@ public class DataProductRepository extends EntityRepository<DataProduct> {
           List<UUID> assetIds =
               allRecords.stream().map(CollectionDAO.EntityRelationshipRecord::getId).toList();
           searchRepository.updateAssetDomainsByIds(assetIds, oldDomainFqns, updatedDomains);
+          List<EntityReference> assetRefs =
+              allRecords.stream()
+                  .map(
+                      record ->
+                          new EntityReference().withId(record.getId()).withType(record.getType()))
+                  .toList();
+          searchRepository.propagateInheritedDomainsToChildren(assetRefs, updatedDomains);
         }
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DomainRepository.java
@@ -317,6 +317,7 @@ public class DomainRepository extends EntityRepository<Domain> {
 
     EntityUtil.populateEntityReferences(request.getAssets());
 
+    EntityReference domainRef = isAdd ? getEntityReferenceById(DOMAIN, entityId, ALL) : null;
     for (EntityReference ref : request.getAssets()) {
       result.setNumberOfRowsProcessed(result.getNumberOfRowsProcessed() + 1);
 
@@ -325,7 +326,6 @@ public class DomainRepository extends EntityRepository<Domain> {
 
       if (isAdd) {
         addRelationship(entityId, ref.getId(), fromEntity, ref.getType(), relationship);
-        EntityReference domainRef = getEntityReferenceById(DOMAIN, entityId, ALL);
         LineageUtil.addDomainLineage(entityId, ref.getType(), domainRef);
       }
 
@@ -339,7 +339,11 @@ public class DomainRepository extends EntityRepository<Domain> {
       success.add(new BulkResponse().withRequest(ref));
       result.setNumberOfRowsPassed(result.getNumberOfRowsPassed() + 1);
 
-      searchRepository.updateEntity(ref);
+      // Re-index the asset and fan its re-derived domains out to inherited descendants in search.
+      // Uniform for add and remove: on add descendants follow the newly assigned domain; on remove
+      // they follow whatever the asset now inherits from its own ancestry (or are cleared if none),
+      // matching the entity page. Descendants with an explicit domain are left untouched.
+      searchRepository.updateEntityAndPropagateInheritedDomainsToChildren(ref);
     }
 
     result.withSuccessRequest(success);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/EntityManagementClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/EntityManagementClient.java
@@ -137,6 +137,23 @@ public interface EntityManagementClient {
       throws IOException;
 
   /**
+   * Updates child entities whose {@code field} matches ANY of {@code values} with a script across
+   * multiple indices, in a single update-by-query. Lets a caller fan a change out to the children of
+   * many parents at once instead of issuing one update-by-query per parent.
+   *
+   * @param indexNames list of index names
+   * @param field field to match documents on
+   * @param values parent values to match (any-of / terms)
+   * @param updates pair of script text and parameters
+   */
+  void updateChildren(
+      List<String> indexNames,
+      String field,
+      List<String> values,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException;
+
+  /**
    * Gets a document by ID from the specified index.
    *
    * @param indexName the name of the index

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchRepository.java
@@ -17,6 +17,7 @@ import static org.openmetadata.service.Entity.QUERY;
 import static org.openmetadata.service.Entity.RAW_COST_ANALYSIS_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_ENTITY_VIEW_REPORT_DATA;
 import static org.openmetadata.service.Entity.WEB_ANALYTIC_USER_ACTIVITY_REPORT_DATA;
+import static org.openmetadata.service.search.SearchClient.ADD_DOMAINS_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.ADD_FOLLOWERS_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.CASCADE_CERTIFICATION_SCRIPT;
 import static org.openmetadata.service.search.SearchClient.DATA_ASSET_SEARCH_ALIAS;
@@ -160,6 +161,13 @@ import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 public class SearchRepository {
 
   private volatile SearchClient searchClient;
+
+  /**
+   * Upper bound on parent ids packed into a single inherited-domain child-propagation terms query,
+   * kept well under Elasticsearch's default {@code index.max_terms_count} (65536). A normal move
+   * carries far fewer and stays one update-by-query.
+   */
+  private static final int MAX_PARENT_IDS_PER_TERMS_QUERY = 1024;
 
   @Getter private Map<String, IndexMapping> entityIndexMap;
   private Map<String, IndexMapping> aliasIndexMap;
@@ -1474,6 +1482,29 @@ public class SearchRepository {
   }
 
   /**
+   * Re-index a moved asset AND propagate its (re-derived) domains to its inherited descendants in
+   * search. Used by the Domain-page asset add/remove route: on add the re-read domains are the newly
+   * assigned domain; on remove they are whatever the asset now inherits from its own ancestry (or
+   * none). Reuses the same rebuilt-from-DB read {@link #updateEntity(EntityReference)} performs, then
+   * fans the same re-derived domains out to children through the inherited-guarded {@code
+   * ADD_DOMAINS_SCRIPT}, leaving descendants with an explicit domain untouched.
+   */
+  public void updateEntityAndPropagateInheritedDomainsToChildren(EntityReference entityReference) {
+    EntityRepository<?> entityRepository = Entity.getEntityRepository(entityReference.getType());
+    String fields =
+        String.join(",", searchIndexFactory.getReindexFieldsFor(entityReference.getType()));
+    EntityInterface entity =
+        entityRepository.get(
+            null, entityReference.getId(), entityRepository.getOnlySupportedFields(fields));
+    entity.setChangeDescription(null);
+    updateEntityIndex(entity);
+    propagateInheritedDomainsForType(
+        entityReference.getType(),
+        List.of(entityReference.getId()),
+        listOrEmpty(entity.getDomains()));
+  }
+
+  /**
    * Bulk update multiple entities in the search index. This is much more efficient than calling
    * updateEntity() for each entity individually.
    *
@@ -1799,6 +1830,77 @@ public class SearchRepository {
       }
     }
     return entityType + ".id";
+  }
+
+  /**
+   * Pushes a moved asset's new domains onto its inherited descendants in search. The asset-move
+   * routes (data product domain change, Domain page asset move) reindex only the direct asset's own
+   * doc, so descendants that inherit their domain keep the stale value in search even though the
+   * entity page recomputes it on read. This mirrors the child fan-out a normal entity update
+   * performs, reusing {@code ADD_DOMAINS_SCRIPT} which overwrites a child only when its domain is
+   * empty or inherited, leaving descendants that carry an explicit domain untouched.
+   */
+  public void propagateInheritedDomainsToChildren(
+      List<EntityReference> assets, List<EntityReference> newDomains) {
+    if (!nullOrEmpty(assets)) {
+      Map<String, List<UUID>> assetIdsByType =
+          assets.stream()
+              .collect(
+                  Collectors.groupingBy(
+                      EntityReference::getType,
+                      Collectors.mapping(EntityReference::getId, Collectors.toList())));
+      assetIdsByType.forEach(
+          (entityType, assetIds) ->
+              propagateInheritedDomainsForType(entityType, assetIds, newDomains));
+    }
+  }
+
+  private void propagateInheritedDomainsForType(
+      String entityType, List<UUID> assetIds, List<EntityReference> newDomains) {
+    IndexMapping indexMapping = entityIndexMap.get(entityType);
+    List<String> childAliases =
+        indexMapping == null
+            ? List.of()
+            : filterChildAliasesByCapability(
+                indexMapping, capability -> capability == null || !capability.isTimeSeries());
+    if (!nullOrEmpty(childAliases)) {
+      Pair<String, Map<String, Object>> updates = buildInheritedDomainUpdate(newDomains);
+      String parentField = resolveParentFieldName(entityType, updates);
+      List<String> parentIds = assetIds.stream().map(UUID::toString).toList();
+      // Chunk so the terms query never approaches Elasticsearch's index.max_terms_count on an
+      // extreme bulk move; a normal move stays a single update-by-query.
+      for (int start = 0; start < parentIds.size(); start += MAX_PARENT_IDS_PER_TERMS_QUERY) {
+        List<String> chunk =
+            List.copyOf(
+                parentIds.subList(
+                    start, Math.min(start + MAX_PARENT_IDS_PER_TERMS_QUERY, parentIds.size())));
+        updateChildrenForInheritedDomains(childAliases, parentField, chunk, updates, entityType);
+      }
+    }
+  }
+
+  private Pair<String, Map<String, Object>> buildInheritedDomainUpdate(
+      List<EntityReference> newDomains) {
+    List<EntityReference> inheritedDomains =
+        newDomains == null
+            ? new ArrayList<>()
+            : JsonUtils.deepCopyList(newDomains, EntityReference.class);
+    inheritedDomains.forEach(domain -> domain.setInherited(true));
+    return new ImmutablePair<>(ADD_DOMAINS_SCRIPT, Map.of("updatedDomains", inheritedDomains));
+  }
+
+  private void updateChildrenForInheritedDomains(
+      List<String> childAliases,
+      String parentField,
+      List<String> parentIds,
+      Pair<String, Map<String, Object>> updates,
+      String entityType) {
+    try {
+      searchClient.updateChildren(childAliases, parentField, parentIds, updates);
+    } catch (IOException e) {
+      String reason = SearchIndexRetryQueue.failureReason("propagateInheritedDomainsToChildren", e);
+      parentIds.forEach(id -> SearchIndexRetryQueue.enqueue(id, null, entityType, reason));
+    }
   }
 
   private void propagateToDomainChildren(
@@ -2313,14 +2415,20 @@ public class SearchRepository {
 
   private String generateRemoveListScript(String fieldName) {
     String cap = capitalizeFirst(fieldName);
+    // Re-add the (inherited) refs only when the child keeps no explicit value of its own.
+    // A domain/owner change is recorded as delete-old + add-new, so this delete branch runs with
+    // params.removed<Field> holding the parent's NEW inherited refs; without the emptiness guard it
+    // would append them onto children that carry an explicit value, matching generateAddListScript.
     return String.format(
         """
         if (ctx._source.%s != null) {
           ctx._source.%s.removeIf(item -> item.inherited == true);
-          ctx._source.%s.addAll(params.removed%s);
+          if (ctx._source.%s.isEmpty()) {
+            ctx._source.%s.addAll(params.removed%s);
+          }
         }
         """,
-        fieldName, fieldName, fieldName, cap);
+        fieldName, fieldName, fieldName, fieldName, cap);
   }
 
   private String generateAddTagLabelListScript() {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -671,6 +671,16 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   @Override
+  public void updateChildren(
+      List<String> indexNames,
+      String field,
+      List<String> values,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    entityManager.updateChildren(indexNames, field, values, updates);
+  }
+
+  @Override
   public void updateEntityRelationship(
       String indexName,
       Pair<String, String> fieldAndValue,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchEntityManager.java
@@ -518,6 +518,55 @@ public class ElasticSearchEntityManager implements EntityManagementClient {
   }
 
   @Override
+  public void updateChildren(
+      List<String> indexNames,
+      String field,
+      List<String> values,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    if (!isClientAvailable) {
+      LOG.error("ElasticSearch client is not available. Cannot update children for indices.");
+      return;
+    }
+    Map<String, JsonData> params =
+        convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
+
+    client.updateByQuery(
+        u ->
+            u.index(indexNames)
+                .query(anyOfFieldQuery(field, values))
+                .conflicts(Conflicts.Proceed)
+                .script(
+                    s ->
+                        s.source(ss -> ss.scriptString(updates.getKey()))
+                            .lang(ScriptLanguage.Painless)
+                            .params(params))
+                .refresh(true));
+
+    LOG.info("Successfully updated children in ElasticSearch for indices: {}", indexNames);
+  }
+
+  private Query anyOfFieldQuery(String field, List<String> values) {
+    List<FieldValue> fieldValues = values.stream().map(FieldValue::of).toList();
+    Query termsOnField =
+        Query.of(q -> q.terms(t -> t.field(field).terms(tv -> tv.value(fieldValues))));
+    Query result;
+    if (field.endsWith(".keyword")) {
+      result = termsOnField;
+    } else {
+      Query termsOnKeyword =
+          Query.of(
+              q -> q.terms(t -> t.field(field + ".keyword").terms(tv -> tv.value(fieldValues))));
+      result =
+          Query.of(
+              q ->
+                  q.bool(
+                      b -> b.should(termsOnField).should(termsOnKeyword).minimumShouldMatch("1")));
+    }
+    return result;
+  }
+
+  @Override
   public Response getDocByID(String indexName, String entityId) throws IOException {
     if (!isClientAvailable) {
       LOG.error("ElasticSearch client is not available. Cannot get document by ID.");

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -633,6 +633,16 @@ public class OpenSearchClient implements SearchClient {
   }
 
   @Override
+  public void updateChildren(
+      List<String> indexNames,
+      String field,
+      List<String> values,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    entityManager.updateChildren(indexNames, field, values, updates);
+  }
+
+  @Override
   public void updateByFqnPrefix(
       String indexName, String oldParentFQN, String newParentFQN, String prefixFieldCondition) {
     entityManager.updateByFqnPrefix(indexName, oldParentFQN, newParentFQN, prefixFieldCondition);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchEntityManager.java
@@ -569,6 +569,63 @@ public class OpenSearchEntityManager implements EntityManagementClient {
   }
 
   @Override
+  public void updateChildren(
+      List<String> indexNames,
+      String field,
+      List<String> values,
+      Pair<String, Map<String, Object>> updates)
+      throws IOException {
+    if (!isClientAvailable) {
+      LOG.error("OpenSearch client is not available. Cannot update children for indices.");
+      return;
+    }
+
+    Map<String, JsonData> params =
+        convertToJsonDataMap(updates.getValue() == null ? Map.of() : updates.getValue());
+
+    client.updateByQuery(
+        u ->
+            u.index(indexNames)
+                .query(anyOfFieldQuery(field, values))
+                .conflicts(Conflicts.Proceed)
+                .script(
+                    s ->
+                        s.inline(
+                            inline ->
+                                inline
+                                    .lang(
+                                        l ->
+                                            l.builtin(
+                                                os.org.opensearch.client.opensearch._types
+                                                    .BuiltinScriptLanguage.Painless))
+                                    .source(updates.getKey())
+                                    .params(params)))
+                .refresh(Refresh.True));
+
+    LOG.info("Successfully updated children in OpenSearch for indices: {}", indexNames);
+  }
+
+  private Query anyOfFieldQuery(String field, List<String> values) {
+    List<FieldValue> fieldValues = values.stream().map(FieldValue::of).toList();
+    Query termsOnField =
+        Query.of(q -> q.terms(t -> t.field(field).terms(tv -> tv.value(fieldValues))));
+    Query result;
+    if (field.endsWith(".keyword")) {
+      result = termsOnField;
+    } else {
+      Query termsOnKeyword =
+          Query.of(
+              q -> q.terms(t -> t.field(field + ".keyword").terms(tv -> tv.value(fieldValues))));
+      result =
+          Query.of(
+              q ->
+                  q.bool(
+                      b -> b.should(termsOnField).should(termsOnKeyword).minimumShouldMatch("1")));
+    }
+    return result;
+  }
+
+  @Override
   public Response getDocByID(String indexName, String entityId) throws IOException {
     if (!isClientAvailable) {
       LOG.error("OpenSearch client is not available. Cannot get document by ID.");


### PR DESCRIPTION
Backport of #31137 onto `1.13` (**adapted** — not a clean cherry-pick, see below).

Fixes #30678 (and the related #31162) on the 1.13 release line.

## What
When an asset's domain changes via an **asset-move** route (Data Product domain change, Domain-page asset add/remove), descendants that **inherit** their domain updated on the entity page but stayed stale in the search index until a reindex — so Explore, domain filters and asset counts kept showing them under the old domain.

## Fix
- New `SearchRepository.propagateInheritedDomainsToChildren` / `updateEntityAndPropagateInheritedDomainsToChildren`, wired into both move routes (`DataProductRepository`, `DomainRepository`), reusing the inherited-guarded `ADD_DOMAINS_SCRIPT` so descendants carrying an **explicit** domain are left untouched.
- **#31162**: `generateRemoveListScript` no longer unconditionally re-adds the parent's new (inherited) refs onto explicit-domain descendants — it re-adds only when no explicit value remains, mirroring the add script (also corrects `owners`/`dataProducts`).

## Cherry-pick / adaptation notes
`3b9512ca` did **not** apply cleanly to 1.13 — resolved 2 conflicts and adapted for one missing subsystem:

1. **Deferral machinery absent on 1.13.** The 2.0/main copies of `updateEntityAndPropagateInheritedDomainsToChildren` and `updateChildrenForInheritedDomains` route their ES round-trip through the `DeferredSearchWrite` / `deferIfFlushScopeActive` flush-deferral subsystem, which does **not** exist on 1.13. Adapted both to call `searchClient.updateChildren(...)` **directly** with the same `try/catch → SearchIndexRetryQueue.enqueue` fallback — matching how the sibling `propagateToDomainChildren` / `updateEntity(EntityReference)` already call it on 1.13. No behavioural change to the fix; only the transaction-deferral wrapper (which 1.13 doesn't have) is dropped.
2. **Unrelated main-only context excluded.** The 3-way merge pulled in `SearchRepository#updateEntitiesByReference` and `DomainResourceIT#test_renameDomainPrefixExtension…` + its `createTableInDomain` helper — neither is part of #31137 (both are pre-existing main code absent on 1.13). Excluded them so this PR carries only #31137's changes.
3. **Test imports.** Added `Table`, `DatabaseSchema`, `Database`, `DatabaseService`, `DatabaseServiceTestFactory`, `Column`, `ColumnDataType`, `JsonNode` imports to `DomainResourceIT` (present on main via other tests, absent on 1.13).

The actual fix logic — the propagate methods, the `generateRemoveListScript` guard, and the `EntityManagementClient`/ES/OS `updateChildren` overload — is byte-for-byte the same as #31137.

## Verified locally
`mvn clean install -pl openmetadata-service,openmetadata-integration-tests -am -DskipTests` → **BUILD SUCCESS**. New methods present in compiled `SearchRepository`; `DataProductResourceIT` and `DomainResourceIT` both compile.

## Tests
`DataProductResourceIT` and `DomainResourceIT` integration tests covering the data-product route, the domain-page add/remove route, multi-level descendants, and the explicit-child over-append case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
