### PR TITLE
fix(ci): default ANTLR download to Google's Central mirror to dodge repo1 429s (2.0.0-rc2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,12 @@ ANTLR_VERSION_RE := $(subst .,\.,$(ANTLR_VERSION))
 # runtimes will reject.
 #
 # For step 3, override ANTLR_MAVEN_BASE to pull from an internal Maven mirror
-# instead of Central. The fallback base is tried if the primary is unreachable,
-# so the default (both = Central) stays correct everywhere else.
-ANTLR_MAVEN_BASE ?= https://repo1.maven.org/maven2
+# instead of Central. The default primary is Google's Central mirror, which is
+# CDN-backed and not subject to repo1's per-IP 429 throttling that breaks
+# multi-arch Docker publishes; repo1 stays as the fallback if the mirror is
+# unreachable. The pinned SHA-256 below verifies whatever is fetched, so the
+# source is swappable without lowering trust.
+ANTLR_MAVEN_BASE ?= https://maven-central.storage-download.googleapis.com/maven2
 ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
 ANTLR_COMPLETE_JAR_PATH := org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
 ANTLR_COMPLETE_JAR_URL := $(ANTLR_MAVEN_BASE)/$(ANTLR_COMPLETE_JAR_PATH)


### PR DESCRIPTION
**Targets `2.0.0-rc2` directly to unblock the release.** Forward-ports to `2.0` and `main` are in separate PRs.

## Problem

The **Publish Local Ingestion Webserver** build fails at `make install_antlr_cli`, on both arches, with the ANTLR jar download rejected by Maven Central:

```
curl: (22) The requested URL returned error: 429
ANTLR 4.9.2 download failed from https://repo1.maven.org/maven2/org/antlr/antlr4/4.9.2/antlr4-4.9.2-complete.jar (attempt 3)
Failed to download a valid ANTLR 4.9.2 CLI after 3 attempts
make: *** [Makefile:102: install_antlr_cli] Error 1
```

`429 = Too Many Requests`. `repo1.maven.org` rate-limits by **egress IP over a sliding window**, and our shared CI/Docker-build egress IP crosses that threshold. The multi-arch publish (amd64 + arm64) doubles the concurrent pulls and the in-recipe retries add more requests into the same window, so all attempts 429. This is unrelated to #30695 (that fixed the post-download `jar` validation); here the download itself is refused before validation is ever reached.

Retrying does not fix it deterministically — the limit depends on external traffic on the shared IP, and both `ANTLR_MAVEN_BASE` and `ANTLR_MAVEN_FALLBACK_BASE` pointed at the same `repo1` host (deduped in the recipe), so the fallback retried the throttled endpoint.

## Fix

Default the primary download to **Google’s Central mirror** (GCS-backed, separate infra, not subject to repo1’s per-IP throttle); keep `repo1` as a genuine fallback.

```make
ANTLR_MAVEN_BASE          ?= https://maven-central.storage-download.googleapis.com/maven2
ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
```

- Verified the mirror returns HTTP 200 and the jar’s SHA-256 is **byte-identical** to the pinned `bb117b14…137cd`, so the checksum gate still guards integrity — source swapped, trust unchanged.
- `?=` preserved, so internal Nexus/Artifactory overrides still work.

## Test

- `curl` + `shasum -a 256` against the Google mirror → `200`, SHA matches the pinned value.
- Compared `repo1`, `repo.maven.apache.org`, Google mirror, and `antlr.org` — all byte-identical; `repo.maven.apache.org` shares repo1’s backend (same throttle), Google mirror is independent.
- After merge, re-trigger **Publish Local Ingestion Webserver** on `2.0.0-rc2`.