### PR TITLE
fix(e2e): handle dry-run modal in DomainDataProductsWidgets remove test (1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/LandingPageWidgets/DomainDataProductsWidgets.spec.ts
@@ -320,8 +320,23 @@ test.describe.serial('Domain and Data Product Asset Counts', () => {
       .locator(`[data-testid="table-data-card_${topicFqn}"] input`)
       .check();
 
-    const removeRes = page.waitForResponse('**/assets/remove');
+    const dryRunRes = page.waitForResponse(
+      (r) =>
+        r.url().includes('/assets/remove') &&
+        r.request().postDataJSON()?.dryRun === true
+    );
     await page.getByTestId('delete-all-button').click();
+    await dryRunRes;
+
+    const removeRes = page.waitForResponse(
+      (r) =>
+        r.url().includes('/assets/remove') &&
+        !r.request().postDataJSON()?.dryRun
+    );
+    await page
+      .getByTestId('domain-dry-run-modal')
+      .getByTestId('save-button')
+      .click();
     await removeRes;
 
     await page.reload();


### PR DESCRIPTION
## Summary

- The `Domain asset count should update when assets are removed` test in `DomainDataProductsWidgets.spec.ts` was failing on the 1.13 nightly CI run ([#31655001287](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31655001287/job/94313571811))
- Root cause: the test used a wildcard response matcher `'**/assets/remove'` which resolved immediately on the **dry-run** request. The confirmation modal was never dismissed, so the actual removal never fired, and `checkAssetsCount(page, 1)` failed because assets remained at 2.
- Fix: add the two-phase wait pattern — await the dry-run response, click the `domain-dry-run-modal` save button, then await the actual remove response — matching what the `main` branch already does.

## Test plan
- [ ] Nightly 1.13 CI run: `DomainDataProductsWidgets.spec.ts > Domain and Data Product Asset Counts > Domain asset count should update when assets are removed` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)