### PR TITLE
fix(redshift): exclude internal materialized view tables (backport #31409)

### DIFF
--- a/ingestion/tests/unit/topology/database/test_redshift.py
+++ b/ingestion/tests/unit/topology/database/test_redshift.py
@@ -28,6 +28,7 @@ from metadata.ingestion.source.database.redshift.models import RedshiftInstanceT
 from metadata.ingestion.source.database.redshift.queries import (
     REDSHIFT_SQL_STATEMENT_MAP,
 )
+from metadata.utils.filters import filter_by_table
 
 mock_redshift_config = {
     "source": {
@@ -78,6 +79,19 @@ class RedshiftUnitTest(unittest.TestCase):
         """Test connection closing"""
         mock_connection.return_value = True
         self.redshift_source.close()
+
+    def test_connection_defaults_filter_internal_materialized_view_tables(self):
+        table_filter = self.redshift_source.service_connection.tableFilterPattern
+        assert table_filter is not None
+
+        self.assertTrue(filter_by_table(table_filter, "mv_tbl__orders_rollup__0"))
+        self.assertTrue(
+            filter_by_table(
+                table_filter,
+                "redshift_service.database.schema.mv_tbl__orders_rollup__0",
+            )
+        )
+        self.assertFalse(filter_by_table(table_filter, "orders_rollup"))
 
     def test_detect_provisioned_when_stl_accessible(self):
         """Test detection of Provisioned cluster when STL tables are accessible"""

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/connections/database/redshiftConnection.json
@@ -92,7 +92,11 @@
     "tableFilterPattern": {
       "title": "Default Table Filter Pattern",
       "description": "Regex to only include/exclude tables that matches the pattern.",
-      "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern"
+      "$ref": "../../../../type/filterPattern.json#/definitions/filterPattern",
+      "default": {
+        "includes": [],
+        "excludes": ["^(?:.*\\.)?mv_tbl__.*__\\d+$"]
+      }
     },
     "databaseFilterPattern": {
       "title": "Default Database Filter Pattern",


### PR DESCRIPTION
### Describe your changes:

Backport of #31409 (`298af54017a86b57668ea633cd49158e7cea5d3c`).

Redshift exposes internal `mv_tbl__...__N` backing tables for materialized views. Metadata and profiler ingestion can discover these objects and then fail on permissions. This adds the same default Redshift service-connection filter merged on `main`, while keeping the user-facing materialized views available.

Clean cherry-pick onto `2.0` at `8f74fbe131`; no conflicts.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small schema-default bug fix.

#
### Tests:

#### Use cases covered

- The default Redshift connection filter excludes unqualified internal `mv_tbl__...__N` tables.
- The default also excludes fully qualified internal table names.
- User-facing materialized-view names remain included.

#### Unit tests

- [x] Regression coverage in `ingestion/tests/unit/topology/database/test_redshift.py`.
- `pytest -q ingestion/tests/unit/topology/database/test_redshift.py::RedshiftUnitTest::test_connection_defaults_filter_internal_materialized_view_tables` — 1 passed.
- Coverage percentage not collected: this changes a JSON Schema default and the regression asserts its observable filter behavior directly.

#### Backend integration tests

- [x] Not applicable; no backend API changes.

#### Ingestion integration tests

- [x] Not applicable; no connector query or connection implementation changes.

#### Playwright (UI) tests

- [x] Not applicable; no UI changes.

#### Manual testing performed

1. Applied the equivalent filter to the Redshift service used for 2.0 validation.
2. Ran metadata ingestion.
3. Confirmed the internal materialized-view backing tables were no longer ingested.

Additional verification on this backport:

- `make generate` — passed with no generated diff.
- `mvn clean install -pl openmetadata-spec -DskipTests` — BUILD SUCCESS.
- `yarn parse-schema` — passed.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] Source PR #31409 is linked; no separate GitHub issue exists for this release finding.
- [x] No explanatory code comments are needed for this schema default.
- [x] No migration is required; this is a runtime connection-model default and does not transform persisted entities.
- [x] No UI changes are involved.
- [x] The exact regression scenario is covered by a unit test.
