### PR TITLE
fix(ingestion): let subclasses override deployed-pipeline cleanup

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -528,7 +528,8 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     return wasRunnerCleanupSkipped;
   }
 
-  boolean deleteDeployedPipeline(IngestionPipeline entity, boolean allowUnavailableRunner) {
+  protected boolean deleteDeployedPipeline(
+      IngestionPipeline entity, boolean allowUnavailableRunner) {
     boolean wasRunnerCleanupSkipped = false;
     if (pipelineServiceClient != null) {
       try {


### PR DESCRIPTION
Follow-up to #31203.

`IngestionPipelineRepository.deleteDeployedPipeline` was package-private, so a repository living outside `org.openmetadata.service.jdbi3` could not take part in the force-delete flow — the `allowUnavailableRunner` argument was unreachable from another package, leaving `?hardDelete=true&force=true` inert wherever the runner cleanup is implemented by a subclass.

Widens it to `protected`. No behaviour change on its own.