### PR TITLE
Fixes #31437: Handle chart data stream teardown failures on unmount

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.test.tsx
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, render } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { noop } from 'lodash';
+import { WorkflowStatus } from '../../generated/governance/workflows/workflowInstance';
+import { ServicesType } from '../../interface/service.interface';
+import {
+  setChartDataStreamConnection,
+  stopChartDataStreamConnection,
+} from '../../rest/DataInsightAPI';
+import ServiceInsightsTab from './ServiceInsightsTab';
+import { ServiceInsightsTabProps } from './ServiceInsightsTab.interface';
+
+const SESSION_ID = 'e5f4b0e1-0000-4000-8000-0000000000ff';
+
+jest.mock('../../rest/DataInsightAPI', () => ({
+  getMultiChartsPreviewByName: jest.fn().mockResolvedValue({}),
+  setChartDataStreamConnection: jest
+    .fn()
+    .mockResolvedValue({ sessionId: 'e5f4b0e1-0000-4000-8000-0000000000ff' }),
+  stopChartDataStreamConnection: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../rest/searchAPI', () => ({
+  searchQuery: jest
+    .fn()
+    .mockResolvedValue({ aggregations: { entityType: { buckets: [] } } }),
+}));
+
+jest.mock('../../rest/applicationAPI', () => ({
+  getAiAutomationRuns: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../context/WebSocketProvider/WebSocketProvider', () => ({
+  useWebSocketConnector: jest.fn().mockReturnValue({ socket: undefined }),
+}));
+
+jest.mock('../../utils/useRequiredParams', () => ({
+  useRequiredParams: jest
+    .fn()
+    .mockReturnValue({ serviceCategory: 'databaseServices' }),
+}));
+
+jest.mock('../../utils/ServiceUtilClassBase', () => ({
+  __esModule: true,
+  default: {
+    getInsightsTabWidgets: jest.fn().mockReturnValue({
+      PlatformInsightsWidget: jest.fn().mockReturnValue(null),
+      TotalDataAssetsWidget: jest.fn().mockReturnValue(null),
+      AgentsStatusWidget: jest.fn().mockReturnValue(null),
+    }),
+  },
+}));
+
+jest.mock('../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+jest.mock('../../utils/EntityPureUtils', () => ({
+  getEntityFeedLink: jest.fn().mockReturnValue('<#E::databaseService::test>'),
+}));
+
+jest.mock('../../utils/EntityIconUtils', () => ({
+  getEntityIcon: jest.fn().mockReturnValue(null),
+}));
+
+const mockSetChartDataStreamConnection =
+  setChartDataStreamConnection as jest.Mock;
+const mockStopChartDataStreamConnection =
+  stopChartDataStreamConnection as jest.Mock;
+
+/**
+ * Builds a rejected promise that records whether the consumer attached a
+ * rejection handler. The tracker's own handler keeps Node from flagging the
+ * rejection as unhandled inside the test runner, so `isHandled` reflects only
+ * what the component under test did.
+ */
+const createTrackedRejection = (error: unknown) => {
+  const tracker = { isHandled: false };
+  const promise = Promise.reject(error);
+  const originalCatch = promise.catch.bind(promise);
+
+  originalCatch(noop);
+
+  promise.catch = (onRejected) => {
+    tracker.isHandled = true;
+
+    return originalCatch(onRejected);
+  };
+
+  return { promise, tracker };
+};
+
+const mockProps: ServiceInsightsTabProps = {
+  serviceDetails: {
+    id: 'a1b2c3d4-0000-4000-8000-00000000000a',
+    name: 'oracle-ui-test',
+    fullyQualifiedName: 'oracle-ui-test',
+  } as ServicesType,
+  workflowStatesData: {
+    mainInstanceState: { status: WorkflowStatus.Running },
+    subInstanceStates: [],
+  },
+  collateAIagentsList: [],
+  ingestionPipelines: [],
+  isIngestionPipelineLoading: false,
+  isCollateAIagentsLoading: false,
+};
+
+const renderTab = async (props?: Partial<ServiceInsightsTabProps>) => {
+  let renderResult!: ReturnType<typeof render>;
+
+  await act(async () => {
+    renderResult = render(<ServiceInsightsTab {...mockProps} {...props} />);
+  });
+
+  return renderResult;
+};
+
+describe('ServiceInsightsTab', () => {
+  it('should stop the chart data stream with the open session id on unmount', async () => {
+    const { unmount } = await renderTab();
+
+    expect(mockSetChartDataStreamConnection).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(mockStopChartDataStreamConnection).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('should handle a rejected stream teardown so unmount raises no unhandled rejection', async () => {
+    const { promise, tracker } = createTrackedRejection(
+      new AxiosError('Request failed with status code 404')
+    );
+    mockStopChartDataStreamConnection.mockReturnValueOnce(promise);
+
+    const { unmount } = await renderTab();
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(tracker.isHandled).toBe(true);
+  });
+
+  it('should handle a rejected stream handshake without an unhandled rejection', async () => {
+    // The handshake rejection is swallowed by the async callback wrapper, so it
+    // can only be observed through the process-level unhandled rejection hook,
+    // which needs real timers to flush
+    jest.useRealTimers();
+
+    const unhandledReasons: unknown[] = [];
+    const collectUnhandled = (reason: unknown) => unhandledReasons.push(reason);
+    process.on('unhandledRejection', collectUnhandled);
+
+    mockSetChartDataStreamConnection.mockRejectedValueOnce(
+      new AxiosError('Request failed with status code 404')
+    );
+
+    await renderTab();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    process.off('unhandledRejection', collectUnhandled);
+    jest.useFakeTimers();
+
+    expect(unhandledReasons).toHaveLength(0);
+  });
+
+  it('should not open or close a stream when the workflow is not running', async () => {
+    const { unmount } = await renderTab({
+      workflowStatesData: {
+        mainInstanceState: { status: WorkflowStatus.Finished },
+        subInstanceStates: [],
+      },
+    });
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(mockSetChartDataStreamConnection).not.toHaveBeenCalled();
+    expect(mockStopChartDataStreamConnection).not.toHaveBeenCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
@@ -13,7 +13,7 @@
 
 import { Col, Row } from 'antd';
 import { AxiosError } from 'axios';
-import { isEmpty, isUndefined } from 'lodash';
+import { isEmpty, isUndefined, noop } from 'lodash';
 import { Bucket, ServiceTypes } from 'Models';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { SOCKET_EVENTS } from '../../constants/constants';
@@ -313,13 +313,17 @@ const ServiceInsightsTab = ({
     if (
       workflowStatesData?.mainInstanceState.status === WorkflowStatus.Running
     ) {
-      triggerSocketConnection();
+      // The stream is best-effort, widgets fall back to the polled chart data,
+      // so a failed handshake must not surface as an unhandled rejection
+      triggerSocketConnection().catch(noop);
     }
 
     return () => {
       // Stop the socket connection if it is started and set the sessionId to undefined
       if (sessionIdRef.current) {
-        stopChartDataStreamConnection(sessionIdRef.current);
+        // The server may have already reaped the session (404 on teardown), and
+        // an unmount has nobody left to report to, so swallow the failure
+        stopChartDataStreamConnection(sessionIdRef.current).catch(noop);
         sessionIdRef.current = undefined;
       }
     };


### PR DESCRIPTION
### Describe your changes:

Fixes #31437

`ServiceInsightsTab` opens a chart-data stream session on mount and stops it in the effect cleanup. Neither call attached a rejection handler, so a failed teardown escaped as an unhandled promise rejection and was reported to Sentry as an uncaught `AxiosError: Request failed with status code 404`.

The 404 is correct server behaviour. `DataInsightSystemChartRepository` holds stream sessions in an in-memory `ConcurrentHashMap` with a hard 10-minute lifetime (`STREAM_DURATION_MS`), after which a scheduled `stopStreaming` removes the entry. `stopChartDataStreaming` then returns `notFound: true` and the resource maps that to 404. The UI opens a session once and never renews it, so the session id it holds goes stale whenever the page stays open past 10 minutes, the server restarts, or the DELETE lands on a replica that never held the session.

Both calls are best-effort — widgets fall back to the polled chart data, and an unmount has no user-facing surface left to report to — so the rejection is swallowed at both call sites:

```diff
-      triggerSocketConnection();
+      // The stream is best-effort, widgets fall back to the polled chart data,
+      // so a failed handshake must not surface as an unhandled rejection
+      triggerSocketConnection().catch(noop);
     }

     return () => {
       if (sessionIdRef.current) {
-        stopChartDataStreamConnection(sessionIdRef.current);
+        // The server may have already reaped the session (404 on teardown), and
+        // an unmount has nobody left to report to, so swallow the failure
+        stopChartDataStreamConnection(sessionIdRef.current).catch(noop);
         sessionIdRef.current = undefined;
       }
     };
```

No behaviour change beyond suppressing the rejection — the DELETE is still issued, and the session id is still cleared.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- User leaves a service's Insights tab after the stream session has expired server-side (404 on teardown) — no unhandled rejection, no Sentry error.
- Stream handshake (`POST .../charts/stream`) fails — no unhandled rejection; the tab keeps rendering with polled chart data.
- Normal unmount with a live session — DELETE is still issued with the correct session id.
- Workflow not in `Running` state — no session is opened, and none is closed on unmount.

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- Files added: `openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.test.tsx` (4 cases, first test file for this component).

```
PASS src/components/ServiceInsights/ServiceInsightsTab.test.tsx
  ✓ should stop the chart data stream with the open session id on unmount
  ✓ should handle a rejected stream teardown so unmount raises no unhandled rejection
  ✓ should handle a rejected stream handshake without an unhandled rejection
  ✓ should not open or close a stream when the workflow is not running
Tests: 4 passed, 4 total
```

Verified the two regression tests fail without the fix (reverted both `.catch(noop)` calls locally):

```
✕ should handle a rejected stream teardown so unmount raises no unhandled rejection
✕ should handle a rejected stream handshake without an unhandled rejection
Tests: 2 failed, 2 passed, 4 total
```

The two rejection paths need different detection. The teardown attaches `.catch` directly to the API promise, so a tracking wrapper around `catch` observes it. The handshake rejection is swallowed inside the async `useCallback` wrapper and is only observable through `process.on('unhandledRejection')`, which needs real timers to flush — that test toggles timers around the flush since the Jest config enables fake timers globally.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — the fix removes a console/Sentry-only error with no DOM-observable effect; the expiry it depends on is a 10-minute server-side timeout that E2E cannot practically reproduce.

#### Manual testing performed
Not performed — reproducing the failure requires either a >10-minute-old stream session or a server restart between mount and unmount. Covered by the unit tests above, which reproduce the exact 404 rejection.

#
### UI screen recording / screenshots:

Not applicable — no visual change.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: no visual change, so no recording attached.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.
