### PR TITLE
fix(security): pin httpcore5 (core) to 5.4.3 for CVE-2026-54399

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -792,6 +792,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>5.4.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
         <version>5.4.3</version>
       </dependency>


### PR DESCRIPTION
## What

Adds a `dependencyManagement` pin for `org.apache.httpcomponents.core5:httpcore5` → **5.4.3**, alongside the existing `httpcore5-h2` pin.

## Why

**CVE-2026-54399** — *Uncontrolled Resource Consumption* (DoS) in the HTTP/1.1 message parser of Apache HttpComponents Core (`5.4.2 and earlier`).

The existing security pin only covers `httpcore5-h2` (the HTTP/2 protocol module). The vulnerable parser lives in the **`httpcore5` core artifact**, which was unmanaged and resolved transitively to `5.3.x` — both as a standalone jar on the service classpath and **shaded into the `elasticsearch-deps` uber-jar** (via `elasticsearch-java` → Apache HTTP transport; those classes are shaded but not relocated, so a scanner reads the bundled `pom.properties`).

Because the `elasticsearch-dep` shade module inherits this `dependencyManagement` from the root `platform` pom, pinning core5 here forces `5.4.3` to be resolved **at shade time** — fixing the bundled copy as well as the standalone one.

## Why 5.4.3 (not 5.5-beta2)

The CVE affected range is `5.4.2 and earlier`, so `5.4.3` is the fix on the stable line — the same line the `httpcore5-h2` pin already sits on. No need to move a production dependency onto the `5.5-beta2` pre-release.

## Verification

- `httpcore5:5.4.3` (core) confirmed present on Maven Central.