### PR TITLE
fix(service): reconcile seeded tags on startup

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TagRepository.java
@@ -224,6 +224,91 @@ public class TagRepository extends EntityRepository<Tag> {
     }
   }
 
+  /**
+   * Heals seeded Tags: system recognizers the Tag lost - or that a later release added - are put
+   * back by name, and a provider knocked off the seeded value is restored. A recognizer that is
+   * still there is never touched, so user edits to it survive.
+   */
+  public void reconcileSeededTags(List<Tag> seedTags) {
+    for (Tag seedTag : listOrEmpty(seedTags)) {
+      try {
+        reconcileSeededTag(seedTag);
+      } catch (Exception e) {
+        LOG.warn("Failed to reconcile seeded tag {}", seedTag.getFullyQualifiedName(), e);
+      }
+    }
+  }
+
+  private void reconcileSeededTag(Tag seedTag) {
+    // A Tag missing altogether was just created from this same seed by initializeEntity()
+    Tag stored = findByNameOrNull(seedTag.getFullyQualifiedName(), ALL);
+    if (stored == null) {
+      return;
+    }
+
+    List<Recognizer> seeded = systemRecognizers(seedTag);
+    List<Recognizer> missing = missingSystemRecognizers(stored.getRecognizers(), seeded);
+    // CreateTag defaults provider to user, so any PUT that omits it downgrades a seeded Tag - and a
+    // Tag that is no longer system provided is no longer protected from deletion
+    boolean providerDrifted =
+        seedTag.getProvider() != null && !seedTag.getProvider().equals(stored.getProvider());
+    if (missing.isEmpty() && !providerDrifted) {
+      return;
+    }
+
+    if (!missing.isEmpty()) {
+      appendRecognizers(stored, seedTag, missing, seeded.size());
+    }
+    if (providerDrifted) {
+      stored.setProvider(seedTag.getProvider());
+    }
+    store(stored, true);
+    LOG.info(
+        "Reconciled seeded tag {}: provider={}, recognizers re-added={}",
+        stored.getFullyQualifiedName(),
+        stored.getProvider(),
+        missing.stream().map(Recognizer::getName).toList());
+  }
+
+  private List<Recognizer> systemRecognizers(Tag seedTag) {
+    return listOrEmpty(seedTag.getRecognizers()).stream()
+        .filter(recognizer -> Boolean.TRUE.equals(recognizer.getIsSystemDefault()))
+        .toList();
+  }
+
+  private void appendRecognizers(
+      Tag stored, Tag seedTag, List<Recognizer> missing, int seededCount) {
+    List<Recognizer> merged = new ArrayList<>(listOrEmpty(stored.getRecognizers()));
+    merged.addAll(missing);
+    stored.setRecognizers(merged);
+    restoreAutoClassification(stored, seedTag, missing.size() == seededCount);
+  }
+
+  /** Seeded recognizers absent from {@code stored}, copied so the seed list stays reusable. */
+  protected List<Recognizer> missingSystemRecognizers(
+      List<Recognizer> stored, List<Recognizer> seeded) {
+    Set<String> storedNames =
+        listOrEmpty(stored).stream().map(Recognizer::getName).collect(Collectors.toSet());
+    return seeded.stream()
+        .filter(recognizer -> !storedNames.contains(recognizer.getName()))
+        .map(recognizer -> JsonUtils.deepCopy(recognizer, Recognizer.class))
+        .map(recognizer -> recognizer.withId(UUID.randomUUID()))
+        .toList();
+  }
+
+  /**
+   * Recognizers are inert while autoClassificationEnabled is false, so a Tag that lost every seeded
+   * recognizer - the signature of a wipe - gets its flags back too. One merely short a newly shipped
+   * recognizer keeps whatever the user configured.
+   */
+  private void restoreAutoClassification(Tag stored, Tag seedTag, boolean lostEverySeeded) {
+    if (!lostEverySeeded || !Boolean.TRUE.equals(seedTag.getAutoClassificationEnabled())) {
+      return;
+    }
+    stored.setAutoClassificationEnabled(true);
+    stored.setAutoClassificationPriority(seedTag.getAutoClassificationPriority());
+  }
+
   @Override
   public void setInheritedFields(Tag tag, Fields fields) {
     if (tag.getClassification() == null || tag.getClassification().getId() == null) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/tags/TagResource.java
@@ -150,6 +150,10 @@ public class TagResource extends EntityResource<Tag, TagRepository> {
       for (Tag tag : tagsToCreate) {
         repository.initializeEntity(tag);
       }
+
+      // initializeEntity() is create-only, so an existing Tag that drifted from the seed - or one
+      // predating a newly seeded recognizer - is reconciled separately
+      repository.reconcileSeededTags(tagsToCreate);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TagRepositoryUnitTest.java
@@ -1,9 +1,13 @@
 package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
@@ -13,9 +17,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.openmetadata.schema.entity.classification.Tag;
+import org.openmetadata.schema.type.Include;
 import org.openmetadata.schema.type.PredefinedRecognizer;
+import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.type.Recognizer;
 import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.service.exception.BadCursorException;
@@ -281,5 +288,157 @@ public class TagRepositoryUnitTest {
     assertEquals(5, result.getData().size());
     assertEquals(tag.getRecognizers().get(14), result.getData().get(0));
     assertEquals(tag.getRecognizers().get(10), result.getData().get(4));
+  }
+
+  private Recognizer systemRecognizer(String name) {
+    return new Recognizer()
+        .withName(name)
+        .withIsSystemDefault(true)
+        .withEnabled(true)
+        .withConfidenceThreshold(0.6)
+        .withRecognizerConfig(
+            new PredefinedRecognizer().withName(PredefinedRecognizer.Name.EMAIL_RECOGNIZER));
+  }
+
+  private Tag seedTag(List<Recognizer> recognizers) {
+    return new Tag()
+        .withName("Sensitive")
+        .withFullyQualifiedName("PII.Sensitive")
+        .withProvider(ProviderType.SYSTEM)
+        .withRecognizers(recognizers)
+        .withAutoClassificationEnabled(true)
+        .withAutoClassificationPriority(100);
+  }
+
+  private Tag storedTag(List<Recognizer> recognizers) {
+    return new Tag()
+        .withFullyQualifiedName("PII.Sensitive")
+        .withProvider(ProviderType.SYSTEM)
+        .withRecognizers(new ArrayList<>(recognizers));
+  }
+
+  /** Mock wired so the reconcile logic runs for real while all DB access is stubbed out. */
+  private TagRepository reconcilingRepository(Tag stored) {
+    TagRepository repository = Mockito.mock(TagRepository.class);
+    Mockito.doCallRealMethod().when(repository).reconcileSeededTags(Mockito.anyList());
+    when(repository.missingSystemRecognizers(Mockito.any(), Mockito.any())).thenCallRealMethod();
+    when(repository.findByNameOrNull(Mockito.anyString(), Mockito.any(Include.class)))
+        .thenReturn(stored);
+    return repository;
+  }
+
+  private Tag captureStoredTag(TagRepository repository) {
+    ArgumentCaptor<Tag> captor = ArgumentCaptor.forClass(Tag.class);
+    Mockito.verify(repository).store(captor.capture(), Mockito.eq(true));
+    return captor.getValue();
+  }
+
+  @Test
+  void test_reconcileSeededTags_restoresEverythingAfterAWipe() {
+    Tag stored =
+        storedTag(List.of())
+            .withProvider(ProviderType.USER)
+            .withAutoClassificationEnabled(false)
+            .withAutoClassificationPriority(50);
+    Tag seed =
+        seedTag(List.of(systemRecognizer("EmailRecognizer"), systemRecognizer("CvvRecognizer")));
+    TagRepository repository = reconcilingRepository(stored);
+
+    repository.reconcileSeededTags(List.of(seed));
+
+    Tag written = captureStoredTag(repository);
+    assertEquals(
+        List.of("EmailRecognizer", "CvvRecognizer"),
+        written.getRecognizers().stream().map(Recognizer::getName).toList());
+    written.getRecognizers().forEach(recognizer -> assertNotNull(recognizer.getId()));
+    // Recognizers are inert without these, so a full wipe restores them too
+    assertTrue(written.getAutoClassificationEnabled());
+    assertEquals(100, written.getAutoClassificationPriority());
+    assertEquals(ProviderType.SYSTEM, written.getProvider());
+  }
+
+  @Test
+  void test_reconcileSeededTags_neverTouchesARecognizerTheUserEdited() {
+    Recognizer edited =
+        systemRecognizer("EmailRecognizer").withEnabled(false).withConfidenceThreshold(0.95);
+    Tag stored =
+        storedTag(List.of(edited))
+            .withAutoClassificationEnabled(false)
+            .withAutoClassificationPriority(30);
+    Tag seed =
+        seedTag(List.of(systemRecognizer("EmailRecognizer"), systemRecognizer("CvvRecognizer")));
+    TagRepository repository = reconcilingRepository(stored);
+
+    repository.reconcileSeededTags(List.of(seed));
+
+    Tag written = captureStoredTag(repository);
+    assertEquals(
+        List.of("EmailRecognizer", "CvvRecognizer"),
+        written.getRecognizers().stream().map(Recognizer::getName).toList());
+    assertSame(edited, written.getRecognizers().getFirst());
+    assertFalse(written.getRecognizers().getFirst().getEnabled());
+    assertEquals(0.95, written.getRecognizers().getFirst().getConfidenceThreshold());
+    // Only a newly seeded recognizer was missing, so the user's tag settings stand
+    assertFalse(written.getAutoClassificationEnabled());
+    assertEquals(30, written.getAutoClassificationPriority());
+  }
+
+  @Test
+  void test_reconcileSeededTags_restoresAProviderDowngradedByAPut() {
+    Tag stored =
+        storedTag(List.of(systemRecognizer("EmailRecognizer")))
+            .withProvider(ProviderType.USER)
+            .withAutoClassificationEnabled(false)
+            .withAutoClassificationPriority(30);
+    Tag seed = seedTag(List.of(systemRecognizer("EmailRecognizer")));
+    TagRepository repository = reconcilingRepository(stored);
+
+    repository.reconcileSeededTags(List.of(seed));
+
+    Tag written = captureStoredTag(repository);
+    assertEquals(ProviderType.SYSTEM, written.getProvider());
+    // Provider drift alone is no reason to touch anything the user owns
+    assertEquals(1, written.getRecognizers().size());
+    assertFalse(written.getAutoClassificationEnabled());
+    assertEquals(30, written.getAutoClassificationPriority());
+  }
+
+  @Test
+  void test_reconcileSeededTags_doesNotWriteWhenNothingHasDrifted() {
+    Tag stored =
+        storedTag(List.of(systemRecognizer("EmailRecognizer")))
+            .withAutoClassificationEnabled(false);
+    Tag seed = seedTag(List.of(systemRecognizer("EmailRecognizer")));
+    TagRepository repository = reconcilingRepository(stored);
+
+    repository.reconcileSeededTags(List.of(seed));
+
+    Mockito.verify(repository, Mockito.never()).store(Mockito.any(Tag.class), Mockito.anyBoolean());
+    assertFalse(stored.getAutoClassificationEnabled());
+  }
+
+  @Test
+  void test_reconcileSeededTags_ignoresSeedRecognizersThatAreNotSystemDefaults() {
+    Tag stored = storedTag(List.of());
+    Tag seed = seedTag(List.of(systemRecognizer("EmailRecognizer").withIsSystemDefault(false)));
+    TagRepository repository = reconcilingRepository(stored);
+
+    repository.reconcileSeededTags(List.of(seed));
+
+    Mockito.verify(repository, Mockito.never()).store(Mockito.any(Tag.class), Mockito.anyBoolean());
+  }
+
+  @Test
+  void test_missingSystemRecognizers_copiesTheSeedAndMintsFreshIds() {
+    TagRepository repository = Mockito.mock(TagRepository.class);
+    when(repository.missingSystemRecognizers(Mockito.any(), Mockito.any())).thenCallRealMethod();
+    Recognizer seeded = systemRecognizer("EmailRecognizer");
+
+    List<Recognizer> missing = repository.missingSystemRecognizers(List.of(), List.of(seeded));
+
+    assertEquals(1, missing.size());
+    assertNotSame(seeded, missing.getFirst());
+    assertNotNull(missing.getFirst().getId());
+    assertNull(seeded.getId());
   }
 }


### PR DESCRIPTION
## Problem

`TagResource.initialize()` seeds tags through `EntityRepository.initializeEntity()`, which is create-if-absent:

```java
T existingEntity = findByNameOrNull(entity.getFullyQualifiedName(), ALL);
if (existingEntity != null) {
  LOG.debug("{} {} is already initialized", entityType, entity.getFullyQualifiedName());
  return;
}
```

The tag row survives a bad write, so the seed is never re-applied. Two ways a seeded tag drifts and then stays drifted across every restart:

- **`CreateTag` defaults `recognizers` to empty**, so a PUT that never mentions them is indistinguishable from one clearing them. #31205 stopped new wipes via `preserveRecognizerConfigOnPut()`, but nothing repairs a tag already emptied.
- **`CreateTag.provider` is a bare `$ref` to `providerType`, whose schema default is `user`**, so the same PUT downgrades `provider` from `system`. That also drops the guard at `EntityRepository.java:8182` that stops a system entity being deleted.

Same gap means recognizers added to the seed in a later release never reach installs that already have the tag — the only paths that re-apply recognizer seed data are the `v1110`/`v1120`/`v1122` migrations, which do not re-run once recorded.

Observed on a 2.0.0 install: `PII.Sensitive` went from 39 recognizers / `provider: system` at v0.1 to 0 recognizers / `provider: user` / `autoClassificationEnabled: false` / priority 100→50 at v0.2, and multiple restarts since did not restore any of it.

## Fix

Reconcile the seed after the create pass in `TagResource.initialize()`:

- Missing recognizers are matched **by name** and appended with a fresh id.
- A recognizer that is still present is **never touched** — user edits to its `confidenceThreshold`, `exceptionList` or `enabled` flag survive.
- A `provider` that no longer matches the seed is restored. Unlike `autoClassificationEnabled`, provider is not a user preference; it records origin.
- Recognizers are inert while `autoClassificationEnabled` is false, so a tag that lost **every** seeded recognizer — the signature of a wipe — also gets that flag and its priority back. A tag merely short a newly shipped recognizer keeps its own settings.
- A tag that has not drifted is not written at all.

Gating is on the seed recognizer's `isSystemDefault`, not on the stored tag's `provider`: the same PUT that wipes recognizers also downgrades provider, so a provider gate would skip exactly the tags that need healing.

Provider reconciliation covers all seeded tags — all five seed classifications (PII, Tier, Certification, PersonalData, KnowledgeCenter) declare `provider: system` and drift identically. Recognizer reconciliation only applies to tags whose seed defines them.

## Tests

`TagRepositoryUnitTest`, 21 passing (6 new):

- wipe → recognizers, `autoClassificationEnabled`, priority and provider all restored
- user-edited recognizer → same instance retained, `enabled: false` and threshold `0.95` survive; tag settings untouched
- provider drifted alone → provider restored, recognizers and autoClassification left as the user had them
- nothing drifted → `verify(never()).store(...)`
- non-`isSystemDefault` seed recognizer → ignored
- `missingSystemRecognizers` deep-copies the seed and mints fresh ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)