### PR TITLE
fix(e2e): stabilize domain/data-product widget count verification (1.13)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customizeLandingPage.ts
@@ -139,12 +139,11 @@ export const navigateToCustomizeLandingPage = async (
   await waitForAllLoadersToDisappear(page);
 
   // Navigate to the customize landing page
-  await page.getByRole('tab', { name: 'Customize UI' }).click();
-
   const getCustomPageDataResponse = page.waitForResponse(
     `/api/v1/docStore/name/persona.${encodeURIComponent(personaName)}`
   );
 
+  await page.getByRole('tab', { name: 'Customize UI' }).click();
   await page.getByTestId('LandingPage').click();
   await getCustomPageDataResponse;
   await waitForAllLoadersToDisappear(page);
@@ -636,6 +635,10 @@ export const verifyDomainCountInDomainWidget = async (
   await expect
     .poll(
       async () => {
+        await page.reload();
+        await removeLandingBanner(page).catch(() => undefined);
+        await waitForAllLoadersToDisappear(page).catch(() => undefined);
+
         const domainWidget = page.getByTestId('KnowledgePanel.Domains');
         await domainWidget.scrollIntoViewIfNeeded().catch(() => undefined);
         const isWidgetVisible = await domainWidget
@@ -657,7 +660,7 @@ export const verifyDomainCountInDomainWidget = async (
 
         return text?.trim() ?? null;
       },
-      { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }
+      { timeout: 60_000, intervals: [5_000] }
     )
     .toContain(expectedCount.toString());
 };
@@ -675,6 +678,10 @@ export const verifyDataProductCountInDataProductWidget = async (
   await expect
     .poll(
       async () => {
+        await page.reload();
+        await removeLandingBanner(page).catch(() => undefined);
+        await waitForAllLoadersToDisappear(page).catch(() => undefined);
+
         const dataProductWidget = page.getByTestId(
           'KnowledgePanel.DataProducts'
         );
@@ -698,7 +705,7 @@ export const verifyDataProductCountInDataProductWidget = async (
 
         return text?.trim() ?? null;
       },
-      { timeout: 60_000, intervals: [1_000, 2_000, 5_000] }
+      { timeout: 60_000, intervals: [5_000] }
     )
     .toContain(expectedCount.toString());
 };


### PR DESCRIPTION
## Summary

Backport of #31476 to 1.13. Two bugs in `customizeLandingPage.ts` causing `DomainDataProductsWidgets.spec.ts` to fail on the 1.13 nightly AUT run ([#31655001287](https://github.com/open-metadata/openmetadata-nightly/actions/runs/31655001287/job/94313571811)):

**Bug 1 — `navigateToCustomizeLandingPage`: `waitForResponse` registered after the trigger action**

The "Customize UI" tab click can itself fire the `docStore` API response. `waitForResponse` was registered afterward, so fast responses were missed — the function hung waiting for a response that already arrived, causing `"Target page, context or browser has been closed"` after the 9-minute test timeout.

Fix: register `waitForResponse` **before** either click.

**Bug 2 — `verifyDomainCountIn*Widget`: poll never reloads the page**

Domain/data-product asset counts propagate asynchronously after mutations. The poll re-checked the same stale DOM on every iteration, always returning `null` until the 60-second timeout exhausted.

Fix: add `page.reload()` at the start of each poll iteration to force the widget to re-fetch live counts from the server.

> Note: PR #31473 (dry-run modal fix on 1.13) is incorrect — the actual failure is not at `checkAssetsCount` but at `verifyDomainCountInDomainWidget`, and 1.13 backend has no dry-run flow. That PR should be closed.

## Test plan
- [ ] Nightly 1.13 AUT `DomainDataProductsWidgets.spec.ts > Assign Widgets` passes without 9-minute hang
- [ ] `Domain asset count should update when assets are removed` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)