### PR TITLE
fix(ui): reliably surface and auto-open CSV jobs in the background tray

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
@@ -296,7 +296,6 @@ test.describe('CsvJobsTray', () => {
       { ...RUNNING_EXPORT_JOB, status: 'COMPLETED', progress: 18 },
     ]);
 
-
     await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible({
       timeout: 30_000,
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/CsvJobsTray.spec.ts
@@ -282,4 +282,24 @@ test.describe('CsvJobsTray', () => {
     });
     await expect(page.getByRole('button', { name: /download/i })).toBeVisible();
   });
+
+  test('auto-opens the tray for download when the poll completes it, minimised and multi-pod', async ({
+    page,
+  }) => {
+    await mockJobsApi(page, [RUNNING_EXPORT_JOB]);
+    await activateJobsTray(page);
+
+    await expect(page.locator('.csv-jobs-tray-launcher')).toBeVisible();
+    await expect(page.locator('.csv-jobs-tray-popover')).not.toBeVisible();
+
+    await mockJobsApi(page, [
+      { ...RUNNING_EXPORT_JOB, status: 'COMPLETED', progress: 18 },
+    ]);
+
+
+    await expect(page.locator('.csv-jobs-tray-popover')).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(page.getByRole('button', { name: /download/i })).toBeVisible();
+  });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Entity/EntityExportModalProvider/EntityExportModalProvider.component.tsx
@@ -38,7 +38,10 @@ import { getCurrentISODate } from '../../../utils/date-time/DateTimeUtils';
 import { isBulkEditRoute } from '../../../utils/EntityBulkEdit/EntityBulkEditUtils';
 import { downloadFile } from '../../../utils/Export/ExportUtils';
 import { showErrorToast } from '../../../utils/ToastUtils';
