### PR TITLE
Cherrypick commits to 2.0

### DIFF
--- a/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/mysql/schemaChanges.sql
@@ -564,3 +564,13 @@ CREATE INDEX idx_security_service_entity_deleted_service_type ON security_servic
 CREATE INDEX idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
 CREATE INDEX idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
 CREATE INDEX idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);
+
+-- App-mode preferences v2: lightweight, app-managed (no FK) per-user preferences bag.
+-- Deliberately not a full entity table - no versioning/audit/soft-delete, cascade-deleted
+-- via UserRepository#postDelete rather than a foreign key.
+CREATE TABLE IF NOT EXISTS user_preferences (
+    userId VARCHAR(36) NOT NULL,
+    json JSON NOT NULL,
+    updatedAt BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (userId)
+);

--- a/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
+++ b/bootstrap/sql/migrations/native/2.0.0/postgres/schemaChanges.sql
@@ -487,3 +487,13 @@ CREATE INDEX IF NOT EXISTS idx_security_service_entity_deleted_service_type ON s
 CREATE INDEX IF NOT EXISTS idx_drive_service_entity_deleted_service_type ON drive_service_entity(deleted, serviceType);
 CREATE INDEX IF NOT EXISTS idx_llm_service_entity_deleted_service_type ON llm_service_entity(deleted, serviceType);
 CREATE INDEX IF NOT EXISTS idx_mcp_service_entity_deleted_service_type ON mcp_service_entity(deleted, serviceType);
+
+-- App-mode preferences v2: lightweight, app-managed (no FK) per-user preferences bag.
+-- Deliberately not a full entity table - no versioning/audit/soft-delete, cascade-deleted
+-- via UserRepository#postDelete rather than a foreign key.
+CREATE TABLE IF NOT EXISTS user_preferences (
+    userId VARCHAR(36) NOT NULL,
+    json JSONB NOT NULL,
+    updatedAt BIGINT NOT NULL,
+    PRIMARY KEY (userId)
+);

--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -854,6 +854,15 @@ rdf:
   dataset: ${RDF_DATASET:-"openmetadata"}
   inferenceEnabled: ${RDF_INFERENCE_ENABLED:-false}
 
