### PR TITLE
Fixes #31462: Align data quality charts with filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/EntityHealthStatusPieChartWidget/EntityHealthStatusPieChartWidget.test.tsx
@@ -36,12 +36,16 @@ jest.mock('../../../../utils/DataQuality/DataQualityUtils', () => ({
   getPieChartLabel: jest.fn().mockReturnValue(<div>Test Label</div>),
 }));
 
-jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
-  getTestCaseTabPath: jest.fn((status: TestCaseStatus) => ({
-    pathname: '/data-quality/test-cases',
-    search: `testCaseStatus=${status}`,
-  })),
-}));
+jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => {
+  const actual = jest.requireActual(
+    '../../../../utils/DataQuality/DataQualityPureUtils'
+  ) as typeof import('../../../../utils/DataQuality/DataQualityPureUtils');
+
+  return {
+    ...actual,
+    getTestCaseTabPath: jest.fn(actual.getTestCaseTabPath),
+  };
+});
 
 jest.mock('../../../Visualisations/Chart/CustomPieChart.component', () =>
   jest
@@ -186,7 +190,12 @@ describe('EntityHealthStatusPieChartWidget', () => {
 
     expect(navigate).toHaveBeenCalledWith({
       pathname: '/observability/data-quality/test-cases',
-      search: `testCaseStatus=${TestCaseStatus.Failed}`,
+      search:
+        `testCaseStatus=${TestCaseStatus.Failed}` +
+        '&lastRunRange%5BstartTs%5D=100' +
+        '&lastRunRange%5BendTs%5D=200' +
+        '&lastRunRange%5Bkey%5D=customRange' +
+        '&lastRunRange%5Btitle%5D=Jan%201%2C%201970%20-%3E%20Jan%201%2C%201970',
     });
 
     const { getTestCaseTabPath } = jest.requireMock(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -57,6 +57,8 @@ const StatusByDimensionCardWidget = ({
     const getStatusByDimension = async () => {
       setIsDqByDimensionLoading(true);
       try {
+        // Dimensioned and unclassified test cases are separate aggregations;
+        // fetch them together and merge them into one set of status cards.
         const [{ data }, { data: noDimensionData }] = await Promise.all([
           fetchTestCaseSummaryByDimension(chartFilter),
           fetchTestCaseSummaryByNoDimension(chartFilter),
@@ -98,6 +100,8 @@ const StatusByDimensionCardWidget = ({
             isLoading={isDqByDimensionLoading}
             key={dimension.title}
             redirectPath={{
+              // Preserve the complete dashboard slice, including its date range,
+              // and narrow only the clicked card to this dimension.
               ...getTestCaseListPath({
                 ...chartFilter,
                 dataQualityDimension: dimension.title,

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.component.tsx
@@ -12,7 +12,6 @@
  */
 import classNames from 'classnames';
 import { isUndefined } from 'lodash';
-import QueryString from 'qs';
 import { useEffect, useMemo, useState } from 'react';
 import { DIMENSIONS_DATA } from '../../../../constants/DataQuality.constants';
 import { DataQualityReport } from '../../../../generated/tests/dataQualityReport';
@@ -24,6 +23,7 @@ import {
 } from '../../../../rest/dataQualityDashboardAPI';
 import {
   getDimensionIcon,
+  getTestCaseListPath,
   transformToTestCaseStatusByDimension,
 } from '../../../../utils/DataQuality/DataQualityPureUtils';
 import observabilityRouterClassBase from '../../../../utils/ObservabilityRouterClassBase';
@@ -57,9 +57,10 @@ const StatusByDimensionCardWidget = ({
     const getStatusByDimension = async () => {
       setIsDqByDimensionLoading(true);
       try {
-        const { data } = await fetchTestCaseSummaryByDimension(chartFilter);
-        const { data: noDimensionData } =
-          await fetchTestCaseSummaryByNoDimension(chartFilter);
+        const [{ data }, { data: noDimensionData }] = await Promise.all([
+          fetchTestCaseSummaryByDimension(chartFilter),
+          fetchTestCaseSummaryByNoDimension(chartFilter),
+        ]);
 
         if (!ignore) {
           setDqByDimensionData([...data, ...noDimensionData]);
@@ -97,12 +98,13 @@ const StatusByDimensionCardWidget = ({
             isLoading={isDqByDimensionLoading}
             key={dimension.title}
             redirectPath={{
+              ...getTestCaseListPath({
+                ...chartFilter,
+                dataQualityDimension: dimension.title,
+              }),
               pathname: observabilityRouterClassBase.getDataQualityPagePath(
                 DataQualityPageTabs.TEST_CASES
               ),
-              search: QueryString.stringify({
-                dataQualityDimension: dimension.title,
-              }),
             }}
             statusData={dimension}
           />

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -35,8 +35,9 @@ jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
 jest.mock('../StatusCardWidget/StatusCardWidget.component', () =>
   jest
     .fn()
-    .mockImplementation(({ statusData }) => (
+    .mockImplementation(({ redirectPath, statusData }) => (
       <div
+        data-redirect-search={redirectPath.search}
         data-testid={mockStatusByDimensionWidgetTestId}
         data-total={statusData.total}
       />
@@ -159,6 +160,58 @@ describe('StatusByDimensionCardWidget', () => {
     expect(
       await screen.findAllByTestId(mockStatusByDimensionWidgetTestId)
     ).toHaveLength(8);
+  });
+
+  it('starts dimension and no-dimension requests together', async () => {
+    let resolveDimension!: (value: { data: [] }) => void;
+    (fetchTestCaseSummaryByDimension as jest.Mock).mockReturnValue(
+      new Promise((resolve) => {
+        resolveDimension = resolve;
+      })
+    );
+    (fetchTestCaseSummaryByNoDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+
+    await waitFor(() =>
+      expect(fetchTestCaseSummaryByNoDimension).toHaveBeenCalledWith(
+        chartFilter
+      )
+    );
+
+    await act(async () => {
+      resolveDimension({ data: [] });
+    });
+  });
+
+  it('preserves active chart filters in dimension links', async () => {
+    (fetchTestCaseSummaryByDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+    (fetchTestCaseSummaryByNoDimension as jest.Mock).mockResolvedValue({
+      data: [],
+    });
+
+    render(<StatusByDimensionCardWidget chartFilter={chartFilter} />);
+
+    const firstDimension = (
+      await screen.findAllByTestId(mockStatusByDimensionWidgetTestId)
+    )[0];
+
+    expect(firstDimension).toHaveAttribute(
+      'data-redirect-search',
+      expect.stringContaining('tags%5B%5D=tag1')
+    );
+    expect(firstDimension).toHaveAttribute(
+      'data-redirect-search',
+      expect.stringContaining('tier=tier1')
+    );
+    expect(firstDimension).toHaveAttribute(
+      'data-redirect-search',
+      expect.stringContaining('dataQualityDimension=Accuracy')
+    );
   });
 
   it('handles API error gracefully', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/StatusByDimensionCardWidget/StatusByDimensionCardWidget.test.tsx
@@ -125,6 +125,8 @@ const chartFilter: DataQualityDashboardChartFilters = {
   ownerFqn: 'ownerFqn',
   tags: ['tag1', 'tag2'],
   tier: ['tier1', 'tier2'],
+  startTs: 100,
+  endTs: 200,
 };
 
 describe('StatusByDimensionCardWidget', () => {
@@ -211,6 +213,14 @@ describe('StatusByDimensionCardWidget', () => {
     expect(firstDimension).toHaveAttribute(
       'data-redirect-search',
       expect.stringContaining('dataQualityDimension=Accuracy')
+    );
+    expect(firstDimension).toHaveAttribute(
+      'data-redirect-search',
+      expect.stringContaining('lastRunRange%5BstartTs%5D=100')
+    );
+    expect(firstDimension).toHaveAttribute(
+      'data-redirect-search',
+      expect.stringContaining('lastRunRange%5BendTs%5D=200')
     );
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/ChartWidgets/TestCaseStatusPieChartWidget/TestCaseStatusPieChartWidget.test.tsx
@@ -39,12 +39,16 @@ jest.mock('../../../../utils/DataQuality/DataQualityUtils', () => ({
   getPieChartLabel: jest.fn().mockReturnValue(<div>Test Label</div>),
 }));
 
-jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => ({
-  getTestCaseTabPath: jest.fn((status: TestCaseStatus) => ({
-    pathname: '/data-quality/test-cases',
-    search: `testCaseStatus=${status}`,
-  })),
-}));
+jest.mock('../../../../utils/DataQuality/DataQualityPureUtils', () => {
+  const actual = jest.requireActual(
+    '../../../../utils/DataQuality/DataQualityPureUtils'
+  ) as typeof import('../../../../utils/DataQuality/DataQualityPureUtils');
+
+  return {
+    ...actual,
+    getTestCaseTabPath: jest.fn(actual.getTestCaseTabPath),
+  };
+});
 
 jest.mock('../../../../constants/TestSuite.constant', () => ({
   INITIAL_TEST_SUMMARY: {
@@ -231,7 +235,12 @@ describe('TestCaseStatusPieChartWidget', () => {
 
     expect(navigate).toHaveBeenCalledWith({
       pathname: '/observability/data-quality/test-cases',
-      search: `testCaseStatus=${TestCaseStatus.Failed}`,
+      search:
+        `testCaseStatus=${TestCaseStatus.Failed}` +
+        '&lastRunRange%5BstartTs%5D=100' +
+        '&lastRunRange%5BendTs%5D=200' +
+        '&lastRunRange%5Bkey%5D=customRange' +
+        '&lastRunRange%5Btitle%5D=Jan%201%2C%201970%20-%3E%20Jan%201%2C%201970',
     });
 
     const { getTestCaseTabPath } = jest.requireMock(

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DqDashboardSectionContent.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/DataQualityDashboard/DqDashboardSectionContent.test.tsx
@@ -11,6 +11,7 @@
  *  limitations under the License.
  */
 import { render, screen } from '@testing-library/react';
+import { TestCaseStatus } from '../../../generated/tests/testCase';
 import { DqDashboardChartFilters } from './DataQualityDashboard.interface';
 import { DqDashboardSectionContent } from './DqDashboardSectionContent.component';
 
@@ -179,14 +180,23 @@ describe('DqDashboardSectionContent component', () => {
     expect(
       screen.getByTestId('test-case-status-area-widget-failed')
     ).toBeInTheDocument();
-    expect(mockTestCaseStatusAreaChartWidget).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'success',
-        redirectPath: expect.objectContaining({
-          search: expect.stringContaining('lastRunRange%5BstartTs%5D=1000'),
-        }),
-      })
-    );
+
+    [
+      ['success', TestCaseStatus.Success],
+      ['aborted', TestCaseStatus.Aborted],
+      ['failed', TestCaseStatus.Failed],
+    ].forEach(([name, status]) => {
+      expect(mockTestCaseStatusAreaChartWidget).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name,
+          redirectPath: expect.objectContaining({
+            search: expect.stringContaining(
+              `testCaseStatus=${status}&lastRunRange%5BstartTs%5D=1000&lastRunRange%5BendTs%5D=2000`
+            ),
+          }),
+        })
+      );
+    });
   });
 
   it('should render the incident-metrics section with incident type and time widgets', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCases.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/TestCases.test.tsx
@@ -477,6 +477,41 @@ describe('TestCases component', () => {
       });
     });
 
+    it('should pass every URL filter, including redirected dates, to the list API', async () => {
+      mockLocation.search =
+        '?tableFqn=sample_service.db.schema.table' +
+        '&testPlatforms%5B%5D=dbt&testPlatforms%5B%5D=Deequ' +
+        '&testCaseType=column&testCaseStatus=Success' +
+        '&lastRunRange%5BstartTs%5D=100&lastRunRange%5BendTs%5D=200' +
+        '&lastRunRange%5Bkey%5D=customRange' +
+        '&lastRunRange%5Btitle%5D=Jul%2014%2C%202026%20-%3E%20Aug%2013%2C%202026' +
+        '&tier=Tier.Tier1&tags%5B%5D=PII.Sensitive' +
+        '&serviceName=sample_service&dataQualityDimension=NoDimension' +
+        '&dataProductFqn=Marketing';
+
+      render(<TestCases />);
+
+      await waitFor(() => {
+        expect(getListTestCaseBySearch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            entityLink: '<#E::table::sample_service.db.schema.table>',
+            testPlatforms: ['dbt', 'Deequ'],
+            testCaseType: 'column',
+            testCaseStatus: 'Success',
+            startTimestamp: '100',
+            endTimestamp: '200',
+            tier: 'Tier.Tier1',
+            tags: ['PII.Sensitive'],
+            serviceName: 'sample_service',
+            dataQualityDimension: 'NoDimension',
+            dataProductFqn: 'Marketing',
+          })
+        );
+      });
+
+      expect(await screen.findByTestId('date-picker-menu')).toBeInTheDocument();
+    });
+
     it('should handle empty URL params', async () => {
       mockLocation.search = '';
       const mockGetListTestCase = getListTestCaseBySearch as jest.Mock;

--- a/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/useTestCaseList.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataQuality/TestCases/useTestCaseList.test.ts
@@ -152,6 +152,23 @@ describe('useTestCaseList', () => {
     expect(lastPayload().testCaseStatus).toBe(TestCaseStatus.Failed);
   });
 
+  it('should apply a redirected lastRunRange to the list request', async () => {
+    const { result } = renderList({
+      params: {
+        lastRunRange: { startTs: 100, endTs: 200 },
+      },
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(lastPayload()).toEqual(
+      expect.objectContaining({
+        startTimestamp: 100,
+        endTimestamp: 200,
+      })
+    );
+  });
+
   it('should not fetch and should stop loading when the view permission is missing', async () => {
     const { result } = renderList({
       testCasePermission: {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.test.tsx
@@ -144,9 +144,13 @@ describe('DataQualityProvider', () => {
     expect(fetchTotalEntityCount).toHaveBeenCalledTimes(1);
   });
 
-  it('should call fetchTestCaseSummary, fetchEntityCoveredWithDQ & fetchTotalEntityCount based on prams change', async () => {
+  it('should pass every supported test-case filter to the summary requests', async () => {
     mockLocation.search =
-      '?testCaseType=table&testCaseStatus=Success&tier=Tier.Tier1';
+      '?testCaseType=column&testCaseStatus=Success&tier=Tier.Tier1' +
+      '&tags%5B%5D=PII.Sensitive&testPlatforms%5B%5D=Dbt' +
+      '&serviceName=sample_service&dataQualityDimension=Accuracy' +
+      '&dataProductFqn=Marketing&tableFqn=sample_service.db.schema.table' +
+      '&lastRunRange%5BstartTs%5D=100&lastRunRange%5BendTs%5D=200';
 
     render(
       <DataQualityProvider>
@@ -156,27 +160,48 @@ describe('DataQualityProvider', () => {
 
     expect(await screen.findByText('test-cases component')).toBeInTheDocument();
     expect(fetchTestCaseSummary).toHaveBeenCalledWith({
-      entityFQN: undefined,
+      dataProductFqns: ['Marketing'],
+      dataQualityDimension: 'Accuracy',
+      endTs: '200',
+      entityFQN: 'sample_service.db.schema.table',
       ownerFqn: undefined,
+      serviceName: 'sample_service',
+      startTs: '100',
+      tags: ['PII.Sensitive'],
       testCaseStatus: 'Success',
-      testCaseType: 'table',
+      testCaseType: 'column',
+      testPlatforms: ['Dbt'],
       tier: ['Tier.Tier1'],
     });
     expect(fetchEntityCoveredWithDQ).toHaveBeenCalledWith(
       {
-        entityFQN: undefined,
+        dataProductFqns: ['Marketing'],
+        dataQualityDimension: 'Accuracy',
+        endTs: '200',
+        entityFQN: 'sample_service.db.schema.table',
         ownerFqn: undefined,
+        serviceName: 'sample_service',
+        startTs: '100',
+        tags: ['PII.Sensitive'],
         testCaseStatus: 'Success',
-        testCaseType: 'table',
+        testCaseType: 'column',
+        testPlatforms: ['Dbt'],
         tier: ['Tier.Tier1'],
       },
       true
     );
     expect(fetchTotalEntityCount).toHaveBeenCalledWith({
-      entityFQN: undefined,
+      dataProductFqns: ['Marketing'],
+      dataQualityDimension: 'Accuracy',
+      endTs: '200',
+      entityFQN: 'sample_service.db.schema.table',
       ownerFqn: undefined,
+      serviceName: 'sample_service',
+      startTs: '100',
+      tags: ['PII.Sensitive'],
       testCaseStatus: 'Success',
-      testCaseType: 'table',
+      testCaseType: 'column',
+      testPlatforms: ['Dbt'],
       tier: ['Tier.Tier1'],
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.test.tsx
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import {
   fetchEntityCoveredWithDQ,
   fetchTestCaseSummary,
@@ -91,6 +91,12 @@ const MockComponent = () => {
   ) : (
     <div>{activeTab} component</div>
   );
+};
+
+const SummaryComponent = () => {
+  const { testCaseSummary } = useDataQualityProvider();
+
+  return <div data-testid="healthy-count">{testCaseSummary.healthy}</div>;
 };
 
 describe('DataQualityProvider', () => {
@@ -200,6 +206,85 @@ describe('DataQualityProvider', () => {
     expect(fetchTotalEntityCount).toHaveBeenCalledTimes(1);
   });
 
+  it('ignores an older summary response after filters change', async () => {
+    const deferred = <T,>() => {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((promiseResolve) => {
+        resolve = promiseResolve;
+      });
+
+      return { promise, resolve };
+    };
+    const oldSummary = deferred<{ data: [] }>();
+    const newSummary = deferred<{ data: [] }>();
+    const oldUnhealthy = deferred<{
+      data: Array<{ originEntityFQN: string }>;
+    }>();
+    const oldCoverage = deferred<{
+      data: Array<{ originEntityFQN: string }>;
+    }>();
+    const newUnhealthy = deferred<{
+      data: Array<{ originEntityFQN: string }>;
+    }>();
+    const newCoverage = deferred<{
+      data: Array<{ originEntityFQN: string }>;
+    }>();
+    const oldEntityCount = deferred<{
+      data: Array<{ fullyQualifiedName: string }>;
+    }>();
+    const newEntityCount = deferred<{
+      data: Array<{ fullyQualifiedName: string }>;
+    }>();
+
+    (fetchTestCaseSummary as jest.Mock)
+      .mockReturnValueOnce(oldSummary.promise)
+      .mockReturnValueOnce(newSummary.promise);
+    (fetchEntityCoveredWithDQ as jest.Mock)
+      .mockReturnValueOnce(oldUnhealthy.promise)
+      .mockReturnValueOnce(oldCoverage.promise)
+      .mockReturnValueOnce(newUnhealthy.promise)
+      .mockReturnValueOnce(newCoverage.promise);
+    (fetchTotalEntityCount as jest.Mock)
+      .mockReturnValueOnce(oldEntityCount.promise)
+      .mockReturnValueOnce(newEntityCount.promise);
+
+    mockLocation.search = '?testCaseStatus=Failed';
+    const { rerender } = render(
+      <DataQualityProvider>
+        <SummaryComponent />
+      </DataQualityProvider>
+    );
+
+    mockLocation.search = '?testCaseStatus=Success';
+    rerender(
+      <DataQualityProvider>
+        <SummaryComponent />
+      </DataQualityProvider>
+    );
+
+    await act(async () => {
+      newSummary.resolve({ data: [] });
+      newUnhealthy.resolve({ data: [{ originEntityFQN: '3' }] });
+      newCoverage.resolve({ data: [{ originEntityFQN: '20' }] });
+      newEntityCount.resolve({ data: [{ fullyQualifiedName: '25' }] });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('healthy-count')).toHaveTextContent('17')
+    );
+
+    await act(async () => {
+      oldSummary.resolve({ data: [] });
+      oldUnhealthy.resolve({ data: [{ originEntityFQN: '8' }] });
+      oldCoverage.resolve({ data: [{ originEntityFQN: '10' }] });
+      oldEntityCount.resolve({ data: [{ fullyQualifiedName: '12' }] });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('healthy-count')).toHaveTextContent('17')
+    );
+  });
+
   it('should handle different tab values correctly', async () => {
     mockUseParam.tab = DataQualityPageTabs.TEST_SUITES;
 
@@ -238,5 +323,8 @@ describe('DataQualityProvider', () => {
     expect(
       await screen.findByText('dashboard tab component')
     ).toBeInTheDocument();
+    expect(fetchTestCaseSummary).not.toHaveBeenCalled();
+    expect(fetchEntityCoveredWithDQ).not.toHaveBeenCalled();
+    expect(fetchTotalEntityCount).not.toHaveBeenCalled();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
@@ -149,6 +149,8 @@ const DataQualityProvider = ({
         totalEntityCount = total;
       }
 
+      // A newer filter request can finish first; do not let this older response
+      // replace the summary that belongs to the current URL filters.
       if (!shouldIgnore()) {
         const updatedData = transformToTestCaseStatusObject(data);
         setTestCaseSummary({
@@ -173,9 +175,9 @@ const DataQualityProvider = ({
   useEffect(() => {
     let ignore = false;
 
-    // Backgrounded: hold the last loaded summary rather than refetching against
-    // a query string that now belongs to another route. Re-running on
-    // re-activation is intentional — it revalidates against the real filters.
+    // The dashboard owns its chart requests. When this provider is backgrounded
+    // or the dashboard is active, retain the last summary instead of issuing
+    // duplicate requests with query parameters owned by another view.
     if (!isActive || activeTab === DataQualityPageTabs.DASHBOARD) {
       setIsTestCaseSummaryLoading(false);
 

--- a/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/DataQuality/DataQualityProvider.tsx
@@ -104,7 +104,10 @@ const DataQualityProvider = ({
     };
   }, [testCaseSummary, isTestCaseSummaryLoading, activeTab, createActions]);
 
-  const fetchTestSummary = async (params?: DataQualityPageParams) => {
+  const fetchTestSummary = async (
+    params?: DataQualityPageParams,
+    shouldIgnore = () => false
+  ) => {
     const filters = {
       ...pick(params, [
         'tags',
@@ -146,35 +149,49 @@ const DataQualityProvider = ({
         totalEntityCount = total;
       }
 
-      const updatedData = transformToTestCaseStatusObject(data);
-      setTestCaseSummary({
-        ...updatedData,
-        unhealthy,
-        healthy: total - unhealthy,
-        totalDQEntities: total,
-        totalEntityCount,
-      });
+      if (!shouldIgnore()) {
+        const updatedData = transformToTestCaseStatusObject(data);
+        setTestCaseSummary({
+          ...updatedData,
+          unhealthy,
+          healthy: total - unhealthy,
+          totalDQEntities: total,
+          totalEntityCount,
+        });
+      }
     } catch (error) {
-      showErrorToast(error as AxiosError);
+      if (!shouldIgnore()) {
+        showErrorToast(error as AxiosError);
+      }
     } finally {
-      setIsTestCaseSummaryLoading(false);
+      if (!shouldIgnore()) {
+        setIsTestCaseSummaryLoading(false);
+      }
     }
   };
 
   useEffect(() => {
+    let ignore = false;
+
     // Backgrounded: hold the last loaded summary rather than refetching against
     // a query string that now belongs to another route. Re-running on
     // re-activation is intentional — it revalidates against the real filters.
-    if (!isActive) {
+    if (!isActive || activeTab === DataQualityPageTabs.DASHBOARD) {
+      setIsTestCaseSummaryLoading(false);
+
       return;
     }
 
     if (getPrioritizedViewPermission(testCasePermission, Operation.ViewBasic)) {
-      fetchTestSummary(filterParams);
+      fetchTestSummary(filterParams, () => ignore);
     } else {
       setIsTestCaseSummaryLoading(false);
     }
-  }, [filterKey, isActive]);
+
+    return () => {
+      ignore = true;
+    };
+  }, [activeTab, filterKey, isActive]);
 
   return (
     <DataQualityContext.Provider value={dataQualityContextValue}>

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
@@ -13,10 +13,12 @@
 /* eslint-disable max-len */
 import { IncidentTimeMetricsType } from '../components/DataQuality/DataQuality.interface';
 import { EntityType } from '../enums/entity.enum';
+import { TestCaseType } from '../enums/TestSuite.enum';
 import { TestCaseStatus } from '../generated/tests/testCase';
 import { TestCaseResolutionStatusTypes } from '../generated/tests/testCaseResolutionStatus';
 import {
   buildDataQualityDashboardFilters,
+  buildDataQualityTableFilters,
   buildMustEsFilterForOwner,
   buildMustEsFilterForTags,
   buildMustEsFilterForTier,
@@ -45,14 +47,58 @@ jest.mock('../utils/DataQuality/DataQualityPureUtils', () => ({
   buildMustEsFilterForTags: jest.fn(),
   buildMustEsFilterForTier: jest.fn(),
   buildDataQualityDashboardFilters: jest.fn().mockReturnValue([]),
+  buildDataQualityTableFilters: jest.fn().mockReturnValue([]),
   buildMustEsFilterForDataProducts: jest.fn(),
 }));
 
 describe('dataQualityDashboardAPI', () => {
   describe('fetchTotalEntityCount', () => {
+    it('should exclude test case filters from the table count query', async () => {
+      const filters = {
+        dataQualityDimension: 'Completeness',
+        serviceName: 'sample_service',
+        testCaseStatus: TestCaseStatus.Success,
+        testCaseType: TestCaseType.table,
+        testPlatforms: ['OpenMetadata'],
+      };
+      const { buildDataQualityTableFilters: actualBuildFilters } =
+        jest.requireActual(
+          '../utils/DataQuality/DataQualityPureUtils'
+        ) as typeof import('../utils/DataQuality/DataQualityPureUtils');
+      (buildDataQualityTableFilters as jest.Mock).mockImplementationOnce(
+        actualBuildFilters
+      );
+
+      await fetchTotalEntityCount(filters);
+
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
+        q: JSON.stringify({
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'service.name.keyword': 'sample_service',
+                  },
+                },
+                {
+                  term: {
+                    deleted: false,
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        index: 'table',
+        aggregationQuery: `bucketName=count:aggType=cardinality:field=fullyQualifiedName`,
+        domain: undefined,
+      });
+    });
+
     it('should call getDataQualityReport with correct query when ownerFqn is provided', async () => {
       const filters = { ownerFqn: 'owner1' };
-      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+      (buildDataQualityTableFilters as jest.Mock).mockReturnValueOnce([
         {
           term: {
             'owners.fullyQualifiedName': 'owner1',
@@ -62,9 +108,8 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTotalEntityCount(filters);
 
-      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
-        filters: { ownerFqn: 'owner1' },
-        isTableApi: true,
+      expect(buildDataQualityTableFilters).toHaveBeenCalledWith({
+        ownerFqn: 'owner1',
       });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
@@ -87,7 +132,7 @@ describe('dataQualityDashboardAPI', () => {
 
     it('should call getDataQualityReport with correct query when tags are provided', async () => {
       const filters = { tags: ['tag1', 'tag2'] };
-      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+      (buildDataQualityTableFilters as jest.Mock).mockReturnValueOnce([
         {
           bool: {
             should: [
@@ -124,7 +169,7 @@ describe('dataQualityDashboardAPI', () => {
 
     it('should call getDataQualityReport with correct query when tier is provided', async () => {
       const filters = { tier: ['tier1', 'tier2'] };
-      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+      (buildDataQualityTableFilters as jest.Mock).mockReturnValueOnce([
         {
           bool: {
             should: [
@@ -161,7 +206,7 @@ describe('dataQualityDashboardAPI', () => {
 
     it('should call getDataQualityReport with correct query when all filters are provided', async () => {
       const filters = { ownerFqn: 'owner1', tags: ['tag1'], tier: ['tier1'] };
-      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+      (buildDataQualityTableFilters as jest.Mock).mockReturnValueOnce([
         {
           term: {
             'owners.fullyQualifiedName': 'owner1',
@@ -181,9 +226,10 @@ describe('dataQualityDashboardAPI', () => {
 
       await fetchTotalEntityCount(filters);
 
-      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
-        filters: { ownerFqn: 'owner1', tags: ['tag1'], tier: ['tier1'] },
-        isTableApi: true,
+      expect(buildDataQualityTableFilters).toHaveBeenCalledWith({
+        ownerFqn: 'owner1',
+        tags: ['tag1'],
+        tier: ['tier1'],
       });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
@@ -412,6 +458,86 @@ describe('dataQualityDashboardAPI', () => {
     },
   ];
 
+  describe('fetchEntityCoveredWithDQ status filtering', () => {
+    const filters = {
+      serviceName: 'sample_service',
+      testCaseStatus: TestCaseStatus.Success,
+    };
+    const { buildDataQualityDashboardFilters: actualBuildFilters } =
+      jest.requireActual(
+        '../utils/DataQuality/DataQualityPureUtils'
+      ) as typeof import('../utils/DataQuality/DataQualityPureUtils');
+
+    it('should exclude the selected status from the covered asset query', async () => {
+      (buildDataQualityDashboardFilters as jest.Mock).mockImplementationOnce(
+        actualBuildFilters
+      );
+
+      await fetchEntityCoveredWithDQ(filters, false);
+
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
+        q: JSON.stringify({
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'service.name.keyword': 'sample_service',
+                  },
+                },
+                {
+                  term: {
+                    deleted: false,
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        index: 'testCase',
+        aggregationQuery: `bucketName=entityWithTests:aggType=cardinality:field=originEntityFQN`,
+        domain: undefined,
+      });
+    });
+
+    it('should use only failed statuses for the unhealthy asset query', async () => {
+      (buildDataQualityDashboardFilters as jest.Mock).mockImplementationOnce(
+        actualBuildFilters
+      );
+
+      await fetchEntityCoveredWithDQ(filters, true);
+
+      expect(batchedDataQualityReport).toHaveBeenCalledWith({
+        q: JSON.stringify({
+          query: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'testCaseStatus.keyword': ['Failed', 'Aborted'],
+                  },
+                },
+                {
+                  term: {
+                    'service.name.keyword': 'sample_service',
+                  },
+                },
+                {
+                  term: {
+                    deleted: false,
+                  },
+                },
+              ],
+            },
+          },
+        }),
+        index: 'testCase',
+        aggregationQuery: `bucketName=entityWithTests:aggType=cardinality:field=originEntityFQN`,
+        domain: undefined,
+      });
+    });
+  });
+
   testCases.map((testData) => {
     describe(`${testData.functionName}`, () => {
       it('should call getDataQualityReport with correct query when ownerFqn is provided', async () => {
@@ -535,11 +661,15 @@ describe('dataQualityDashboardAPI', () => {
           query: { term: { 'owners.name': 'owner1' } },
         },
       };
-      (buildMustEsFilterForOwner as jest.Mock).mockReturnValueOnce(ownerFilter);
+      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+        ownerFilter,
+      ]);
 
       await fetchTestCaseSummaryByNoDimension({ ownerFqn: 'owner1' });
 
-      expect(buildMustEsFilterForOwner).toHaveBeenCalledWith('owner1');
+      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
+        filters: { ownerFqn: 'owner1' },
+      });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
@@ -569,11 +699,15 @@ describe('dataQualityDashboardAPI', () => {
           },
         },
       };
-      (buildMustEsFilterForTags as jest.Mock).mockReturnValueOnce(tagsFilter);
+      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+        tagsFilter,
+      ]);
 
       await fetchTestCaseSummaryByNoDimension({ tags: ['tag1', 'tag2'] });
 
-      expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1', 'tag2']);
+      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
+        filters: { tags: ['tag1', 'tag2'] },
+      });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
@@ -596,12 +730,15 @@ describe('dataQualityDashboardAPI', () => {
           minimum_should_match: 1,
         },
       };
-      (buildMustEsFilterForTier as jest.Mock).mockReturnValueOnce(tierFilter);
+      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+        tierFilter,
+      ]);
 
       await fetchTestCaseSummaryByNoDimension({ tier: ['Tier.Tier1'] });
 
-      expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['Tier.Tier1']);
-      expect(buildMustEsFilterForTags).not.toHaveBeenCalled();
+      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
+        filters: { tier: ['Tier.Tier1'] },
+      });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
@@ -634,16 +771,19 @@ describe('dataQualityDashboardAPI', () => {
           minimum_should_match: 1,
         },
       };
-      (buildMustEsFilterForTags as jest.Mock).mockReturnValueOnce(tagsFilter);
-      (buildMustEsFilterForTier as jest.Mock).mockReturnValueOnce(tierFilter);
+      (buildDataQualityDashboardFilters as jest.Mock).mockReturnValueOnce([
+        tagsFilter,
+        tierFilter,
+      ]);
 
       await fetchTestCaseSummaryByNoDimension({
         tags: ['tag1'],
         tier: ['Tier.Tier1'],
       });
 
-      expect(buildMustEsFilterForTags).toHaveBeenCalledWith(['tag1']);
-      expect(buildMustEsFilterForTier).toHaveBeenCalledWith(['Tier.Tier1']);
+      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
+        filters: { tags: ['tag1'], tier: ['Tier.Tier1'] },
+      });
       expect(batchedDataQualityReport).toHaveBeenCalledWith({
         q: JSON.stringify({
           query: {
@@ -693,6 +833,33 @@ describe('dataQualityDashboardAPI', () => {
           }),
         })
       );
+    });
+
+    it('should apply all test-case filters except the dimension itself', async () => {
+      const filters = {
+        dataQualityDimension: 'Accuracy',
+        entityFQN: 'service.db.schema.table',
+        serviceName: 'service',
+        startTs: 100,
+        endTs: 200,
+        testCaseStatus: TestCaseStatus.Success,
+        testCaseType: TestCaseType.table,
+        testPlatforms: ['OpenMetadata'],
+      };
+
+      await fetchTestCaseSummaryByNoDimension(filters);
+
+      expect(buildDataQualityDashboardFilters).toHaveBeenCalledWith({
+        filters: {
+          entityFQN: 'service.db.schema.table',
+          serviceName: 'service',
+          startTs: 100,
+          endTs: 200,
+          testCaseStatus: TestCaseStatus.Success,
+          testCaseType: TestCaseType.table,
+          testPlatforms: ['OpenMetadata'],
+        },
+      });
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.test.ts
@@ -53,12 +53,12 @@ jest.mock('../utils/DataQuality/DataQualityPureUtils', () => ({
 
 describe('dataQualityDashboardAPI', () => {
   describe('fetchTotalEntityCount', () => {
-    it('should exclude test case filters from the table count query', async () => {
+    it('should exclude column-only test case filters from the table count query', async () => {
       const filters = {
         dataQualityDimension: 'Completeness',
         serviceName: 'sample_service',
         testCaseStatus: TestCaseStatus.Success,
-        testCaseType: TestCaseType.table,
+        testCaseType: TestCaseType.column,
         testPlatforms: ['OpenMetadata'],
       };
       const { buildDataQualityTableFilters: actualBuildFilters } =
@@ -514,7 +514,7 @@ describe('dataQualityDashboardAPI', () => {
               must: [
                 {
                   terms: {
-                    'testCaseStatus.keyword': ['Failed', 'Aborted'],
+                    'testCaseResult.testCaseStatus': ['Failed', 'Aborted'],
                   },
                 },
                 {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
@@ -31,6 +31,8 @@ export const fetchEntityCoveredWithDQ = (
   filters?: DataQualityDashboardChartFilters,
   unhealthy = false
 ) => {
+  // The selected status filters test-case charts, but must not redefine the
+  // Healthy (Success + Queued) and Unhealthy (Failed + Aborted) asset groups.
   const assetFilters = filters ? omit(filters, 'testCaseStatus') : undefined;
   const mustFilter = buildDataQualityDashboardFilters({
     filters: assetFilters,
@@ -54,6 +56,8 @@ export const fetchEntityCoveredWithDQ = (
 export const fetchTotalEntityCount = (
   filters?: DataQualityDashboardChartFilters
 ) => {
+  // The table index does not contain test-case-only fields such as entityLink,
+  // result status, dimension, platform, or last-run timestamp.
   const mustFilter = buildDataQualityTableFilters(filters);
 
   return batchedDataQualityReport({
@@ -113,6 +117,8 @@ export const fetchTestCaseSummaryByDimension = (
 export const fetchTestCaseSummaryByNoDimension = (
   filters?: DataQualityDashboardChartFilters
 ) => {
+  // Apply every active test-case filter except dimension, then select documents
+  // where the dimension field is absent for the dedicated No Dimension card.
   const mustFilter = buildDataQualityDashboardFilters({
     filters: filters ? omit(filters, 'dataQualityDimension') : undefined,
   });

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityDashboardAPI.ts
@@ -11,12 +11,14 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { omit } from 'lodash';
 import { IncidentTimeMetricsType } from '../components/DataQuality/DataQuality.interface';
 import { TestCaseStatus } from '../generated/tests/testCase';
 import { TestCaseResolutionStatusTypes } from '../generated/tests/testCaseResolutionStatus';
 import { DataQualityDashboardChartFilters } from '../pages/DataQuality/DataQualityPage.interface';
 import {
   buildDataQualityDashboardFilters,
+  buildDataQualityTableFilters,
   buildMustEsFilterForDataProducts,
   buildMustEsFilterForOwner,
   buildMustEsFilterForTags,
@@ -29,7 +31,11 @@ export const fetchEntityCoveredWithDQ = (
   filters?: DataQualityDashboardChartFilters,
   unhealthy = false
 ) => {
-  const mustFilter = buildDataQualityDashboardFilters({ filters, unhealthy });
+  const assetFilters = filters ? omit(filters, 'testCaseStatus') : undefined;
+  const mustFilter = buildDataQualityDashboardFilters({
+    filters: assetFilters,
+    unhealthy,
+  });
 
   return batchedDataQualityReport({
     q: JSON.stringify({
@@ -48,10 +54,7 @@ export const fetchEntityCoveredWithDQ = (
 export const fetchTotalEntityCount = (
   filters?: DataQualityDashboardChartFilters
 ) => {
-  const mustFilter = buildDataQualityDashboardFilters({
-    filters,
-    isTableApi: true,
-  });
+  const mustFilter = buildDataQualityTableFilters(filters);
 
   return batchedDataQualityReport({
     q: JSON.stringify({
@@ -110,19 +113,9 @@ export const fetchTestCaseSummaryByDimension = (
 export const fetchTestCaseSummaryByNoDimension = (
   filters?: DataQualityDashboardChartFilters
 ) => {
-  const mustFilter = [];
-  if (filters?.ownerFqn) {
-    mustFilter.push(buildMustEsFilterForOwner(filters.ownerFqn));
-  }
-  if (filters?.tags && filters.tags.length > 0) {
-    mustFilter.push(buildMustEsFilterForTags(filters.tags));
-  }
-  if (filters?.tier && filters.tier.length > 0) {
-    mustFilter.push(buildMustEsFilterForTier(filters.tier));
-  }
-  if (filters?.dataProductFqns && filters.dataProductFqns.length > 0) {
-    mustFilter.push(buildMustEsFilterForDataProducts(filters.dataProductFqns));
-  }
+  const mustFilter = buildDataQualityDashboardFilters({
+    filters: filters ? omit(filters, 'dataQualityDimension') : undefined,
+  });
 
   return batchedDataQualityReport({
     q: JSON.stringify({

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.test.ts
@@ -48,6 +48,49 @@ describe('dataQualityReportBatcher', () => {
     expect(second).toEqual({ data: [{ b: '2' }], metadata: {} });
   });
 
+  it('should coalesce identical requests and resolve every caller', async () => {
+    mockGetDataQualityReportBatch.mockResolvedValue({
+      results: [
+        { key: '0', report: { data: [{ status: 'success' }], metadata: {} } },
+      ],
+    });
+    const params = {
+      index: 'testCase',
+      aggregationQuery: 'status',
+      q: '{"query":{"bool":{"must":[]}}}',
+    };
+
+    const [first, second] = await Promise.all([
+      batchedDataQualityReport(params),
+      batchedDataQualityReport(params),
+    ]);
+
+    expect(mockGetDataQualityReportBatch).toHaveBeenCalledWith({
+      requests: [{ ...params, key: '0' }],
+    });
+    expect(first).toEqual(second);
+  });
+
+  it('should map shuffled batch results back to the correct callers', async () => {
+    mockGetDataQualityReportBatch.mockResolvedValue({
+      results: [
+        { key: '1', report: { data: [{ value: 'second' }], metadata: {} } },
+        { key: '0', report: { data: [{ value: 'first' }], metadata: {} } },
+      ],
+    });
+
+    const [first, second] = await Promise.all([
+      batchedDataQualityReport({
+        index: 'testCase',
+        aggregationQuery: 'first',
+      }),
+      batchedDataQualityReport({ index: 'table', aggregationQuery: 'second' }),
+    ]);
+
+    expect(first.data).toEqual([{ value: 'first' }]);
+    expect(second.data).toEqual([{ value: 'second' }]);
+  });
+
   it('should reject only the failed item and resolve the rest', async () => {
     mockGetDataQualityReportBatch.mockResolvedValue({
       results: [

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
@@ -52,7 +52,9 @@ const flushChunk = async (chunk: PendingReport[]): Promise<void> => {
       const result = resultByKey.get(String(index));
 
       if (result?.report) {
-        pending.subscribers.forEach(({ resolve }) => resolve(result.report as DataQualityReport));
+        pending.subscribers.forEach(({ resolve }) =>
+          resolve(result.report as DataQualityReport)
+        );
       } else {
         const error = new Error(
           result?.error ?? 'Data quality report request failed'

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
@@ -42,6 +42,8 @@ const flushChunk = async (chunk: PendingReport[]): Promise<void> => {
 
   try {
     const { results } = await getDataQualityReportBatch({ requests });
+    // Match by the generated key because the batch response is not required to
+    // preserve request order.
     const resultByKey = new Map(
       results.map((result) => [result.key, result] as const)
     );
@@ -50,7 +52,7 @@ const flushChunk = async (chunk: PendingReport[]): Promise<void> => {
       const result = resultByKey.get(String(index));
 
       if (result?.report) {
-        pending.subscribers.forEach(({ resolve }) => resolve(result.report));
+        pending.subscribers.forEach(({ resolve }) => resolve(result.report as DataQualityReport));
       } else {
         const error = new Error(
           result?.error ?? 'Data quality report request failed'
@@ -86,6 +88,8 @@ export const batchedDataQualityReport = (
   params: DataQualityReportParamsType
 ): Promise<DataQualityReport> => {
   return new Promise<DataQualityReport>((resolve, reject) => {
+    // Identical requests in the same microtask share one batch entry while each
+    // caller still receives an independently settled promise.
     const matchingReport = pendingReports.find(
       (pending) => JSON.stringify(pending.params) === JSON.stringify(params)
     );

--- a/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/dataQualityReportBatcher.ts
@@ -19,8 +19,10 @@ import {
 
 interface PendingReport {
   params: DataQualityReportParamsType;
-  resolve: (value: DataQualityReport) => void;
-  reject: (reason?: unknown) => void;
+  subscribers: Array<{
+    resolve: (value: DataQualityReport) => void;
+    reject: (reason?: unknown) => void;
+  }>;
 }
 
 let pendingReports: PendingReport[] = [];
@@ -48,15 +50,18 @@ const flushChunk = async (chunk: PendingReport[]): Promise<void> => {
       const result = resultByKey.get(String(index));
 
       if (result?.report) {
-        pending.resolve(result.report);
+        pending.subscribers.forEach(({ resolve }) => resolve(result.report));
       } else {
-        pending.reject(
-          new Error(result?.error ?? 'Data quality report request failed')
+        const error = new Error(
+          result?.error ?? 'Data quality report request failed'
         );
+        pending.subscribers.forEach(({ reject }) => reject(error));
       }
     });
   } catch (error) {
-    chunk.forEach((pending) => pending.reject(error));
+    chunk.forEach((pending) =>
+      pending.subscribers.forEach(({ reject }) => reject(error))
+    );
   }
 };
 
@@ -81,7 +86,15 @@ export const batchedDataQualityReport = (
   params: DataQualityReportParamsType
 ): Promise<DataQualityReport> => {
   return new Promise<DataQualityReport>((resolve, reject) => {
-    pendingReports.push({ params, resolve, reject });
+    const matchingReport = pendingReports.find(
+      (pending) => JSON.stringify(pending.params) === JSON.stringify(params)
+    );
+
+    if (matchingReport) {
+      matchingReport.subscribers.push({ resolve, reject });
+    } else {
+      pendingReports.push({ params, subscribers: [{ resolve, reject }] });
+    }
 
     if (!isFlushScheduled) {
       isFlushScheduled = true;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
@@ -376,8 +376,17 @@ const buildDataQualityDimensionFilter = (dimension: string) => {
 export const buildDataQualityDashboardFilters = (data: {
   filters?: DataQualityDashboardChartFilters;
   unhealthy?: boolean;
+  /** Retained for compatibility with callers using the former table mode. */
+  isTableApi?: boolean;
 }) => {
-  const { filters, unhealthy = false } = data;
+  const { filters, unhealthy = false, isTableApi = false } = data;
+
+  // Route legacy table-mode calls through the dedicated builder so private
+  // consumers keep their existing contract without mixing index field sets.
+  if (isTableApi) {
+    return buildDataQualityTableFilters(filters);
+  }
+
   const mustFilter = [];
 
   if (unhealthy) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
@@ -291,12 +291,71 @@ export const buildMustEsFilterForDataProducts = (
   };
 };
 
+export const buildDataQualityTableFilters = (
+  filters?: DataQualityDashboardChartFilters
+) => {
+  const mustFilter = [];
+
+  if (filters?.ownerFqn) {
+    mustFilter.push(buildMustEsFilterForOwner(filters.ownerFqn));
+  }
+
+  if (filters?.tags?.length) {
+    mustFilter.push({
+      bool: {
+        should: filters.tags.map((tag) => ({
+          term: { 'tags.tagFQN': tag },
+        })),
+      },
+    });
+  }
+
+  if (filters?.tier?.length) {
+    mustFilter.push({
+      bool: {
+        should: filters.tier.map((tier) => ({
+          term: { 'tier.tagFQN': tier },
+        })),
+      },
+    });
+  }
+
+  if (filters?.certification?.length) {
+    mustFilter.push({
+      bool: {
+        should: filters.certification.map((fqn) => ({
+          term: { 'certification.tagLabel.tagFQN': fqn },
+        })),
+      },
+    });
+  }
+
+  if (filters?.dataProductFqns?.length) {
+    mustFilter.push(buildMustEsFilterForDataProducts(filters.dataProductFqns));
+  }
+
+  if (filters?.entityFQN) {
+    mustFilter.push({
+      term: { 'fullyQualifiedName.keyword': filters.entityFQN },
+    });
+  }
+
+  if (filters?.serviceName) {
+    mustFilter.push({
+      term: { 'service.name.keyword': filters.serviceName },
+    });
+  }
+
+  mustFilter.push({ term: { deleted: false } });
+
+  return mustFilter;
+};
+
 export const buildDataQualityDashboardFilters = (data: {
   filters?: DataQualityDashboardChartFilters;
   unhealthy?: boolean;
-  isTableApi?: boolean;
 }) => {
-  const { filters, unhealthy = false, isTableApi = false } = data;
+  const { filters, unhealthy = false } = data;
   const mustFilter = [];
 
   if (unhealthy) {
@@ -311,30 +370,6 @@ export const buildDataQualityDashboardFilters = (data: {
     mustFilter.push(buildMustEsFilterForOwner(filters.ownerFqn));
   }
 
-  if (filters?.tags && isTableApi) {
-    mustFilter.push({
-      bool: {
-        should: filters.tags.map((tag) => ({
-          term: {
-            'tags.tagFQN': tag,
-          },
-        })),
-      },
-    });
-  }
-
-  if (filters?.tier && isTableApi) {
-    mustFilter.push({
-      bool: {
-        should: filters.tier.map((tag) => ({
-          term: {
-            'tier.tagFQN': tag,
-          },
-        })),
-      },
-    });
-  }
-
   if (filters?.certification) {
     mustFilter.push({
       bool: {
@@ -345,11 +380,11 @@ export const buildDataQualityDashboardFilters = (data: {
     });
   }
 
-  if (filters?.tags && filters.tags.length > 0 && !isTableApi) {
+  if (filters?.tags && filters.tags.length > 0) {
     mustFilter.push(buildMustEsFilterForTags(filters.tags));
   }
 
-  if (filters?.tier && filters.tier.length > 0 && !isTableApi) {
+  if (filters?.tier && filters.tier.length > 0) {
     mustFilter.push(buildMustEsFilterForTier(filters.tier));
   }
 
@@ -359,10 +394,7 @@ export const buildDataQualityDashboardFilters = (data: {
 
   if (filters?.entityFQN) {
     mustFilter.push({
-      term: {
-        [isTableApi ? 'fullyQualifiedName.keyword' : 'originEntityFQN']:
-          filters.entityFQN,
-      },
+      term: { originEntityFQN: filters.entityFQN },
     });
   }
 
@@ -410,7 +442,7 @@ export const buildDataQualityDashboardFilters = (data: {
     }
   }
 
-  if (filters?.startTs && filters?.endTs && !isTableApi) {
+  if (filters?.startTs && filters?.endTs) {
     mustFilter.push({
       range: {
         'testCaseResult.timestamp': {
@@ -678,14 +710,14 @@ export function getColumnNameFromColumnFilterKey(
  * Builds a test-case list link that preserves the dashboard slice represented
  * by the clicked card or chart segment.
  */
-export const getTestCaseTabPath = (
-  testCaseStatus: TestCaseStatus,
-  filters?: DataQualityDashboardChartFilters
+export const getTestCaseListPath = (
+  filters?: DataQualityDashboardChartFilters,
+  overrides?: Partial<TestCaseSearchParams>
 ) => ({
   pathname: getDataQualityPagePath(DataQualityPageTabs.TEST_CASES),
   search: QueryString.stringify(
     {
-      testCaseStatus,
+      testCaseStatus: filters?.testCaseStatus,
       lastRunRange:
         filters?.startTs && filters.endTs
           ? { startTs: filters.startTs, endTs: filters.endTs }
@@ -698,10 +730,16 @@ export const getTestCaseTabPath = (
       testPlatforms: filters?.testPlatforms,
       dataQualityDimension: filters?.dataQualityDimension,
       testCaseType: filters?.testCaseType,
+      ...overrides,
     },
     { arrayFormat: 'brackets' }
   ),
 });
+
+export const getTestCaseTabPath = (
+  testCaseStatus: TestCaseStatus,
+  filters?: DataQualityDashboardChartFilters
+) => getTestCaseListPath(filters, { testCaseStatus });
 
 export const transformToTestCaseStatusByDimension = (
   inputData: DataQualityReport['data']

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityPureUtils.ts
@@ -57,6 +57,8 @@ import {
   type DataQualityDashboardChartFilters,
 } from '../../pages/DataQuality/DataQualityPage.interface';
 import type { ListTestCaseParamsBySearch } from '../../rest/testAPI';
+import { formatDate } from '../date-time/DateTimeUtils';
+import { CUSTOM_DATE_RANGE_KEY } from '../DatePickerMenuUtils';
 import EntityLink from '../EntityLink';
 import { getColumnNameFromEntityLink } from '../EntityPureUtils';
 import { getEntityFQN } from '../FeedUtilsPure';
@@ -291,6 +293,11 @@ export const buildMustEsFilterForDataProducts = (
   };
 };
 
+/**
+ * Builds only filters backed by fields in the table index. Test-case filters
+ * must stay out of this query so values such as Column do not exclude all
+ * table documents while calculating total asset coverage.
+ */
 export const buildDataQualityTableFilters = (
   filters?: DataQualityDashboardChartFilters
 ) => {
@@ -351,6 +358,21 @@ export const buildDataQualityTableFilters = (
   return mustFilter;
 };
 
+const buildDataQualityDimensionFilter = (dimension: string) => {
+  // No Dimension is represented by an absent field in the search document,
+  // matching the Test Cases listing endpoint's filter semantics.
+  if (dimension === DataQualityDimensions.NoDimension) {
+    return {
+      bool: {
+        must_not: [{ exists: { field: 'dataQualityDimension' } }],
+      },
+    };
+  }
+
+  return { term: { dataQualityDimension: dimension } };
+};
+
+/** Builds the complete filter set supported by the testCase index. */
 export const buildDataQualityDashboardFilters = (data: {
   filters?: DataQualityDashboardChartFilters;
   unhealthy?: boolean;
@@ -361,7 +383,9 @@ export const buildDataQualityDashboardFilters = (data: {
   if (unhealthy) {
     mustFilter.push({
       terms: {
-        'testCaseStatus.keyword': ['Failed', 'Aborted'],
+        // The latest status is stored under testCaseResult in the testCase
+        // index; the top-level testCaseStatus field belongs to result documents.
+        'testCaseResult.testCaseStatus': ['Failed', 'Aborted'],
       },
     });
   }
@@ -415,11 +439,9 @@ export const buildDataQualityDashboardFilters = (data: {
   }
 
   if (filters?.dataQualityDimension) {
-    mustFilter.push({
-      term: {
-        dataQualityDimension: filters.dataQualityDimension,
-      },
-    });
+    mustFilter.push(
+      buildDataQualityDimensionFilter(filters.dataQualityDimension)
+    );
   }
 
   if (filters?.testCaseStatus) {
@@ -708,7 +730,8 @@ export function getColumnNameFromColumnFilterKey(
 
 /**
  * Builds a test-case list link that preserves the dashboard slice represented
- * by the clicked card or chart segment.
+ * by the clicked card or chart segment. Dashboard timestamps are serialized as
+ * lastRunRange because that is the date-filter shape consumed by the list page.
  */
 export const getTestCaseListPath = (
   filters?: DataQualityDashboardChartFilters,
@@ -720,7 +743,17 @@ export const getTestCaseListPath = (
       testCaseStatus: filters?.testCaseStatus,
       lastRunRange:
         filters?.startTs && filters.endTs
-          ? { startTs: filters.startTs, endTs: filters.endTs }
+          ? {
+              startTs: filters.startTs,
+              endTs: filters.endTs,
+              // Mark redirected timestamps as a custom range so the Test Cases
+              // Last Run control displays the exact dashboard selection.
+              key: CUSTOM_DATE_RANGE_KEY,
+              title: `${formatDate(filters.startTs, true)} -> ${formatDate(
+                filters.endTs,
+                true
+              )}`,
+            }
           : undefined,
       tags: filters?.tags,
       tier: filters?.tier?.[0],

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -13,6 +13,7 @@
 
 import { TestCaseFormType } from '../../components/DataQuality/AddDataQualityTest/AddDataQualityTest.interface';
 import { TestCaseSearchParams } from '../../components/DataQuality/DataQuality.interface';
+import { TestCaseType } from '../../enums/TestSuite.enum';
 import { Table } from '../../generated/entity/data/table';
 import { DataQualityReport } from '../../generated/tests/dataQualityReport';
 import { TestCase, TestCaseStatus } from '../../generated/tests/testCase';
@@ -30,6 +31,7 @@ import {
 import { ListTestCaseParamsBySearch } from '../../rest/testAPI';
 import {
   buildDataQualityDashboardFilters,
+  buildDataQualityTableFilters,
   buildMustEsFilterForDataProducts,
   buildMustEsFilterForOwner,
   buildMustEsFilterForTags,
@@ -816,6 +818,33 @@ describe('DataQualityUtils', () => {
           minimum_should_match: 1,
         },
       });
+    });
+  });
+
+  describe('buildDataQualityTableFilters', () => {
+    it('includes table fields and excludes test-case-only filters', () => {
+      const result = buildDataQualityTableFilters({
+        serviceName: 'service',
+        entityFQN: 'service.db.schema.table',
+        testPlatforms: [TestPlatform.Dbt],
+        dataQualityDimension: 'Accuracy',
+        testCaseStatus: TestCaseStatus.Success,
+        testCaseType: TestCaseType.table,
+        startTs: 100,
+        endTs: 200,
+      });
+      const query = JSON.stringify(result);
+
+      expect(result).toContainEqual({
+        term: { 'service.name.keyword': 'service' },
+      });
+      expect(result).toContainEqual({
+        term: { 'fullyQualifiedName.keyword': 'service.db.schema.table' },
+      });
+      expect(query).not.toContain('testPlatforms');
+      expect(query).not.toContain('dataQualityDimension');
+      expect(query).not.toContain('testCaseStatus');
+      expect(query).not.toContain('testCaseResult.timestamp');
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -18,6 +18,7 @@ import { Table } from '../../generated/entity/data/table';
 import { DataQualityReport } from '../../generated/tests/dataQualityReport';
 import { TestCase, TestCaseStatus } from '../../generated/tests/testCase';
 import {
+  DataQualityDimensions,
   TestDataType,
   TestDefinition,
   TestPlatform,
@@ -61,6 +62,8 @@ jest.mock('../../constants/profiler.constant', () => ({
     tier: 'tier',
     tags: 'tags',
     service: 'serviceName',
+    dimension: 'dataQualityDimension',
+    dataProduct: 'dataProductFqn',
   },
   DEFAULT_SELECTED_RANGE: {
     key: 'last7Days',
@@ -71,6 +74,7 @@ jest.mock('../../constants/profiler.constant', () => ({
 }));
 
 jest.mock('../date-time/DateTimeUtils', () => ({
+  formatDate: jest.fn((timestamp: number) => String(timestamp)),
   formatDateTimeLong: jest.fn(),
   getEpochMillisForPastDays: jest.fn().mockReturnValue(1609459200000),
   getCurrentMillis: jest.fn().mockReturnValue(1640995200000),
@@ -117,6 +121,12 @@ describe('DataQualityUtils', () => {
       expect(path.search).toContain('testCaseStatus=Failed');
       expect(path.search).toContain('lastRunRange%5BstartTs%5D=100');
       expect(path.search).toContain('lastRunRange%5BendTs%5D=200');
+      expect(path.search).toContain(
+        'lastRunRange%5Bkey%5D=customRange'
+      );
+      expect(path.search).toContain(
+        'lastRunRange%5Btitle%5D=100%20-%3E%20200'
+      );
       expect(path.search).toContain('tags%5B%5D=PII.Sensitive');
       expect(path.search).toContain('tier=Tier.Tier1');
       expect(path.search).toContain('dataProductFqn=marketing');
@@ -289,6 +299,8 @@ describe('DataQualityUtils', () => {
       tags: ['PII.None'],
       tier: 'Tier.Tier1',
       serviceName: 'sample_data',
+      dataQualityDimension: 'Accuracy',
+      dataProductFqn: 'Marketing',
       tableFqn: 'sample_data.ecommerce_db.shopify.fact_sale',
     } as unknown as TestCaseSearchParams;
 
@@ -302,6 +314,8 @@ describe('DataQualityUtils', () => {
         'tags',
         'tier',
         'serviceName',
+        'dataQualityDimension',
+        'dataProductFqn',
         'tableFqn',
       ];
 
@@ -315,6 +329,8 @@ describe('DataQualityUtils', () => {
         tags: ['PII.None'],
         tier: 'Tier.Tier1',
         serviceName: 'sample_data',
+        dataQualityDimension: 'Accuracy',
+        dataProductFqn: 'Marketing',
       };
 
       const result = getTestCaseFiltersValue(
@@ -798,6 +814,59 @@ describe('DataQualityUtils', () => {
       expect(tierFilter).toBeDefined();
     });
 
+    it('includes every test-case filter in the report query', () => {
+      const result = buildDataQualityDashboardFilters({
+        filters: {
+          ownerFqn: 'owner',
+          certification: ['Certification.Gold'],
+          tags: ['PII.Sensitive'],
+          tier: ['Tier.Tier1'],
+          dataProductFqns: ['Marketing'],
+          entityFQN: 'service.db.schema.table',
+          serviceName: 'service',
+          testPlatforms: [TestPlatform.Dbt],
+          dataQualityDimension: 'Accuracy',
+          testCaseStatus: TestCaseStatus.Success,
+          testCaseType: TestCaseType.column,
+          startTs: 100,
+          endTs: 200,
+        },
+      });
+      const query = JSON.stringify(result);
+
+      [
+        'owners.name',
+        'certification.tagLabel.tagFQN',
+        'tags.tagFQN',
+        'tier.tagFQN',
+        'dataProducts.fullyQualifiedName',
+        'originEntityFQN',
+        'service.name.keyword',
+        'testPlatforms',
+        'dataQualityDimension',
+        'testCaseResult.testCaseStatus',
+        'entityLink',
+        'testCaseResult.timestamp',
+      ].forEach((field) => expect(query).toContain(field));
+    });
+
+    it('matches test cases with a missing dimension for No Dimension', () => {
+      const result = buildDataQualityDashboardFilters({
+        filters: {
+          dataQualityDimension: DataQualityDimensions.NoDimension,
+        },
+      });
+
+      expect(result).toContainEqual({
+        bool: {
+          must_not: [{ exists: { field: 'dataQualityDimension' } }],
+        },
+      });
+      expect(result).not.toContainEqual({
+        term: { dataQualityDimension: DataQualityDimensions.NoDimension },
+      });
+    });
+
     it('should not add tier filter when tier array is empty', () => {
       const result = buildDataQualityDashboardFilters({
         filters: {
@@ -824,12 +893,17 @@ describe('DataQualityUtils', () => {
   describe('buildDataQualityTableFilters', () => {
     it('includes table fields and excludes test-case-only filters', () => {
       const result = buildDataQualityTableFilters({
+        ownerFqn: 'owner',
+        tags: ['PII.Sensitive'],
+        tier: ['Tier.Tier1'],
+        certification: ['Certification.Gold'],
+        dataProductFqns: ['Marketing'],
         serviceName: 'service',
         entityFQN: 'service.db.schema.table',
         testPlatforms: [TestPlatform.Dbt],
         dataQualityDimension: 'Accuracy',
         testCaseStatus: TestCaseStatus.Success,
-        testCaseType: TestCaseType.table,
+        testCaseType: TestCaseType.column,
         startTs: 100,
         endTs: 200,
       });
@@ -841,9 +915,16 @@ describe('DataQualityUtils', () => {
       expect(result).toContainEqual({
         term: { 'fullyQualifiedName.keyword': 'service.db.schema.table' },
       });
+      expect(query).toContain('owners.name');
+      expect(query).toContain('tags.tagFQN');
+      expect(query).toContain('tier.tagFQN');
+      expect(query).toContain('certification.tagLabel.tagFQN');
+      expect(query).toContain('dataProducts.fullyQualifiedName');
       expect(query).not.toContain('testPlatforms');
       expect(query).not.toContain('dataQualityDimension');
       expect(query).not.toContain('testCaseStatus');
+      expect(query).not.toContain('testCaseType');
+      expect(query).not.toContain('entityLink');
       expect(query).not.toContain('testCaseResult.timestamp');
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/DataQuality/DataQualityUtils.test.ts
@@ -121,12 +121,8 @@ describe('DataQualityUtils', () => {
       expect(path.search).toContain('testCaseStatus=Failed');
       expect(path.search).toContain('lastRunRange%5BstartTs%5D=100');
       expect(path.search).toContain('lastRunRange%5BendTs%5D=200');
-      expect(path.search).toContain(
-        'lastRunRange%5Bkey%5D=customRange'
-      );
-      expect(path.search).toContain(
-        'lastRunRange%5Btitle%5D=100%20-%3E%20200'
-      );
+      expect(path.search).toContain('lastRunRange%5Bkey%5D=customRange');
+      expect(path.search).toContain('lastRunRange%5Btitle%5D=100%20-%3E%20200');
       expect(path.search).toContain('tags%5B%5D=PII.Sensitive');
       expect(path.search).toContain('tier=Tier.Tier1');
       expect(path.search).toContain('dataProductFqn=marketing');
@@ -812,6 +808,36 @@ describe('DataQualityUtils', () => {
 
       expect(tagsFilter).toBeDefined();
       expect(tierFilter).toBeDefined();
+    });
+
+    it('preserves table-index filtering for legacy isTableApi callers', () => {
+      const result = buildDataQualityDashboardFilters({
+        // Keep this legacy option covered because private consumers can call
+        // the exported helper directly even though current UI code does not.
+        isTableApi: true,
+        filters: {
+          tags: ['PII.Sensitive'],
+          entityFQN: 'service.db.schema.table',
+          testCaseStatus: TestCaseStatus.Success,
+          testCaseType: TestCaseType.column,
+          startTs: 100,
+          endTs: 200,
+        },
+      });
+
+      expect(result).toEqual([
+        {
+          bool: {
+            should: [{ term: { 'tags.tagFQN': 'PII.Sensitive' } }],
+          },
+        },
+        {
+          term: {
+            'fullyQualifiedName.keyword': 'service.db.schema.table',
+          },
+        },
+        { term: { deleted: false } },
+      ]);
     });
 
     it('includes every test-case filter in the report query', () => {


### PR DESCRIPTION
### Describe your changes:

Fixes #31462

Align data quality chart queries and drill-down filters while keeping the existing healthy and unhealthy categories unchanged.

- Keep data asset health independent of the test-case status filter.
- Use explicit table-index filters so test-case-only fields are never sent to table aggregations.
- Preserve the legacy `isTableApi` filter-builder contract for private consumers.
- Apply the shared test-case filter set to dimension and no-dimension summaries.
- Preserve supported dashboard filters and the selected date range during drill-down.
- Skip hidden provider summary requests and ignore stale filter responses.
- Coalesce duplicate report requests and map batch responses by key.

This PR is UI-only. The healthy asset drill-down remains limited to Success because the current test-case list API accepts one status value; showing Success and Queued together requires multi-status API support.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

Dashboard aggregations use index-specific filter builders. Test-case summaries share one filter contract, while provider and batch orchestration prevent stale or duplicate work. The former `isTableApi` option delegates to the dedicated table builder for backward compatibility.

#
### Tests:

#### Use cases covered
- Status-filtered test-case charts keep healthy asset counts consistent.
- Table aggregations exclude test-case-only filters.
- Legacy table-mode callers continue producing table-index queries.
- All dashboard filters, including Table and Column type filters, scope chart requests correctly.
- Dimension and no-dimension charts use the same filter scope.
- Dashboard navigation preserves supported filters and selected dates.
- Stale summary responses do not overwrite newer filter results.
- Duplicate and shuffled batch responses resolve correctly.
- Shared Tag, Glossary, Domain, and Data Product dashboard consumers remain covered.

#### Unit tests
- [x] Added and updated focused React, utility, and API tests.
- 23 suites and 418 tests pass.

#### Backend integration tests
- [x] Not applicable; no backend API changes.

#### Ingestion integration tests
- [x] Not applicable; no ingestion changes.

#### Playwright (UI) tests
- [x] Existing PR Playwright run passed: 771 tests.

#### Manual testing performed
- Local verification requested before merge.

#
### UI screen recording / screenshots:

Not attached; this change corrects chart query and filter behavior without changing the visual design.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] My PR title is Fixes <issue-number>: <short explanation>.
- [x] My PR is linked to a GitHub issue via Fixes #<issue-number> above.
- [x] For JSON Schema changes: not applicable.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests and listed them above.
