### PR TITLE
Fixes #31086: Match latest-run banner assertion casing

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -789,7 +789,9 @@ test.describe(
           await expect(banner).toContainText(
             'This test has not run yet. Add it to a pipeline to start collecting results.'
           );
-          await expect(banner).toContainText('Next · Not scheduled');
+          await expect(banner.getByTestId('test-case-next-run')).toHaveText(
+            'Next · Not Scheduled'
+          );
         });
 
         const runResults = [

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -790,7 +790,7 @@ test.describe(
             'This test has not run yet. Add it to a pipeline to start collecting results.'
           );
           await expect(banner.getByTestId('test-case-next-run')).toHaveText(
-            'Next · Not Scheduled'
+            /^Next · Not scheduled$/i
           );
         });
 


### PR DESCRIPTION
### Describe your changes:

Fixes #31086

Updates the Data Quality Playwright assertion to target the dedicated next-run element and match the full `Next · Not scheduled` phrase without depending on capitalization. This avoids matching against the combined banner content while keeping the expected words and punctuation strict.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small test-only change.

#
### Tests:

#### Use cases covered

- A test case with no runs shows exactly one latest-run banner with the expected unscheduled next-run text.

#### Unit tests

- Not applicable — test-only assertion update.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Updated `DataQuality.spec.ts` to assert the exact next-run state.
- Full Playwright E2E was not run locally.

#### Manual testing performed

- Verified the assertion against both known capitalization variants and confirmed it rejects unrelated text.
- Ran `git diff HEAD^ --check`.

#
### UI screen recording / screenshots:

Not applicable — no UI behavior changed.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable; this is a test-only change.
- [x] I have updated the Playwright test for the exact scenario being fixed.
