### PR TITLE
fix(e2e): large-glossary drag-drop test consistently timing out in AUT

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts
@@ -353,13 +353,20 @@ test.describe('Large Glossary Performance Tests', () => {
   });
 
   test('should handle drag and drop for term reordering', async ({ page }) => {
+    test.slow();
+
     await dragAndDropTerm(page, 'Term_10', 'Term_1');
 
     await confirmationDragAndDropGlossary(page, 'Term_10', 'Term_1');
 
     await expect(page.getByTestId('Term_10')).not.toBeVisible();
 
-    const termRes = page.waitForResponse('/api/v1/glossaryTerms?*');
+    const termRes = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/glossaryTerms') &&
+        res.url().includes('directChildrenOf=') &&
+        res.status() === 200
+    );
 
     // verify the term is moved under the parent term
     await page.getByTestId('expand-collapse-all-button').click();


### PR DESCRIPTION
## Root cause (traced from nightly run #31585212160, shard 2, retry #2)

The test `Large Glossary Performance Tests › should handle drag and drop for term reordering` failed on all 3 attempts with **60 s test-timeout** — not an assertion failure.

The full stack trace from retry #2 pins the exact hang:

```
Error: page.waitForResponse: Test timeout of 60000ms exceeded.
=========================== logs ===========================
waiting for response "/api/v1/glossaryTerms/*"
============================================================
    at confirmationDragAndDropGlossary (playwright/utils/glossary.ts:1196:42)
    at LargeGlossaryPerformance.spec.ts:320:5
```

### What was happening

`confirmationDragAndDropGlossary` sets up `patchGlossaryTermResponse = page.waitForResponse('/api/v1/glossaryTerms/*')` and then calls:

```ts
// nightly version (before #29728 fix)
await page.getByRole('button', { name: 'Move' }).click();
```

**`getByRole('button', { name: 'Move' })` is ambiguous** in a 100-term glossary. TableV2 renders a drag handle for every row; those handles expose an accessible label that matches `'Move'`. Playwright clicks the **first matching element in DOM order**, which is a drag handle — _not_ the confirmation modal's Move button. No PATCH request fires, `waitForResponse` never resolves, and the test hangs until the 60 s ceiling.

### Fix already in `main`

The unscoped click was fixed in #29728 (merged Jul 15):

```ts
// Scope to the modal: TableV2 drag handles expose aria-label "Move the term",
// which otherwise also matches getByRole('button', { name: 'Move' }).
await page
  .getByTestId('confirmation-modal')
  .getByRole('button', { name: 'Move' })
  .click();
```

The nightly AUT 1.13 branch predates that fix.

### This PR — spec-level resilience

The spec itself has two additional fragility points that this PR corrects:

1. **`page.waitForResponse('/api/v1/glossaryTerms?*')`** — Playwright's URL matcher treats `?` as a glob wildcard (exactly one character), not the URL query-string separator. The predicate is replaced with a function that checks `url.includes('directChildrenOf=')`, matching the actual child-load request fired by the Expand All button.

2. **No `test.slow()`** — a drag-drop test that navigates a page, fires a PATCH, then expands 100+ terms has no extra timeout headroom. `test.slow()` triples the budget to 180 s, preventing future timeouts in loaded AUT environments.

## Changes

| File | Change |
|---|---|
| `playwright/e2e/Features/Glossary/LargeGlossaryPerformance.spec.ts` | Add `test.slow()`, replace `waitForResponse` string glob with reliable predicate |

## Test plan

- [ ] Drag-and-drop test passes locally against a dev server with 100+ glossary terms
- [ ] No other test in `LargeGlossaryPerformance.spec.ts` is affected (all use independent `waitForResponse` calls or none at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)