-import { CSV_JOBS_REFRESH_EVENT } from '../../common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
+import {
+  CSV_JOBS_REFRESH_EVENT,
+  markCsvJobOwned,
+} from '../../common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
 import {
   CSVExportJob,
   CSVExportWebsocketResponse,
@@ -665,6 +668,9 @@ export const EntityExportModalProvider = ({
       if (isString(result)) {
         downloadFile(result, `${data.name}_${getCurrentISODate()}.csv`);
       } else {
+        // Claim the just-started job so the tray always surfaces it, even if it
+        // finishes before the tray's first fetch.
+        markCsvJobOwned((result as { jobId?: string })?.jobId);
         window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
       }
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ExploreV1/ExploreV1.component.tsx
@@ -69,7 +69,10 @@ import {
 import searchClassBase from '../../utils/SearchClassBase';
 import { showSuccessToast } from '../../utils/ToastUtils';
 import withSuspenseFallback from '../AppRouter/withSuspenseFallback';
-import { CSV_JOBS_REFRESH_EVENT } from '../common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
+import {
+  CSV_JOBS_REFRESH_EVENT,
+  markCsvJobOwned,
+} from '../common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
 import FilterErrorPlaceHolder from '../common/ErrorWithPlaceholder/FilterErrorPlaceHolder';
 import Loader from '../common/Loader/Loader';
 import ResizableLeftPanels from '../common/ResizablePanels/ResizableLeftPanels';
@@ -320,7 +323,10 @@ const ExploreV1: React.FC<ExploreProps> = ({
     try {
       // The export runs as a background job; the Background jobs tray surfaces
       // progress and the Download action once it completes.
-      await exportSearchResultsAsync(params);
+      const exportJob = await exportSearchResultsAsync(params);
+      // Claim the just-started job so the tray always surfaces it, even if it
+      // finishes before the tray's first fetch.
+      markCsvJobOwned(exportJob?.jobId);
       window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
       showSuccessToast(t('message.search-export-job-started'));
       setShowExportScopeModal(false);

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
@@ -26,7 +26,10 @@ import {
   getCsvAsyncJobs,
 } from '../../../../rest/csvAPI';
 import { CsvJobsTray } from './CsvJobsTray.component';
-import { CSV_JOBS_REFRESH_EVENT } from './CsvJobsTray.constants';
+import {
+  CSV_JOBS_REFRESH_EVENT,
+  markCsvJobOwned,
+} from './CsvJobsTray.constants';
 
 jest.mock('@openmetadata/ui-core-components', () => ({
   Button: jest
@@ -130,6 +133,163 @@ describe('CsvJobsTray', () => {
 
     expect(
       screen.queryByText('label.background-job-plural')
+    ).not.toBeInTheDocument();
+  });
+
+  // A fast export can finish before the tray's first fetch resolves, so the job
+  // is already terminal on that fetch and would otherwise be hidden as "stale".
+  // Because the user just started it (it is marked owned), it must be surfaced
+  // and the tray must auto-open for the download.
+  it('surfaces an owned job that is already terminal on the initial fetch', async () => {
+    markCsvJobOwned('owned-fast-job');
+
+    mockGetCsvAsyncJobs.mockResolvedValue([
+      createJob({ jobId: 'owned-fast-job', status: 'COMPLETED' }),
+    ]);
+
+    await renderComponent();
+
+    await waitFor(() => expect(mockGetCsvAsyncJobs).toHaveBeenCalledTimes(1));
+
+    expect(
+      await screen.findByText('label.background-job-plural')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('label.exported-entity-plural')
+    ).toBeInTheDocument();
+  });
+
+  // Regression: after Clear completed the tray must collapse, a freshly started
+  // job must not reuse the old open state and pop the popover while still
+  // running, and the tray must auto-open again once that job finishes — instead
+  // of leaving the user stuck on the "N running" launcher.
+  it('collapses on clear and re-opens only when the next job finishes', async () => {
+    mockGetCsvAsyncJobs
+      .mockResolvedValueOnce([
+        createJob({
+          jobId: 'job-a',
+          progress: 20,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ])
+      .mockResolvedValueOnce([
+        createJob({ jobId: 'job-a', status: 'COMPLETED' }),
+      ])
+      .mockResolvedValueOnce([
+        createJob({ jobId: 'job-a', status: 'COMPLETED' }),
+        createJob({
+          jobId: 'job-b',
+          progress: 10,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ])
+      .mockResolvedValue([
+        createJob({ jobId: 'job-a', status: 'COMPLETED' }),
+        createJob({ jobId: 'job-b', status: 'COMPLETED' }),
+      ]);
+
+    await renderComponent();
+
+    // Job A finishes -> tray auto-opens.
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      await screen.findByText('label.background-job-plural')
+    ).toBeInTheDocument();
+
+    // Clear completed empties the tray -> it collapses.
+    fireEvent.click(screen.getByText('label.clear-completed'));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('label.background-job-plural')
+      ).not.toBeInTheDocument()
+    );
+
+    // A newly started job must surface as the launcher, not reopen the popover.
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      await screen.findByText('label.count-jobs-running')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('label.background-job-plural')
+    ).not.toBeInTheDocument();
+
+    // Once it finishes, the tray auto-opens even though it was minimised.
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      await screen.findByText('label.background-job-plural')
+    ).toBeInTheDocument();
+  });
+
+  // Many sources fetch concurrently (mount, refresh event, sockets, poll). A
+  // slow older fetch resolving after a newer one must not overwrite the fresher
+  // state and flip a completed job back to running.
+  it('ignores a stale fetch that resolves after a newer one', async () => {
+    let resolveSlow: (jobs: CsvAsyncJob[]) => void = () => undefined;
+    let resolveFast: (jobs: CsvAsyncJob[]) => void = () => undefined;
+
+    mockGetCsvAsyncJobs
+      .mockResolvedValueOnce([
+        createJob({
+          jobId: 'job-1',
+          progress: 20,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ])
+      .mockImplementationOnce(
+        () =>
+          new Promise<CsvAsyncJob[]>((resolve) => {
+            resolveSlow = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<CsvAsyncJob[]>((resolve) => {
+            resolveFast = resolve;
+          })
+      );
+
+    await renderComponent();
+
+    // Two concurrent refreshes: the second (newer) fetch is the one that wins.
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    await act(async () => {
+      resolveFast([createJob({ jobId: 'job-1', status: 'COMPLETED' })]);
+    });
+
+    // Older fetch resolves later with the stale RUNNING snapshot — ignored.
+    await act(async () => {
+      resolveSlow([
+        createJob({
+          jobId: 'job-1',
+          progress: 20,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ]);
+    });
+
+    expect(
+      await screen.findByText('label.exported-entity-plural')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('label.count-jobs-running')
     ).not.toBeInTheDocument();
   });
 
@@ -294,6 +454,46 @@ describe('CsvJobsTray', () => {
     });
 
     expect(mockGetCsvAsyncJobs).toHaveBeenCalledTimes(callsAfterCompletion);
+  });
+
+  it('auto-opens an owned export for download via polling alone on multi-pod', async () => {
+    const multipodExportJobId = 'multipod-export-job';
+    markCsvJobOwned(multipodExportJobId);
+
+    mockGetCsvAsyncJobs
+      .mockResolvedValueOnce([
+        createJob({
+          jobId: multipodExportJobId,
+          progress: 20,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ])
+      .mockResolvedValue([
+        createJob({ jobId: multipodExportJobId, status: 'COMPLETED' }),
+      ]);
+
+    await act(async () => {
+      render(<CsvJobsTray />);
+    });
+
+    expect(
+      await screen.findByText('label.count-jobs-running')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'label.download' })
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'label.download' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('label.exported-entity-plural')
+    ).toBeInTheDocument();
   });
 
   // The poll is self-scheduling rather than a fixed interval, so a response

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.test.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../../rest/csvAPI';
 import { CsvJobsTray } from './CsvJobsTray.component';
 import {
+  CSV_JOBS_POST_ACTION_REFRESH_MS,
   CSV_JOBS_REFRESH_EVENT,
   markCsvJobOwned,
 } from './CsvJobsTray.constants';
@@ -493,6 +494,91 @@ describe('CsvJobsTray', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText('label.exported-entity-plural')
+    ).toBeInTheDocument();
+  });
+
+  it('fires a follow-up fetch after a refresh event to catch a late-registering job', async () => {
+    mockGetCsvAsyncJobs
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([
+        createJob({
+          jobId: 'late-job',
+          progress: 10,
+          result: undefined,
+          status: 'RUNNING',
+        }),
+      ]);
+
+    await renderComponent();
+
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      screen.queryByText('label.count-jobs-running')
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(CSV_JOBS_POST_ACTION_REFRESH_MS);
+    });
+
+    expect(
+      await screen.findByText('label.count-jobs-running')
+    ).toBeInTheDocument();
+  });
+
+  it('stays closed after the user minimises an auto-opened job', async () => {
+    markCsvJobOwned('minimise-job');
+    mockGetCsvAsyncJobs.mockResolvedValue([
+      createJob({ jobId: 'minimise-job', status: 'COMPLETED' }),
+    ]);
+
+    await renderComponent();
+
+    expect(
+      await screen.findByRole('button', { name: 'label.download' })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      document.querySelector('.csv-jobs-tray-close') as HTMLElement
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'label.download' })
+      ).not.toBeInTheDocument()
+    );
+
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      screen.queryByRole('button', { name: 'label.download' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('auto-opens for a failed job discovered after the initial fetch', async () => {
+    mockGetCsvAsyncJobs.mockResolvedValueOnce([]).mockResolvedValue([
+      createJob({
+        error: 'Boom',
+        jobId: 'failed-job',
+        operation: 'IMPORT',
+        result: undefined,
+        status: 'FAILED',
+      }),
+    ]);
+
+    await renderComponent();
+
+    await act(async () => {
+      window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
+    });
+
+    expect(
+      await screen.findByText('label.clear-completed')
     ).toBeInTheDocument();
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.component.tsx
@@ -47,7 +47,11 @@ import {
 } from '../../../../rest/csvAPI';
 import { showErrorToast } from '../../../../utils/ToastUtils';
 import './csv-jobs-tray.less';
-import { CSV_JOBS_REFRESH_EVENT } from './CsvJobsTray.constants';
+import {
+  CSV_JOBS_POST_ACTION_REFRESH_MS,
+  CSV_JOBS_REFRESH_EVENT,
+  isCsvJobOwned,
+} from './CsvJobsTray.constants';
 
 const ACTIVE_STATUSES: CsvAsyncJobStatus[] = [
   'QUEUED',
@@ -62,6 +66,10 @@ const TERMINAL_STATUSES: CsvAsyncJobStatus[] = [
 ];
 
 const ACTIVE_JOBS_POLL_INTERVAL_MS = 5000;
+
+// Fetch well beyond the handful the tray renders so a just-finished job cannot
+// fall outside the fetched window (which would silently skip its auto-open).
+const CSV_JOBS_FETCH_LIMIT = 50;
 
 type StatusVariant = 'running' | 'success' | 'error';
 
@@ -109,20 +117,44 @@ export const CsvJobsTray = () => {
   );
   const hasLoadedInitialJobs = useRef(false);
   const autoOpenedJobIds = useRef<Set<string>>(new Set());
+  const postActionTimeoutIds = useRef<Set<ReturnType<typeof setTimeout>>>(
+    new Set()
+  );
+  const latestFetchId = useRef(0);
 
   const fetchJobs = useCallback(async () => {
+    const fetchId = (latestFetchId.current += 1);
     try {
-      const response = await getCsvAsyncJobs();
+      const response = await getCsvAsyncJobs(CSV_JOBS_FETCH_LIMIT);
+
+      // Many sources trigger fetches (mount, refresh event, both socket
+      // channels, the poll, the launcher). If a newer fetch was issued while
+      // this one was in flight, drop this result: a slow response must not
+      // overwrite fresher state and, e.g., flip a completed job back to running
+      // and restart the poll.
+      if (fetchId !== latestFetchId.current) {
+        return;
+      }
 
       if (!hasLoadedInitialJobs.current) {
-        const initialTerminalJobIds = response
-          .filter((job) => TERMINAL_STATUSES.includes(job.status))
+        // Jobs already terminal on the very first fetch are stale (e.g. leftovers
+        // shown after a page refresh) and must not pop the tray. The exception is
+        // a job the user just started this session: a fast export can finish
+        // before this first fetch resolves, so it would look "stale" here even
+        // though it is exactly what the user is waiting to download. Owned jobs
+        // are therefore never pre-dismissed.
+        const staleTerminalJobIds = response
+          .filter(
+            (job) =>
+              TERMINAL_STATUSES.includes(job.status) &&
+              !isCsvJobOwned(job.jobId)
+          )
           .map((job) => job.jobId);
 
-        if (!isEmpty(initialTerminalJobIds)) {
+        if (!isEmpty(staleTerminalJobIds)) {
           setDismissedJobIds((current) => {
             const next = new Set(current);
-            initialTerminalJobIds.forEach((jobId) => next.add(jobId));
+            staleTerminalJobIds.forEach((jobId) => next.add(jobId));
 
             return next;
           });
@@ -157,6 +189,20 @@ export const CsvJobsTray = () => {
   const hasActiveJobs = !isEmpty(activeJobs);
 
   useEffect(() => {
+    // Nothing left to show (e.g. right after Clear completed): collapse the tray
+    // so it does not carry a stale open state into the next job. Otherwise a job
+    // started next would reuse open=true and pop the popover while still merely
+    // running — the tray must only open on its own when a job actually finishes.
+    if (isEmpty(visibleJobs)) {
+      setOpen(false);
+
+      return;
+    }
+
+    // A job reaching a terminal state (ready to download, failed, or cancelled)
+    // opens the tray even if the user had minimised it, so completion is never
+    // left hidden behind the launcher. Each job triggers this only once, so the
+    // user can still close the tray and it stays closed.
     const newlyFinished = visibleJobs.filter(
       (job) =>
         TERMINAL_STATUSES.includes(job.status) &&
@@ -261,10 +307,29 @@ export const CsvJobsTray = () => {
 
   useEffect(() => {
     fetchJobs();
-    window.addEventListener(CSV_JOBS_REFRESH_EVENT, fetchJobs);
+
+    // A refresh event means the user just started an export/import. Fetch now,
+    // then once more shortly after: some actions (notably import) fire the event
+    // before their job exists, so the immediate fetch can miss it and — with no
+    // active job yet — polling never starts. The follow-up fetch picks the job
+    // up so the active-jobs poll can take over.
+    const handleRefreshEvent = () => {
+      fetchJobs();
+      const timeoutId = setTimeout(() => {
+        postActionTimeoutIds.current.delete(timeoutId);
+        fetchJobs();
+      }, CSV_JOBS_POST_ACTION_REFRESH_MS);
+      postActionTimeoutIds.current.add(timeoutId);
+    };
+
+    window.addEventListener(CSV_JOBS_REFRESH_EVENT, handleRefreshEvent);
+
+    const timeoutIds = postActionTimeoutIds.current;
 
     return () => {
-      window.removeEventListener(CSV_JOBS_REFRESH_EVENT, fetchJobs);
+      window.removeEventListener(CSV_JOBS_REFRESH_EVENT, handleRefreshEvent);
+      timeoutIds.forEach((id) => clearTimeout(id));
+      timeoutIds.clear();
     };
   }, [fetchJobs]);
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/EntityImport/CsvJobsTray/CsvJobsTray.constants.ts
@@ -15,3 +15,27 @@
 // the (lazily mounted) jobs tray refreshes. Kept in its own module so importing
 // it does not pull the heavy CsvJobsTray component into the caller's bundle.
 export const CSV_JOBS_REFRESH_EVENT = 'csv-jobs-refresh';
+
+// One extra refresh a short while after an action fires the event above, to
+// catch a job that only registers slightly afterwards. The import path in
+// particular dispatches before its job exists, so a socket-less client that
+// misses it on the immediate fetch would otherwise never start polling for it.
+export const CSV_JOBS_POST_ACTION_REFRESH_MS = 2000;
+
+// Job IDs the current user started in this browser-tab session via an export or
+// import action. The tray must always surface these — even a fast job that
+// finishes before the tray's first jobs fetch — so the stale-job guard (which
+// hides jobs already terminal on first load, e.g. leftovers shown after a page
+// refresh) never suppresses a job the user just triggered. Kept module-level so
+// dispatch sites can record ownership without threading state into the lazily
+// mounted tray.
+const ownedCsvJobIds = new Set<string>();
+
+export const markCsvJobOwned = (jobId?: string): void => {
+  if (jobId) {
+    ownedCsvJobIds.add(jobId);
+  }
+};
+
+export const isCsvJobOwned = (jobId: string): boolean =>
+  ownedCsvJobIds.has(jobId);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/MetricsPage/MetricListPage/MetricListPage.tsx
@@ -56,7 +56,10 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import DeleteModal from '../../../components/common/DeleteModal/DeleteModal';
-import { CSV_JOBS_REFRESH_EVENT } from '../../../components/common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
+import {
+  CSV_JOBS_REFRESH_EVENT,
+  markCsvJobOwned,
+} from '../../../components/common/EntityImport/CsvJobsTray/CsvJobsTray.constants';
 import ErrorPlaceHolder from '../../../components/common/ErrorWithPlaceholder/ErrorPlaceHolder';
 import HeaderBreadcrumb from '../../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.component';
 import { getGlossaryHomeCrumb } from '../../../components/common/HeaderBreadcrumb/HeaderBreadcrumb.utils';
@@ -337,7 +340,10 @@ const MetricListPage = () => {
     try {
       setIsMetricActionsOpen(false);
       setIsExporting(true);
-      await exportMetricDetailsInCSV(WILD_CARD_CHAR);
+      const exportJob = await exportMetricDetailsInCSV(WILD_CARD_CHAR);
+      // Claim the just-started job so the tray always surfaces it, even if it
+      // finishes before the tray's first fetch.
+      markCsvJobOwned((exportJob as { jobId?: string })?.jobId);
       window.dispatchEvent(new Event(CSV_JOBS_REFRESH_EVENT));
     } catch (error) {
       showErrorToast(error as AxiosError);


### PR DESCRIPTION
## What & Why

The background **CSV jobs tray** (async export/import launcher + popover) could silently drop or fail to auto-open a job the user had just started. This makes the tray reliably surface every job the user initiates and auto-open it once it is ready to download — importantly, **including multi-pod deployments** where the completion websocket event is delivered to a peer node and the client only learns of completion via polling.

## Problems fixed

- **Fast export hidden as "stale".** A job that finished before the tray's first fetch resolved was treated as a leftover (like post-refresh terminals) and suppressed — even though it's exactly what the user is waiting to download.
- **Out-of-order fetches.** Many sources fetch concurrently (mount, refresh event, both socket channels, poll, launcher). A slow older response could overwrite fresher state and flip a completed job back to running.
- **Stale open-state after "Clear completed".** The next job reused `open=true` and popped the popover while still merely running.
- **Multi-pod completion.** The completion socket event only reaches the pod that ran the job, so on multi-node it usually lands on a peer — the active-job poll must be the reliable auto-open path.

## How

- Track jobs the user starts this session as **owned** (`markCsvJobOwned`) so the stale-job guard never hides them.
- Drop out-of-order fetch results via a **fetch-id guard** (`latestFetchId`).
- **Collapse** the tray when there are no visible jobs so open-state doesn't leak into the next job; auto-open only on a genuine terminal transition (once per job, so the user can still close it).
- Bump the fetch window to 50 so a just-finished job can't fall outside it.
- Add a short **post-action follow-up fetch** so an import job that registers slightly after the dispatch still starts polling.

## Testing

- **Unit** (`CsvJobsTray.component.test.tsx`): owned fast-terminal job surfaces + auto-opens; **owned export auto-opens for download via polling alone on multi-pod** (no socket, no refresh event); collapse-on-clear then re-open on next completion; ignores a stale fetch resolving after a newer one; poll stops when nothing is active. — 12/12 passing.
- **Playwright** (`CsvJobsTray.spec.ts`): running → completed via **polling only, no websocket** (multi-pod); and **auto-opens the tray for download when the poll completes it while minimised** (multi-pod, no manual open).
- Lint/format: ESLint 0 errors, Prettier clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)