### PR TITLE
fix(sigma): populate dataModels field on dashboard during ingestion (#29608)

### DIFF
--- a/ingestion/src/metadata/ingestion/source/dashboard/sigma/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/dashboard/sigma/metadata.py
@@ -136,6 +136,19 @@ class SigmaSource(DashboardServiceSource):
                     )
                     for chart in self.context.get().charts or []
                 ],
+                dataModels=[
+                    FullyQualifiedEntityName(
+                        fqn.build(  # pyright: ignore[reportArgumentType]  # always a str for DashboardDataModel
+                            self.metadata,
+                            entity_type=DashboardDataModel,
+                            service_name=self.context.get().dashboard_service,  # pyright: ignore[reportAttributeAccessIssue]
+                            data_model_name=data_model,
+                        )
+                    )
+                    for data_model in self.context.get().dataModels or []  # pyright: ignore[reportAttributeAccessIssue]
+                ]
+                if self.source_config.includeDataModels
+                else None,
                 service=FullyQualifiedEntityName(self.context.get().dashboard_service),
                 sourceUrl=SourceUrl(dashboard_details.url),
                 owners=self.get_owner_ref(dashboard_details=dashboard_details),

--- a/ingestion/tests/unit/topology/dashboard/test_sigma.py
+++ b/ingestion/tests/unit/topology/dashboard/test_sigma.py
@@ -156,6 +156,7 @@ EXPECTED_DASHBOARD = [
         description="SAMPLE DESCRIPTION",
         sourceUrl="http://url.com/to/dashboard",
         charts=[],
+        dataModels=[],
         service=FullyQualifiedEntityName("mock_sigma"),
     )
 ]
@@ -263,6 +264,36 @@ class SigmaUnitTest(TestCase):
         """
         results = list(self.sigma.yield_dashboard(MOCK_DASHBOARD_DETAILS))
         self.assertEqual(EXPECTED_DASHBOARD, [res.right for res in results])
+
+    def test_yield_dashboard_with_datamodels(self):
+        original_flag = self.sigma.source_config.includeDataModels
+        self.sigma.source_config.includeDataModels = True
+        original_data_models = self.sigma.context.get().dataModels
+        self.sigma.context.get().__dict__["dataModels"] = ["elem1", "elem2"]
+
+        try:
+            results = list(self.sigma.yield_dashboard(MOCK_DASHBOARD_DETAILS))
+            dashboard_request = results[0].right
+
+            assert dashboard_request.dataModels is not None
+            assert len(dashboard_request.dataModels) == 2
+            assert dashboard_request.dataModels[0].root == "mock_sigma.model.elem1"
+            assert dashboard_request.dataModels[1].root == "mock_sigma.model.elem2"
+        finally:
+            self.sigma.source_config.includeDataModels = original_flag
+            self.sigma.context.get().__dict__["dataModels"] = original_data_models
+
+    def test_yield_dashboard_datamodels_disabled(self):
+        original_flag = self.sigma.source_config.includeDataModels
+        self.sigma.source_config.includeDataModels = False
+
+        try:
+            results = list(self.sigma.yield_dashboard(MOCK_DASHBOARD_DETAILS))
+            dashboard_request = results[0].right
+
+            assert dashboard_request.dataModels is None
+        finally:
+            self.sigma.source_config.includeDataModels = original_flag
 
     def test_yield_chart(self):
         """


### PR DESCRIPTION
Backport of #29608 (0bb664330e4).

Sigma's `yield_dashboard` built the `CreateDashboardRequest` without `dataModels`, so every Sigma dashboard stored `dataModels: null` even though `yield_datamodel` had already registered the models in the topology context one stage earlier.

Cherry-picked clean — both files were byte-identical to main immediately before the merge.

The three `# pyright: ignore` comments are required on this branch too. Against 2.0's own baseline, `basedpyright -p pyproject.toml --baselinefile .basedpyright/baseline.json --baselinemode=discard` reports 3 errors without them and 0 with them: `fqn.build`'s `Optional[str]` dispatch return, plus two attributes that `TopologyContext` creates dynamically via `create_model`.

`Validate PR Metadata` will be red here — GitHub will not link the already-closed #29607.