### PR TITLE
fix(playwright): wait for filtered search response before interacting with metric list header checkbox

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1678,12 +1678,13 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
+
+      const searchResponse = waitForMetricsSearchResponse(page);
       await filterMetrics(page, fixtures.prefix);
+      await searchResponse;
 
       await expect(page.getByTestId('metric-name').first()).toBeVisible();
 
-      // The table is React Aria — click the visible <label slot="selection"> in
-      // the header to trigger select-all (no force needed; the label is visible).
       await page.locator('thead label[slot="selection"]').click();
 
       await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
@@ -1697,7 +1698,10 @@ test.describe(
     }) => {
       await redirectToHomePage(page);
       await waitForMetricsPage(page);
+
+      const searchResponse = waitForMetricsSearchResponse(page);
       await filterMetrics(page, fixtures.prefix);
+      await searchResponse;
 
       await expect(page.getByTestId('metric-name').first()).toBeVisible();
 


### PR DESCRIPTION
## Summary

- `filterMetrics()` types in the search box and triggers a **500ms debounced search request**. The two header-checkbox tests were interacting with the table before the filtered results settled.
- Without the wait, the first header-click operated on the **pre-filter (stale) collection**. When the filtered response arrived, the collection rows changed — making React Aria compute `isSelectAll = false` (new collection keys ≠ old selected IDs → indeterminate state).
- The second header-click then fired `"all"` **again** instead of deselecting, so `selectedMetricIds` stayed non-empty and the selection bar never hid.

## Fix

Add `waitForMetricsSearchResponse` before `filterMetrics` and `await` the promise after, in both affected tests:

```diff
+ const searchResponse = waitForMetricsSearchResponse(page);
  await filterMetrics(page, fixtures.prefix);
+ await searchResponse;
```

This ensures the checkbox clicks only happen after the filtered rows are stable, so React Aria's `isSelectAll` correctly transitions from `true` → `false` (deselect) on the second click.

## Test plan

- [x] `MetricListPage unchecking header checkbox clears the selection bar` passes
- [x] `MetricListPage header checkbox selects all visible metrics` passes

Fixes #31452

🤖 Generated with [Claude Code](https://claude.com/claude-code)