### PR TITLE
Fixes #31479: check the dialect, not the inspector, before extracting owners

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/database_service.py
+++ b/ingestion/src/metadata/ingestion/source/database/database_service.py
@@ -725,7 +725,10 @@ class DatabaseServiceSource(TopologyRunnerMixin, Source, ABC):  # pylint: disabl
                 if owner_ref and owner_ref.root:
                     return owner_ref
 
-            if self.source_config.includeOwners and hasattr(self.inspector, "get_table_owner"):
+            # The Postgres source patches `get_table_owner` onto SQLAlchemy's global
+            # `Inspector` class, so probing the inspector reports True on every
+            # connector. Only the dialect carries a real implementation.
+            if self.source_config.includeOwners and hasattr(self.inspector.dialect, "get_table_owner"):
                 owner_name = self.inspector.get_table_owner(
                     connection=self.connection,  # pylint: disable=no-member
                     table_name=table_name,

--- a/ingestion/tests/unit/topology/database/test_database_service_owner.py
+++ b/ingestion/tests/unit/topology/database/test_database_service_owner.py
@@ -1,0 +1,93 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for DatabaseServiceSource.get_owner_ref source-owner extraction.
+
+The Postgres source monkeypatches ``Inspector.get_table_owner`` onto SQLAlchemy's
+global ``Inspector`` class, and importing anything under ``metadata`` pulls that
+module in. Probing the inspector for the method therefore always succeeds, on
+every connector, so these tests exercise the guard with real SQLAlchemy dialects
+rather than mocks.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.mssql.pyodbc import MSDialect_pyodbc
+from sqlalchemy.dialects.mysql.pymysql import MySQLDialect_pymysql
+from sqlalchemy.dialects.oracle.cx_oracle import OracleDialect_cx_oracle
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+from sqlalchemy.engine.reflection import Inspector
+
+import metadata.ingestion.source.database.postgres.metadata  # noqa: F401  (applies the global patch)
+from metadata.generated.schema.metadataIngestion.databaseServiceMetadataPipeline import (
+    DatabaseServiceMetadataPipeline,
+)
+from metadata.ingestion.source.database.database_service import DatabaseServiceSource
+
+NON_POSTGRES_DIALECTS = [
+    MySQLDialect_pymysql,
+    MSDialect_pyodbc,
+    OracleDialect_cx_oracle,
+]
+
+
+def make_source(dialect_class, include_owners=True):
+    """Build the minimal object graph get_owner_ref touches, with a real dialect."""
+    inspector = Inspector.__new__(Inspector)
+    inspector.dialect = dialect_class()
+    inspector.get_table_owner = MagicMock(return_value="alice")
+
+    source = MagicMock()
+    source.inspector = inspector
+    source.source_config = DatabaseServiceMetadataPipeline(includeOwners=include_owners)
+    source.get_owner_ref = DatabaseServiceSource.get_owner_ref.__get__(source)
+    return source
+
+
+def test_global_inspector_patch_makes_the_inspector_probe_useless():
+    """Guards the premise of the tests below: every dialect looks capable."""
+    for dialect_class in NON_POSTGRES_DIALECTS:
+        inspector = Inspector.__new__(Inspector)
+        inspector.dialect = dialect_class()
+        assert hasattr(inspector, "get_table_owner")
+        assert not hasattr(inspector.dialect, "get_table_owner")
+
+
+@pytest.mark.parametrize("dialect_class", NON_POSTGRES_DIALECTS, ids=lambda d: d.__name__)
+def test_owner_extraction_is_skipped_when_the_dialect_cannot_do_it(dialect_class, caplog):
+    source = make_source(dialect_class)
+
+    with caplog.at_level(logging.WARNING):
+        assert source.get_owner_ref(table_name="customers") is None
+
+    assert "Error processing owner" not in caplog.text
+    source.inspector.get_table_owner.assert_not_called()
+    source.metadata.get_reference_by_name.assert_not_called()
+
+
+def test_owner_extraction_still_runs_on_a_dialect_that_implements_it():
+    source = make_source(PGDialect_psycopg2)
+
+    owner_ref = source.get_owner_ref(table_name="customers")
+
+    source.inspector.get_table_owner.assert_called_once()
+    source.metadata.get_reference_by_name.assert_called_once_with(name="alice", is_owner=True)
+    assert owner_ref is source.metadata.get_reference_by_name.return_value
+
+
+def test_owner_extraction_is_skipped_when_include_owners_is_off():
+    source = make_source(PGDialect_psycopg2, include_owners=False)
+
+    assert source.get_owner_ref(table_name="customers") is None
+    source.inspector.get_table_owner.assert_not_called()


### PR DESCRIPTION
### Describe your changes:

Fixes #31479

I worked on the `includeOwners` guard in `DatabaseServiceSource.get_owner_ref` because it never rejected anything: `postgres/metadata.py:121` assigns `get_table_owner` onto SQLAlchemy's **global** `Inspector` class, and `metadata/__init__.py` transitively imports that module on every run, so `hasattr(self.inspector, "get_table_owner")` was `True` on every connector. `get_etable_owner` then delegates to `self.dialect.get_table_owner`, which only `PGDialect` defines — so the guard passed and the call raised `AttributeError: 'MySQLDialect_pymysql' object has no attribute 'get_table_owner'` once per table *and* per view, on every run, for every non-Postgres SQLAlchemy connector. The fix probes the dialect, which is where a real implementation lives.

No owner data changes anywhere: `get_etable_owner` dereferences the dialect attribute before doing anything else, so a dialect lacking it could never have returned an owner. What goes away is a guaranteed per-table failure — the warning plus an eagerly-evaluated `traceback.format_exc()` for each table (the argument is built regardless of log level).

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change (one guard condition + a regression test).

#
### Tests:

#### Use cases covered
- MySQL Metadata ingestion with `includeOwners: true` skips source-owner extraction silently instead of logging `Error processing owner for table <name>` for every table and view. MySQL has no per-table owner concept, so a clean skip is the correct outcome.
- Same for `mssql+pyodbc`/`+pymssql`/`+pytds`, `oracle+cx_oracle`, `awsathena+rest`, `clickhouse+http`/`+native`, `hive+http`/`+https`, `exa+websocket`, `sqlite+pysqlite`, `db2+ibm_db`, `pinot+http`/`+https`.
- Postgres, Redshift, CockroachDB, PGSpider, Vertica and Timescale (PG-derived dialects that really implement the method) continue to extract owners unchanged.
- Snowflake, Databricks and Unity Catalog override `get_owner_ref` and never reach this code.

#### Unit tests
- [x] I added unit tests for the changed logic.
- File added: `ingestion/tests/unit/topology/database/test_database_service_owner.py` (6 tests).
- These use **real SQLAlchemy dialect instances** on a real `Inspector`, not mocks — a `MagicMock` inspector satisfies any `hasattr` probe, so a mock-based test would pass against the broken code. One test pins that premise explicitly.
- Verified RED before the fix (3 failures — the guard let the call through on MySQL, MSSQL and Oracle) and green after: `6 passed`.
- Coverage: the changed line and the whole owner-extraction branch (`database_service.py:731-738`) are covered, with both outcomes of the new guard exercised. Module-level coverage reads 4% because `database_service.py` is 286 statements and this PR touches one line; the pre-existing `ownerConfig` branch is untouched and remains uncovered.
- Regression run: `tests/unit/topology/database` → `909 passed, 6 skipped`. The remaining failures/errors in that directory are pre-existing missing optional dialects in my venv (`sqlalchemy_redshift`, `sqlalchemy.dialects:databricks`, salesforce) and do not touch `get_owner_ref`.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- Not added. The bug is a pure capability-probe defect with no source interaction, and reproducing it needs only a dialect object — covered by the unit tests above.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
1. Reproduced the exact logged error string in a clean interpreter against real dialects, no MySQL server involved:
   ```
   guard hasattr(Inspector,"get_table_owner"): True
     MySQLDialect_pymysql       dialect.get_table_owner -> False
     PGDialect_psycopg2         dialect.get_table_owner -> True
     MSDialect_pyodbc           dialect.get_table_owner -> False
     OracleDialect_cx_oracle    dialect.get_table_owner -> False
   reproduced: "'MySQLDialect_pymysql' object has no attribute 'get_table_owner'"
   ```
2. Confirmed the import leak: `hasattr(Inspector, "get_table_owner")` is `False` in a bare interpreter and `True` after importing `mysql.service_spec` alone; traced the chain to `metadata/__init__.py` → … → `timescale/metadata` → `postgres.metadata`.
3. Enumerated every `scheme` in the generated connection models against SQLAlchemy's dialect registry to classify affected vs. unaffected connectors (lists in the "Use cases" section).
4. `ruff format --check` and `ruff check` clean on both files.

Not yet done: a live MySQL ingestion run with `includeOwners: true` on a full stack to observe the logs before/after. Worth doing during 2.0 connector testing, though the unit tests exercise both guard outcomes directly.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #31479` above.
- [x] I have commented on my code, particularly in hard-to-understand areas (the guard carries a comment explaining the global monkeypatch, since the condition looks redundant otherwise).
- [x] For JSON Schema changes: not applicable — no schema changes.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.
- [x] I have added a test that covers the exact scenario we are fixing.

#
### Follow-up not in this PR

The global `Inspector.get_table_owner` monkeypatch in `postgres/metadata.py:121` is still there. Scoping it to Postgres is the deeper cleanup, but the same `Inspector.get_all_table_ddls` / `get_table_ddl` pattern is used by several connectors including MySQL, so it deserves its own change; it is harmless now that the guard no longer trusts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)