### PR TITLE
fix(playwright): wait for filtered search response before interacting with metric list header checkbox

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/MetricBulkImportExportEdit.spec.ts
@@ -1661,12 +1661,13 @@ test.describe('Metrics bulk import, export, and edit', () => {
   }) => {
     await redirectToHomePage(page);
     await waitForMetricsPage(page);
+
+    const searchResponse = waitForMetricsSearchResponse(page);
     await filterMetrics(page, fixtures.prefix);
+    await searchResponse;
 
     await expect(page.getByTestId('metric-name').first()).toBeVisible();
 
-    // The table is React Aria — click the visible <label slot="selection"> in
-    // the header to trigger select-all (no force needed; the label is visible).
     await page.locator('thead label[slot="selection"]').click();
 
     await expect(page.locator('.metric-list-selection-bar')).toBeVisible();
@@ -1680,7 +1681,10 @@ test.describe('Metrics bulk import, export, and edit', () => {
   }) => {
     await redirectToHomePage(page);
     await waitForMetricsPage(page);
+
+    const searchResponse = waitForMetricsSearchResponse(page);
     await filterMetrics(page, fixtures.prefix);
+    await searchResponse;
 
     await expect(page.getByTestId('metric-name').first()).toBeVisible();
 


### PR DESCRIPTION
Backport of #31444 to the 2.0 branch.

## Summary

- `filterMetrics()` triggers a 500ms debounced search. The header-checkbox tests were clicking before the filtered results settled, so React Aria saw stale/indeterminate selection state and re-selected on the second click instead of deselecting.
- Fix: await `waitForMetricsSearchResponse` before any header-checkbox interaction in both the failing test and the related select-all test.

## Test plan

- [ ] `MetricBulkImportExportEdit.spec.ts` passes consistently on the 2.0 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)