### PR TITLE
Fixes #31431 - Install the spaCy PII model as a test dependency

### DIFF
--- a/ingestion/setup.py
+++ b/ingestion/setup.py
@@ -52,6 +52,13 @@ VERSIONS = {
     "databricks-sqlalchemy": "databricks-sqlalchemy~=2.0.9",
     "trino": "trino[sqlalchemy]",
     "spacy": "spacy<3.8",
+    # spaCy models are published as GitHub release wheels, not on PyPI, and are pinned per
+    # spaCy minor: 3.7.1 is what spacy<3.8 resolves to via spaCy's compatibility index.
+    # Bump this alongside the "spacy" pin above.
+    "spacy-en-model": (
+        "en_core_web_md @ https://github.com/explosion/spacy-models/releases/download/"
+        "en_core_web_md-3.7.1/en_core_web_md-3.7.1-py3-none-any.whl"
+    ),
     "looker-sdk": "looker-sdk>=22.20.0,!=24.18.0",
     "lkml": "lkml~=1.3",
     "tableau": "tableauserverclient==0.40",  # pre-0.37 pins urllib3<2, which conflicts with collate-data-diff's urllib3>=2.7
@@ -498,6 +505,12 @@ test = {
     VERSIONS["pyarrow"],
     VERSIONS["trino"],
     VERSIONS["spacy"],
+    # The PII tests build a Presidio analyzer, which loads this spaCy model. Installing it as a
+    # declared test dependency keeps the download out of the test run: build_analyzer_engine()
+    # otherwise fetches it on first use, and because a failed load never populates
+    # load_nlp_engine's @cache, every test module retries the download -- so a transient
+    # github.com blip fails the whole job. Installed here it also lands in the cached venv.
+    VERSIONS["spacy-en-model"],
     VERSIONS["pydomo"],
     VERSIONS["looker-sdk"],
     VERSIONS["lkml"],


### PR DESCRIPTION
Fixes #31431

## Problem

`py-tests` has failed **5 of its last 6 runs on `main`**. The PII unit tests die on a network error, not an assertion:

```
ERROR: Could not install packages due to an OSError: HTTPSConnectionPool(host='github.com', port=443):
Max retries exceeded with url: /explosion/spacy-models/releases/download/en_core_web_md-3.7.1/...whl
(Caused by ProtocolError('Connection aborted.', RemoteDisconnected(...)))
```

- `test_presidio_utils.py::test_analyzer_supports_all_expected_pii_entities` — FAILED
- `test_feature_extraction.py::test_credit_card_extraction` — ERROR at setup
- `test_feature_extraction.py::test_date_time_extraction_with_date` — ERROR at setup
- `test_feature_extraction.py::test_date_time_extraction_with_datetime` — ERROR at setup

## Cause

Nothing installs the `en_core_web_md` model these tests need, so `build_analyzer_engine()` falls through to spaCy's `download()`, which shells out to `pip install <github release wheel>` **during the test run**. Fine for production ingestion — the model is fetched on demand for whatever language is configured — but a poor fit for unit tests, and two details amplify it:

1. The `analyzer` fixture is `scope="module"`, and a failed load never populates `load_nlp_engine`'s `@cache`, so **every test module retries the same 42MB download**. The failing run attempted it four times before giving up.
2. Unit tests run under `pytest-xdist` (`-n auto --dist loadfile`), so those attempts can land as concurrent `pip install`s into one venv.

A transient github.com blip therefore takes down the whole Python job.

## Fix

Declare the model as a test dependency instead of downloading it mid-run. One entry in `VERSIONS`, one line in the `test` extra.

spaCy models ship as GitHub release wheels rather than on PyPI, so this is a PEP 508 direct reference. **`3.7.1` is exactly what `download()` was already fetching** — it is what `spacy<3.8` resolves to through spaCy's compatibility index — so this front-loads the identical install rather than changing which model is used.

Installing it up front also lands it in the venv CI already caches (keyed on `setup.py`), so after the first run it needs no network at all.

## Verification

- spaCy's compatibility index for spacy `3.7` → `en_core_web_md: ["3.7.1", "3.7.0"]`, confirming the pin.
- The wheel's own metadata is `Requires-Dist: spacy <3.8.0,>=3.7.2`, which agrees with the existing `"spacy": "spacy<3.8"` pin.
- The requirement string parses as valid PEP 508 (`name=en_core_web_md`), and `pip download --no-deps` resolves and fetches the wheel successfully.
- `VERSIONS` is local to `setup.py` — no other consumer parses it.

Bump this pin alongside the `spacy` pin; the comment in `VERSIONS` says so.

## Note

This is unrelated to, but currently blocking, #31425 — `py-tests-status` is a required check there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)