+# App Configuration
+# Tenant-wide "first impression" UI default, seeded into the DB-backed appConfiguration
+# setting on first boot only. After that, admins mutate it at runtime via
+# /v1/system/settings/appConfiguration and this yaml value is ignored.
+appConfiguration:
+  # Non-null seeds the app mode for users who have not chosen one (e.g. "ai" or "classic");
+  # user preference and persona-level app mode still win over this default.
+  defaultAppMode: ${APP_DEFAULT_MODE:-null}
+
 # Cache Configuration
 # Caching layer for entity metadata, relationships, and tag usage to reduce database load
 # Default: none (no external dependency). Set CACHE_PROVIDER=redis to enable the

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserPreferencesIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/UserPreferencesIT.java
@@ -1,0 +1,210 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.api.teams.UserPreferences;
+import org.openmetadata.schema.api.teams.preferences.AppModePreference;
+import org.openmetadata.schema.api.teams.preferences.Config;
+import org.openmetadata.schema.entity.teams.User;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.exceptions.ForbiddenException;
+import org.openmetadata.sdk.network.HttpMethod;
+
+/**
+ * IT tests for the lightweight {@code user_preferences} resource: {@code GET/PUT/DELETE
+ * /v1/users/{userId}/preferences[/{type}]}, the self-or-admin auth rule, and the delete cascade
+ * wired via {@code UserRepository#postDelete}. Each preference entry is a typed discriminated
+ * union {@code {type, config}} - only {@code appMode} is wired end-to-end today.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class UserPreferencesIT {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String APP_MODE = "appMode";
+
+  @Test
+  void getPreferences_default_returnsEmptyList() throws Exception {
+    User user = createUser("prefs-default");
+    try {
+      OpenMetadataClient self = clientFor(user);
+
+      UserPreferences preferences = getPreferences(self, user.getId());
+
+      assertTrue(preferences.getPreferences().isEmpty(), "New user should have no preferences");
+    } finally {
+      deleteUser(user);
+    }
+  }
+
+  @Test
+  void putPreference_appMode_persists() throws Exception {
+    User user = createUser("prefs-put");
+    try {
+      OpenMetadataClient self = clientFor(user);
+
+      UserPreferences putResponse = putAppMode(self, user.getId(), "ai");
+      assertEquals("ai", appModeValue(putResponse));
+
+      UserPreferences fetched = getPreferences(self, user.getId());
+      assertEquals("ai", appModeValue(fetched));
+    } finally {
+      deleteUser(user);
+    }
+  }
+
+  @Test
+  void putPreference_appMode_updatesExisting() throws Exception {
+    User user = createUser("prefs-replace");
+    try {
+      OpenMetadataClient self = clientFor(user);
+      putAppMode(self, user.getId(), "ai");
+
+      UserPreferences updated = putAppMode(self, user.getId(), "classic");
+      assertEquals("classic", appModeValue(updated));
+      assertEquals(1, updated.getPreferences().size(), "PUT must replace, not duplicate, by type");
+
+      UserPreferences fetched = getPreferences(self, user.getId());
+      assertEquals("classic", appModeValue(fetched));
+      assertEquals(1, fetched.getPreferences().size());
+    } finally {
+      deleteUser(user);
+    }
+  }
+
+  @Test
+  void deletePreference_appMode_removes() throws Exception {
+    User user = createUser("prefs-delete");
+    try {
+      OpenMetadataClient self = clientFor(user);
+      putAppMode(self, user.getId(), "ai");
+
+      UserPreferences afterDelete = deletePreference(self, user.getId(), APP_MODE);
+      assertTrue(afterDelete.getPreferences().isEmpty());
+
+      UserPreferences fetched = getPreferences(self, user.getId());
+      assertTrue(fetched.getPreferences().isEmpty());
+    } finally {
+      deleteUser(user);
+    }
+  }
+
+  @Test
+  void deleteUser_cascadesToPreferences() throws Exception {
+    User user = createUser("prefs-cascade");
+    OpenMetadataClient self = clientFor(user);
+    UserPreferences beforeDelete = putAppMode(self, user.getId(), "ai");
+    assertEquals("ai", appModeValue(beforeDelete));
+
+    deleteUser(user);
+
+    // The user row is gone, so only an admin can still read the (now-orphaned) preferences path.
+    UserPreferences afterDelete = getPreferences(SdkClients.adminClient(), user.getId());
+    assertTrue(
+        afterDelete.getPreferences().isEmpty(),
+        "Cascade delete should have purged the user_preferences row");
+  }
+
+  @Test
+  void putPreference_nonAdminOtherUser_returns403() throws Exception {
+    User userA = createUser("prefs-a");
+    User userB = createUser("prefs-b");
+    try {
+      OpenMetadataClient clientA = clientFor(userA);
+
+      assertThrows(
+          ForbiddenException.class,
+          () -> putAppMode(clientA, userB.getId(), "ai"),
+          "A non-admin user must not be able to put another user's preferences");
+    } finally {
+      deleteUser(userA);
+      deleteUser(userB);
+    }
+  }
+
+  private static User createUser(String label) {
+    String shortId = UUID.randomUUID().toString().substring(0, 8);
+    String userName = "userprefs_" + label + "_" + shortId;
+    String email = userName + "@test.openmetadata.org";
+    return SdkClients.adminClient()
+        .users()
+        .create(new CreateUser().withName(userName).withEmail(email).withIsBot(false));
+  }
+
+  private static void deleteUser(User user) {
+    Map<String, String> deleteParams = new HashMap<>();
+    deleteParams.put("hardDelete", "true");
+    SdkClients.adminClient().users().delete(user.getId().toString(), deleteParams);
+  }
+
+  private static OpenMetadataClient clientFor(User user) {
+    return SdkClients.createClient(user.getEmail(), user.getEmail(), new String[] {});
+  }
+
+  private static UserPreferences getPreferences(OpenMetadataClient client, UUID userId) {
+    return client
+        .getHttpClient()
+        .execute(
+            HttpMethod.GET, "/v1/users/" + userId + "/preferences", null, UserPreferences.class);
+  }
+
+  private static UserPreferences putAppMode(OpenMetadataClient client, UUID userId, String value) {
+    AppModePreference preference =
+        new AppModePreference()
+            .withType(AppModePreference.Type.APP_MODE)
+            .withConfig(new Config().withValue(Config.Value.fromValue(value)));
+
+    return client
+        .getHttpClient()
+        .execute(
+            HttpMethod.PUT,
+            "/v1/users/" + userId + "/preferences/" + APP_MODE,
+            preference,
+            UserPreferences.class);
+  }
+
+  private static UserPreferences deletePreference(
+      OpenMetadataClient client, UUID userId, String type) {
+    return client
+        .getHttpClient()
+        .execute(
+            HttpMethod.DELETE,
+            "/v1/users/" + userId + "/preferences/" + type,
+            null,
+            UserPreferences.class);
+  }
+
+  /** Pulls the {@code appMode} entry's {@code config.value} out of the typed preferences list. */
+  private static String appModeValue(UserPreferences preferences) {
+    return preferences.getPreferences().stream()
+        .map(entry -> MAPPER.convertValue(entry, Map.class))
+        .filter(entry -> APP_MODE.equals(entry.get("type")))
+        .findFirst()
+        .map(entry -> (Map<?, ?>) entry.get("config"))
+        .map(config -> (String) config.get("value"))
+        .orElse(null);
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/OpenMetadataApplicationConfig.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import org.openmetadata.DefaultOperationalConfigProvider;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
 import org.openmetadata.schema.api.configuration.dataQuality.DataQualityConfiguration;
 import org.openmetadata.schema.api.configuration.events.EventHandlerConfiguration;
 import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
@@ -187,6 +188,10 @@ public class OpenMetadataApplicationConfig extends Configuration {
 
   @JsonProperty("rdf")
   private RdfConfiguration rdfConfiguration = new RdfConfiguration();
+
+  @JsonProperty("appConfiguration")
+  @Valid
+  private AppConfiguration appConfiguration = new AppConfiguration();
 
   @JsonProperty("cache")
   private org.openmetadata.service.cache.CacheConfig cacheConfig;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -71,6 +71,7 @@ import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.schema.TokenInterface;
 import org.openmetadata.schema.analytics.ReportData;
 import org.openmetadata.schema.analytics.WebAnalyticEvent;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
 import org.openmetadata.schema.api.configuration.MCPConfiguration;
 import org.openmetadata.schema.api.configuration.OpenMetadataBaseUrlConfiguration;
@@ -257,6 +258,9 @@ public interface CollectionDAO {
 
   @CreateSqlObject
   UserDAO userDAO();
+
+  @CreateSqlObject
+  UserPreferencesDAO userPreferencesDAO();
 
   @CreateSqlObject
   TeamDAO teamDAO();
@@ -1917,6 +1921,34 @@ public interface CollectionDAO {
   class QueryList {
     private String fqn;
     private Query query;
+  }
+
+  /**
+   * Lightweight, app-managed (no FK) storage for the {@code user_preferences} table. Deliberately
+   * not an {@code EntityDAO} - the preferences bag is not a full entity (no versioning, audit, or
+   * soft-delete); see {@link org.openmetadata.service.jdbi3.UserPreferencesRepository}.
+   */
+  interface UserPreferencesDAO {
+    @ConnectionAwareSqlUpdate(
+        value =
+            "INSERT INTO user_preferences (userId, json, updatedAt) VALUES (:userId, :json, :updatedAt) "
+                + "ON DUPLICATE KEY UPDATE json = :json, updatedAt = :updatedAt",
+        connectionType = MYSQL)
+    @ConnectionAwareSqlUpdate(
+        value =
+            "INSERT INTO user_preferences (userId, json, updatedAt) VALUES (:userId, (:json :: jsonb), :updatedAt) "
+                + "ON CONFLICT (userId) DO UPDATE SET json = (:json :: jsonb), updatedAt = :updatedAt",
+        connectionType = POSTGRES)
+    void upsert(
+        @BindUUID("userId") UUID userId,
+        @Bind("json") String json,
+        @Bind("updatedAt") long updatedAt);
+
+    @SqlQuery("SELECT json FROM user_preferences WHERE userId = :userId")
+    String findByUserId(@BindUUID("userId") UUID userId);
+
+    @SqlUpdate("DELETE FROM user_preferences WHERE userId = :userId")
+    void deleteByUserId(@BindUUID("userId") UUID userId);
   }
 
   interface EntityRelationshipDAO {
@@ -11011,6 +11043,7 @@ public interface CollectionDAO {
             case MCP_CONFIGURATION -> JsonUtils.readValue(json, MCPConfiguration.class);
             case GLOSSARY_TERM_RELATION_SETTINGS -> JsonUtils.readValue(
                 json, GlossaryTermRelationSettings.class);
+            case APP_CONFIGURATION -> JsonUtils.readValue(json, AppConfiguration.class);
             default -> throw new IllegalArgumentException("Invalid Settings Type " + configType);
           };
       settings.setConfigValue(value);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserPreferencesRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserPreferencesRepository.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.jdbi3;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.util.concurrent.Striped;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.locks.Lock;
+import java.util.stream.Collectors;
+import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
+
+/**
+ * Thin, app-managed (no FK, no versioning/audit/soft-delete) wrapper around the {@code
+ * user_preferences} table. See {@link CollectionDAO.UserPreferencesDAO}.
+ *
+ * <p>{@code preferences} is stored as a JSON array of typed discriminated unions, each shaped
+ * {@code {type, config}} (see {@code openmetadata-spec/.../api/teams/preferences/*.json}).
+ * Entries are addressed by their {@code type} field; at most one entry per {@code type} exists in
+ * the list at a time.
+ *
+ * <p>Concurrency: {@link #putByType} and {@link #deleteByType} do a
+ * {@code get()} → mutate list → {@code upsert()} cycle with a full-row JSON overwrite. Two
+ * concurrent writes for different {@code type}s targeting the same user would both read the same
+ * base list and the second persist would clobber the first (lost update). We serialize per-user
+ * with {@link Striped} locks — same pattern used elsewhere in this service (see
+ * {@code CachedLineage}). This is a per-JVM guarantee; cross-JVM races on the same user are still
+ * possible but unlikely in practice (a user typically hits a single node via sticky sessions or
+ * the auth cookie), and the ON CONFLICT / ON DUPLICATE KEY upsert prevents duplicate rows.
+ */
+@Repository
+public class UserPreferencesRepository {
+  private static final TypeReference<List<Object>> PREFERENCES_TYPE = new TypeReference<>() {};
+  private static final String TYPE_FIELD = "type";
+
+  /**
+   * 64 stripes give bounded memory (one lock per stripe) while keeping contention negligible in
+   * practice — a user's writes hash to a single stripe, so all their read-modify-write cycles
+   * across preference types are serialized regardless of the stripe count.
+   */
+  private static final Striped<Lock> USER_LOCKS = Striped.lazyWeakLock(64);
+
+  private final CollectionDAO.UserPreferencesDAO dao;
+
+  public UserPreferencesRepository() {
+    this.dao = Entity.getCollectionDAO().userPreferencesDAO();
+  }
+
+  public List<Object> get(UUID userId) {
+    String json = dao.findByUserId(userId);
+    return json == null
+        ? new ArrayList<>()
+        : new ArrayList<>(JsonUtils.readValue(json, PREFERENCES_TYPE));
+  }
+
+  /** Replaces the entry matching {@code type}, or appends {@code typedPreference} if absent. */
+  public List<Object> putByType(UUID userId, String type, Object typedPreference) {
+    Lock lock = USER_LOCKS.get(userId);
+    lock.lock();
+    try {
+      List<Object> current = get(userId);
+      boolean replaced = false;
+      List<Object> updated = new ArrayList<>();
+      for (Object item : current) {
+        if (type.equals(typeOf(item))) {
+          updated.add(typedPreference);
+          replaced = true;
+        } else {
+          updated.add(item);
+        }
+      }
+      if (!replaced) {
+        updated.add(typedPreference);
+      }
+      persist(userId, updated);
+      return updated;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** Removes any entry matching {@code type}. No-op (but still persists) if absent. */
+  public List<Object> deleteByType(UUID userId, String type) {
+    Lock lock = USER_LOCKS.get(userId);
+    lock.lock();
+    try {
+      List<Object> updated =
+          get(userId).stream()
+              .filter(item -> !type.equals(typeOf(item)))
+              .collect(Collectors.toList());
+      persist(userId, updated);
+      return updated;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  public void delete(UUID userId) {
+    dao.deleteByUserId(userId);
+  }
+
+  private void persist(UUID userId, List<Object> preferences) {
+    dao.upsert(userId, JsonUtils.pojoToJson(preferences), System.currentTimeMillis());
+  }
+
+  /** Reads the discriminator {@code type} field off a preference entry, typed or raw map. */
+  private static String typeOf(Object preferenceEntry) {
+    Map<String, Object> asMap = JsonUtils.getMap(preferenceEntry);
+    Object type = asMap.get(TYPE_FIELD);
+    return type == null ? null : type.toString();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/UserRepository.java
@@ -137,6 +137,8 @@ public class UserRepository extends EntityRepository<User> {
   private static final String DIRECT_OWNS_ONLY_PARAM = "directOwnsOnly";
   private volatile EntityReference organization;
   private InheritedFieldEntitySearch inheritedFieldEntitySearch;
+  private final UserPreferencesRepository userPreferencesRepository =
+      new UserPreferencesRepository();
 
   public UserRepository() {
     super(
@@ -1325,6 +1327,8 @@ public class UserRepository extends EntityRepository<User> {
     if (Boolean.TRUE.equals(entity.getIsBot())) {
       BotTokenCache.invalidateToken(entity.getName());
     }
+    // Lightweight app-managed table, no FK - clean up explicitly rather than via cascade.
+    userPreferencesRepository.delete(entity.getId());
     deleteSuggestionTasksForUser(entity);
 
     ExecutorService executorService = AsyncService.getInstance().getExecutorService();

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/settings/SettingsCache.java
@@ -13,6 +13,7 @@
 
 package org.openmetadata.service.resources.settings;
 
+import static org.openmetadata.schema.settings.SettingsType.APP_CONFIGURATION;
 import static org.openmetadata.schema.settings.SettingsType.ASSET_CERTIFICATION_SETTINGS;
 import static org.openmetadata.schema.settings.SettingsType.AUTHENTICATION_CONFIGURATION;
 import static org.openmetadata.schema.settings.SettingsType.AUTHORIZER_CONFIGURATION;
@@ -46,6 +47,7 @@ import org.openmetadata.api.configuration.LogoConfiguration;
 import org.openmetadata.api.configuration.ThemeConfiguration;
 import org.openmetadata.api.configuration.UiThemePreference;
 import org.openmetadata.common.utils.CommonUtil;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
 import org.openmetadata.schema.api.lineage.LineageLayer;
 import org.openmetadata.schema.api.lineage.LineageSettings;
@@ -167,6 +169,9 @@ public class SettingsCache {
                       .withJwtTokenExpiryTime(3600));
       Entity.getSystemRepository().createNewSetting(setting);
     }
+
+    // Initialise App Configuration (tenant-wide "first impression" default app mode)
+    seedAppConfiguration(applicationConfig);
 
     // Initialise Search Settings
     Settings storedSearchSettings =
@@ -490,6 +495,28 @@ public class SettingsCache {
               .withConfigType(GLOSSARY_TERM_RELATION_SETTINGS)
               .withConfigValue(
                   new GlossaryTermRelationSettings().withRelationTypes(defaultRelationTypes));
+      Entity.getSystemRepository().createNewSetting(setting);
+    }
+  }
+
+  /**
+   * Seeds {@link SettingsType#APP_CONFIGURATION} from yaml on first boot only. If a DB row
+   * already exists, yaml is ignored - the DB is the source of truth once seeded, and admins
+   * mutate it at runtime via {@code /v1/system/settings/appConfiguration}.
+   *
+   * <p>Extracted from {@link #createDefaultConfiguration} so it can be unit tested in isolation
+   * without exercising every other settings-seed block in that method.
+   */
+  public static void seedAppConfiguration(OpenMetadataApplicationConfig applicationConfig) {
+    Settings storedAppConfig =
+        Entity.getSystemRepository().getConfigWithKey(APP_CONFIGURATION.toString());
+    if (storedAppConfig == null) {
+      AppConfiguration appConfig =
+          applicationConfig.getAppConfiguration() != null
+              ? applicationConfig.getAppConfiguration()
+              : new AppConfiguration();
+      Settings setting =
+          new Settings().withConfigType(APP_CONFIGURATION).withConfigValue(appConfig);
       Entity.getSystemRepository().createNewSetting(setting);
     }
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/SystemResource.java
@@ -1,6 +1,7 @@
 package org.openmetadata.service.resources.system;
 
 import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+import static org.openmetadata.schema.settings.SettingsType.APP_CONFIGURATION;
 import static org.openmetadata.schema.settings.SettingsType.AUTHENTICATION_CONFIGURATION;
 import static org.openmetadata.schema.settings.SettingsType.AUTHORIZER_CONFIGURATION;
 import static org.openmetadata.schema.settings.SettingsType.GLOSSARY_TERM_RELATION_SETTINGS;
@@ -132,7 +133,10 @@ public class SystemResource {
   private static final Set<String> USER_READABLE_SETTINGS =
       Set.of(
           LINEAGE_SETTINGS.value().toLowerCase(Locale.ROOT),
-          GLOSSARY_TERM_RELATION_SETTINGS.value().toLowerCase(Locale.ROOT));
+          GLOSSARY_TERM_RELATION_SETTINGS.value().toLowerCase(Locale.ROOT),
+          // appConfiguration is read by every user at boot (fallback-chain resolution),
+          // not just admins; PATCH remains admin-only.
+          APP_CONFIGURATION.value().toLowerCase(Locale.ROOT));
   private static final ExecutorService SEARCH_FITNESS_EXECUTOR =
       Executors.newFixedThreadPool(
           2,

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/teams/UserResource.java
@@ -59,6 +59,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
@@ -83,6 +84,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -97,6 +99,8 @@ import org.openmetadata.schema.api.data.RestoreEntity;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.api.security.AuthorizerConfiguration;
 import org.openmetadata.schema.api.teams.CreateUser;
+import org.openmetadata.schema.api.teams.UserPreferences;
+import org.openmetadata.schema.api.teams.preferences.AppModePreference;
 import org.openmetadata.schema.auth.BasicAuthMechanism;
 import org.openmetadata.schema.auth.ChangePasswordRequest;
 import org.openmetadata.schema.auth.CreatePersonalToken;
@@ -134,6 +138,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.jdbi3.RoleRepository;
 import org.openmetadata.service.jdbi3.TokenRepository;
+import org.openmetadata.service.jdbi3.UserPreferencesRepository;
 import org.openmetadata.service.jdbi3.UserRepository;
 import org.openmetadata.service.jdbi3.UserRepository.UserCsv;
 import org.openmetadata.service.limits.Limits;
@@ -184,6 +189,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
   private final JWTTokenGenerator jwtTokenGenerator;
   private final TokenRepository tokenRepository;
   private final RoleRepository roleRepository;
+  private final UserPreferencesRepository preferencesRepository;
   private AuthenticationConfiguration authenticationConfiguration;
   private AuthorizerConfiguration authorizerConfiguration;
   private final AuthenticatorHandler authHandler;
@@ -210,6 +216,7 @@ public class UserResource extends EntityResource<User, UserRepository> {
     allowedFields.remove(USER_PROTECTED_FIELDS);
     tokenRepository = Entity.getTokenRepository();
     roleRepository = Entity.getRoleRepository();
+    preferencesRepository = new UserPreferencesRepository();
     UserTokenCache.initialize();
     authHandler = authenticatorHandler;
   }
@@ -1110,6 +1117,142 @@ public class UserResource extends EntityResource<User, UserRepository> {
       }
     }
     return patchInternal(uriInfo, securityContext, id, patch);
+  }
+
+  /** Preference {@code type} discriminator -> the concrete POJO it deserializes to. */
+  private static final Map<String, Class<?>> PREFERENCE_TYPES =
+      Map.of(AppModePreference.Type.APP_MODE.value(), AppModePreference.class);
+
+  @GET
+  @Path("/{userId}/preferences")
+  @Operation(
+      operationId = "getUserPreferences",
+      summary = "Get user preferences",
+      description =
+          "Get the per-user UI preferences list. Users can read their own; admins can read anyone's.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "User preferences",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserPreferences.class)))
+      })
+  public UserPreferences getPreferences(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Id of the user", schema = @Schema(type = "UUID"))
+          @PathParam("userId")
+          UUID userId) {
+    authorizeSelfOrAdmin(uriInfo, securityContext, userId);
+    List<Object> preferences = preferencesRepository.get(userId);
+    return new UserPreferences().withUserId(userId).withPreferences(preferences);
+  }
+
+  @PUT
+  @Path("/{userId}/preferences/{type}")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Operation(
+      operationId = "putUserPreference",
+      summary = "Create or replace a user preference",
+      description =
+          "Create or replace the preference entry of the given `type`. The request body is a "
+              + "typed discriminated union `{type, config}` (see "
+              + "`api/teams/preferences/*.json`). Users can update their own; admins can update "
+              + "anyone's.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "User preferences",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserPreferences.class)))
+      })
+  public UserPreferences putPreference(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Id of the user", schema = @Schema(type = "UUID"))
+          @PathParam("userId")
+          UUID userId,
+      @Parameter(description = "Discriminator of the preference entry, e.g. `appMode`")
+          @PathParam("type")
+          String type,
+      @RequestBody(
+              description = "Typed preference entry `{type, config}`",
+              content =
+                  @Content(
+                      mediaType = MediaType.APPLICATION_JSON,
+                      examples = {
+                        @ExampleObject("{\"type\": \"appMode\", \"config\": {\"value\": \"ai\"}}")
+                      }))
+          Map<String, Object> preference) {
+    authorizeSelfOrAdmin(uriInfo, securityContext, userId);
+    Object typedPreference = convertPreference(type, preference);
+    List<Object> preferences = preferencesRepository.putByType(userId, type, typedPreference);
+    return new UserPreferences().withUserId(userId).withPreferences(preferences);
+  }
+
+  @DELETE
+  @Path("/{userId}/preferences/{type}")
+  @Operation(
+      operationId = "deleteUserPreference",
+      summary = "Delete a user preference",
+      description =
+          "Remove the preference entry of the given `type`, if present. Users can update their "
+              + "own; admins can update anyone's.",
+      responses = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "User preferences",
+            content =
+                @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = UserPreferences.class)))
+      })
+  public UserPreferences deletePreference(
+      @Context UriInfo uriInfo,
+      @Context SecurityContext securityContext,
+      @Parameter(description = "Id of the user", schema = @Schema(type = "UUID"))
+          @PathParam("userId")
+          UUID userId,
+      @Parameter(description = "Discriminator of the preference entry, e.g. `appMode`")
+          @PathParam("type")
+          String type) {
+    authorizeSelfOrAdmin(uriInfo, securityContext, userId);
+    List<Object> preferences = preferencesRepository.deleteByType(userId, type);
+    return new UserPreferences().withUserId(userId).withPreferences(preferences);
+  }
+
+  /**
+   * Converts the raw request body into the concrete POJO registered for {@code type} in {@link
+   * #PREFERENCE_TYPES}, so JAX-RS can accept a single generic body shape for the `{type}`
+   * path-templated endpoint while still storing (and returning) fully typed preference entries.
+   * Adding a new preference type only requires a new schema + a new map entry here.
+   */
+  private static Object convertPreference(String type, Map<String, Object> preference) {
+    Class<?> preferenceClass = PREFERENCE_TYPES.get(type);
+    if (preferenceClass == null) {
+      throw new BadRequestException("Unsupported user preference type: " + type);
+    }
+    Object bodyType = preference == null ? null : preference.get("type");
+    if (!type.equals(bodyType)) {
+      throw new BadRequestException(
+          String.format(
+              "Preference type in path (%s) does not match request body (%s)", type, bodyType));
+    }
+    return JsonUtils.convertValue(preference, preferenceClass);
+  }
+
+  /** Users can act on their own preferences; anyone else requires admin. */
+  private void authorizeSelfOrAdmin(UriInfo uriInfo, SecurityContext securityContext, UUID userId) {
+    String authenticatedUserName = securityContext.getUserPrincipal().getName();
+    User authenticatedUser =
+        repository.getByName(uriInfo, authenticatedUserName, new Fields(Set.of("id")));
+    if (!authenticatedUser.getId().equals(userId)) {
+      authorizer.authorizeAdmin(securityContext);
+    }
   }
 
   @DELETE

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/AppConfigurationSettingTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/settings/AppConfigurationSettingTest.java
@@ -1,0 +1,153 @@
+/*
+ *  Copyright 2021 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.resources.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.openmetadata.schema.settings.SettingsType.APP_CONFIGURATION;
+
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.configuration.AppConfiguration;
+import org.openmetadata.schema.api.configuration.AppConfiguration.DefaultAppMode;
+import org.openmetadata.schema.settings.Settings;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.OpenMetadataApplicationConfig;
+import org.openmetadata.service.jdbi3.SystemRepository;
+import org.openmetadata.service.resources.system.SystemResource;
+import org.openmetadata.service.security.AuthorizationException;
+import org.openmetadata.service.security.Authorizer;
+
+/**
+ * Unit tests (Mockito, no infra) for the {@code appConfiguration} setting: first-boot yaml
+ * seeding via {@link SettingsCache#seedAppConfiguration}, and the read/write auth gating on the
+ * generic {@code /v1/system/settings/appConfiguration} endpoints on {@link SystemResource}.
+ */
+class AppConfigurationSettingTest {
+
+  @Test
+  void seedAppConfiguration_seedsFromYaml_whenDbRowAbsent() {
+    SystemRepository systemRepository = mock(SystemRepository.class);
+    when(systemRepository.getConfigWithKey(APP_CONFIGURATION.toString())).thenReturn(null);
+    OpenMetadataApplicationConfig config = mock(OpenMetadataApplicationConfig.class);
+    AppConfiguration yamlConfig = new AppConfiguration().withDefaultAppMode(DefaultAppMode.AI);
+    when(config.getAppConfiguration()).thenReturn(yamlConfig);
+
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(Entity::getSystemRepository).thenReturn(systemRepository);
+      SettingsCache.seedAppConfiguration(config);
+    }
+
+    ArgumentCaptor<Settings> captor = ArgumentCaptor.forClass(Settings.class);
+    verify(systemRepository).createNewSetting(captor.capture());
+    assertEquals(APP_CONFIGURATION, captor.getValue().getConfigType());
+    assertEquals(yamlConfig, captor.getValue().getConfigValue());
+  }
+
+  @Test
+  void seedAppConfiguration_yamlIgnored_whenDbRowPresent() {
+    SystemRepository systemRepository = mock(SystemRepository.class);
+    Settings existing =
+        new Settings()
+            .withConfigType(APP_CONFIGURATION)
+            .withConfigValue(new AppConfiguration().withDefaultAppMode(DefaultAppMode.CLASSIC));
+    when(systemRepository.getConfigWithKey(APP_CONFIGURATION.toString())).thenReturn(existing);
+    OpenMetadataApplicationConfig config = mock(OpenMetadataApplicationConfig.class);
+    when(config.getAppConfiguration())
+        .thenReturn(new AppConfiguration().withDefaultAppMode(DefaultAppMode.AI));
+
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(Entity::getSystemRepository).thenReturn(systemRepository);
+      SettingsCache.seedAppConfiguration(config);
+    }
+
+    verify(systemRepository, never()).createNewSetting(any());
+  }
+
+  @Test
+  void getSettingByName_appConfiguration_nonAdminAllowed_returnsDbValueVerbatim() {
+    SystemRepository systemRepository = mock(SystemRepository.class);
+    Settings dbValue =
+        new Settings()
+            .withConfigType(APP_CONFIGURATION)
+            .withConfigValue(new AppConfiguration().withDefaultAppMode(DefaultAppMode.CLASSIC));
+    when(systemRepository.getConfigWithKey("appConfiguration")).thenReturn(dbValue);
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+
+    SystemResource resource = buildResource(systemRepository, authorizer);
+
+    Settings result = resource.getSettingByName(null, securityContext, "appConfiguration");
+
+    assertSame(dbValue, result);
+    verify(authorizer, never()).authorizeAdmin(any(SecurityContext.class));
+  }
+
+  @Test
+  void patch_appConfiguration_nonAdmin_isRejectedBeforeTouchingRepository() {
+    SystemRepository systemRepository = mock(SystemRepository.class);
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+    doThrow(new AuthorizationException("Not an admin"))
+        .when(authorizer)
+        .authorizeAdmin(securityContext);
+    JsonPatch patch = Json.createPatchBuilder().add("/defaultAppMode", "ai").build();
+
+    SystemResource resource = buildResource(systemRepository, authorizer);
+
+    assertThrows(
+        AuthorizationException.class,
+        () -> resource.patch(null, securityContext, "appConfiguration", patch));
+    verify(systemRepository, never()).patchSetting(any(), any());
+  }
+
+  @Test
+  void patch_appConfiguration_admin_delegatesToRepository() {
+    SystemRepository systemRepository = mock(SystemRepository.class);
+    Authorizer authorizer = mock(Authorizer.class);
+    SecurityContext securityContext = mock(SecurityContext.class);
+    JsonPatch patch = Json.createPatchBuilder().add("/defaultAppMode", "ai").build();
+    Response expected = Response.ok().build();
+    when(systemRepository.patchSetting(eq("appConfiguration"), eq(patch))).thenReturn(expected);
+
+    SystemResource resource = buildResource(systemRepository, authorizer);
+
+    Response result = resource.patch(null, securityContext, "appConfiguration", patch);
+
+    assertSame(expected, result);
+    verify(authorizer).authorizeAdmin(securityContext);
+  }
+
+  private static SystemResource buildResource(
+      SystemRepository systemRepository, Authorizer authorizer) {
+    try (MockedStatic<Entity> mockedEntity = mockStatic(Entity.class)) {
+      mockedEntity.when(Entity::getSystemRepository).thenReturn(systemRepository);
+      return new SystemResource(authorizer);
+    }
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/api/configuration/appConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/configuration/appConfiguration.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://open-metadata.org/schema/api/configuration/appConfiguration.json",
+  "title": "AppConfiguration",
+  "description": "App-wide UI configuration. Seeded from yaml/env on first boot; DB-backed and admin-mutable at runtime afterwards (yaml is ignored once a DB row exists).",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.api.configuration.AppConfiguration",
+  "properties": {
+    "defaultAppMode": {
+      "description": "Tenant-wide 'first impression' app-mode default. Seeds the app mode for users who have not chosen one; user preference and persona-level app mode still win over this default. Null means no tenant default is configured.",
+      "type": ["string", "null"],
+      "enum": ["ai", "classic", null],
+      "default": null
+    }
+  },
+  "additionalProperties": false
+}

--- a/openmetadata-spec/src/main/resources/json/schema/api/teams/preferences/appModePreference.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/teams/preferences/appModePreference.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://open-metadata.org/schema/api/teams/preferences/appModePreference.json",
+  "title": "AppModePreference",
+  "description": "User preference for app-mode boot behavior (AI vs Classic).",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.api.teams.preferences.AppModePreference",
+  "properties": {
+    "type": { "type": "string", "enum": ["appMode"] },
+    "config": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": ["string", "null"],
+          "enum": ["ai", "classic", null]
+        }
+      },
+      "required": ["value"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["type", "config"],
+  "additionalProperties": false
+}

--- a/openmetadata-spec/src/main/resources/json/schema/api/teams/userPreferences.json
+++ b/openmetadata-spec/src/main/resources/json/schema/api/teams/userPreferences.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://open-metadata.org/schema/api/teams/userPreferences.json",
+  "title": "UserPreferences",
+  "description": "Per-user UI preferences. Each entry is a typed discriminated union — see preferences/*.json for concrete schemas.",
+  "type": "object",
+  "javaType": "org.openmetadata.schema.api.teams.UserPreferences",
+  "properties": {
+    "userId": {
+      "description": "Unique identifier of the User this preferences bag belongs to.",
+      "$ref": "../../type/basic.json#/definitions/uuid"
+    },
+    "preferences": {
+      "description": "List of typed per-user UI preferences (e.g. appMode). Each entry is a discriminated union keyed by `type`.",
+      "type": "array",
+      "items": {
+        "oneOf": [{ "$ref": "./preferences/appModePreference.json" }]
+      },
+      "default": []
+    },
+    "updatedAt": {
+      "description": "Last update time corresponding to the new version of the preferences in Unix epoch time milliseconds.",
+      "$ref": "../../type/basic.json#/definitions/timestamp"
+    }
+  },
+  "required": ["userId", "preferences"],
+  "additionalProperties": false
+}

--- a/openmetadata-spec/src/main/resources/json/schema/settings/settings.json
+++ b/openmetadata-spec/src/main/resources/json/schema/settings/settings.json
@@ -41,7 +41,8 @@
         "entityRulesSettings",
         "openLineageSettings",
         "mcpConfiguration",
-        "glossaryTermRelationSettings"
+        "glossaryTermRelationSettings",
+        "appConfiguration"
       ]
     }
   },
@@ -117,6 +118,9 @@
         },
         {
           "$ref": "../configuration/glossaryTermRelationSettings.json"
+        },
+        {
+          "$ref": "../api/configuration/appConfiguration.json"
         }
       ]
     }

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -51,6 +51,15 @@ jest.mock('../../../rest/miscAPI', () => ({
 jest.mock('../../../rest/userAPI', () => ({
   getLoggedInUser: jest.fn().mockImplementation(() => Promise.resolve()),
   updateUser: jest.fn().mockImplementation(() => Promise.resolve()),
+  getUserPreferences: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ preferences: [] })),
+}));
+
+jest.mock('../../../rest/settingConfigAPI', () => ({
+  getAppConfiguration: jest
+    .fn()
+    .mockImplementation(() => Promise.resolve({ defaultAppMode: null })),
 }));
 
 jest.mock('../../../utils/ToastUtils', () => ({

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -178,7 +178,14 @@ const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
   //      tuple check is satisfied by our write and it never consults
   //      the hint, so a cmd+click from an AI tab silently boots the new
   //      tab into Classic.
-  if (readAppModeSession()?.mode) {
+  // A returning tab (a `'manual'` or `'resolver'` tuple from a prior
+  // resolve) or a fresh tab that inherits an active hint from a
+  // sibling — leave both alone. `useResolvedAppMode` treats these as
+  // sticky and returns without rewriting. A `'boot'` tuple from an
+  // earlier auth cycle is NOT sticky and should be re-resolved, so
+  // don't skip on that.
+  const existingSession = readAppModeSession();
+  if (existingSession?.mode && existingSession.source !== 'boot') {
     return;
   }
   const hint = readAppModeHint();
@@ -188,7 +195,18 @@ const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
 
   const userPref =
     derivePreferencesFromList(prefsRes.preferences).appMode ?? null;
-  writeAppMode(resolveEffectiveAppMode(userPref, null, appDefault));
+
+  // Provisional boot write — persona isn't known synchronously (its
+  // docStore doc is fetched by `useResolvedAppMode`), so we compute
+  // the best guess from what IS available (userPref, appDefault) and
+  // mark it `source: 'boot'`. The async resolver is allowed to
+  // override this tuple once it has the persona-doc result and the
+  // route registry has settled. The `writeHint` call inside
+  // `writeAppMode` is skipped for `'boot'` writes so a provisional
+  // guess doesn't leak to sibling tabs as an authoritative hint.
+  writeAppMode(resolveEffectiveAppMode(userPref, null, appDefault), null, {
+    source: 'boot',
+  });
 };
 
 let requestInterceptor: number | null = null;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -65,6 +65,8 @@ import {
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import {
   clearAppMode,
+  isAppModeHintFresh,
+  readAppModeHint,
   readAppModeSession,
   resolveEffectiveAppMode,
   resolveInitialAppMode,
@@ -162,14 +164,25 @@ const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
   const appDefault = translateWireMode(appConfig?.defaultAppMode ?? null);
   setAppDefaultMode(appDefault);
 
-  // If this tab already has a session tuple (a manual toggle earlier in
-  // this tab, or a reload of one) leave it alone. `useResolvedAppMode`
-  // is the authoritative source and treats the tuple as the highest-
-  // priority signal once persona information is available — writing
-  // here would clobber a valid in-tab choice with the boot-time best-
-  // effort resolve (which cannot yet see persona) and break "toggle to
-  // AI, then reload" for users who did not tick "remember".
+  // Skip the boot-time write when this tab already has a signal that
+  // `useResolvedAppMode` will resolve authoritatively — the resolver is
+  // the single source of truth once it has persona + registry
+  // information, and writing to the session tuple here poisons the
+  // subsequent resolve. Two signals count:
+  //
+  //   1. A session tuple this tab already owns (returning tab, or a
+  //      manual toggle earlier in this tab).
+  //   2. A fresh cross-tab `omAppModeHint` — the mechanism by which a
+  //      sibling tab's active mode carries into a newly-opened tab.
+  //      Once we write `DEFAULT_APP_MODE` here, the resolver's session-
+  //      tuple check is satisfied by our write and it never consults
+  //      the hint, so a cmd+click from an AI tab silently boots the new
+  //      tab into Classic.
   if (readAppModeSession()?.mode) {
+    return;
+  }
+  const hint = readAppModeHint();
+  if (isAppModeHintFresh(hint) && hint?.mode) {
     return;
   }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -65,6 +65,7 @@ import {
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
 import {
   clearAppMode,
+  readAppModeSession,
   resolveEffectiveAppMode,
   resolveInitialAppMode,
   setAppDefaultMode,
@@ -160,6 +161,17 @@ const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
 
   const appDefault = translateWireMode(appConfig?.defaultAppMode ?? null);
   setAppDefaultMode(appDefault);
+
+  // If this tab already has a session tuple (a manual toggle earlier in
+  // this tab, or a reload of one) leave it alone. `useResolvedAppMode`
+  // is the authoritative source and treats the tuple as the highest-
+  // priority signal once persona information is available — writing
+  // here would clobber a valid in-tab choice with the boot-time best-
+  // effort resolve (which cannot yet see persona) and break "toggle to
+  // AI, then reload" for users who did not tick "remember".
+  if (readAppModeSession()?.mode) {
+    return;
+  }
 
   const userPref =
     derivePreferencesFromList(prefsRes.preferences).appMode ?? null;

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -57,8 +57,20 @@ import { AuthProvider as AuthProviderEnum } from '../../../generated/settings/se
 import { withActivePersonaHeader } from '../../../hoc/withActivePersonaHeader';
 import { withDomainFilter } from '../../../hoc/withDomainFilter';
 import { withLanguageHeader } from '../../../hoc/withLanguageHeader';
+import {
+  derivePreferencesFromList,
+  hydrateBackendSyncedPreferences,
+  resetBackendSyncState,
+} from '../../../hooks/currentUserStore/useCurrentUserStore';
 import { useApplicationStore } from '../../../hooks/useApplicationStore';
-import { clearAppMode, resolveInitialAppMode } from '../../../hooks/useAppMode';
+import {
+  clearAppMode,
+  resolveEffectiveAppMode,
+  resolveInitialAppMode,
+  setAppDefaultMode,
+  translateWireMode,
+  writeAppMode,
+} from '../../../hooks/useAppMode';
 import useCustomLocation from '../../../hooks/useCustomLocation/useCustomLocation';
 import { useExploreCache } from '../../../hooks/useExploreCache';
 import { queryClient } from '../../../queryClient';
@@ -68,7 +80,8 @@ import {
   fetchAuthenticationConfig,
   fetchAuthorizerConfig,
 } from '../../../rest/miscAPI';
-import { getLoggedInUser } from '../../../rest/userAPI';
+import { getAppConfiguration } from '../../../rest/settingConfigAPI';
+import { getLoggedInUser, getUserPreferences } from '../../../rest/userAPI';
 import applicationRoutesClass from '../../../utils/ApplicationRoutesClassBase';
 import TokenService from '../../../utils/Auth/TokenService/TokenServiceUtil';
 import {
@@ -121,6 +134,37 @@ const userAPIQueryFields = [
 ];
 
 const isEmailVerifyField = 'isEmailVerified';
+
+/**
+ * Boot-time app-mode plumbing, run once `currentUser` is known (both the
+ * returning-session path and the fresh-login path need it). Fetches the
+ * user's own preferences bag and the tenant-wide app-mode default in
+ * parallel — neither depends on the other, only on `user.id` being
+ * resolved already, so a true 3-way `Promise.all` alongside
+ * `getLoggedInUser` isn't possible (the preferences fetch needs the id
+ * `getLoggedInUser` itself returns).
+ *
+ * Hydrates the local preferences store from the server (or migrates a
+ * local-only value up, on first boot after this feature ships), then
+ * resolves and writes the effective app mode via the fallback chain:
+ * user preference -> persona (unknown synchronously here; refined shortly
+ * after by `useResolvedAppMode` once the persona doc loads) -> tenant
+ * default -> `DEFAULT_APP_MODE`.
+ */
+const hydrateAndResolveAppMode = async (user: User): Promise<void> => {
+  const [prefsRes, appConfig] = await Promise.all([
+    getUserPreferences(user.id).catch(() => ({ preferences: [] })),
+    getAppConfiguration().catch(() => null),
+  ]);
+  hydrateBackendSyncedPreferences(user, prefsRes);
+
+  const appDefault = translateWireMode(appConfig?.defaultAppMode ?? null);
+  setAppDefaultMode(appDefault);
+
+  const userPref =
+    derivePreferencesFromList(prefsRes.preferences).appMode ?? null;
+  writeAppMode(resolveEffectiveAppMode(userPref, null, appDefault));
+};
 
 let requestInterceptor: number | null = null;
 let responseInterceptor: number | null = null;
@@ -255,6 +299,11 @@ export const AuthProvider = ({
     // this user's transient mode.
     clearAppMode();
 
+    // Reset the debounced backend-sync bookkeeping so a pending PATCH
+    // from user A cannot be flushed with user B's value/id when the SPA
+    // logs out + back in within the 300ms window.
+    resetBackendSyncState();
+
     setApplicationLoading(false);
 
     // Clear the refresh flag (used after refresh is complete)
@@ -342,6 +391,7 @@ export const AuthProvider = ({
       if (res) {
         setCurrentUser(res);
         setIsAuthenticated(true);
+        await hydrateAndResolveAppMode(res);
       } else {
         resetUserDetails();
       }
@@ -482,6 +532,7 @@ export const AuthProvider = ({
         if (res) {
           const userDetails = await checkIfUpdateRequired(res, newUser);
           setCurrentUser(userDetails);
+          await hydrateAndResolveAppMode(userDetails);
 
           handledVerifiedUser();
           // Start expiry timer on successful login

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/configuration/appConfiguration.ts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * App-wide UI configuration. Seeded from yaml/env on first boot; DB-backed and
+ * admin-mutable at runtime afterwards (yaml is ignored once a DB row exists).
+ */
+export interface AppConfiguration {
+    /**
+     * Tenant-wide 'first impression' app-mode default. Seeds the app mode for users who have
+     * not chosen one; user preference and persona-level app mode still win over this default.
+     * Null means no tenant default is configured.
+     */
+    defaultAppMode?: DefaultAppMode | null;
+}
+
+export enum DefaultAppMode {
+    AI = "ai",
+    Classic = "classic",
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/preferences/appModePreference.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/preferences/appModePreference.ts
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * User preference for app-mode boot behavior (AI vs Classic).
+ */
+export interface AppModePreference {
+    config: Config;
+    type:   Type;
+}
+
+export interface Config {
+    value: Value | null;
+}
+
+export enum Value {
+    AI = "ai",
+    Classic = "classic",
+}
+
+export enum Type {
+    AppMode = "appMode",
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/userPreferences.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/api/teams/userPreferences.ts
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Per-user UI preferences. Each entry is a typed discriminated union — see
+ * preferences/*.json for concrete schemas.
+ */
+export interface UserPreferences {
+    /**
+     * List of typed per-user UI preferences (e.g. appMode). Each entry is a discriminated union
+     * keyed by `type`.
+     */
+    preferences: AppModePreference[];
+    /**
+     * Last update time corresponding to the new version of the preferences in Unix epoch time
+     * milliseconds.
+     */
+    updatedAt?: number;
+    /**
+     * Unique identifier of the User this preferences bag belongs to.
+     */
+    userId: string;
+}
+
+/**
+ * User preference for app-mode boot behavior (AI vs Classic).
+ */
+export interface AppModePreference {
+    config: Config;
+    type:   Type;
+}
+
+export interface Config {
+    value: Value | null;
+}
+
+export enum Value {
+    AI = "ai",
+    Classic = "classic",
+}
+
+export enum Type {
+    AppMode = "appMode",
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
@@ -29,6 +29,7 @@ export interface Settings {
  */
 export enum SettingType {
     AirflowConfiguration = "airflowConfiguration",
+    AppConfiguration = "appConfiguration",
     AssetCertificationSettings = "assetCertificationSettings",
     AuthenticationConfiguration = "authenticationConfiguration",
     AuthorizerConfiguration = "authorizerConfiguration",
@@ -108,6 +109,9 @@ export enum SettingType {
  *
  * This schema defines the Glossary Term Relation Settings for configuring typed semantic
  * relations between glossary terms.
+ *
+ * App-wide UI configuration. Seeded from yaml/env on first boot; DB-backed and
+ * admin-mutable at runtime afterwards (yaml is ignored once a DB row exists).
  */
 export interface PipelineServiceClientConfiguration {
     /**
@@ -649,6 +653,12 @@ export interface PipelineServiceClientConfiguration {
      * List of configured glossary term relation types.
      */
     relationTypes?: GlossaryTermRelationType[];
+    /**
+     * Tenant-wide 'first impression' app-mode default. Seeds the app mode for users who have
+     * not chosen one; user preference and persona-level app mode still win over this default.
+     * Null means no tenant default is configured.
+     */
+    defaultAppMode?: DefaultAppMode | null;
 }
 
 export interface AllowedFieldValueBoostFields {
@@ -1815,6 +1825,11 @@ export interface Aws {
      */
     serviceName?: string;
     [property: string]: any;
+}
+
+export enum DefaultAppMode {
+    AI = "ai",
+    Classic = "classic",
 }
 
 /**

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.test.ts
@@ -11,8 +11,12 @@
  *  limitations under the License.
  */
 import { renderHook, waitFor } from '@testing-library/react';
+import { deleteUserPreference, putUserPreference } from '../../rest/userAPI';
+import { showErrorToast } from '../../utils/ToastUtils';
 import { useApplicationStore } from '../useApplicationStore';
 import {
+  hydrateBackendSyncedPreferences,
+  resetBackendSyncState,
   useCurrentUserPreferences,
   usePersistentStorage,
 } from './useCurrentUserStore';
@@ -26,9 +30,55 @@ jest.mock('../../constants/constants', () => ({
   PAGE_SIZE_BASE: 15,
 }));
 
+jest.mock('../../rest/userAPI', () => ({
+  putUserPreference: jest.fn(),
+  deleteUserPreference: jest.fn(),
+}));
+
+jest.mock('../../utils/ToastUtils', () => ({
+  showErrorToast: jest.fn(),
+}));
+
 const mockUseApplicationStore = useApplicationStore as jest.MockedFunction<
   typeof useApplicationStore
 >;
+
+const putUserPreferenceMock = putUserPreference as jest.Mock;
+const deleteUserPreferenceMock = deleteUserPreference as jest.Mock;
+const showErrorToastMock = showErrorToast as jest.Mock;
+
+// Test helper: seeds useApplicationStore's currentUser (id + name) and,
+// optionally, the local persisted slice for that user — mirroring what a
+// prior hydration/local write would have produced.
+const seedCurrentUser = ({
+  id,
+  name,
+  preferences,
+}: {
+  id: string;
+  name: string;
+  preferences?: Record<string, unknown>;
+}) => {
+  mockUseApplicationStore.mockImplementation((selector) => {
+    const mockState = {
+      currentUser: { id, name },
+    } as any;
+
+    return selector(mockState);
+  });
+
+  if (preferences) {
+    usePersistentStorage.getState().setUserPreference(name, preferences);
+  }
+};
+
+// Test helper: renders useCurrentUserPreferences and returns its current
+// setPreference callback.
+const renderUseCurrentUserPreferences = () => {
+  const { result } = renderHook(() => useCurrentUserPreferences());
+
+  return result.current;
+};
 
 describe('useCurrentUserStore', () => {
   beforeEach(() => {
@@ -36,6 +86,7 @@ describe('useCurrentUserStore', () => {
     localStorage.clear();
     // Proper store reset
     usePersistentStorage.setState({ preferences: {} });
+    resetBackendSyncState();
 
     // Set up the default mock implementation
     mockUseApplicationStore.mockImplementation((selector) => {
@@ -207,6 +258,267 @@ describe('useCurrentUserStore', () => {
       rerender();
 
       expect(result.current.setPreference).toBe(firstSetPreference);
+    });
+  });
+
+  describe('backend-synced appMode', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('hydrates appMode from userPreferences on bootstrap (server wins)', () => {
+      const userName = 'alice';
+      usePersistentStorage
+        .getState()
+        .setUserPreference(userName, { appMode: 'classic' });
+
+      hydrateBackendSyncedPreferences(
+        { id: 'u1', name: userName },
+        { preferences: [{ type: 'appMode', config: { value: 'ai' } }] }
+      );
+
+      const slice = usePersistentStorage.getState().preferences[userName];
+
+      expect(slice.appMode).toBe('ai');
+      expect(slice.isSidebarCollapsed).toBe(false); // local-only field untouched
+    });
+
+    it('does not touch appMode when neither server nor local has a value', () => {
+      const userName = 'bob';
+      // local slice default appMode is null
+
+      hydrateBackendSyncedPreferences(
+        { id: 'u1', name: userName },
+        { preferences: [] }
+      );
+
+      const slice = usePersistentStorage.getState().preferences[userName];
+
+      expect(slice?.appMode ?? null).toBeNull();
+    });
+
+    it('debounces a PUT when appMode is written', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({ id: 'u1', name: 'alice' });
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: 'ai' });
+
+      expect(putUserPreferenceMock).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).toHaveBeenCalledTimes(1);
+      expect(putUserPreferenceMock).toHaveBeenCalledWith('u1', 'appMode', {
+        value: 'ai',
+      });
+    });
+
+    it('coalesces rapid writes into a single PUT with the last value', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({ id: 'u1', name: 'alice' });
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: 'ai' });
+      setPreference({ appMode: 'classic' });
+      setPreference({ appMode: 'ai' });
+
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).toHaveBeenCalledTimes(1);
+      expect(putUserPreferenceMock).toHaveBeenCalledWith('u1', 'appMode', {
+        value: 'ai',
+      });
+    });
+
+    it('does not PUT when a non-whitelisted key is written', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({ id: 'u1', name: 'alice' });
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ isSidebarCollapsed: true });
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).not.toHaveBeenCalled();
+      expect(
+        usePersistentStorage.getState().preferences.alice.isSidebarCollapsed
+      ).toBe(true);
+    });
+
+    it('emits a DELETE when appMode is set to null (and server had the key)', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({
+        id: 'u1',
+        name: 'alice',
+        preferences: { appMode: 'ai' },
+      });
+      // Seed serverKnown so the DELETE is emitted — see the skip-remove test
+      // below for the absent-key case.
+      hydrateBackendSyncedPreferences({ id: 'u1', name: 'alice' } as any, {
+        preferences: [{ type: 'appMode', config: { value: 'ai' } }],
+      });
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: null });
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(deleteUserPreferenceMock).toHaveBeenCalledWith('u1', 'appMode');
+      expect(putUserPreferenceMock).not.toHaveBeenCalled();
+    });
+
+    it('skips the request entirely when null is set on a key the server never had', async () => {
+      // Regression: a DELETE on a key the server never persisted would be a
+      // wasted round trip for what is semantically already a no-op.
+      jest.useFakeTimers();
+      // Seed hydration with an empty server-known state — no `appMode`.
+      seedCurrentUser({
+        id: 'u1',
+        name: 'alice',
+        preferences: {},
+      });
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: null });
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).not.toHaveBeenCalled();
+      expect(deleteUserPreferenceMock).not.toHaveBeenCalled();
+    });
+
+    it('rolls back local state and toasts when the PUT fails', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({
+        id: 'u1',
+        name: 'alice',
+        preferences: { appMode: 'classic' },
+      });
+      putUserPreferenceMock.mockRejectedValue(new Error('boom'));
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: 'ai' });
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+      await Promise.resolve(); // let the catch handler run
+
+      expect(usePersistentStorage.getState().preferences.alice.appMode).toBe(
+        'classic'
+      );
+      expect(showErrorToastMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('migrates local appMode to backend when server has none', async () => {
+      jest.useFakeTimers();
+      usePersistentStorage
+        .getState()
+        .setUserPreference('alice', { appMode: 'ai' });
+      putUserPreferenceMock.mockResolvedValue({
+        preferences: [{ type: 'appMode', config: { value: 'ai' } }],
+      });
+
+      hydrateBackendSyncedPreferences(
+        { id: 'u1', name: 'alice' },
+        { preferences: [] }
+      );
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).toHaveBeenCalledWith('u1', 'appMode', {
+        value: 'ai',
+      });
+    });
+
+    it('does not migrate when the server already has appMode', async () => {
+      jest.useFakeTimers();
+      usePersistentStorage
+        .getState()
+        .setUserPreference('alice', { appMode: 'ai' });
+
+      hydrateBackendSyncedPreferences(
+        { id: 'u1', name: 'alice' },
+        { preferences: [{ type: 'appMode', config: { value: 'classic' } }] }
+      );
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).not.toHaveBeenCalled();
+      expect(usePersistentStorage.getState().preferences.alice.appMode).toBe(
+        'classic'
+      );
+    });
+
+    it('resetBackendSyncState clears pending patch state so a re-login with different user does not leak', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({ id: 'u1', name: 'alice' });
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: 'ai' });
+
+      // Simulate logout before the debounce fires.
+      resetBackendSyncState();
+
+      // Re-login as a different user; their write should get its own PUT.
+      seedCurrentUser({ id: 'u2', name: 'bob' });
+      const bobHook = renderUseCurrentUserPreferences();
+      bobHook.setPreference({ appMode: 'classic' });
+
+      jest.advanceTimersByTime(300);
+      await Promise.resolve();
+
+      expect(putUserPreferenceMock).toHaveBeenCalledTimes(1);
+      expect(putUserPreferenceMock).toHaveBeenCalledWith('u2', 'appMode', {
+        value: 'classic',
+      });
+    });
+
+    it('does not roll back a key whose local value has changed since the failed attempt', async () => {
+      jest.useFakeTimers();
+      seedCurrentUser({
+        id: 'u1',
+        name: 'alice',
+        preferences: { appMode: 'classic' },
+      });
+
+      // First PUT will hang; capture its resolver so we can reject after a newer write.
+      let rejectFirst: (e: Error) => void = () => {};
+      putUserPreferenceMock.mockImplementationOnce(
+        () =>
+          new Promise((_res, rej) => {
+            rejectFirst = rej;
+          })
+      );
+
+      const { setPreference } = renderUseCurrentUserPreferences();
+      setPreference({ appMode: 'ai' }); // triggers first flush at t=300ms
+      jest.advanceTimersByTime(300);
+      await Promise.resolve(); // let the flush await hit await
+
+      expect(putUserPreferenceMock).toHaveBeenCalledTimes(1);
+
+      // Newer optimistic write while the earlier PUT is still in flight.
+      // Deliberately distinct from both the original seed ('classic') and the
+      // in-flight attempt ('ai') so a naive rollback-to-pre-attempt-value is
+      // observably wrong: it would clobber 'auto' with 'classic'.
+      setPreference({ appMode: 'auto' });
+
+      expect(usePersistentStorage.getState().preferences.alice.appMode).toBe(
+        'auto'
+      );
+
+      // Now the earlier PUT rejects; rollback must NOT restore the
+      // pre-attempt value ('classic') because the local value has diverged
+      // from what we tried to write ('ai') — a newer write ('auto') landed.
+      rejectFirst(new Error('boom'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(usePersistentStorage.getState().preferences.alice.appMode).toBe(
+        'auto'
+      );
+      expect(showErrorToastMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/currentUserStore/useCurrentUserStore.ts
@@ -11,11 +11,14 @@
  *  limitations under the License.
  */
 
+import { AxiosError } from 'axios';
 import { RecentlySearchedData, RecentlyViewedData } from 'Models';
 import { useCallback, useMemo } from 'react';
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { PAGE_SIZE_BASE } from '../../constants/constants';
+import { deleteUserPreference, putUserPreference } from '../../rest/userAPI';
+import { showErrorToast } from '../../utils/ToastUtils';
 import { useApplicationStore } from '../useApplicationStore';
 
 export interface MarketplaceRecentSearchEntry {
@@ -35,8 +38,8 @@ export interface UserPreferences {
   /**
    * Boot-time app-mode preference — the "open in this mode when I log in"
    * checkbox in the app-mode switcher. `null` means "no explicit preference,
-   * fall back to persona/default at boot." Only the switcher's checkbox
-   * writes this field; runtime mode-switching does NOT touch it.
+   * fall back to persona/app-default/constant at boot." Only the switcher's
+   * checkbox writes this field; runtime mode-switching does NOT touch it.
    */
   appMode: string | null;
 }
@@ -104,23 +107,311 @@ export const usePersistentStorage = create<Store>()(
   )
 );
 
+// Preference keys that are synced to the backend (the standalone
+// `user_preferences` side table, via `putUserPreference` /
+// `deleteUserPreference`) in addition to being persisted locally. Everything
+// else in UserPreferences stays purely on-device. Keep this to a single entry
+// for now — see the task brief for the rollout plan of additional keys.
+export const BACKEND_SYNCED_KEYS = new Set<keyof UserPreferences>(['appMode']);
+const DEBOUNCE_MS = 300;
+
+/**
+ * A single backend-synced-key entry off the wire, shaped `{ type, config }`
+ * per `api/teams/preferences/*.json`. `config` is intentionally loose here —
+ * each branch in {@link deriveKeyedPreferences} / {@link buildPreferenceConfig}
+ * knows its own concrete shape.
+ */
+interface WirePreferenceEntry {
+  type?: string;
+  config?: { value?: string | null };
+}
+
+/**
+ * Wire discriminator (`type`) for a backend-synced local key. Each key gets
+ * its own branch — mirrors {@link deriveKeyedPreferences} and
+ * {@link buildPreferenceConfig} below. Returns `null` for keys that aren't
+ * backend-synced (callers should have already filtered via
+ * `BACKEND_SYNCED_KEYS`, this is just a safety net).
+ */
+function preferenceTypeFor(key: keyof UserPreferences): string | null {
+  if (key === 'appMode') {
+    return 'appMode';
+  }
+
+  return null;
+}
+
+/** Builds the `config` object for a PUT of the given backend-synced key. */
+function buildPreferenceConfig(
+  key: keyof UserPreferences,
+  value: unknown
+): unknown {
+  if (key === 'appMode') {
+    return { value };
+  }
+
+  return undefined;
+}
+
+/**
+ * Translates the wire-format `preferences` list (list of typed discriminated
+ * unions keyed by `type`) into the local keyed shape consumed by
+ * `useCurrentUserPreferences`. Future preference types get their own branch
+ * here, mirroring `preferenceTypeFor` / `buildPreferenceConfig` above.
+ */
+function deriveKeyedPreferences(
+  entries?: WirePreferenceEntry[]
+): Partial<UserPreferences> {
+  const keyed: Partial<UserPreferences> = {};
+  for (const item of entries ?? []) {
+    if (item?.type === 'appMode') {
+      keyed.appMode = item.config?.value ?? null;
+    }
+    // future preference types get their own branch here.
+  }
+
+  return keyed;
+}
+
+// Exposed so `AuthProvider`'s boot-time resolver can read `appMode` (and any
+// future backend-synced key) straight off the list-shaped `GET .../preferences`
+// response without duplicating the `{type, config}` unwrapping logic.
+export const derivePreferencesFromList = deriveKeyedPreferences;
+
+// Module-level state for the debounced backend sync. `pendingPatch` holds
+// the last-write-wins value per key for the in-flight debounce window
+// (`null` means "delete this key's preference entry"). `previousValues`
+// snapshots what each key's value was immediately before the *first* write
+// in the current batch, so a failed write can roll the local store back to
+// exactly what the user saw beforehand (not to whatever the server last
+// confirmed, which may be stale or absent for keys that were never migrated
+// up).
+const pendingPatch = new Map<string, unknown>();
+const previousValues = new Map<string, unknown>();
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+let serverKnown: Partial<UserPreferences> = {};
+
+/**
+ * PUTs (or, for a `null` write, DELETEs) the given key's backend-synced
+ * preference entry, updates `serverKnown` from the authoritative response,
+ * and rolls back + toasts on failure. Scoped to a single key so one key's
+ * failure can't clobber a sibling key's successful write in the same flush.
+ */
+async function flushOneKey(
+  userName: string,
+  userId: string,
+  key: keyof UserPreferences,
+  value: unknown,
+  previousValue: unknown
+): Promise<void> {
+  const type = preferenceTypeFor(key);
+  if (!type) {
+    return;
+  }
+
+  const isRemoval = value === null;
+  // A DELETE on a key the server never had would be a wasted round trip for
+  // what is semantically already a no-op (and, under the prior JSON-Patch
+  // design, `remove` on an absent member throws per RFC 6902).
+  if (isRemoval && !(key in serverKnown)) {
+    return;
+  }
+
+  try {
+    const updated = isRemoval
+      ? await deleteUserPreference(userId, type)
+      : await putUserPreference(
+          userId,
+          type,
+          buildPreferenceConfig(key, value)
+        );
+
+    const keyed = deriveKeyedPreferences(
+      updated?.preferences as WirePreferenceEntry[] | undefined
+    );
+    if (key in keyed) {
+      (serverKnown as Record<string, unknown>)[key] = (
+        keyed as Record<string, unknown>
+      )[key];
+    } else {
+      delete (serverKnown as Record<string, unknown>)[key];
+    }
+  } catch (error) {
+    // A newer write may have landed locally while this request was in
+    // flight (e.g. the user changed the same key again before the rejected
+    // request settled). Only roll back if the local value still equals what
+    // we attempted to persist — if it has diverged, a subsequent write
+    // already superseded this attempt and clobbering it with the
+    // pre-attempt value would silently discard that newer write.
+    const currentSlice = (usePersistentStorage.getState().preferences[
+      userName
+    ] ?? {}) as unknown as Record<string, unknown>;
+    if (currentSlice[key] === value) {
+      usePersistentStorage.getState().setUserPreference(userName, {
+        [key]: previousValue ?? null,
+      } as Partial<UserPreferences>);
+    }
+    showErrorToast(error as AxiosError);
+  }
+}
+
+async function flushPendingPatch(
+  userName: string,
+  userId: string
+): Promise<void> {
+  flushTimer = null;
+  if (pendingPatch.size === 0) {
+    return;
+  }
+
+  const attempted = new Map(pendingPatch);
+  pendingPatch.clear();
+  const attemptedPrevious = new Map(previousValues);
+  previousValues.clear();
+
+  await Promise.all(
+    Array.from(attempted.entries()).map(([key, value]) =>
+      flushOneKey(
+        userName,
+        userId,
+        key as keyof UserPreferences,
+        value,
+        attemptedPrevious.get(key)
+      )
+    )
+  );
+}
+
+/**
+ * Enqueues a debounced backend PUT/DELETE for any backend-synced keys
+ * present in `patch`. Non-whitelisted keys are ignored here entirely — they
+ * still get written to the local persisted store by the caller, they just
+ * never reach the server.
+ *
+ * `previous` (when supplied) is the pre-write snapshot of the affected keys,
+ * used only to seed the rollback value for this batch. When omitted (e.g.
+ * the one-shot migration call from `hydrateBackendSyncedPreferences`), the
+ * last known server value is used instead.
+ */
+export function syncBackendKeys(
+  userName: string,
+  userId: string,
+  patch: Partial<UserPreferences>,
+  previous?: Partial<UserPreferences>
+): void {
+  let queued = false;
+  for (const [key, value] of Object.entries(patch)) {
+    if (!BACKEND_SYNCED_KEYS.has(key as keyof UserPreferences)) {
+      continue;
+    }
+    if (!previousValues.has(key)) {
+      const serverFallback =
+        (serverKnown as Record<string, unknown>)[key] ?? null;
+      const previousValue =
+        previous && key in previous
+          ? (previous as Record<string, unknown>)[key] ?? null
+          : serverFallback;
+      previousValues.set(key, previousValue);
+    }
+    pendingPatch.set(key, value ?? null);
+    queued = true;
+  }
+  if (!queued) {
+    return;
+  }
+  if (flushTimer !== null) {
+    return;
+  }
+  flushTimer = setTimeout(() => {
+    void flushPendingPatch(userName, userId);
+  }, DEBOUNCE_MS);
+}
+
+/**
+ * Bootstrap hook: call once, right after `getLoggedInUser()` resolves and
+ * `currentUser` is set, passing the sibling `GET /users/{id}/preferences`
+ * response as `userPreferences`. Reconciles the freshly-fetched server
+ * preferences with whatever is already in the local persisted store:
+ *  - server has a value  -> server wins, overwrite local.
+ *  - server has no value but local does -> one-shot migration, PUT it up.
+ *  - neither has a value -> no-op.
+ */
+export function hydrateBackendSyncedPreferences(
+  user: { id: string; name: string },
+  userPreferences?: { preferences?: WirePreferenceEntry[] }
+): void {
+  if (!user?.name || !user.id) {
+    return;
+  }
+  const server = deriveKeyedPreferences(userPreferences?.preferences);
+  serverKnown = { ...server };
+
+  const localSlice =
+    usePersistentStorage.getState().preferences[user.name] ??
+    ({} as UserPreferences);
+
+  for (const key of BACKEND_SYNCED_KEYS) {
+    const serverValue = (server as Record<string, unknown>)[key];
+    const localValue = (localSlice as unknown as Record<string, unknown>)[key];
+
+    if (serverValue !== undefined) {
+      // Server wins.
+      usePersistentStorage.getState().setUserPreference(user.name, {
+        [key]: serverValue,
+      } as Partial<UserPreferences>);
+    } else if (localValue !== undefined && localValue !== null) {
+      // Migrate the local-only value up to the server.
+      syncBackendKeys(user.name, user.id, {
+        [key]: localValue,
+      } as Partial<UserPreferences>);
+    }
+  }
+}
+
+/**
+ * Resets all module-level backend-sync bookkeeping (pending patch, rollback
+ * snapshots, debounce timer, last-known server state). Exists primarily so
+ * tests can isolate each case; also safe to call on logout.
+ */
+export function resetBackendSyncState(): void {
+  pendingPatch.clear();
+  previousValues.clear();
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  serverKnown = {};
+}
+
 // Hook to easily access current user's preferences
 export const useCurrentUserPreferences = () => {
   const currentUser = useApplicationStore((state) => state.currentUser);
   const { preferences, setUserPreference } = usePersistentStorage();
   const userName = currentUser?.name;
+  const currentUserId = currentUser?.id;
 
-  // Memoized (deps: userName, stable store action) so consumers such as
-  // usePaging, which capture setPreference in the dependency array of
-  // handlePageChange, don't get a fresh callback every render — an unstable
-  // identity would recreate those callbacks and cancel debounced work.
+  // Memoized (deps: userName, currentUserId, stable store action) so
+  // consumers such as usePaging, which capture setPreference in the
+  // dependency array of handlePageChange, don't get a fresh callback every
+  // render — an unstable identity would recreate those callbacks and cancel
+  // debounced work.
   const setPreference = useCallback(
     (newPreferences: Partial<UserPreferences>) => {
-      if (userName) {
-        setUserPreference(userName, newPreferences);
+      if (!userName) {
+        return;
+      }
+      // Snapshot pre-write values before the optimistic local update so a
+      // failed backend sync can roll back to what the user actually saw.
+      const previous = usePersistentStorage.getState().preferences[userName];
+      setUserPreference(userName, newPreferences);
+      // Backend sync needs the user's id (for the PUT/DELETE URL);
+      // local-only users (e.g. not yet resolved) still get the local write
+      // above.
+      if (currentUserId) {
+        syncBackendKeys(userName, currentUserId, newPreferences, previous);
       }
     },
-    [userName, setUserPreference]
+    [userName, currentUserId, setUserPreference]
   );
 
   const resolvedPreferences = useMemo(
@@ -136,3 +427,19 @@ export const useCurrentUserPreferences = () => {
     setPreference,
   };
 };
+
+// Best-effort flush of any still-debounced write when the tab is closing —
+// otherwise a write made just before navigation/close would be silently
+// dropped once the debounce timer never gets to fire.
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', () => {
+    if (flushTimer !== null) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+      const user = useApplicationStore.getState().currentUser;
+      if (user?.id && user?.name) {
+        void flushPendingPatch(user.name, user.id);
+      }
+    }
+  });
+}

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
@@ -111,6 +111,7 @@ describe('writeAppMode', () => {
     expect(JSON.parse(raw ?? '')).toEqual({
       personaAppMode: 'ai',
       mode: 'ai',
+      source: 'manual',
     });
   });
 
@@ -123,6 +124,7 @@ describe('writeAppMode', () => {
     expect(JSON.parse(raw ?? '')).toEqual({
       personaAppMode: 'ai',
       mode: DEFAULT_APP_MODE,
+      source: 'manual',
     });
   });
 
@@ -134,6 +136,7 @@ describe('writeAppMode', () => {
     expect(JSON.parse(raw ?? '')).toEqual({
       personaAppMode: null,
       mode: 'ai',
+      source: 'manual',
     });
   });
 
@@ -146,7 +149,40 @@ describe('writeAppMode', () => {
     expect(JSON.parse(raw ?? '')).toEqual({
       personaAppMode: null,
       mode: 'ai',
+      source: 'manual',
     });
+  });
+
+  it('records the source when `options.source` is passed', () => {
+    writeAppMode('ai', null, { source: 'boot' });
+
+    const raw = globalThis.window.sessionStorage.getItem(APP_MODE_SESSION_KEY);
+
+    expect(JSON.parse(raw ?? '')).toEqual({
+      personaAppMode: null,
+      mode: 'ai',
+      source: 'boot',
+    });
+  });
+
+  it('does NOT write the cross-tab hint for `source: "boot"` writes', () => {
+    writeAppMode('ai', null, { source: 'boot' });
+
+    // Boot-provisional writes must not leak to sibling tabs as an
+    // authoritative "user chose this" hint — the hint only carries
+    // deliberate user choices (`manual`) and resolver conclusions
+    // (`resolver`), not synchronous best-guesses.
+    expect(
+      globalThis.window.localStorage.getItem(APP_MODE_HINT_STORAGE_KEY)
+    ).toBeNull();
+  });
+
+  it('writes the cross-tab hint for `source: "resolver"` writes', () => {
+    writeAppMode('ai', null, { source: 'resolver' });
+
+    expect(
+      globalThis.window.localStorage.getItem(APP_MODE_HINT_STORAGE_KEY)
+    ).not.toBeNull();
   });
 
   it('writes the cross-tab hint to localStorage', () => {

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.test.ts
@@ -14,6 +14,7 @@
 import { renderHook } from '@testing-library/react';
 import { act } from 'react';
 import {
+  AI_APP_MODE,
   APP_MODE_HINT_STORAGE_KEY,
   APP_MODE_HINT_TTL_MS,
   APP_MODE_SESSION_KEY,
@@ -22,10 +23,15 @@ import {
 import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 import {
   clearAppMode,
+  CONFIG_MODE_TO_RUNTIME,
+  getAppDefaultMode,
   isAppModeHintFresh,
   readAppModeHint,
   readAppModeSession,
+  resolveEffectiveAppMode,
   resolveInitialAppMode,
+  setAppDefaultMode,
+  translateWireMode,
   useAppMode,
   useAppModeStore,
   writeAppMode,
@@ -485,5 +491,66 @@ describe('resolveInitialAppMode', () => {
       .setUserPreference(TEST_USER, { appMode: DEFAULT_APP_MODE });
 
     expect(resolveInitialAppMode(TEST_USER)).toBe('ai');
+  });
+});
+
+describe('resolveEffectiveAppMode', () => {
+  it('user preference wins over everything', () => {
+    expect(resolveEffectiveAppMode('ai', 'default', 'default')).toBe('ai');
+  });
+
+  it('persona wins over app default', () => {
+    expect(resolveEffectiveAppMode(null, 'ai', 'default')).toBe('ai');
+  });
+
+  it('app default wins over constant', () => {
+    expect(resolveEffectiveAppMode(null, null, 'ai')).toBe('ai');
+  });
+
+  it('constant is the final fallback', () => {
+    expect(resolveEffectiveAppMode(null, null, null)).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('treats undefined the same as null for every signal', () => {
+    expect(resolveEffectiveAppMode(undefined, undefined, undefined)).toBe(
+      DEFAULT_APP_MODE
+    );
+  });
+});
+
+describe('CONFIG_MODE_TO_RUNTIME / translateWireMode', () => {
+  it('maps the wire "classic" value to DEFAULT_APP_MODE', () => {
+    expect(CONFIG_MODE_TO_RUNTIME.classic).toBe(DEFAULT_APP_MODE);
+    expect(translateWireMode('classic')).toBe(DEFAULT_APP_MODE);
+  });
+
+  it('maps the wire "ai" value to AI_APP_MODE', () => {
+    expect(CONFIG_MODE_TO_RUNTIME.ai).toBe(AI_APP_MODE);
+    expect(translateWireMode('ai')).toBe(AI_APP_MODE);
+  });
+
+  it('returns null for a null/undefined wire value', () => {
+    expect(translateWireMode(null)).toBeNull();
+    expect(translateWireMode(undefined)).toBeNull();
+  });
+
+  it('returns null for an unrecognised wire value', () => {
+    expect(translateWireMode('bogus')).toBeNull();
+  });
+});
+
+describe('setAppDefaultMode / getAppDefaultMode', () => {
+  afterEach(() => {
+    setAppDefaultMode(null);
+  });
+
+  it('defaults to null', () => {
+    expect(getAppDefaultMode()).toBeNull();
+  });
+
+  it('stores and returns whatever was set', () => {
+    setAppDefaultMode(AI_APP_MODE);
+
+    expect(getAppDefaultMode()).toBe(AI_APP_MODE);
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
@@ -26,14 +26,30 @@ import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 /**
  * Payload persisted in `sessionStorage[APP_MODE_SESSION_KEY]`.
  * `personaAppMode` is the value the resolver saw from the persona doc
- * when this tuple was last written. `useResolvedAppMode` compares its
- * current view of the persona's `appMode` against this snapshot to
- * decide whether the persona has something new to say (invalidate the
- * session) or not (respect the tab's chosen mode).
+ * when this tuple was last written.
+ *
+ * `source` records WHO wrote the tuple:
+ *   - `'manual'` — a UI toggle (profile dropdown, switcher popover,
+ *     plugin click). The user's active choice for this tab.
+ *   - `'resolver'` — `useResolvedAppMode` after it has full context
+ *     (persona doc, registered routes). The authoritative resolve.
+ *   - `'boot'` — `AuthProvider.hydrateAndResolveAppMode`'s pre-persona
+ *     write. **Provisional** — the resolver is allowed to override
+ *     when it has better info (persona / registered routes).
+ *   - `undefined` — legacy tuples from before this field existed;
+ *     treated as `'manual'` (respect them). Backward-compatible.
+ *
+ * `useResolvedAppMode`'s "keep the current session" branch only fires
+ * when `source !== 'boot'`. Boot-provisional tuples are cleared and
+ * the resolver runs the full precedence chain with the async context
+ * it has now.
  */
+export type AppModeSessionSource = 'manual' | 'resolver' | 'boot';
+
 export interface AppModeSession {
   personaAppMode: string | null;
   mode: string;
+  source?: AppModeSessionSource;
 }
 
 /**
@@ -80,8 +96,19 @@ const readSession = (): AppModeSession | null => {
       const tuple = parsed as AppModeSession;
       const personaAppMode =
         typeof tuple.personaAppMode === 'string' ? tuple.personaAppMode : null;
+      // Preserve `source` when it's one of the known values. Legacy
+      // tuples written before this field existed omit it — treat that
+      // as "manual" via the resolver's `source !== 'boot'` check.
+      const source: AppModeSessionSource | undefined =
+        tuple.source === 'manual' ||
+        tuple.source === 'resolver' ||
+        tuple.source === 'boot'
+          ? tuple.source
+          : undefined;
 
-      return { personaAppMode, mode: tuple.mode };
+      return source
+        ? { personaAppMode, mode: tuple.mode, source }
+        : { personaAppMode, mode: tuple.mode };
     }
   } catch {
     // fall through — malformed payloads are treated as absent
@@ -259,21 +286,38 @@ export const useAppMode = (): string =>
  * resolver saw from the persona doc at the moment of write. Callers
  * that don't know the persona value (the switcher, the desktop lock)
  * omit it and the current tuple's `personaAppMode` is preserved.
+ *
+ * `source` records who is writing:
+ *   - `'manual'` (default) — a UI toggle; sticky against resolver
+ *     override.
+ *   - `'resolver'` — `useResolvedAppMode`'s authoritative write; sticky.
+ *   - `'boot'` — `AuthProvider.hydrateAndResolveAppMode`'s pre-persona
+ *     provisional write; overrideable by the async resolver once it
+ *     has persona / route registry info.
+ *
+ * All existing callers (UI switches) default to `'manual'`, so this
+ * is a backward-compatible signature change.
  */
 export const writeAppMode = (
   mode: string,
-  personaAppMode?: string | null
+  personaAppMode?: string | null,
+  options?: { source?: AppModeSessionSource }
 ): void => {
   const nextPersonaAppMode =
     personaAppMode === undefined
       ? readSession()?.personaAppMode ?? null
       : personaAppMode;
+  const source: AppModeSessionSource = options?.source ?? 'manual';
 
   useAppModeStore.getState().setMode(mode);
-  writeSession({ personaAppMode: nextPersonaAppMode, mode });
+  writeSession({ personaAppMode: nextPersonaAppMode, mode, source });
   // Cross-tab hint: sibling / newly-opened tabs read this at boot when
   // their sessionStorage is empty (see APP_MODE_HINT_STORAGE_KEY docs).
-  writeHint(mode);
+  // Do NOT write the hint for `'boot'` writes: a boot-provisional
+  // tuple shouldn't leak to sibling tabs as a "user chose this" hint.
+  if (source !== 'boot') {
+    writeHint(mode);
+  }
 };
 
 export const clearAppMode = (): void => {
@@ -292,6 +336,24 @@ export const clearAppMode = (): void => {
  */
 export const clearAppModeSessionOnly = (): void => {
   useAppModeStore.getState().reset();
+  removeSession();
+};
+
+/**
+ * Remove only the sessionStorage tuple; DO NOT touch the in-memory store
+ * or the cross-tab hint. Used by the resolver's boot-provisional override
+ * — the boot write has already set the store to a best-guess mode, and
+ * the resolver is about to overwrite the store via `writeAppMode(candidate)`
+ * once it has full context. Zustand notifies subscribers synchronously on
+ * every `set`, so calling `.reset()` between the boot write and the
+ * resolver's write forces a transient `currentMode === DEFAULT_APP_MODE`
+ * render that flips a non-default route ('/ai-automations',
+ * '/observability/*', etc.) through the Classic route tree's catch-all
+ * and redirects it to `/404` before the resolver's write lands. Leaving
+ * the store on boot's value means the only mode change subscribers see
+ * is the final resolver value, not an intermediate default.
+ */
+export const removeAppModeSession = (): void => {
   removeSession();
 };
 
@@ -393,14 +455,28 @@ export const translateWireMode = (
   wireMode ? CONFIG_MODE_TO_RUNTIME[wireMode] ?? null : null;
 
 /**
- * Resolve the effective app mode at boot from the fallback chain, highest
- * precedence first:
+ * Canonical precedence for the "no valid session tuple, no fresh hint"
+ * case. Used by BOTH `AuthProvider.hydrateAndResolveAppMode` (boot-time
+ * pre-session write) and `useResolvedAppMode` (async resolver), so the
+ * two entry points can never encode different fallback chains.
  *
- *   1. `userPref`    — the user's own stored preference (`user_preferences`).
+ * Signals, highest precedence first:
+ *
+ *   1. `userPref`    — the user's own stored preference (`user_preferences`,
+ *                       aka the "remember" server-side toggle). A
+ *                       persistent user choice made through the switcher.
  *   2. `personaMode` — the admin-curated persona app mode, when known.
+ *                       The group-level default for this user's persona.
  *   3. `appDefault`  — the tenant-wide "first impression" default
  *                       (`appConfiguration.defaultAppMode`, translated).
  *   4. `DEFAULT_APP_MODE` — the hardcoded constant, last resort.
+ *
+ * Not included here (higher-priority signals handled by callers):
+ *   - Session tuple (`sessionStorage['omAppMode']`) — the manual in-tab
+ *     switch, wins unconditionally when valid. See
+ *     `useResolvedAppMode`'s `validSession` guard.
+ *   - Fresh cross-tab hint (`localStorage['omAppModeHint']`) — sits
+ *     between session and the chain above. See `useResolvedAppMode`.
  *
  * Pure — no side effects, no storage reads. Callers are responsible for
  * supplying each signal (see `AuthProvider`'s bootstrap wiring).

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useAppMode.ts
@@ -14,11 +14,13 @@
 import { isUndefined } from 'lodash';
 import { create } from 'zustand';
 import {
+  AI_APP_MODE,
   APP_MODE_HINT_STORAGE_KEY,
   APP_MODE_HINT_TTL_MS,
   APP_MODE_SESSION_KEY,
   DEFAULT_APP_MODE,
 } from '../constants/appMode.constants';
+import { DefaultAppMode } from '../generated/api/configuration/appConfiguration';
 import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 
 /**
@@ -366,3 +368,59 @@ export const resolveInitialAppMode = (userName?: string): string => {
 
   return DEFAULT_APP_MODE;
 };
+
+/**
+ * Translate the yaml/DB-facing `appConfiguration.defaultAppMode` wire value
+ * ("ai" | "classic") into the runtime mode string consumed by `useAppMode` /
+ * `useResolvedAppMode`. Core has always used `DEFAULT_APP_MODE` ("default")
+ * for Classic, while the Collate plugin registers its routes under
+ * `AI_APP_MODE` ("ai"). The wire value stays the readable "ai"/"classic"
+ * pair for admins; this map is the only place that needs to know the
+ * runtime strings differ.
+ */
+export const CONFIG_MODE_TO_RUNTIME: Record<string, string> = {
+  [DefaultAppMode.Classic]: DEFAULT_APP_MODE,
+  [DefaultAppMode.AI]: AI_APP_MODE,
+};
+
+/**
+ * Safe wrapper around {@link CONFIG_MODE_TO_RUNTIME} for the nullable wire
+ * value returned by `getAppConfiguration()` / `AppConfiguration.defaultAppMode`.
+ */
+export const translateWireMode = (
+  wireMode: string | null | undefined
+): string | null =>
+  wireMode ? CONFIG_MODE_TO_RUNTIME[wireMode] ?? null : null;
+
+/**
+ * Resolve the effective app mode at boot from the fallback chain, highest
+ * precedence first:
+ *
+ *   1. `userPref`    — the user's own stored preference (`user_preferences`).
+ *   2. `personaMode` — the admin-curated persona app mode, when known.
+ *   3. `appDefault`  — the tenant-wide "first impression" default
+ *                       (`appConfiguration.defaultAppMode`, translated).
+ *   4. `DEFAULT_APP_MODE` — the hardcoded constant, last resort.
+ *
+ * Pure — no side effects, no storage reads. Callers are responsible for
+ * supplying each signal (see `AuthProvider`'s bootstrap wiring).
+ */
+export const resolveEffectiveAppMode = (
+  userPref: string | null | undefined,
+  personaMode: string | null | undefined,
+  appDefault: string | null | undefined
+): string => userPref ?? personaMode ?? appDefault ?? DEFAULT_APP_MODE;
+
+// In-memory cache of the tenant-wide app-mode default (already translated
+// to the runtime string), populated once at boot from `getAppConfiguration()`
+// by `AuthProvider`. Deliberately NOT persisted anywhere — it is a soft
+// fallback consulted only when neither the user's preference nor the
+// persona have an opinion. See `resolveEffectiveAppMode` and
+// `useResolvedAppMode`, which both consult it as the third-priority signal.
+let appDefaultMode: string | null = null;
+
+export const setAppDefaultMode = (mode: string | null): void => {
+  appDefaultMode = mode;
+};
+
+export const getAppDefaultMode = (): string | null => appDefaultMode;

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.test.ts
@@ -24,7 +24,11 @@ import {
 import { AppMode } from '../generated/type/personaPreferences';
 import { usePersistentStorage } from './currentUserStore/useCurrentUserStore';
 import { useApplicationStore } from './useApplicationStore';
-import { readAppModeSession, useAppModeStore } from './useAppMode';
+import {
+  readAppModeSession,
+  setAppDefaultMode,
+  useAppModeStore,
+} from './useAppMode';
 import { useAppRoutesRegistry } from './useAppRoutesRegistry';
 import { useResolvedAppMode } from './useResolvedAppMode';
 
@@ -91,7 +95,11 @@ const seedUserPref = (appMode: string | null) => {
 };
 
 const seedSessionTuple = (
-  tuple: { personaAppMode: string | null; mode: string } | null
+  tuple: {
+    personaAppMode: string | null;
+    mode: string;
+    source?: 'boot' | 'resolver' | 'manual';
+  } | null
 ) => {
   if (tuple === null) {
     globalThis.window.sessionStorage.removeItem(APP_MODE_SESSION_KEY);
@@ -143,6 +151,7 @@ describe('useResolvedAppMode', () => {
     seedSessionTuple(null);
     seedHint(null);
     seedRegistry(false);
+    setAppDefaultMode(null);
     usePersistentStorage.setState({ preferences: {} } as never);
     seedUser({ authenticated: false });
     getDocumentByFQN.mockReset();
@@ -169,6 +178,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: DEFAULT_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -185,6 +195,62 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: AI_APP_MODE,
         mode: AI_APP_MODE,
+        source: 'resolver',
+      });
+    });
+  });
+
+  it('rung 4 (user pref) beats rung 5 (persona) — both set, no session', async () => {
+    // User has "remembered" Classic via the switcher; persona says AI.
+    // The user's persisted choice beats the admin's group default.
+    seedUser({ personaId: 'persona-1', personaName: 'p' });
+    seedRegistry(true);
+    seedUserPref(DEFAULT_APP_MODE);
+    getDocumentByFQN.mockResolvedValue(personaDoc(AppMode.AI));
+
+    renderHook(() => useResolvedAppMode(), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(useAppModeStore.getState().currentMode).toBe(DEFAULT_APP_MODE);
+      expect(readAppModeSession()).toEqual({
+        personaAppMode: AI_APP_MODE,
+        mode: DEFAULT_APP_MODE,
+        source: 'resolver',
+      });
+    });
+  });
+
+  it('rung 5 (persona) beats rung 6 (tenant default) — persona set, no user pref, tenant Classic', async () => {
+    seedUser({ personaId: 'persona-1', personaName: 'p' });
+    seedRegistry(true);
+    setAppDefaultMode(DEFAULT_APP_MODE);
+    getDocumentByFQN.mockResolvedValue(personaDoc(AppMode.AI));
+
+    renderHook(() => useResolvedAppMode(), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(useAppModeStore.getState().currentMode).toBe(AI_APP_MODE);
+      expect(readAppModeSession()).toEqual({
+        personaAppMode: AI_APP_MODE,
+        mode: AI_APP_MODE,
+        source: 'resolver',
+      });
+    });
+  });
+
+  it('rung 6 (tenant default) beats rung 7 (DEFAULT_APP_MODE) — no user pref, no persona, tenant AI', async () => {
+    seedUser({});
+    seedRegistry(true);
+    setAppDefaultMode(AI_APP_MODE);
+
+    renderHook(() => useResolvedAppMode(), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(useAppModeStore.getState().currentMode).toBe(AI_APP_MODE);
+      expect(readAppModeSession()).toEqual({
+        personaAppMode: null,
+        mode: AI_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -218,15 +284,15 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: AI_APP_MODE,
+        source: 'resolver',
       });
     });
   });
 
-  it('respects an existing session tuple when persona appMode matches its snapshot', async () => {
+  it('respects a valid session tuple regardless of what persona says (rung 1 wins)', async () => {
     seedUser({ personaId: 'persona-1', personaName: 'p' });
     seedRegistry(true);
-    // User previously switched to Classic during this tab (personaAppMode
-    // snapshot stored as `ai` — the persona still says AI).
+    // User manually switched to Classic during this tab.
     seedSessionTuple({ personaAppMode: AI_APP_MODE, mode: DEFAULT_APP_MODE });
     useAppModeStore.setState({ currentMode: DEFAULT_APP_MODE });
     getDocumentByFQN.mockResolvedValue(personaDoc(AppMode.AI));
@@ -237,7 +303,7 @@ describe('useResolvedAppMode', () => {
       expect(getDocumentByFQN).toHaveBeenCalled();
     });
 
-    // Tuple matches persona snapshot — session sticks, mode unchanged.
+    // Session wins even though persona (AI) disagrees with the tuple's mode.
     expect(useAppModeStore.getState().currentMode).toBe(DEFAULT_APP_MODE);
     expect(readAppModeSession()).toEqual({
       personaAppMode: AI_APP_MODE,
@@ -245,11 +311,44 @@ describe('useResolvedAppMode', () => {
     });
   });
 
-  it('overrides an existing session tuple when persona appMode differs from its snapshot', async () => {
+  it('overrides a `source: "boot"` session tuple with the persona-based candidate', async () => {
+    // The classic rung-4 case: `AuthProvider.hydrateAndResolveAppMode`
+    // wrote `default` at boot because persona wasn't known
+    // synchronously; the resolver now has persona=AI and MUST
+    // override the boot-provisional tuple. Under the pre-provisional
+    // design this override was blocked by `if (validSession) return`,
+    // and Rung 4 could not be satisfied without deferring the boot
+    // write entirely (which broke fast-boot rendering).
+    seedUser({ personaId: 'persona-1', personaName: 'p' });
+    seedRegistry(true);
+    seedSessionTuple({
+      personaAppMode: null,
+      mode: DEFAULT_APP_MODE,
+      source: 'boot',
+    });
+    useAppModeStore.setState({ currentMode: DEFAULT_APP_MODE });
+    getDocumentByFQN.mockResolvedValue(personaDoc(AppMode.AI));
+
+    renderHook(() => useResolvedAppMode(), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(useAppModeStore.getState().currentMode).toBe(AI_APP_MODE);
+      expect(readAppModeSession()).toEqual({
+        personaAppMode: AI_APP_MODE,
+        mode: AI_APP_MODE,
+        source: 'resolver',
+      });
+    });
+  });
+
+  it('keeps a valid session tuple even when persona changed since it was written (regression guard)', async () => {
     seedUser({ personaId: 'persona-1', personaName: 'p' });
     seedRegistry(true);
     // Prior tuple recorded `null` for personaAppMode (no persona at time
-    // of write) — persona now says Classic. Should snap to Classic.
+    // of write); persona now says Classic. The old behaviour clobbered
+    // the tuple in this asymmetric case — new behaviour keeps it, so
+    // the user's manual `ai` switch survives an admin persona edit
+    // made after the click.
     seedSessionTuple({ personaAppMode: null, mode: AI_APP_MODE });
     useAppModeStore.setState({ currentMode: AI_APP_MODE });
     getDocumentByFQN.mockResolvedValue(personaDoc(AppMode.Classic));
@@ -257,11 +356,13 @@ describe('useResolvedAppMode', () => {
     renderHook(() => useResolvedAppMode(), { wrapper: makeWrapper() });
 
     await waitFor(() => {
-      expect(useAppModeStore.getState().currentMode).toBe(DEFAULT_APP_MODE);
-      expect(readAppModeSession()).toEqual({
-        personaAppMode: DEFAULT_APP_MODE,
-        mode: DEFAULT_APP_MODE,
-      });
+      expect(getDocumentByFQN).toHaveBeenCalled();
+    });
+
+    expect(useAppModeStore.getState().currentMode).toBe(AI_APP_MODE);
+    expect(readAppModeSession()).toEqual({
+      personaAppMode: null,
+      mode: AI_APP_MODE,
     });
   });
 
@@ -310,6 +411,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: DEFAULT_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -371,6 +473,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: AI_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -389,6 +492,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: AI_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -410,6 +514,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: DEFAULT_APP_MODE,
         mode: AI_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -426,6 +531,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: DEFAULT_APP_MODE,
+        source: 'resolver',
       });
     });
   });
@@ -470,6 +576,7 @@ describe('useResolvedAppMode', () => {
       expect(readAppModeSession()).toEqual({
         personaAppMode: null,
         mode: DEFAULT_APP_MODE,
+        source: 'resolver',
       });
     });
 

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.ts
@@ -26,6 +26,7 @@ import { useCurrentUserPreferences } from './currentUserStore/useCurrentUserStor
 import { useApplicationStore } from './useApplicationStore';
 import {
   clearAppModeSessionOnly,
+  getAppDefaultMode,
   isAppModeHintFresh,
   readAppModeHint,
   readAppModeSession,
@@ -77,7 +78,9 @@ const resolvePersonaAppMode = (
  *      re-runs leave the user's chosen mode alone.
  *   3. Persona's `appMode` if set.
  *   4. User preference (`usePersistentStorage[user].appMode`).
- *   5. `DEFAULT_APP_MODE`.
+ *   5. Tenant-wide app-mode default (`appConfiguration.defaultAppMode`,
+ *      cached via `setAppDefaultMode` — see `AuthProvider`'s bootstrap).
+ *   6. `DEFAULT_APP_MODE`.
  *
  * The install gate is applied on top of the candidate: if a non-default
  * candidate is not registered in `useAppRoutesRegistry`, the resolver
@@ -234,7 +237,10 @@ export const useResolvedAppMode = (): boolean => {
 
     const preferredMode = preferences.appMode ?? null;
     const candidate =
-      currentPersonaAppMode ?? preferredMode ?? DEFAULT_APP_MODE;
+      currentPersonaAppMode ??
+      preferredMode ??
+      getAppDefaultMode() ??
+      DEFAULT_APP_MODE;
 
     // Install gate: refuse to write a non-default mode that isn't
     // registered yet. When the route registers later, this effect

--- a/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/hooks/useResolvedAppMode.ts
@@ -25,11 +25,14 @@ import { getDocumentByFQN } from '../rest/DocStoreAPI';
 import { useCurrentUserPreferences } from './currentUserStore/useCurrentUserStore';
 import { useApplicationStore } from './useApplicationStore';
 import {
+  AppModeSession,
   clearAppModeSessionOnly,
   getAppDefaultMode,
   isAppModeHintFresh,
   readAppModeHint,
   readAppModeSession,
+  removeAppModeSession,
+  resolveEffectiveAppMode,
   writeAppMode,
 } from './useAppMode';
 import { useAppRoutesRegistry } from './useAppRoutesRegistry';
@@ -68,19 +71,28 @@ const resolvePersonaAppMode = (
 /**
  * Single source of truth for resolving the active app mode at boot.
  *
- * Precedence (top wins):
+ * Precedence (top wins) — this order is shared with
+ * `resolveEffectiveAppMode` (used by `AuthProvider`'s pre-session
+ * bootstrap) so the two entry points can never disagree:
+ *
  *   1. Desktop app — handled outside this hook; the desktop shell calls
  *      `writeAppMode(AI_APP_MODE)` directly and the resolver bails on the
  *      relevant state (no persona to fetch, sessionStorage tuple always
  *      present after that write).
- *   2. Current session tuple whose `personaAppMode` matches what the
- *      persona currently says → keep it. Refreshes and same-persona
- *      re-runs leave the user's chosen mode alone.
- *   3. Persona's `appMode` if set.
- *   4. User preference (`usePersistentStorage[user].appMode`).
- *   5. Tenant-wide app-mode default (`appConfiguration.defaultAppMode`,
+ *   2. Current session tuple, if valid (mode is registered). This is
+ *      the user's manual in-tab switch and it wins unconditionally —
+ *      including over a persona change that happened after the tuple
+ *      was written. Rationale: the user's *right-now* click in this
+ *      tab must not be silently undone by an admin editing the
+ *      persona doc mid-session.
+ *   3. Fresh cross-tab hint (`localStorage['omAppModeHint']`) — carries
+ *      the user's most-recent active choice into a newly-opened tab.
+ *   4. User preference (`usePersistentStorage[user].appMode`) — the
+ *      server-side "remember" toggle. A persistent user choice.
+ *   5. Persona's `appMode` if set — the admin-curated group default.
+ *   6. Tenant-wide app-mode default (`appConfiguration.defaultAppMode`,
  *      cached via `setAppDefaultMode` — see `AuthProvider`'s bootstrap).
- *   6. `DEFAULT_APP_MODE`.
+ *   7. `DEFAULT_APP_MODE`.
  *
  * The install gate is applied on top of the candidate: if a non-default
  * candidate is not registered in `useAppRoutesRegistry`, the resolver
@@ -195,7 +207,7 @@ export const useResolvedAppMode = (): boolean => {
     //     plugin owning the mode is truly uninstalled. Clear ONLY
     //     this tab's session tuple (not the shared hint — sibling
     //     tabs might legitimately be using it) and fall through.
-    const validSession =
+    let validSession: AppModeSession | null =
       session && isModeRegistered(session.mode) ? session : null;
     if (session && !validSession) {
       if (!registrySettled) {
@@ -204,8 +216,31 @@ export const useResolvedAppMode = (): boolean => {
       clearAppModeSessionOnly();
     }
 
-    if (validSession && validSession.personaAppMode === currentPersonaAppMode) {
+    // Non-boot sessions win unconditionally — a `'manual'` tuple came
+    // from a user's UI toggle in this tab (rung 1: manual switch
+    // wins) and a `'resolver'` tuple is our own authoritative resolve
+    // from a prior run, both immune to persona / registry updates
+    // that happen after the write. A `'boot'` tuple is provisional
+    // (see `AuthProvider.hydrateAndResolveAppMode`) — we clear it
+    // and null out the local reference so downstream code (hint
+    // adoption, candidate write) proceeds as if there had been no
+    // session at all.
+    if (validSession && validSession.source !== 'boot') {
       return;
+    }
+    if (validSession && validSession.source === 'boot') {
+      // Remove the sessionStorage tuple but leave the store on the
+      // boot-written value: `writeAppMode(candidate, ..., 'resolver')`
+      // below overwrites the store cleanly, so the only currentMode
+      // change subscribers see is the final resolver value. A
+      // `clearAppModeSessionOnly()` here would reset the store to
+      // DEFAULT_APP_MODE first, and Zustand's synchronous subscriber
+      // notification would drive one render at DEFAULT before the
+      // resolver's write lands — enough to route a non-default URL
+      // (e.g. /ai-automations, /observability/*) through the Classic
+      // catch-all and redirect it to /404.
+      removeAppModeSession();
+      validSession = null;
     }
 
     // Cross-tab hint: when this tab has no session (fresh open, e.g. a
@@ -217,7 +252,7 @@ export const useResolvedAppMode = (): boolean => {
     const hint = validSession ? null : readAppModeHint();
     if (isAppModeHintFresh(hint) && hint) {
       if (isModeRegistered(hint.mode)) {
-        writeAppMode(hint.mode, currentPersonaAppMode);
+        writeAppMode(hint.mode, currentPersonaAppMode, { source: 'resolver' });
 
         return;
       }
@@ -235,12 +270,16 @@ export const useResolvedAppMode = (): boolean => {
       }
     }
 
-    const preferredMode = preferences.appMode ?? null;
-    const candidate =
-      currentPersonaAppMode ??
-      preferredMode ??
-      getAppDefaultMode() ??
-      DEFAULT_APP_MODE;
+    // Precedence for the "no valid session, no fresh hint" case: user
+    // pref (server "remember") > persona > tenant default > constant.
+    // Shared with `resolveEffectiveAppMode` in `useAppMode.ts` so the
+    // async resolver here and the boot-time write in `AuthProvider`
+    // encode exactly the same policy.
+    const candidate = resolveEffectiveAppMode(
+      preferences.appMode ?? null,
+      currentPersonaAppMode,
+      getAppDefaultMode()
+    );
 
     // Install gate: refuse to write a non-default mode that isn't
     // registered yet. When the route registers later, this effect
@@ -249,7 +288,7 @@ export const useResolvedAppMode = (): boolean => {
       return;
     }
 
-    writeAppMode(candidate, currentPersonaAppMode);
+    writeAppMode(candidate, currentPersonaAppMode, { source: 'resolver' });
   }, [
     isAuthenticated,
     currentUser?.name,

--- a/openmetadata-ui/src/main/resources/ui/src/rest/settingConfigAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/settingConfigAPI.ts
@@ -14,6 +14,7 @@
 import { AxiosResponse } from 'axios';
 import axiosClient from '.';
 import { APPLICATION_JSON_CONTENT_TYPE_HEADER } from '../constants/constants';
+import { AppConfiguration } from '../generated/api/configuration/appConfiguration';
 import { RelationCardinality } from '../generated/configuration/glossaryTermRelationSettings';
 import { LineageSettings } from '../generated/configuration/lineageSettings';
 import { LoginConfiguration } from '../generated/configuration/loginConfiguration';
@@ -75,6 +76,36 @@ export const getLoginConfig = async () => {
   );
 
   return response.data;
+};
+
+/**
+ * Tenant-wide "first impression" app-mode default. DB-backed via the
+ * generic settings store (yaml-seeded on first boot only); readable by any
+ * authenticated user since the boot-time app-mode fallback chain needs it,
+ * not just admins.
+ */
+export const getAppConfiguration = async (): Promise<AppConfiguration> => {
+  const response = await axiosClient.get<Settings>(
+    `/system/settings/${SettingType.AppConfiguration}`
+  );
+
+  return (response.data.config_value as AppConfiguration) ?? {};
+};
+
+/**
+ * Admin-only. Writes through the generic `/system/settings` PUT, matching
+ * the `config_type`/`config_value` shape the backend's `createOrUpdateSetting`
+ * expects (see how `updateGlossaryTermRelationSettings` above writes).
+ */
+export const patchAppConfiguration = async (
+  patch: Partial<AppConfiguration>
+): Promise<AppConfiguration> => {
+  const response = await axiosClient.put<Settings>(`/system/settings`, {
+    config_type: SettingType.AppConfiguration,
+    config_value: patch,
+  });
+
+  return (response.data.config_value as AppConfiguration) ?? {};
 };
 
 export const testEmailConnection = async (data: { email: string }) => {

--- a/openmetadata-ui/src/main/resources/ui/src/rest/userAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/userAPI.ts
@@ -19,6 +19,7 @@ import {
   AuthenticationMechanism,
   CreateUser,
 } from '../generated/api/teams/createUser';
+import { UserPreferences } from '../generated/api/teams/userPreferences';
 import { PersonalAccessToken } from '../generated/auth/personalAccessToken';
 import { JWTTokenExpiry, User } from '../generated/entity/teams/user';
 import { Include } from '../generated/type/include';
@@ -90,6 +91,48 @@ export const getUserById = async (id: string, params?: ListParams) => {
 
 export const getLoggedInUser = async (params?: ListParams) => {
   const response = await APIClient.get<User>('/users/loggedInUser', { params });
+
+  return response.data;
+};
+
+/**
+ * Per-user UI preferences list (e.g. the boot-time `appMode` preference).
+ * Backed by a lightweight side table, not the `User` entity. Each entry is a
+ * typed discriminated union `{ type, config }` — see
+ * `hooks/currentUserStore/useCurrentUserStore.ts` for the debounced write
+ * path that calls `putUserPreference` / `deleteUserPreference`.
+ */
+export const getUserPreferences = async (userId: string) => {
+  const response = await APIClient.get<UserPreferences>(
+    `/users/${userId}/preferences`
+  );
+
+  return response.data;
+};
+
+/**
+ * Creates or replaces the preference entry of the given `type`. `config` is
+ * the type-specific shape (e.g. `{ value: 'ai' }` for `appMode`) — see
+ * `api/teams/preferences/*.json`.
+ */
+export const putUserPreference = async (
+  userId: string,
+  type: string,
+  config: unknown
+) => {
+  const response = await APIClient.put<UserPreferences>(
+    `/users/${userId}/preferences/${type}`,
+    { type, config }
+  );
+
+  return response.data;
+};
+
+/** Removes the preference entry of the given `type`, if present. */
+export const deleteUserPreference = async (userId: string, type: string) => {
+  const response = await APIClient.delete<UserPreferences>(
+    `/users/${userId}/preferences/${type}`
+  );
 
   return response.data;
 };


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **New Feature (Preferences):**
    - Added `user_preferences` table and backend repository for app-managed per-user preferences (`UserPreferencesIT.java`)
    - Added new `/v1/users/{userId}/preferences` endpoints supporting `appMode` configuration (`UserResource.java`)
- **New Feature (App Configuration):**
    - Added tenant-wide `appConfiguration` setting seeded from yaml on first boot and mutable by admins (`AppConfigurationSettingTest.java`)
- **Frontend Improvements:**
    - Integrated backend-synced preferences hydration and debounced synchronization in `AuthProvider` and `useCurrentUserStore` (`AuthProvider.tsx`)
    - Refined app mode resolution precedence chain to properly weigh session source, user preference, persona, and tenant default (`useAppMode.ts`, `useResolvedAppMode.ts`)

<sub>This will update automatically on new commits.</sub>