### PR TITLE
Fixes #31086: Ignore latest-run banner assertion casing on 2.0

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -789,7 +789,9 @@ test.describe(
           await expect(banner).toContainText(
             'This test has not run yet. Add it to a pipeline to start collecting results.'
           );
-          await expect(banner).toContainText('Next · Not scheduled');
+          await expect(banner.getByTestId('test-case-next-run')).toHaveText(
+            /^Next · Not scheduled$/i
+          );
         });
 
         const runResults = [


### PR DESCRIPTION
### Describe your changes:

Fixes #31086

Backports #31453 to the `2.0` branch. The Data Quality Playwright assertion now targets the dedicated next-run element and matches the full `Next · Not scheduled` phrase without depending on capitalization. The expected words and punctuation remain strict.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small test-only backport.

#
### Tests:

#### Use cases covered

- A test case with no runs shows exactly one latest-run banner with the expected unscheduled next-run text, regardless of capitalization.

#### Unit tests

- Not applicable — test-only assertion update.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] Updated `DataQuality.spec.ts` to assert the complete next-run state case-insensitively.
- Full Playwright E2E was not run locally.

#### Manual testing performed

- Verified both known capitalization variants match and unrelated text is rejected.
- Ran `git diff origin/2.0...HEAD --check`.

#
### UI screen recording / screenshots:

Not applicable — no UI behavior changed.

#
### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable; this is a test-only change.
- [x] I have updated the Playwright test for the exact scenario being fixed.
