### PR TITLE
Fixes 31390: quote lowercase Snowflake schemas in profiler

### DIFF
--- a/ingestion/src/metadata/profiler/orm/converter/base.py
+++ b/ingestion/src/metadata/profiler/orm/converter/base.py
@@ -155,6 +155,7 @@ def ometa_to_sqa_orm(
                 "schema": orm_schema_name,
                 "extend_existing": True,  # Recreates the table ORM object if it already exists. Useful for testing
                 "quote": check_snowflake_case_sensitive(table.serviceType, table.name.root) or None,
+                "quote_schema": check_snowflake_case_sensitive(table.serviceType, orm_schema_name) or None,
             },
             **cols,
             "metadata": _metadata,

--- a/ingestion/tests/unit/observability/profiler/test_converter.py
+++ b/ingestion/tests/unit/observability/profiler/test_converter.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 import sqlalchemy
 from pytest import mark
+from snowflake.sqlalchemy import dialect as snowflake_dialect
 
 from metadata.generated.schema.entity.data.table import Column, DataType, Table
 from metadata.generated.schema.entity.services.databaseService import (
@@ -84,6 +85,22 @@ def test_snowflake_case_sensitive_orm(mock_schema, mock_database, column_definit
     assert orm_table.__table_args__["schema"] == "schema"
     for name, _ in column_definition:
         assert hasattr(orm_table, name)
+
+
+@patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="lowercase_schema")
+@patch("metadata.profiler.orm.converter.base.get_orm_database", return_value="DATABASE")
+def test_snowflake_lowercase_schema_is_quoted(mock_schema, mock_database):
+    table = Table(
+        id=UUID("1f8c1222-09a0-11ed-871b-ca4e864bb16a"),
+        name="ALBUM",
+        columns=[Column(name="ID", dataType=DataType.INT)],
+        serviceType=DatabaseServiceType.Snowflake,
+    )
+
+    orm_table = ometa_to_sqa_orm(table, None)
+
+    compiled_query = str(sqlalchemy.select(orm_table).compile(dialect=snowflake_dialect()))
+    assert 'FROM "lowercase_schema"."ALBUM"' in compiled_query
 
 
 @patch("metadata.profiler.orm.converter.base.get_orm_schema", return_value="schema")


### PR DESCRIPTION
### Describe your changes:

Backport of #31391 (`e04314909e3`).
