### PR TITLE
fix(ci): default ANTLR download to Google's Central mirror to dodge repo1 429s (2.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,12 @@ ANTLR_VERSION_RE := $(subst .,\.,$(ANTLR_VERSION))
 # runtimes will reject.
 #
 # For step 3, override ANTLR_MAVEN_BASE to pull from an internal Maven mirror
-# instead of Central. The fallback base is tried if the primary is unreachable,
-# so the default (both = Central) stays correct everywhere else.
-ANTLR_MAVEN_BASE ?= https://repo1.maven.org/maven2
+# instead of Central. The default primary is Google's Central mirror, which is
+# CDN-backed and not subject to repo1's per-IP 429 throttling that breaks
+# multi-arch Docker publishes; repo1 stays as the fallback if the mirror is
+# unreachable. The pinned SHA-256 below verifies whatever is fetched, so the
+# source is swappable without lowering trust.
+ANTLR_MAVEN_BASE ?= https://maven-central.storage-download.googleapis.com/maven2
 ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
 ANTLR_COMPLETE_JAR_PATH := org/antlr/antlr4/$(ANTLR_VERSION)/antlr4-$(ANTLR_VERSION)-complete.jar
 ANTLR_COMPLETE_JAR_URL := $(ANTLR_MAVEN_BASE)/$(ANTLR_COMPLETE_JAR_PATH)


### PR DESCRIPTION
Forward-port of the ANTLR 429 mirror fix (rc2: #31485) so the mirror default survives the rc2 → GA branch-cut and future releases.

## Problem

`make install_antlr_cli` downloads the pinned ANTLR jar from `repo1.maven.org`, which rate-limits by egress IP:

```
curl: (22) The requested URL returned error: 429
Failed to download a valid ANTLR 4.9.2 CLI after 3 attempts
```

Our shared CI/Docker-build egress IP crosses Maven Central’s per-IP threshold (amplified by the multi-arch amd64+arm64 publish and the in-recipe retries). Both `ANTLR_MAVEN_BASE` and `ANTLR_MAVEN_FALLBACK_BASE` pointed at the same `repo1` host, so the fallback retried the throttled endpoint. Unrelated to #30695 (which fixed the post-download `jar` validation) — here the download itself is refused.

## Fix

Default the primary download to **Google’s Central mirror** (separate infra, not throttled like repo1); keep `repo1` as a real fallback.

```make
ANTLR_MAVEN_BASE          ?= https://maven-central.storage-download.googleapis.com/maven2
ANTLR_MAVEN_FALLBACK_BASE ?= https://repo1.maven.org/maven2
```

- Mirror verified HTTP 200 and **byte-identical** to the pinned SHA-256 `bb117b14…137cd`, so the checksum gate still guards integrity.
- `?=` preserved → internal Nexus/Artifactory overrides still work.