### PR TITLE
Fixes #29824: Ingest dbt pass results with null message

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/dbt/metadata.py
@@ -1978,8 +1978,9 @@ class DbtSource(DbtServiceSource):
 
                 # Skip compiled-only entries: `dbt run` includes test nodes in
                 # run_results.json with status="success" but message=null since
-                # no test SQL was executed. Real results always have a message.
-                if not dbt_test_result.message:
+                # no test SQL was executed. Executed dbt tests can also have
+                # message=null, e.g. passing tests with status="pass".
+                if not dbt_test_result.message and dbt_test_result.status.value == DbtTestSuccessEnum.SUCCESS.value:
                     logger.debug(
                         "Skipping compiled-only test result for '%s' (message is null).",
                         manifest_node.name,

--- a/ingestion/tests/unit/test_dbt.py
+++ b/ingestion/tests/unit/test_dbt.py
@@ -3588,6 +3588,40 @@ class TestAddDbtTestResultSkipsCompiledOnly(TestCase):
             DbtCommonEnum.UPSTREAM.value: upstream or [],
         }
 
+    @staticmethod
+    def _make_parsed_test_result(status, message):
+        run_results = parse_run_results(
+            {
+                "metadata": {
+                    "dbt_schema_version": "https://schemas.getdbt.com/dbt/run-results/v4.json",
+                    "dbt_version": "1.11.6",
+                    "generated_at": "2026-03-27T07:01:00.000000Z",
+                    "invocation_id": "00000000-0000-0000-0000-000000000000",
+                    "env": {},
+                },
+                "results": [
+                    {
+                        "status": status,
+                        "timing": [
+                            {
+                                "name": "execute",
+                                "started_at": "2026-03-27T07:00:00.000000Z",
+                                "completed_at": "2026-03-27T07:00:01.000000Z",
+                            }
+                        ],
+                        "thread_id": "Thread-1",
+                        "execution_time": 1.0,
+                        "message": message,
+                        "adapter_response": {},
+                        "unique_id": "test.pkg.test_not_null_orders_id",
+                    }
+                ],
+                "elapsed_time": 1.0,
+                "args": {},
+            }
+        )
+        return run_results.results[0]
+
     def test_compiled_only_null_message_is_skipped(self):
         """
         Compiled-only entry: status=success, message=None.
@@ -3630,6 +3664,54 @@ class TestAddDbtTestResultSkipsCompiledOnly(TestCase):
         source.metadata.add_test_case_results.assert_called_once()
         test_case_result = source.metadata.add_test_case_results.call_args.kwargs["test_results"]
         self.assertIsNone(test_case_result.result)
+
+    def test_real_pass_result_with_null_message_is_ingested(self):
+        """
+        Real test pass: status=pass, message=None.
+        Must call add_test_case_results exactly once.
+        """
+        from metadata.ingestion.source.database.dbt.constants import DbtCommonEnum
+
+        timing = MagicMock()
+        timing.name = "execute"
+        timing.completed_at = "2026-03-27T07:00:00.000000Z"
+
+        source = self._make_dbt_source()
+        dbt_test = {
+            DbtCommonEnum.MANIFEST_NODE.value: self._make_manifest_node(),
+            DbtCommonEnum.RESULTS.value: self._make_test_result(status="pass", message=None, timing=[timing]),
+            DbtCommonEnum.UPSTREAM.value: ["snowflake.db.schema.orders"],
+        }
+        with patch("metadata.ingestion.source.database.dbt.metadata.fqn") as mock_fqn:
+            mock_fqn.split.return_value = ["snowflake", "db", "schema", "orders"]
+            mock_fqn.build.return_value = "snowflake.db.schema.orders.test_not_null_orders_id"
+            source.add_dbt_test_result(dbt_test)
+
+        source.metadata.add_test_case_results.assert_called_once()
+
+    def test_parsed_pass_result_with_null_message_is_ingested(self):
+        """
+        Real dbt artifact result: status=pass, message=None.
+        Must be ingested after parsing run_results.json.
+        """
+        from metadata.generated.schema.tests.basic import TestCaseStatus
+        from metadata.ingestion.source.database.dbt.constants import DbtCommonEnum
+
+        source = self._make_dbt_source()
+        dbt_test = {
+            DbtCommonEnum.MANIFEST_NODE.value: self._make_manifest_node(),
+            DbtCommonEnum.RESULTS.value: self._make_parsed_test_result(status="pass", message=None),
+            DbtCommonEnum.UPSTREAM.value: ["snowflake.db.schema.orders"],
+        }
+        with patch("metadata.ingestion.source.database.dbt.metadata.fqn") as mock_fqn:
+            mock_fqn.split.return_value = ["snowflake", "db", "schema", "orders"]
+            mock_fqn.build.return_value = "snowflake.db.schema.orders.test_not_null_orders_id"
+            source.add_dbt_test_result(dbt_test)
+
+        source.metadata.add_test_case_results.assert_called_once()
+        test_case_result = source.metadata.add_test_case_results.call_args.kwargs["test_results"]
+        assert test_case_result.testCaseStatus == TestCaseStatus.Success
+        assert test_case_result.testResultValue[0].value == "1"
 
     def test_real_failure_result_is_ingested(self):
         """


### PR DESCRIPTION
### Describe your changes:

Fixes #29824

Backports #29828 to the `2.0` release branch.

PR #26812 introduced a broad guard that skipped every dbt test result with a null or empty `message`. That correctly excluded compiled-only entries produced by `dbt run` (`status="success", message=null`), but also dropped real executed data-test results emitted as `status="pass", message=null`.

This change narrows the guard to the compiled-only `success` case. Executed `pass` results are ingested while the original skip behavior is retained.

The cherry-pick was rebased onto the current `2.0` tip and applied without conflicts.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small bug fix backported from #29828.

#
### Tests:

#### Use cases covered

- Compiled-only `status="success", message=null` entries remain skipped.
- Executed `status="pass", message=null` data-test results are ingested.
- Parser-backed dbt artifacts preserve the expected behavior.
- Failed results with messages continue to be ingested.

#### Unit tests

- [x] Regression tests are included in `ingestion/tests/unit/test_dbt.py`.
- `PYTHONPATH=ingestion/src pytest -q ingestion/tests/unit/test_dbt.py::TestAddDbtTestResultSkipsCompiledOnly` — 7 passed on the rebased `2.0` branch.
- The original backport was also validated with the complete `test_dbt.py` file — 154 passed.

#### Backend integration tests

- [x] Not applicable; no backend API changes.

#### Ingestion integration tests

- [x] Existing E2E validation confirmed a real dbt `pass/null` result is written with Success status, value `1`, and the artifact timestamp; compiled-only `success/null` remains skipped.

#### Playwright (UI) tests

- [x] Not applicable; no UI changes.

#### Manual testing performed

1. Generated dbt 1.11 `run_results.json` containing executed `pass/null` entries.
2. Ingested artifacts into OpenMetadata.
3. Verified successful test history, retained failed-result handling, compiled-only skipping, and idempotent reruns.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to GitHub issue #29824.
- [x] No JSON Schema changes are involved.
- [x] No UI changes are involved.
- [x] I have added tests covering the exact regression.

### Source

- Original PR: #29828
- Original merge commit: `6ebcd9a2da`
- Backport commit: `1051a7f1ce`

> Release backport note: issue #29824 was already closed by the mainline fix, so the documented maintainer `skip-pr-checks` label is applied for this `2.0` backport.