### PR TITLE
fix(playwright): seed activity events instead of polling the async consumer

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ActivityFeed.spec.ts
@@ -13,6 +13,7 @@
 import {
   APIRequestContext,
   expect,
+  Locator,
   Page,
   test as base,
 } from '@playwright/test';
@@ -21,7 +22,10 @@ import { DatabaseClass } from '../../support/entity/DatabaseClass';
 import { TableClass } from '../../support/entity/TableClass';
 import { PersonaClass } from '../../support/persona/PersonaClass';
 import { UserClass } from '../../support/user/UserClass';
-import { insertActivityEventForTest } from '../../utils/activityAPI';
+import {
+  FEED_ITEM_TIMEOUT,
+  insertActivityEventForTest,
+} from '../../utils/activityAPI';
 import { REACTION_EMOJIS, reactOnFeedCard } from '../../utils/activityFeed';
 import { performAdminLogin } from '../../utils/admin';
 import {
@@ -903,6 +907,11 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   let entity: TableClass;
   const conversationMessage = `Merge regression conversation ${uuid()}`;
   const conversationMessage2 = `Second regression conversation ${uuid()}`;
+  // Run-unique so the seeded change-event can be pinned by text. Matching the
+  // generic "created" header instead would also match the table's own auto
+  // "Created" event if the consumer happens to deliver it mid-run, and every
+  // worker in a shard shares one database.
+  const activityMarker = `Merge regression activity ${uuid()}`;
 
   const test = base.extend<{ adminPage: Page }>({
     adminPage: async ({ browser }, use) => {
@@ -913,9 +922,35 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
     },
   });
 
+  const openActivityFeedTab = async (page: Page) => {
+    await entity.visitEntityPage(page);
+    await page.getByTestId('activity_feed').click();
+    await waitForAllLoadersToDisappear(page);
+
+    // Scoped to #feedData throughout: the right-hand panel renders
+    // message-container for the selected item, so an unscoped match could be
+    // satisfied by the panel and would not prove both kinds share the list.
+    return page.locator('#feedData [data-testid="message-container"]');
+  };
+
+  // The list is merged from two independent fetches (/api/v1/feed and
+  // /api/v1/activity) and re-sorts — moving the auto-selection with it — as each
+  // one lands. Anything asserting on order, counts or the active item has to
+  // wait for BOTH kinds to be on screen first, or it races the slower response.
+  const waitForBothFeedKinds = async (feedList: Locator) => {
+    await expect(
+      feedList.filter({ hasText: conversationMessage }).first()
+    ).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
+    await expect(
+      feedList.filter({ hasText: activityMarker }).first()
+    ).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
+  };
+
   test.beforeAll(
     'Setup entity and seeded conversation',
     async ({ browser }) => {
+      test.slow(true);
+
       adminUser = new UserClass();
       entity = new TableClass();
 
@@ -924,6 +959,21 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
       await adminUser.create(apiContext);
       await adminUser.setAdminRole(apiContext);
       await entity.create(apiContext);
+
+      // Seed the change-event directly instead of waiting for the table's own
+      // auto "Created" event to arrive through the ActivityFeedAlert consumer.
+      // That consumer ticks on its pollInterval, drains at most batchSize
+      // change_event rows per tick, and parks on any commit-order offset gap —
+      // so on an AUT running the whole suite in parallel the backlog puts the
+      // event arbitrarily far behind and no poll timeout here can outlast it.
+      // Async delivery is the backend's contract (ActivityResourceIT); these
+      // tests are about how the merged list renders.
+      await insertActivityEventForTest(
+        apiContext,
+        entity,
+        activityMarker,
+        'EntityCreated'
+      );
 
       for (const message of [conversationMessage, conversationMessage2]) {
         await apiContext.post('/api/v1/feed', {
@@ -939,6 +989,8 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
         `<#E::table::${entity.entityResponseData.fullyQualifiedName}>`
       )}&type=Conversation&limit=25`;
 
+      // /api/v1/feed writes synchronously, so this only covers read-your-write
+      // lag on a loaded server — nothing here waits on an async pipeline.
       await expect
         .poll(
           async () => {
@@ -953,29 +1005,9 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
               messages.includes(conversationMessage2)
             );
           },
-          { timeout: 60_000, intervals: [2_000] }
+          { timeout: 30_000, intervals: [1_000] }
         )
         .toBe(true);
-
-      // Wait until the auto "Created" change-event activity is indexed into the
-      // activity stream, so the merged list deterministically contains an
-      // activity in every test (indexing is near-instant in CI but can lag on a
-      // local backend).
-      const activityUrl = `/api/v1/activity/entity/table/name/${encodeURIComponent(
-        entity.entityResponseData.fullyQualifiedName ?? ''
-      )}?days=30&limit=50`;
-
-      await expect
-        .poll(
-          async () => {
-            const response = await apiContext.get(activityUrl);
-            const data = await response.json();
-
-            return (data.data ?? []).length;
-          },
-          { timeout: 90_000, intervals: [3_000] }
-        )
-        .toBeGreaterThan(0);
 
       await afterAction();
     }
@@ -991,43 +1023,29 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   test('All tab shows BOTH the change-event activity and the conversation', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
-
-    // Scoped to #feedData throughout: the right-hand panel renders
-    // message-container for the selected item, so an unscoped match could be
-    // satisfied by the panel and would not prove both kinds share the list.
-    const feedList = adminPage.locator(
-      '#feedData [data-testid="message-container"]'
-    );
+    const feedList = await openActivityFeedTab(adminPage);
 
     // Conversation thread (from /api/v1/feed) must be visible...
     await expect(
       feedList.filter({ hasText: conversationMessage }).first()
-    ).toBeVisible({ timeout: 30_000 });
+    ).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
 
-    // ...alongside the auto "Created" change-event activity (from /api/v1/activity).
+    // ...alongside the seeded change-event activity (from /api/v1/activity).
     // On the buggy either-or code these two never render together.
     await expect(
-      feedList.filter({ hasText: /created/i }).first()
-    ).toBeVisible();
+      feedList.filter({ hasText: activityMarker }).first()
+    ).toBeVisible({ timeout: FEED_ITEM_TIMEOUT });
   });
 
   test('A change-event activity is read-only (no comment editor)', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
+    const feedList = await openActivityFeedTab(adminPage);
+    await waitForBothFeedKinds(feedList);
 
-    // Open the auto "Created …" change-event activity in the right panel.
-    // Scoped to #feedData so this is the list card, not the panel's own copy.
-    const activityCard = adminPage
-      .locator('#feedData [data-testid="message-container"]')
-      .filter({ hasText: /created/i })
-      .first();
-    await expect(activityCard).toBeVisible({ timeout: 30_000 });
+    // Open the seeded change-event activity in the right panel. Scoped to
+    // #feedData so this is the list card, not the panel's own copy.
+    const activityCard = feedList.filter({ hasText: activityMarker }).first();
     await activityCard.click();
     await waitForAllLoadersToDisappear(adminPage);
 
@@ -1043,9 +1061,7 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   test('Replying to a conversation stays isolated to that thread', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
+    const feedList = await openActivityFeedTab(adminPage);
 
     const newThreadCalls: string[] = [];
     const replyPostCalls: string[] = [];
@@ -1061,23 +1077,17 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
       }
     });
 
-    const feedList = adminPage.locator(
-      '#feedData [data-testid="message-container"]'
-    );
     const feedListCount = () => feedList.count();
 
-    // Scoped to #feedData deliberately: the right-hand panel renders
-    // message-container too, so an unscoped wait can be satisfied by the panel
-    // while the list is still empty — leaving the same 0 baseline this gate
-    // exists to prevent.
+    // Loaders disappearing does not mean the merged list has rendered, and the
+    // conversation alone is not enough either: the activity fetch lands
+    // separately and would grow the list between the baseline and the
+    // post-reply count. Both kinds have to be on screen before counting.
+    await waitForBothFeedKinds(feedList);
+
     const seededConversation = feedList
       .filter({ hasText: conversationMessage })
       .first();
-
-    // Loaders disappearing does not mean the merged list has rendered. Taking
-    // the baseline before the seeded conversation is on screen recorded a 0,
-    // which then mismatched the real count after the reply.
-    await expect(seededConversation).toBeVisible({ timeout: 30_000 });
 
     const countBeforeReply = await feedListCount();
 
@@ -1114,9 +1124,11 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   });
 
   test('Activity is NOT fetched on the Tasks tab', async ({ adminPage }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
+    const feedList = await openActivityFeedTab(adminPage);
+
+    // Switch away only once the ALL tab has fully settled, so its own activity
+    // fetch cannot still be in flight when the listener below is attached.
+    await waitForBothFeedKinds(feedList);
 
     await adminPage.getByRole('menuitem', { name: /task/i }).click();
     await waitForAllLoadersToDisappear(adminPage);
@@ -1155,26 +1167,29 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   test('All badge, header and rendered list agree on the count', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
-
-    await expect(
-      adminPage.locator('#feedData [data-testid="message-container"]').first()
-    ).toBeVisible({ timeout: 30_000 });
-
-    const renderedCount = await adminPage
-      .locator('#feedData [data-testid="message-container"]')
-      .count();
-    const allBadge = (
-      await adminPage.getByTestId('left-panel-all-count').innerText()
-    ).trim();
+    const feedList = await openActivityFeedTab(adminPage);
+    await waitForBothFeedKinds(feedList);
 
     // The "All" badge must equal the number of rendered items (conversations +
     // activity events) — not the old activity-only / double-counted value.
-    expect(Number(allBadge)).toBe(renderedCount);
+    // Polled rather than compared once because the consumer can deliver this
+    // table's own "Created" event mid-test, growing both numbers a beat apart.
+    await expect
+      .poll(
+        async () => {
+          const rendered = await feedList.count();
+          const allBadge = (
+            await adminPage.getByTestId('left-panel-all-count').innerText()
+          ).trim();
+
+          return Number(allBadge) === rendered;
+        },
+        { timeout: 15_000, intervals: [1_000] }
+      )
+      .toBe(true);
 
     // With no tasks, the entity tab header total equals the same count.
+    const renderedCount = await feedList.count();
     await expect(
       adminPage.getByRole('tab', { name: /activity feeds & tasks/i })
     ).toContainText(String(renderedCount));
@@ -1183,14 +1198,12 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
   test('Auto-selects the first (newest) item on load', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
+    const items = await openActivityFeedTab(adminPage);
 
-    const items = adminPage.locator(
-      '#feedData [data-testid="message-container"]'
-    );
-    await expect(items.first()).toBeVisible({ timeout: 30_000 });
+    // Both sources must have landed first. The merged list re-sorts as each one
+    // arrives and the auto-selection follows the new top item, so asserting the
+    // position mid-settle can catch the active card at index 1.
+    await waitForBothFeedKinds(items);
 
     // The FIRST (newest) item is the auto-selected one — deterministically,
     // regardless of whether the conversation or activity request resolved first.
@@ -1198,25 +1211,21 @@ test.describe('ActivityFeed: activity + conversation merge (regression #25894)',
     // can change which conversation is newest.)
     await expect(items.first().locator('.is-active')).toBeVisible();
     // ...and no item below it is the active one.
-    const activeCount = await adminPage
-      .locator('#feedData [data-testid="message-container"] .is-active')
-      .count();
-    expect(activeCount).toBe(1);
+    await expect(
+      adminPage.locator(
+        '#feedData [data-testid="message-container"] .is-active'
+      )
+    ).toHaveCount(1);
   });
 
   test('Reacting to an activity updates its reactions in the right panel', async ({
     adminPage,
   }) => {
-    await entity.visitEntityPage(adminPage);
-    await adminPage.getByTestId('activity_feed').click();
-    await waitForAllLoadersToDisappear(adminPage);
+    const feedList = await openActivityFeedTab(adminPage);
+    await waitForBothFeedKinds(feedList);
 
-    // Select the auto "Created …" change-event activity into the right panel.
-    const activityCard = adminPage
-      .locator('#feedData [data-testid="message-container"]')
-      .filter({ hasText: /created/i })
-      .first();
-    await expect(activityCard).toBeVisible({ timeout: 30_000 });
+    // Select the seeded change-event activity into the right panel.
+    const activityCard = feedList.filter({ hasText: activityMarker }).first();
     await activityCard.click();
     await waitForAllLoadersToDisappear(adminPage);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/activityAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/activityAPI.ts
@@ -28,6 +28,7 @@ export const THUMBS_UP_EMOJI = '👍';
 const JSON_PATCH_CONTENT_TYPE = 'application/json-patch+json';
 
 export type ActivityEventType =
+  | 'EntityCreated'
   | 'DescriptionUpdated'
   | 'OwnerUpdated'
   | 'TagsUpdated';


### PR DESCRIPTION
## Summary

The `ActivityFeed: activity + conversation merge (regression #25894)` describe fails in the nightly AUT. Its `beforeAll` waited for a freshly-created table's auto `EntityCreated` activity to show up on `/api/v1/activity`:

```ts
await expect
  .poll(async () => (await (await apiContext.get(activityUrl)).json()).data?.length,
        { timeout: 90_000, intervals: [3_000] })
  .toBeGreaterThan(0);
```

That endpoint is not written by the entity CRUD request. It is filled asynchronously by the **`ActivityFeedAlert` event subscription** draining the `change_event` table:

| Knob | Value | Source |
|---|---|---|
| `pollInterval` | 30 s | `openmetadata-service/src/main/resources/json/data/eventsubscription/ActivityFeedEvents.json` |
| `batchSize` | 100 rows per tick (schema default) | `openmetadata-spec/.../json/schema/events/eventSubscription.json` |
| gap stall | up to 30 s per commit-order gap | `AbstractEventConsumer.java` — `GAP_RESOLVE_TIMEOUT_MS`, `planCursor()` |

`planCursor()` advances only over a **contiguous** prefix of `change_event` offsets — AUTO_INCREMENT values become visible at commit, so a concurrent transaction can temporarily hide a lower offset while a higher one is readable, and the consumer parks there. Combined, throughput is capped at ~200 events/min. An AUT running the whole suite at 30+ concurrent workers generates change events far faster than that, so the backlog puts this table's `EntityCreated` minutes behind and the poll returns `0` for its entire budget. **No poll timeout can fix this.**

Two independent defects on top of that:

1. **The poll could never complete.** Its `90_000` budget exceeded the project's `60000` test timeout, which a `beforeAll` inherits — so the hook was killed at 60 s regardless. The reported error is `Test timeout of 60000ms exceeded` with `expect(received).toBeGreaterThan(expected) / Received: 0`.
2. **A failing `beforeAll` fails every test in the group**, which is why unrelated-looking tests in this describe (e.g. `Auto-selects the first (newest) item on load`) showed up in the nightly report.

## Changes

**`playwright/utils/activityAPI.ts`**
- Widen `ActivityEventType` with `'EntityCreated'`. It is already in the `activityEvent.json` enum, and `getActivityEventHeaderText()` (`FeedUtils.tsx`) already renders it as "created" — only the test-side union was missing it.

**`playwright/e2e/Features/ActivityFeed.spec.ts`**
- **Seed instead of poll.** `beforeAll` now calls `insertActivityEventForTest(apiContext, entity, activityMarker, 'EntityCreated')` → `POST /api/v1/activity/test-insert` (admin-only, synchronous insert) and the `/api/v1/activity` poll is deleted. This is the helper's documented purpose ("bypassing the async consumer… the delivery contract is covered by the backend `ActivityResourceIT`") and the same pattern the `FeedWidget on landing page` describe in this very file already uses.
- **Run-unique marker.** Every `hasText: /created/i` filter becomes `hasText: activityMarker`. Workers in a shard share one database, and the real consumer may still deliver this table's own `EntityCreated` later in the run — matching the generic header would make the target ambiguous.
- **Wait for both merged sources** before asserting on order, counts, or the active item. The list is built from two independent fetches (`/api/v1/feed` and `/api/v1/activity`) and re-sorts as each lands; `ActivityFeedListV1New`'s auto-select follows the new top item, so asserting position mid-settle could catch the active card at index 1. New `waitForBothFeedKinds()` helper, applied in every test that reads order or counts — this is the second half of the `Auto-selects the first (newest) item on load` fix and also closes a latent flake in the reply-isolation baseline count.
- **`test.slow(true)`** on the hook (matching the existing `beforeAll` at the top of this file); the conversation poll drops `60_000` → `30_000` since `/api/v1/feed` writes synchronously and only read-your-write lag is in play.
- **Count agreement** now polls badge-vs-rendered instead of comparing once, so a mid-test delivery from the real consumer that grows both numbers a beat apart cannot fail it.
- `activeCount` uses web-first `toHaveCount(1)` instead of `count()` + `expect()`, per `.claude/rules/frontend-playwright.md`.
- Extracted `openActivityFeedTab()` to remove the visit/click/loader triplet repeated in all 7 tests.

## Why this is backlog-immune

Every assertion now matches `activityMarker`, a run-unique string that exists on exactly one row — the one inserted synchronously via `/api/v1/activity/test-insert`. Verified the read path finds it: `ActivityStreamRepository.toRow()` keys on `event.getEntity().getId()`, and `ActivityResource.getEntityActivityByFqn()` resolves the FQN to that same entity id before calling `listByEntity()`. Nothing in the describe reads anything the `ActivityFeedAlert` consumer produces.

## Test plan

- [x] `yarn lint:playwright` — zero findings in both changed files
- [x] `yarn tsc:playwright` — zero errors in both changed files (pre-existing errors elsewhere in `playwright/utils/**` are untouched)
- [x] `prettier --check` clean
- [x] Ran the full describe against a local server — **7 passed (21.2 s)**, including both nightly failures (`All tab shows BOTH the change-event activity and the conversation`, `Auto-selects the first (newest) item on load`):

  ```
  npx playwright test playwright/e2e/Features/ActivityFeed.spec.ts \
    --project=chromium --no-deps -g "regression #25894" --workers=1
  ```

  A pass proves the seeded row was found and rendered (the marker exists nowhere else), that `EntityCreated` renders through `getActivityEventHeaderText`, and that the `waitForBothFeedKinds` refactor did not regress the other five tests.

- [ ] Nightly run confirms the describe is stable under real AUT concurrency — the backlog condition cannot be reproduced on an idle local server, so that is the remaining signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
