### PR TITLE
Fixes #31426 : Record SUGGESTED provenance when a description suggestion is accepted

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4406,8 +4406,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
   @Transaction
   public void patchChangeSummary(
       UUID entityId, String fieldName, ChangeSource changeSource, String user) {
-    // find(), not get(): this re-persists the whole entity, and get() runs clearFields, which
-    // nulls fields outside the requested set — for a Table, tableConstraints and schemaDefinition.
+    // We rewrite the whole entity below, so we need all of it. get() returns only the fields
+    // asked for and nulls the rest, which would drop data like a Table's tableConstraints.
     T entity = find(entityId, NON_DELETED);
     ChangeDescription cd = entity.getChangeDescription();
     if (cd == null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4406,9 +4406,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
   @Transaction
   public void patchChangeSummary(
       UUID entityId, String fieldName, ChangeSource changeSource, String user) {
-    // find(), not get(): this method re-persists the whole entity, and get() runs clearFields,
-    // which nulls every field outside the requested set. Storing that back would drop the
-    // cleared-but-persisted attributes — for a Table, tableConstraints and schemaDefinition.
+    // find(), not get(): this re-persists the whole entity, and get() runs clearFields, which
+    // nulls fields outside the requested set — for a Table, tableConstraints and schemaDefinition.
     T entity = find(entityId, NON_DELETED);
     ChangeDescription cd = entity.getChangeDescription();
     if (cd == null) {
@@ -4433,11 +4432,8 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // Direct dao.update skips invalidateCachesAfterStore, so drop every cached variant so the
     // next read picks up the new changeSummary instead of serving stale JSON.
     invalidateCacheForEntity(entityType, entity.getId(), entity.getFullyQualifiedName());
-    // No search-index update: SearchRepository.updateEntity() nulls changeDescription before
-    // indexing, so re-indexing here cannot move the doc's descriptionSource anyway (verified
-    // against a live server). Callers that change a value carry the source on the patch instead,
-    // which reindexes correctly through the normal lifecycle. This method only runs when the
-    // value is unchanged, so the doc's text stays accurate and only its provenance lags.
+    // The search doc's descriptionSource lags until the entity is next written; the value is
+    // unchanged here, so only its provenance is stale.
   }
 
   @Transaction

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/EntityRepository.java
@@ -4406,7 +4406,10 @@ public abstract class EntityRepository<T extends EntityInterface> {
   @Transaction
   public void patchChangeSummary(
       UUID entityId, String fieldName, ChangeSource changeSource, String user) {
-    T entity = get(null, entityId, getFields("changeDescription"));
+    // find(), not get(): this method re-persists the whole entity, and get() runs clearFields,
+    // which nulls every field outside the requested set. Storing that back would drop the
+    // cleared-but-persisted attributes — for a Table, tableConstraints and schemaDefinition.
+    T entity = find(entityId, NON_DELETED);
     ChangeDescription cd = entity.getChangeDescription();
     if (cd == null) {
       cd = new ChangeDescription().withPreviousVersion(entity.getVersion());
@@ -4430,6 +4433,11 @@ public abstract class EntityRepository<T extends EntityInterface> {
     // Direct dao.update skips invalidateCachesAfterStore, so drop every cached variant so the
     // next read picks up the new changeSummary instead of serving stale JSON.
     invalidateCacheForEntity(entityType, entity.getId(), entity.getFullyQualifiedName());
+    // No search-index update: SearchRepository.updateEntity() nulls changeDescription before
+    // indexing, so re-indexing here cannot move the doc's descriptionSource anyway (verified
+    // against a live server). Callers that change a value carry the source on the patch instead,
+    // which reindexes correctly through the normal lifecycle. This method only runs when the
+    // value is unchanged, so the doc's text stays accurate and only its provenance lags.
   }
 
   @Transaction

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -1019,36 +1019,25 @@ public class TaskWorkflowHandler {
   }
 
   /**
-   * Stamp {@code SUGGESTED} on the accepted field's change summary, for agent-authored suggestions.
+   * Whether the text being applied is what the agent actually proposed.
    *
-   * <p>Applies to both accept paths. The no-op path has no FieldChange to summarize, and the
-   * value-changing path goes through {@link FieldPathUtils#updateFieldDescription}, which patches
-   * without a change source — so its summary would otherwise default to {@code Manual} and read as
-   * hand-authored. Both cases are content an agent produced and a reviewer approved, which consumers
-   * (search's descriptionSource, automations deciding whether an asset still needs work) must be
-   * able to tell apart from a human writing the text themselves.
-   *
-   * <p>A suggestion a person wrote is left alone: accepting it records a human's words, whoever
-   * clicked approve. The payload's {@code source} is client-supplied, so anything that is not
-   * recognizably an agent counts as human — the direction that keeps an asset under review rather
-   * than silently exempting it.
+   * <p>The payload here is the reviewer's resolution merged over the task's, and the merge keeps the
+   * original {@code source} — so a reviewer who rewrote the text still arrives labelled
+   * {@code Agent}. Comparing against the task's own suggestion separates the two.
    */
-  private void recordSuggestedChangeSummary(
-      EntityRepository<?> repository,
-      EntityInterface entity,
-      JsonNode payloadNode,
-      String fieldPath,
-      String user) {
-    String changeSummaryField = resolveSuggestionChangeSummaryField(fieldPath);
-    if (changeSummaryField != null && isAgentAuthored(payloadNode)) {
-      repository.patchChangeSummary(
-          entity.getId(), changeSummaryField, ChangeSource.SUGGESTED, user);
+  private boolean isAgentAuthored(Task task, JsonNode payloadNode, String appliedValue) {
+    if (!AGENT_SUGGESTION_SOURCE.equalsIgnoreCase(payloadNode.path("source").asText(null))) {
+      return false;
     }
+    String proposed = originalSuggestedValue(task);
+    return proposed == null || proposed.equals(appliedValue);
   }
 
-  private boolean isAgentAuthored(JsonNode payloadNode) {
-    String source = payloadNode.path("source").asText(null);
-    return AGENT_SUGGESTION_SOURCE.equalsIgnoreCase(source);
+  private String originalSuggestedValue(Task task) {
+    if (task == null || task.getPayload() == null) {
+      return null;
+    }
+    return JsonUtils.valueToTree(task.getPayload()).path("suggestedValue").asText(null);
   }
 
   private void applySuggestion(
@@ -1073,7 +1062,11 @@ public class TaskWorkflowHandler {
       if ("Description".equals(suggestionType)) {
         Optional<String> currentDescription = FieldPathUtils.getFieldDescription(entity, fieldPath);
         if (currentDescription.isPresent() && suggestedValue.equals(currentDescription.get())) {
-          recordSuggestedChangeSummary(repository, entity, payloadNode, fieldPath, user);
+          String changeSummaryField = resolveSuggestionChangeSummaryField(fieldPath);
+          if (changeSummaryField != null && isAgentAuthored(task, payloadNode, suggestedValue)) {
+            repository.patchChangeSummary(
+                entity.getId(), changeSummaryField, ChangeSource.SUGGESTED, user);
+          }
           LOG.info(
               "[TaskWorkflowHandler] Recorded no-op description suggestion change summary: fieldPath={}",
               fieldPath);
@@ -1086,7 +1079,7 @@ public class TaskWorkflowHandler {
                 user,
                 fieldPath,
                 suggestedValue,
-                isAgentAuthored(payloadNode) ? ChangeSource.SUGGESTED : null);
+                isAgentAuthored(task, payloadNode, suggestedValue) ? ChangeSource.SUGGESTED : null);
         if (success) {
           LOG.info("[TaskWorkflowHandler] Applied description suggestion: fieldPath={}", fieldPath);
         } else {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -1026,18 +1026,14 @@ public class TaskWorkflowHandler {
    * {@code Agent}. Comparing against the task's own suggestion separates the two.
    */
   private boolean isAgentAuthored(Task task, JsonNode payloadNode, String appliedValue) {
-    if (!AGENT_SUGGESTION_SOURCE.equalsIgnoreCase(payloadNode.path("source").asText(null))) {
-      return false;
-    }
-    String proposed = originalSuggestedValue(task);
-    return proposed == null || proposed.equals(appliedValue);
-  }
-
-  private String originalSuggestedValue(Task task) {
-    if (task == null || task.getPayload() == null) {
-      return null;
-    }
-    return JsonUtils.valueToTree(task.getPayload()).path("suggestedValue").asText(null);
+    boolean agentSourced =
+        AGENT_SUGGESTION_SOURCE.equalsIgnoreCase(payloadNode.path("source").asText(null));
+    String proposed =
+        Optional.ofNullable(task)
+            .map(Task::getPayload)
+            .map(payload -> JsonUtils.valueToTree(payload).path("suggestedValue").asText(null))
+            .orElse(null);
+    return agentSourced && (proposed == null || proposed.equals(appliedValue));
   }
 
   private void applySuggestion(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -1015,6 +1015,25 @@ public class TaskWorkflowHandler {
     }
   }
 
+  /**
+   * Stamp {@code SUGGESTED} on the accepted field's change summary.
+   *
+   * <p>Applies to both accept paths. The no-op path has no FieldChange to summarize, and the
+   * value-changing path goes through {@link FieldPathUtils#updateFieldDescription}, which patches
+   * without a change source — so its summary would otherwise default to {@code Manual} and read as
+   * hand-authored. Both cases are content the suggester produced and a reviewer approved, which
+   * consumers (search's descriptionSource, automations deciding whether an asset still needs work)
+   * must be able to tell apart from a human writing the text themselves.
+   */
+  private void recordSuggestedChangeSummary(
+      EntityRepository<?> repository, EntityInterface entity, String fieldPath, String user) {
+    String changeSummaryField = resolveSuggestionChangeSummaryField(fieldPath);
+    if (changeSummaryField != null) {
+      repository.patchChangeSummary(
+          entity.getId(), changeSummaryField, ChangeSource.SUGGESTED, user);
+    }
+  }
+
   private void applySuggestion(
       Task task,
       Object payload,
@@ -1037,11 +1056,7 @@ public class TaskWorkflowHandler {
       if ("Description".equals(suggestionType)) {
         Optional<String> currentDescription = FieldPathUtils.getFieldDescription(entity, fieldPath);
         if (currentDescription.isPresent() && suggestedValue.equals(currentDescription.get())) {
-          String changeSummaryField = resolveSuggestionChangeSummaryField(fieldPath);
-          if (changeSummaryField != null) {
-            repository.patchChangeSummary(
-                entity.getId(), changeSummaryField, ChangeSource.SUGGESTED, user);
-          }
+          recordSuggestedChangeSummary(repository, entity, fieldPath, user);
           LOG.info(
               "[TaskWorkflowHandler] Recorded no-op description suggestion change summary: fieldPath={}",
               fieldPath);
@@ -1051,6 +1066,7 @@ public class TaskWorkflowHandler {
             FieldPathUtils.updateFieldDescription(
                 entity, repository, user, fieldPath, suggestedValue);
         if (success) {
+          recordSuggestedChangeSummary(repository, entity, fieldPath, user);
           LOG.info("[TaskWorkflowHandler] Applied description suggestion: fieldPath={}", fieldPath);
         } else {
           LOG.warn(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/tasks/TaskWorkflowHandler.java
@@ -79,6 +79,9 @@ import org.openmetadata.service.util.RestUtil.PatchResponse;
 @Slf4j
 public class TaskWorkflowHandler {
 
+  /** Suggestion payload {@code source} marking a suggestion an agent produced. */
+  private static final String AGENT_SUGGESTION_SOURCE = "Agent";
+
   private static TaskWorkflowHandler instance;
 
   private TaskWorkflowHandler() {}
@@ -1016,22 +1019,36 @@ public class TaskWorkflowHandler {
   }
 
   /**
-   * Stamp {@code SUGGESTED} on the accepted field's change summary.
+   * Stamp {@code SUGGESTED} on the accepted field's change summary, for agent-authored suggestions.
    *
    * <p>Applies to both accept paths. The no-op path has no FieldChange to summarize, and the
    * value-changing path goes through {@link FieldPathUtils#updateFieldDescription}, which patches
    * without a change source — so its summary would otherwise default to {@code Manual} and read as
-   * hand-authored. Both cases are content the suggester produced and a reviewer approved, which
-   * consumers (search's descriptionSource, automations deciding whether an asset still needs work)
-   * must be able to tell apart from a human writing the text themselves.
+   * hand-authored. Both cases are content an agent produced and a reviewer approved, which consumers
+   * (search's descriptionSource, automations deciding whether an asset still needs work) must be
+   * able to tell apart from a human writing the text themselves.
+   *
+   * <p>A suggestion a person wrote is left alone: accepting it records a human's words, whoever
+   * clicked approve. The payload's {@code source} is client-supplied, so anything that is not
+   * recognizably an agent counts as human — the direction that keeps an asset under review rather
+   * than silently exempting it.
    */
   private void recordSuggestedChangeSummary(
-      EntityRepository<?> repository, EntityInterface entity, String fieldPath, String user) {
+      EntityRepository<?> repository,
+      EntityInterface entity,
+      JsonNode payloadNode,
+      String fieldPath,
+      String user) {
     String changeSummaryField = resolveSuggestionChangeSummaryField(fieldPath);
-    if (changeSummaryField != null) {
+    if (changeSummaryField != null && isAgentAuthored(payloadNode)) {
       repository.patchChangeSummary(
           entity.getId(), changeSummaryField, ChangeSource.SUGGESTED, user);
     }
+  }
+
+  private boolean isAgentAuthored(JsonNode payloadNode) {
+    String source = payloadNode.path("source").asText(null);
+    return AGENT_SUGGESTION_SOURCE.equalsIgnoreCase(source);
   }
 
   private void applySuggestion(
@@ -1056,7 +1073,7 @@ public class TaskWorkflowHandler {
       if ("Description".equals(suggestionType)) {
         Optional<String> currentDescription = FieldPathUtils.getFieldDescription(entity, fieldPath);
         if (currentDescription.isPresent() && suggestedValue.equals(currentDescription.get())) {
-          recordSuggestedChangeSummary(repository, entity, fieldPath, user);
+          recordSuggestedChangeSummary(repository, entity, payloadNode, fieldPath, user);
           LOG.info(
               "[TaskWorkflowHandler] Recorded no-op description suggestion change summary: fieldPath={}",
               fieldPath);
@@ -1064,9 +1081,13 @@ public class TaskWorkflowHandler {
         }
         boolean success =
             FieldPathUtils.updateFieldDescription(
-                entity, repository, user, fieldPath, suggestedValue);
+                entity,
+                repository,
+                user,
+                fieldPath,
+                suggestedValue,
+                isAgentAuthored(payloadNode) ? ChangeSource.SUGGESTED : null);
         if (success) {
-          recordSuggestedChangeSummary(repository, entity, fieldPath, user);
           LOG.info("[TaskWorkflowHandler] Applied description suggestion: fieldPath={}", fieldPath);
         } else {
           LOG.warn(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/FieldPathUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/FieldPathUtils.java
@@ -63,9 +63,8 @@ public class FieldPathUtils {
   /**
    * Update a field's description, recording where the new text came from.
    *
-   * <p>The change source rides the patch rather than being stamped afterwards: one versioned write
-   * that carries the provenance into the change summary and through the normal lifecycle, so the
-   * search document's {@code descriptionSource} follows. A follow-up write cannot do either.
+   * <p>The source rides the patch, so one versioned write carries the provenance into the change
+   * summary and, through the normal lifecycle, the search document's {@code descriptionSource}.
    *
    * @param changeSource provenance of the new text, or null to leave it defaulted
    */

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/FieldPathUtils.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/FieldPathUtils.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.openmetadata.schema.EntityInterface;
+import org.openmetadata.schema.type.change.ChangeSource;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.jdbi3.EntityRepository;
 
@@ -56,6 +57,25 @@ public class FieldPathUtils {
       String user,
       String fieldPath,
       String newDescription) {
+    return updateFieldDescription(entity, repository, user, fieldPath, newDescription, null);
+  }
+
+  /**
+   * Update a field's description, recording where the new text came from.
+   *
+   * <p>The change source rides the patch rather than being stamped afterwards: one versioned write
+   * that carries the provenance into the change summary and through the normal lifecycle, so the
+   * search document's {@code descriptionSource} follows. A follow-up write cannot do either.
+   *
+   * @param changeSource provenance of the new text, or null to leave it defaulted
+   */
+  public static boolean updateFieldDescription(
+      EntityInterface entity,
+      EntityRepository<?> repository,
+      String user,
+      String fieldPath,
+      String newDescription,
+      ChangeSource changeSource) {
 
     // Take snapshot before modification
     String originalJson = JsonUtils.pojoToJson(entity);
@@ -77,7 +97,7 @@ public class FieldPathUtils {
     }
 
     // Apply patch
-    repository.patch(null, entity.getId(), user, patch, null, null);
+    repository.patch(null, entity.getId(), user, patch, changeSource, null);
     LOG.info(
         "[FieldPathUtils] Updated description at '{}' in entity '{}'", fieldPath, entity.getName());
     return true;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #31426 
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I made accepting a description suggestion record where the text came from, because it previously recorded nothing: the value-changing branch of `applySuggestion` patched with a null change source, so the field's `changeSummary` defaulted to Manual and approved agent text read as hand-authored. Only the rarely-hit no-op branch stamped `SUGGESTED`, and its javadoc assumed the normal path already did — which was never true.

While routing accepts through patchChangeSummary, I found it re-persists the whole entity after loading it with `get(..., getFields("changeDescription")). get() runs clearFields`, which nulls every field outside the requested set, and the write is a full json replace — so each call silently dropped tableConstraints and schemaDefinition. Latent on main because only the no-op branch reached it.

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [x] Bug fix

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

- FieldPathUtils.updateFieldDescription takes an optional ChangeSource and puts it on the patch. The source rides the single versioned write, so it lands in the change summary and flows through the normal lifecycle to the search document's descriptionSource. The existing 5-arg overload is unchanged, so the plain description-task path still records Manual.
- TaskWorkflowHandler.applySuggestion passes SUGGESTED only when the suggestion is agent-authored and the applied value still matches the task's original suggestedValue. `mergeResolutionPayload` overlays the reviewer's resolution while keeping source: "Agent", so without the value comparison a reviewer who rewrites the text before approving would have their words credited to the agent.
- EntityRepository.patchChangeSummary loads with find(entityId, NON_DELETED) instead of get(...), reading the stored row without clearFields.

Alternative rejected: stamping the provenance in a follow-up patchChangeSummary call after the patch. It cannot fix the search index — SearchRepository.updateEntity(EntityReference) nulls changeDescription before indexing, so the rebuilt doc has no summary to derive a source from (verified against a running server) — and it adds a second full-entity write.

Backward compatibility: rows written before this change keep no changeSource and continue to read as Manual. No migration; provenance corrects itself the next time a field is written. One visible effect: descriptions whose agent suggestion was approved now index as Suggested rather than falling through to the Ingested default, so source-breakdown dashboards will see counts shift.

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

- Approving an agent suggestion unchanged records changeSource=Suggested and the reviewer as `changedBy`, via both `/tasks/{id}/suggestion/apply` and `/tasks/{id}/resolve`
- Approving with an overriding payload applies the reviewer's text and records Manual
- Approving a human-authored suggestion (payload source not Agent) records Manual
- Accepting a suggestion on a View preserves tableConstraints and schemaDefinition
- A search document's descriptionSources reflects Suggested after an approved agent suggestion


#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes #31426 : Record SUGGESTED provenance when a description suggestion is accepted`
- [x] My PR is linked to a GitHub issue via `Fixes #31426 ` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not needed — no schema change.
- [x] For UI changes: not applicable.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
