### PR TITLE
test(e2e): fix the root causes behind the six worst AUT nightly flakes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/GlobalSearch.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/GlobalSearch.spec.ts
@@ -60,6 +60,4 @@ test('searching for longer description should work', async ({ page }) => {
       )
       .getByTestId('entity-link')
   ).toHaveText('dim_customer');
-
-  await expect(page.getByTestId('alert-bar')).not.toBeVisible();
 });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceCreationPermissions.spec.ts
@@ -646,7 +646,16 @@ test.describe(
       await openPipelineActions(page);
 
       await expect(page.getByTestId('edit-button')).toBeVisible();
-      await expect(page.getByTestId('re-deploy-button')).toBeVisible();
+      // AgentOverflowMenu swaps these two by run state — `kill-button` while
+      // `status` is running or queued, `re-deploy-button` once it is neither —
+      // and PERMISSION_BY_ITEM gates both on the same `permissions.edit`, which
+      // is what this test is actually asserting. Matching either keeps the
+      // assertion about the permission instead of racing the agent's first run:
+      // the failure snapshot showed the agent still "Running", so the menu held
+      // Pause / Kill run / Edit / Delete and no re-deploy entry existed at all.
+      await expect(
+        page.getByTestId('re-deploy-button').or(page.getByTestId('kill-button'))
+      ).toBeVisible();
       await expect(
         getAgentCard(page, ingestionPipelineName).getByTestId(
           'run-agent-button'

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -30,6 +30,7 @@ import {
   addInputPortToDataProduct,
   addOutputPortToDataProduct,
   expandLineageSection,
+  expandPopulatedLineageSection,
   navigateToPortsTab,
   selectDataProduct,
   verifyPortCounts,
@@ -1468,6 +1469,9 @@ test.describe('Input Output Ports', () => {
         await selectDataProduct(page, dataProduct.data);
         await navigateToPortsTab(page);
         await expandLineageSection(page);
+        // The fullscreen button only exists on the populated view; without this
+        // an empty read left the click waiting out the whole test budget.
+        await expandPopulatedLineageSection(page);
       });
 
       await test.step('Enter fullscreen mode', async () => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -417,9 +417,26 @@ export class TableClass extends EntityClass {
       return;
     }
 
+    // The global-search flow types `searchTerm` into the search box and waits
+    // for the resulting query response. An empty term types nothing, so no
+    // request ever fires and the wait burns its full 30s before the test times
+    // out — a hang with no useful error. Every route to an FQN above has
+    // already been tried by this point, so fail here with the reason instead.
+    const effectiveSearchTerm = searchTerm ?? tableFqn;
+
+    if (!effectiveSearchTerm) {
+      throw new Error(
+        `TableClass.visitEntityPage: cannot resolve a fullyQualifiedName for table "${
+          this.entityResponseData?.name ?? this.entity.name
+        }" (id: ${
+          this.entityResponseData?.id ?? 'unknown'
+        }). Refusing to fall back to global search with an empty term.`
+      );
+    }
+
     await visitEntityPage({
       page,
-      searchTerm: searchTerm ?? tableFqn,
+      searchTerm: effectiveSearchTerm,
       dataTestId: `${
         this.entityResponseData.service?.name ?? this.service.name
       }-${this.entityResponseData.name ?? this.entity.name}`,
@@ -603,6 +620,19 @@ export class TableClass extends EntityClass {
         },
       }
     );
+
+    // Only adopt the response body when the PATCH succeeded. An error body
+    // ({code, message}) carries neither id nor fullyQualifiedName, so assigning
+    // it unconditionally erased the table's identity and left every later
+    // `visitEntityPage` unable to navigate — surfacing much later as a 30s
+    // search hang rather than as the failed PATCH it actually was.
+    if (!response.ok()) {
+      throw new Error(
+        `TableClass.patch: PATCH failed with ${response.status()} for table "${
+          this.entityResponseData?.name ?? this.entity.name
+        }": ${await response.text()}`
+      );
+    }
 
     this.entityResponseData = await response.json();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/domain.ts
@@ -1674,15 +1674,33 @@ export const navigateToSubDomain = async (
 export const navigateToPortsTab = async (page: Page) => {
   await waitForAllLoadersToDisappear(page);
 
+  // A reload lands back on this tab and /portsView is fetched during page load,
+  // before any listener below could exist. Clicking the already-active tab is
+  // then a no-op that fires no second request, so the wait never settled — and
+  // it was unbounded, so called from inside waitForPortRow's poll it consumed
+  // the entire remaining test budget: expect.poll cannot interrupt its own
+  // callback, which is why raising the poll timeout would have changed nothing.
+  const portsPanel = page.getByTestId('input-output-ports-tab');
+
+  if (await portsPanel.isVisible()) {
+    return;
+  }
+
   const portsTab = page.getByTestId('input_output_ports');
   await portsTab.waitFor({ state: 'visible' });
 
-  const portsViewResponse = page.waitForResponse((response) =>
-    response.url().includes('/portsView')
-  );
+  // Bounded, and tolerant of a miss: the request may already have been answered
+  // during load. The rendered panel below is the real signal, not the response.
+  const portsViewResponse = page
+    .waitForResponse((response) => response.url().includes('/portsView'), {
+      timeout: 15_000,
+    })
+    .catch(() => null);
+
   await portsTab.click();
   await portsViewResponse;
   await waitForAllLoadersToDisappear(page);
+  await portsPanel.waitFor({ state: 'visible', timeout: 15_000 });
 };
 
 /**
@@ -1700,7 +1718,19 @@ export const waitForPortRow = async (page: Page, portId: string) => {
   await expect
     .poll(
       async () => {
-        if (await portRow.isVisible()) {
+        // Give the row a bounded chance to arrive before reloading. isVisible()
+        // samples once, with no retry, and the poll's first pass runs with no
+        // initial delay — so on a slow render it fired while the /inputPorts
+        // request was still in flight (measured on a failing run: the response
+        // landed 3ms after this check had already decided to reload) and threw
+        // away the render that was about to happen. The reload is the heavy,
+        // destructive branch; it should be the fallback, not the first move.
+        const appeared = await portRow
+          .waitFor({ state: 'visible', timeout: 5_000 })
+          .then(() => true)
+          .catch(() => false);
+
+        if (appeared) {
           return true;
         }
 
@@ -1713,7 +1743,12 @@ export const waitForPortRow = async (page: Page, portId: string) => {
 
         return portRow.isVisible();
       },
-      { timeout: 60_000, intervals: [2_000, 5_000, 10_000] }
+      // Every await in the callback above is now bounded, so the poll can
+      // actually iterate and lose its own race. 30s leaves room inside the
+      // default 60s test budget for the setup that precedes it; the previous
+      // 60s matched the whole test timeout, so a genuine failure could only
+      // ever surface as a bare test timeout naming nothing.
+      { timeout: 30_000, intervals: [2_000, 5_000, 10_000] }
     )
     .toBe(true);
 };
@@ -1737,10 +1772,14 @@ export const expandLineageSection = async (page: Page) => {
     // /portsView endpoint but always carries pagination params, so matching on
     // '/portsView' alone can resolve against the counts response while the
     // lineage request is still in flight.
+    // Bounded explicitly: an unbounded wait here inherits the whole remaining
+    // test budget, so a missed match reports a bare test timeout instead of
+    // naming the request that never arrived.
     const lineageResponse = page.waitForResponse(
       (response) =>
         response.url().includes('/portsView') &&
-        !response.url().includes('inputLimit=')
+        !response.url().includes('inputLimit='),
+      { timeout: 30_000 }
     );
 
     await header.click();
@@ -1757,6 +1796,51 @@ export const expandLineageSection = async (page: Page) => {
     .or(page.locator('.ports-lineage-view-empty'))
     .first()
     .waitFor({ state: 'visible' });
+};
+
+/**
+ * Expands the lineage section and waits for it to render *with* ports,
+ * reloading when it comes back empty.
+ *
+ * This is a mitigation for a server-side defect, not a fix for it. The failure
+ * snapshot shows the tab badge reading "Input Ports (1)" — the count probe's
+ * `paging.total` — next to a lineage that rendered its empty branch, because
+ * the same response carried zero rows. `DataProductRepository.getPaginatedPorts`
+ * takes `total` from an independent count query while rows have to survive an
+ * index-zip against an unordered `WHERE id IN (...)` result and a silent
+ * `if (entity != null)` drop, so the payload can contradict its own count.
+ *
+ * The visible consequence here: PortsLineageView renders
+ * `.ports-lineage-view-empty` whenever `hasAnyPorts` is false, and that branch
+ * carries no `toggle-fullscreen-btn` at all — so a caller that clicked it waited
+ * out the entire test budget rather than failing, reporting only "Target page,
+ * context or browser has been closed". `expandLineageSection` settles on either
+ * state by design (several tests assert the empty one), so a caller needing the
+ * populated view has to ask for it.
+ *
+ * Remounting re-runs the query and has been observed to return the full set, so
+ * the reload recovers it — but the count/rows contradiction is fixed server-side.
+ */
+export const expandPopulatedLineageSection = async (page: Page) => {
+  const lineageView = page.getByTestId('ports-lineage-view');
+
+  await expect
+    .poll(
+      async () => {
+        if (await lineageView.isVisible()) {
+          return true;
+        }
+
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await waitForAllLoadersToDisappear(page);
+        await navigateToPortsTab(page);
+        await expandLineageSection(page);
+
+        return lineageView.isVisible();
+      },
+      { timeout: 30_000, intervals: [2_000, 5_000, 10_000] }
+    )
+    .toBe(true);
 };
 
 /**


### PR DESCRIPTION
## What

Fixes the root causes behind the six worst flaky tests in the AUT nightly.

Measured across the **20 `1.11.13 → 2.0` AUT nightlies from Aug 9–13** (MySQL and PostgreSQL lanes), 188 distinct tests flaked across 379 occurrences — but the distribution is top-heavy. These six accounted for **26% of all flake volume**, while 129 tests flaked exactly once (environmental noise). None correlate with the database engine.

| Flake rate | Test |
|---|---|
| 19/20 (95%) | `InputOutputPorts › Toggle fullscreen mode` |
| 19/20 (95%) | `PlatformLineage › Verify domain platform view` |
| 18/20 (90%) | `InputOutputPorts › Remove last port shows empty state` |
| 18/20 (90%) | `PlatformLineage › Verify platform view switching` |
| 16/20 (80%) | `ServiceCreationPermissions › User with EditAll but not Trigger cannot run a pipeline` |
| 10/20 (50%) | `GlobalSearch › searching for longer description should work` |

Each diagnosis below is drawn from the failing run's own step timeline, network log or page snapshot; where something is inferred rather than captured, it says so. **No test budget is raised by this change; the net movement on timeouts is downward.**

## Root causes

### 1. `TableClass.patch` silently erased entity identity — both `PlatformLineage` tests

`patch()` ended with an unconditional `this.entityResponseData = await response.json()`. When the domain PATCH in `beforeAll` returned non-2xx, the error body (`{code, message}`) replaced the table's response data, **erasing both `id` and `fullyQualifiedName`**.

`visitEntityPage` then could not resolve an FQN and fell through to the global-search flow with `searchTerm: ''` — typing an empty string into the search box and waiting the full 30s for a `/search/query` response that no keystroke had triggered:

```
failing attempt:   5001ms  Wait for selector getByTestId('searchBox')   <== ERROR
                  30001ms  Wait for event "response"                    <== ERROR
                      70ms  Fill "" getByTestId('searchBox')

passing retry:      951ms  Navigate to "/table/pw-database-service-..."
```

A sibling test sharing the same `beforeEach` flaked only **1/20**, which is why the `beforeEach` was not itself the cause — each worker rolls the dice on that PATCH independently.

`patch()` now throws on a failed response rather than adopting its body, and `visitEntityPage` refuses to search on an empty term.

**Confidence:** the hang is captured — `Fill ""` and the 30s wait are in the timeline. The *reason* the identity was missing is inferred, not captured: the failing attempt recorded no trace, so the PATCH's status code is not in evidence. What is observable is that only the by-**name** recovery lookup fired in `beforeEach` and never the by-**id** one, which `visitEntityPage` attempts first whenever `entityResponseData.id` is set. Both were therefore absent, while `create()` sets both — consistent with `patch()` having overwritten them with a body carrying neither. The empty-term guard makes this fail fast and legibly whatever the origin.

### 2. Two compounding test defects — `Remove last port shows empty state`

**The backend was healthy throughout**: the trace shows every request 200, `paging.total: 1`, one row present. This was entirely test-side.

**a. The poll reloaded before the row could render.** `waitForPortRow`'s callback opened with an instantaneous `isVisible()` — one sample, no retry — and `expect.poll` runs its first pass with no initial delay. It fired while the `/inputPorts` request was still in flight and took the destructive reload branch. Measured on the failing run, the response that would have rendered the row arrived **3ms** after the check had already decided to reload.

**b. An unbounded wait then ate the whole test.** `navigateToPortsTab` waited on `/portsView` with no timeout. After a reload the app remounts already on the ports tab and `/portsView` is answered during page load — **202ms before this listener was attached** — so nothing further ever fired:

| time | event |
|---|---|
| 06.833 | `inputPorts?limit=15…` starts (46ms) |
| 06.851 | `expect.poll` starts, samples `isVisible()` instantly |
| 06.876 | not painted yet → **reload** |
| 06.879 | the response that would have rendered the row arrives |
| 08.296 | after reload, `/portsView` answered during load |
| 08.498 | `navigateToPortsTab` attaches its listener — too late |

`expect.poll` **cannot interrupt its own callback**, so that single unbounded `await` consumed the entire 60s test: 50,984ms of a 51,835ms poll. This is also why raising the poll timeout would have changed nothing.

The row now gets a bounded 5s chance to appear before any reload; the `/portsView` wait is bounded and tolerant of a miss; the rendered panel is what the helper settles on rather than the network event. The poll timeout drops **60s → 30s** — it previously matched the whole test timeout, so a genuine failure could only surface as a bare timeout naming nothing.

### 3. A server-side count/rows contradiction — `Toggle fullscreen mode`

Not slowness: setup took 2.9s. The failure snapshot shows the tab badge reading **`Input Ports (1)`** next to a Ports Lineage panel rendering its **empty** branch — the count probe's `paging.total` said one port, the lineage's own `/portsView` carried zero rows.

`PortsLineageView` keys `hasAnyPorts` off the row array, and its empty branch carries no `toggle-fullscreen-btn` at all, so the click waited out the remaining budget — **55,396ms on one click** — reporting only "Target page, context or browser has been closed".

That contradiction is a **server-side defect** — `DataProductRepository.getPaginatedPorts` takes `total` from an independent count query while rows must survive an index-zip against an unordered `WHERE id IN (...)` result and a silent `if (entity != null)` drop. It is fixed separately. `expandPopulatedLineageSection` here is a **mitigation**, documented as such, that remounts until the populated view appears.

### 4. Asserting a button that only exists while the agent is idle — `ServiceCreationPermissions`

The failure snapshot shows the agent still **`Running`**, with its menu holding `Pause / Kill run / Edit configuration / Delete agent` — **no re-deploy entry exists at all in that state**.

`AgentOverflowMenu` swaps the two by run state:

```js
const isActive = status === 'running' || status === 'queued';
...isActive ? [{ testId: 'kill-button' }] : [{ testId: 're-deploy-button' }]
```

and `PERMISSION_BY_ITEM` gates both on the same `permissions.edit` — which is what this test actually asserts. It now matches either, so it tests the permission rather than racing the agent's first ingestion run.

> Note: `PipelineActionsDropdown` has a similarly-named button gated on `ingestion.deployed`. That is a different component and not what this page renders; an earlier revision of this description cited it by mistake.

### 5. An assertion that could only pass by luck — `GlobalSearch`

`expect(getByTestId('alert-bar')).not.toBeVisible()` throws a **strict-mode violation** whenever more than one toast is present. The toasts were `bulk-download-*` and `download-doc-*.txt` — app-level notifications raised by export specs running concurrently under the same shared admin `storageState`, nothing to do with search.

Removed rather than narrowed: it asserts nothing about search results, and any global toast assertion will keep catching unrelated background jobs. **If reviewers prefer to keep a guard**, narrowing it to an error-variant toast is the alternative.

## Reviewer notes

- **Blast radius:** `TableClass` is shared across many suites. Making `patch()` throw is correct — silent identity corruption is never wanted — but any suite where that PATCH has been quietly failing will now fail loudly instead of flaking later. That is the intent, though it may surface new failures in the next nightly.
- **Not verified by local execution.** This class of failure does not reproduce at low worker counts: #31063 verified 43/43 at `workers=2` and still flaked in 18/18 nightlies, because the failure needs the list request to still be in flight when the poll first samples. Acceptance is a drop in the measured rates over the next few nightlies.
- A matching PR against `2.0` will follow — the two branches carry these files byte-identically today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
