### PR TITLE
fix(security): bump c3p0 0.12.0 -> 0.14.1 to clear CVE-2026-55223 (1.13)

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -826,10 +826,13 @@
       <version>${quartz.version}</version>
     </dependency>
     <!-- Needed for Quartz -->
+    <!-- 0.14.1 clears CVE-2026-55223 (deserialization sink via DataSource
+         property lookup); natively depends on mchange-commons-java 0.6.1 which
+         also clears SNYK-JAVA-COMMCHANGE-17796416. -->
     <dependency>
       <groupId>com.mchange</groupId>
       <artifactId>c3p0</artifactId>
-      <version>0.12.0</version>
+      <version>0.14.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
## Summary

Backport of the c3p0 bump already on `main` (see 5d2d6d88d4-ish security bumps).

- Bumps `com.mchange:c3p0` `0.12.0` -> `0.14.1` in `openmetadata-service/pom.xml`.
- Clears **CVE-2026-55223** (medium, CVSS 4.0 6.3) — c3p0's `DataSource.getConnection()` / `ConnectionPoolDataSource.getPooledConnection()` matched the JavaBean `getXXX()` form, letting attackers smuggle malicious `DataSource` objects through commons-beanutils comparator gadgets on the classpath to invoke vulnerable JDBC drivers on deserialization. Container scan flagged `/opt/openmetadata/libs/c3p0-0.12.0.jar` on `collate/server`.
- `0.14.1` natively pulls `mchange-commons-java` `0.6.1`, which also clears **SNYK-JAVA-COMMCHANGE-17796416**. No explicit `mchange-commons-java` pin exists on `1.13`, so no dep-management change is required.
- No Java source references `com.mchange` / `ComboPooledDataSource` directly — c3p0 is transitively used by Quartz; no API surface change on the 0.12 -> 0.14 bump for this codebase.

## Test plan

- [x] `mvn install -DskipTests -DonlyBackend -pl '!openmetadata-ui'` succeeds (BUILD SUCCESS).
- [x] `mvn dependency:tree -pl openmetadata-service -Dincludes=com.mchange` resolves to `c3p0:0.14.1` + `mchange-commons-java:0.6.1`.
- [ ] CI passes (unit + integration).