### PR TITLE
fix(e2e): stabilize domain/data-product widget count verification in DomainDataProductsWidgets

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
@@ -183,12 +183,11 @@ export const navigateToCustomizeLandingPage = async (
   await waitForAllLoadersToDisappear(page);
 
   // Navigate to the customize landing page
-  await page.getByRole('tab', { name: 'Customize UI' }).click();
-
   const getCustomPageDataResponse = page.waitForResponse(
     `/api/v1/docStore/name/persona.${encodeURIComponent(personaName)}`
   );
 
+  await page.getByRole('tab', { name: 'Customize UI' }).click();
   await page.getByTestId('LandingPage').click();
   await getCustomPageDataResponse;
   await waitForAllLoadersToDisappear(page);
@@ -751,6 +750,10 @@ export const verifyDomainCountInDomainWidget = async (
   await expect
     .poll(
       async () => {
+        await page.reload();
+        await removeLandingBanner(page).catch(() => undefined);
+        await waitForAllLoadersToDisappear(page).catch(() => undefined);
+
         if (
           !(await isLandingPageWidgetVisible(page, 'KnowledgePanel.Domains'))
         ) {
@@ -773,7 +776,7 @@ export const verifyDomainCountInDomainWidget = async (
 
         return text?.trim() ?? null;
       },
-      { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }
+      { timeout: 60_000, intervals: [5_000] }
     )
     .toContain(expectedCount.toString());
 };
@@ -791,6 +794,10 @@ export const verifyDataProductCountInDataProductWidget = async (
   await expect
     .poll(
       async () => {
+        await page.reload();
+        await removeLandingBanner(page).catch(() => undefined);
+        await waitForAllLoadersToDisappear(page).catch(() => undefined);
+
         if (
           !(await isLandingPageWidgetVisible(
             page,
@@ -818,7 +825,7 @@ export const verifyDataProductCountInDataProductWidget = async (
 
         return text?.trim() ?? null;
       },
-      { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }
+      { timeout: 60_000, intervals: [5_000] }
     )
     .toContain(expectedCount.toString());
 };


### PR DESCRIPTION
## Summary

Two bugs in `customizeLandingPage.ts` that cause `DomainDataProductsWidgets.spec.ts` to fail on the nightly 1.13 AUT run ([#31655001287](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31655001287/job/94313571811)):

**Bug 1 — `navigateToCustomizeLandingPage`: `waitForResponse` registered after the trigger action**

The "Customize UI" tab click at line 186 can itself fire the `docStore` API response. `waitForResponse` was registered afterward (line 188 previously), so fast responses were missed — the function would hang waiting for a response that already arrived. Test timed out after 9 minutes with `"Target page, context or browser has been closed"`.

Fix: register `waitForResponse` **before** either click, so no response can arrive before the listener is set up.

**Bug 2 — `verifyDomainCountIn*Widget`: poll never reloads the page**

Domain/data-product asset counts propagate asynchronously after mutations (search-index lag). The poll re-checked the same DOM state on every iteration, always seeing stale data and returning `null` until the 60-second timeout exhausted.

Fix: add `page.reload()` at the start of each poll iteration to force the widget to re-fetch live counts from the server. Interval increased to 5 s since each iteration now includes a full page load.

## Test plan
- [ ] Nightly AUT `DomainDataProductsWidgets.spec.ts > Assign Widgets` passes without 9-minute hang
- [ ] `Domain asset count should update when assets are removed` passes (widget count updates within poll)
- [ ] `Data Product asset count should update when assets are removed` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)