### PR TITLE
fix(docker): move OS security upgrades into a late layer so cached builds ship them

### DIFF
--- a/ingestion/Dockerfile
+++ b/ingestion/Dockerfile
@@ -42,17 +42,8 @@ RUN apt-get -qq update \
   wget --no-install-recommends \
   # Accept MSSQL ODBC License
   && ACCEPT_EULA=Y apt-get install -y msodbcsql18 \
-  # Pull bookworm-security fixes for known-vulnerable packages
-  # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
-  # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
-  # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-  # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-  # --only-upgrade is a no-op for packages not present in the base image.
-  && apt-get -qq install -y --only-upgrade \
-       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
-       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
-       curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+  # Security upgrades are deliberately NOT done here -- see the RUN just above
+  # `USER airflow`.
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \
@@ -99,6 +90,26 @@ COPY --chown=airflow:0 ingestion/examples/airflow/dags /opt/airflow/dags
 # and bare `python` resolves to /home/airflow/.local/bin/python. Both would miss the very
 # copy this line exists to fix.
 RUN /usr/local/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
+# Pull bookworm-security fixes for packages that came in as dependencies of the apt
+# install near the top of this file (libnss3 via default-jre-headless, perl, curl,
+# libgnutls30, ...). Those land at whatever the apt index held when that layer ran.
+#
+# Keep this layer here, and do NOT fold it back into that apt RUN. A RUN's build cache
+# key is its literal text plus its parent layer digest -- the top-of-file apt layer's
+# parents never change, so the moment a layer cache is in play it is a permanent hit and
+# the Debian index freezes with it. That is how CVE-2026-16389 shipped in a 13 Aug
+# ingestion image: its apt layer was a 6 Aug cache hit, four days before nss
+# 2:3.87.1-1+deb12u4 reached bookworm-security. The release build runs without a layer
+# cache, but keeping the upgrade in a late layer is what keeps that true by construction
+# rather than by pipeline configuration.
+RUN apt-get -qq update \
+  && apt-get -qq install -y --only-upgrade \
+       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
+       curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+  && rm -rf /var/lib/apt/lists/*
 
 USER airflow
 # Argument to provide for Ingestion Dependencies to install. Defaults to all

--- a/ingestion/Dockerfile.ci
+++ b/ingestion/Dockerfile.ci
@@ -41,17 +41,8 @@ RUN dpkg --configure -a \
   wget --no-install-recommends \
   # Accept MSSQL ODBC License
   && ACCEPT_EULA=Y apt-get -qq install -y msodbcsql18 \
-  # Pull bookworm-security fixes for known-vulnerable packages
-  # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
-  # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
-  # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-  # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-  # --only-upgrade is a no-op for packages not present in the base image.
-  && apt-get -qq install -y --only-upgrade \
-       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
-       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
-       curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+  # Security upgrades are deliberately NOT done here -- see the RUN just above
+  # `USER airflow`.
   && apt-get -qq purge -y \
        'imagemagick*' 'libmagick*' 'graphicsmagick*' \
   && apt-get -qq autoremove -y --purge \
@@ -105,6 +96,25 @@ COPY --chown=airflow:0 ingestion/airflow-constraints-3.3.0.txt /home/airflow/air
 # and bare `python` resolves to /home/airflow/.local/bin/python. Both would miss the very
 # copy this line exists to fix.
 RUN /usr/local/bin/python -m pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
+# Pull bookworm-security fixes for packages that came in as dependencies of the apt
+# install near the top of this file (libnss3 via default-jre-headless, perl, curl,
+# libgnutls30, ...). Those land at whatever the apt index held when that layer ran.
+#
+# Keep this layer here, and do NOT fold it back into that apt RUN. A RUN's build cache
+# key is its literal text plus its parent layer digest -- the top-of-file apt layer's
+# parents never change, so once it is in the cache it is a permanent hit and the Debian
+# index freezes with it. That is how CVE-2026-16389 shipped in a 13 Aug image: its apt
+# layer was a 6 Aug cache hit, four days before nss 2:3.87.1-1+deb12u4 reached
+# bookworm-security. Down here the parent is the COPY of the source tree above, which
+# changes on every commit, so the index is re-read on every build.
+RUN apt-get -qq update \
+  && apt-get -qq install -y --only-upgrade \
+       libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+       libpam0g libpam-modules libpam-modules-bin libpam-runtime \
+       curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+       perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+  && rm -rf /var/lib/apt/lists/*
 
 USER airflow
 

--- a/ingestion/operators/docker/Dockerfile
+++ b/ingestion/operators/docker/Dockerfile
@@ -49,17 +49,8 @@ RUN dpkg --configure -a \
     wget --no-install-recommends \
     # Accept MSSQL ODBC License
     && ACCEPT_EULA=Y apt-get -qq install -y msodbcsql18 \
-    # Pull bookworm-security fixes for known-vulnerable packages
-    # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
-    # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
-    # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-    # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-    # --only-upgrade is a no-op for packages not present in the base image.
-    && apt-get -qq install -y --only-upgrade \
-         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
-         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
-         curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-         perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+    # Security upgrades are deliberately NOT done here -- see the RUN just above
+    # `USER openmetadata`.
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq
@@ -118,6 +109,26 @@ ENV PATH="/home/openmetadata/.local/bin:${PATH}"
 # /usr/local copy stays on disk and image scanners keep reporting it
 # (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
 RUN pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
+# Pull bookworm-security fixes for packages that came in as dependencies of the apt
+# install near the top of this file (libnss3 via default-jre-headless, perl, curl,
+# libgnutls30, ...). Those land at whatever the apt index held when that layer ran.
+#
+# Keep this layer here, and do NOT fold it back into that apt RUN. A RUN's build cache
+# key is its literal text plus its parent layer digest -- the top-of-file apt layer's
+# parents never change, so the moment a layer cache is in play it is a permanent hit and
+# the Debian index freezes with it. That is how CVE-2026-16389 shipped in a 13 Aug
+# ingestion image: its apt layer was a 6 Aug cache hit, four days before nss
+# 2:3.87.1-1+deb12u4 reached bookworm-security. The release build runs without a layer
+# cache, but keeping the upgrade in a late layer is what keeps that true by construction
+# rather than by pipeline configuration.
+RUN apt-get -qq update \
+    && apt-get -qq install -y --only-upgrade \
+         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
+         curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+         perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+    && rm -rf /var/lib/apt/lists/*
 
 USER openmetadata
 

--- a/ingestion/operators/docker/Dockerfile.ci
+++ b/ingestion/operators/docker/Dockerfile.ci
@@ -48,17 +48,8 @@ RUN apt-get -qq update \
     wget --no-install-recommends \
     # Accept MSSQL ODBC License
     && ACCEPT_EULA=Y apt-get -qq install -y msodbcsql18 \
-    # Pull bookworm-security fixes for known-vulnerable packages
-    # (gnutls28 -> 3.7.9-2+deb12u7, libcap2 -> 1:2.66-4+deb12u3,
-    # openssh -> 1:9.2p1-2+deb12u10, rsync -> 3.2.7-1+deb12u5,
-    # curl/libcurl* -> 7.88.1-10+deb12u15, libmariadb3 -> 1:10.11.18-0+deb12u1,
-    # wget, perl*, libnss3 -> tracked; upstream fix pending, no-op until Debian ships it).
-    # --only-upgrade is a no-op for packages not present in the base image.
-    && apt-get -qq install -y --only-upgrade \
-         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
-         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
-         curl libcurl4 libcurl3-gnutls libmariadb3 wget \
-         perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+    # Security upgrades are deliberately NOT done here -- see the RUN just above
+    # `USER openmetadata`.
     && rm -rf /var/lib/apt/lists/*
 
 # Add updated postgres/redshift dependencies based on libq
@@ -119,6 +110,25 @@ ENV PATH="/home/openmetadata/.local/bin:${PATH}"
 # /usr/local copy stays on disk and image scanners keep reporting it
 # (CVE-2025-8869, CVE-2026-3219, CVE-2026-6357, CVE-2026-8643 -- fixed in 26.1.2).
 RUN pip install --no-cache-dir --upgrade "pip>=26.2,<27"
+
+# Pull bookworm-security fixes for packages that came in as dependencies of the apt
+# install near the top of this file (libnss3 via default-jre-headless, perl, curl,
+# libgnutls30, ...). Those land at whatever the apt index held when that layer ran.
+#
+# Keep this layer here, and do NOT fold it back into that apt RUN. A RUN's build cache
+# key is its literal text plus its parent layer digest -- the top-of-file apt layer's
+# parents never change, so once it is in the cache it is a permanent hit and the Debian
+# index freezes with it. That is how CVE-2026-16389 shipped in a 13 Aug image: its apt
+# layer was a 6 Aug cache hit, four days before nss 2:3.87.1-1+deb12u4 reached
+# bookworm-security. Down here the parent is the COPY of the source tree above, which
+# changes on every commit, so the index is re-read on every build.
+RUN apt-get -qq update \
+    && apt-get -qq install -y --only-upgrade \
+         libgnutls30 libcap2 libcap2-bin openssh-client rsync sudo \
+         libpam0g libpam-modules libpam-modules-bin libpam-runtime \
+         curl libcurl4 libcurl3-gnutls libmariadb3 wget \
+         perl perl-base perl-modules-5.36 libperl5.36 libnss3 \
+    && rm -rf /var/lib/apt/lists/*
 
 USER openmetadata
 


### PR DESCRIPTION
## Problem

AWS Inspector flagged `openmetadata/ingestion-slim` for **CVE-2026-16389** (nss, CVSS 9.8)
on an image pushed 13 Aug — installed `2:3.87.1-1+deb12u3`, fixed `2:3.87.1-1+deb12u4`.

The Dockerfiles were already pulling bookworm-security fixes, so this looked wrong.
Reading the image's layer history explains it:

| Layer | Built |
|---|---|
| `RUN apt-get -qq update && apt-get -qq install -y build-essential … default-jre-headless …` | **6 Aug** |
| `COPY ingestion/ .` and everything after | **13 Aug** |

Only the Python half rebuilt. A `RUN`'s build cache key is its literal text plus its
parent layer digest — the top-of-file apt layer's parents never change, so once it is in
the cache it is a permanent hit and its Debian index freezes with it. nss `u4` reached
bookworm-security on **10 Aug**, four days after that layer was built, so it could never
arrive. The same Aug-6 layer flows into `collate/ingestion-slim`, whose own stage pins a
`BASE_IMAGE` tag and never refreshes it.

## Fix

Move the `--only-upgrade` set out of the top-of-file apt `RUN` into its own layer placed
after the `COPY` layers and immediately before the `USER` drop (still root). Its parent is
now a layer that changes every commit, so the index is re-read on every build.

Collate's stage folds the same set into its existing `mdbtools` install — that layer always
cache-misses (`BASE_IMAGE`'s digest changes each build), so it is the one deterministic
place to pin the shipped image to the current security archive. No extra layer, no extra
index fetch.

Package list is unchanged. Each site now carries a comment explaining why the layer must
stay where it is.

## Verification

Three image chains built end to end on `linux/amd64`:

| Image | Dockerfile | `libnss3` |
|---|---|---|
| `om-ingestion-slim` | `ingestion/operators/docker/Dockerfile.ci` | `2:3.87.1-1+deb12u4` |
| `collate-ingestion-slim` | `ingestion-extension/operators/docker/Dockerfile` (on the above) | `2:3.87.1-1+deb12u4` |
| `om-ingestion-airflow` | `ingestion/Dockerfile.ci` | `2:3.87.1-1+deb12u4` |

Rest of the security set came through with it (`libgnutls30 3.7.9-2+deb12u7`,
`libcap2 1:2.66-4+deb12u3+b1`, `perl-base 5.36.0-7+deb12u3`, `openjdk-17-jre-headless
17.0.20+8-1~deb12u1`). `mdbtools` still installs, the `imagemagick*` purge chain still
leaves zero matching packages, and runtime imports (`metadata`, `sqlalchemy_redshift`,
`spacy`, `pandas`, `pyodbc`) pass with `setuptools 84.0.0`.

## Notes

- These edits change the affected `RUN` cache keys, so the next CI build picks them up
  against the existing layer cache — no `no-cache` run needed.
- Not addressed here: the tag-existence skip in `build-docker.yaml` still short-circuits
  the whole ingestion build when the image tag already exists, and that tag is keyed on
  short SHAs only. Worth a separate look.
