### PR TITLE
Fixes #31437: Handle chart data stream teardown failures on unmount

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.test.tsx
@@ -1,0 +1,201 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { act, render } from '@testing-library/react';
+import { AxiosError } from 'axios';
+import { noop } from 'lodash';
+import { WorkflowStatus } from '../../generated/governance/workflows/workflowInstance';
+import { ServicesType } from '../../interface/service.interface';
+import {
+  setChartDataStreamConnection,
+  stopChartDataStreamConnection,
+} from '../../rest/DataInsightAPI';
+import ServiceInsightsTab from './ServiceInsightsTab';
+import { ServiceInsightsTabProps } from './ServiceInsightsTab.interface';
+
+const SESSION_ID = 'e5f4b0e1-0000-4000-8000-0000000000ff';
+
+jest.mock('../../rest/DataInsightAPI', () => ({
+  getMultiChartsPreviewByName: jest.fn().mockResolvedValue({}),
+  setChartDataStreamConnection: jest
+    .fn()
+    .mockResolvedValue({ sessionId: 'e5f4b0e1-0000-4000-8000-0000000000ff' }),
+  stopChartDataStreamConnection: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../rest/searchAPI', () => ({
+  searchQuery: jest
+    .fn()
+    .mockResolvedValue({ aggregations: { entityType: { buckets: [] } } }),
+}));
+
+jest.mock('../../rest/applicationAPI', () => ({
+  getAiAutomationRuns: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../context/WebSocketProvider/WebSocketProvider', () => ({
+  useWebSocketConnector: jest.fn().mockReturnValue({ socket: undefined }),
+}));
+
+jest.mock('../../utils/useRequiredParams', () => ({
+  useRequiredParams: jest
+    .fn()
+    .mockReturnValue({ serviceCategory: 'databaseServices' }),
+}));
+
+jest.mock('../../utils/ServiceUtilClassBase', () => ({
+  __esModule: true,
+  default: {
+    getInsightsTabWidgets: jest.fn().mockReturnValue({
+      PlatformInsightsWidget: jest.fn().mockReturnValue(null),
+      TotalDataAssetsWidget: jest.fn().mockReturnValue(null),
+      AgentsStatusWidget: jest.fn().mockReturnValue(null),
+    }),
+  },
+}));
+
+jest.mock('../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
+jest.mock('../../utils/EntityPureUtils', () => ({
+  getEntityFeedLink: jest.fn().mockReturnValue('<#E::databaseService::test>'),
+}));
+
+jest.mock('../../utils/EntityIconUtils', () => ({
+  getEntityIcon: jest.fn().mockReturnValue(null),
+}));
+
+const mockSetChartDataStreamConnection =
+  setChartDataStreamConnection as jest.Mock;
+const mockStopChartDataStreamConnection =
+  stopChartDataStreamConnection as jest.Mock;
+
+/**
+ * Builds a rejected promise that records whether the consumer attached a
+ * rejection handler. The tracker's own handler keeps Node from flagging the
+ * rejection as unhandled inside the test runner, so `isHandled` reflects only
+ * what the component under test did.
+ */
+const createTrackedRejection = (error: unknown) => {
+  const tracker = { isHandled: false };
+  const promise = Promise.reject(error);
+  const originalCatch = promise.catch.bind(promise);
+
+  originalCatch(noop);
+
+  promise.catch = (onRejected) => {
+    tracker.isHandled = true;
+
+    return originalCatch(onRejected);
+  };
+
+  return { promise, tracker };
+};
+
+const mockProps: ServiceInsightsTabProps = {
+  serviceDetails: {
+    id: 'a1b2c3d4-0000-4000-8000-00000000000a',
+    name: 'oracle-ui-test',
+    fullyQualifiedName: 'oracle-ui-test',
+  } as ServicesType,
+  workflowStatesData: {
+    mainInstanceState: { status: WorkflowStatus.Running },
+    subInstanceStates: [],
+  },
+  collateAIagentsList: [],
+  ingestionPipelines: [],
+  isIngestionPipelineLoading: false,
+  isCollateAIagentsLoading: false,
+};
+
+const renderTab = async (props?: Partial<ServiceInsightsTabProps>) => {
+  let renderResult!: ReturnType<typeof render>;
+
+  await act(async () => {
+    renderResult = render(<ServiceInsightsTab {...mockProps} {...props} />);
+  });
+
+  return renderResult;
+};
+
+describe('ServiceInsightsTab', () => {
+  it('should stop the chart data stream with the open session id on unmount', async () => {
+    const { unmount } = await renderTab();
+
+    expect(mockSetChartDataStreamConnection).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(mockStopChartDataStreamConnection).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('should handle a rejected stream teardown so unmount raises no unhandled rejection', async () => {
+    const { promise, tracker } = createTrackedRejection(
+      new AxiosError('Request failed with status code 404')
+    );
+    mockStopChartDataStreamConnection.mockReturnValueOnce(promise);
+
+    const { unmount } = await renderTab();
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(tracker.isHandled).toBe(true);
+  });
+
+  it('should handle a rejected stream handshake without an unhandled rejection', async () => {
+    // The handshake rejection is swallowed by the async callback wrapper, so it
+    // can only be observed through the process-level unhandled rejection hook,
+    // which needs real timers to flush
+    jest.useRealTimers();
+
+    const unhandledReasons: unknown[] = [];
+    const collectUnhandled = (reason: unknown) => unhandledReasons.push(reason);
+    process.on('unhandledRejection', collectUnhandled);
+
+    mockSetChartDataStreamConnection.mockRejectedValueOnce(
+      new AxiosError('Request failed with status code 404')
+    );
+
+    await renderTab();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    process.off('unhandledRejection', collectUnhandled);
+    jest.useFakeTimers();
+
+    expect(unhandledReasons).toHaveLength(0);
+  });
+
+  it('should not open or close a stream when the workflow is not running', async () => {
+    const { unmount } = await renderTab({
+      workflowStatesData: {
+        mainInstanceState: { status: WorkflowStatus.Finished },
+        subInstanceStates: [],
+      },
+    });
+
+    await act(async () => {
+      unmount();
+    });
+
+    expect(mockSetChartDataStreamConnection).not.toHaveBeenCalled();
+    expect(mockStopChartDataStreamConnection).not.toHaveBeenCalled();
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceInsights/ServiceInsightsTab.tsx
@@ -13,7 +13,7 @@
 
 import { Col, Row } from 'antd';
 import { AxiosError } from 'axios';
-import { isEmpty, isUndefined } from 'lodash';
+import { isEmpty, isUndefined, noop } from 'lodash';
 import { Bucket, ServiceTypes } from 'Models';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { SOCKET_EVENTS } from '../../constants/constants';
@@ -313,13 +313,17 @@ const ServiceInsightsTab = ({
     if (
       workflowStatesData?.mainInstanceState.status === WorkflowStatus.Running
     ) {
-      triggerSocketConnection();
+      // The stream is best-effort, widgets fall back to the polled chart data,
+      // so a failed handshake must not surface as an unhandled rejection
+      triggerSocketConnection().catch(noop);
     }
 
     return () => {
       // Stop the socket connection if it is started and set the sessionId to undefined
       if (sessionIdRef.current) {
-        stopChartDataStreamConnection(sessionIdRef.current);
+        // The server may have already reaped the session (404 on teardown), and
+        // an unmount has nobody left to report to, so swallow the failure
+        stopChartDataStreamConnection(sessionIdRef.current).catch(noop);
         sessionIdRef.current = undefined;
       }
     };


### PR DESCRIPTION
The Service Insights tab opens a chart data stream session on mount and stops it in the effect cleanup, but neither call attached a rejection handler. Stream sessions live in an in-memory map with a 10 minute lifetime, so the DELETE on unmount legitimately returns 404 once the session has expired, the server has restarted, or the request lands on a replica that never held it. With no handler, that 404 surfaced as an unhandled promise rejection and was reported to Sentry as an uncaught AxiosError.

Both the handshake and the teardown are best-effort - widgets fall back to the polled chart data, and an unmount has no user-facing surface left to report to - so swallow the rejection at both call sites.

<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->
