### PR TITLE
Fixes 28585: Sample Data tab crashes when a column is named `children`

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataTableOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataTableOperations.spec.ts
@@ -45,11 +45,7 @@ test.describe('Sample Data Tab - Download and Delete Functionality', () => {
 
     await addSampleDataViaApi(apiContext, tableWithData);
     await addSampleDataViaApi(apiContext, tableForDelete);
-    await addSampleDataViaApi(
-      apiContext,
-      tableWithReservedColumns,
-      RESERVED_SAMPLE_COLUMN_NAMES
-    );
+    await addSampleDataViaApi(apiContext, tableWithReservedColumns);
 
     await afterAction();
   });
@@ -102,29 +98,28 @@ test.describe('Sample Data Tab - Download and Delete Functionality', () => {
       await expect(page.getByTestId('sample-data-table')).toBeVisible();
     });
 
-    await test.step('Verify every reserved column header is rendered', async () => {
-      for (const columnName of RESERVED_SAMPLE_COLUMN_NAMES) {
-        await expect(
-          page.getByTestId('sample-data-table').getByRole('columnheader', {
-            name: columnName,
-            exact: false,
-          })
-        ).toBeVisible();
+    await test.step('Verify every reserved column header is rendered in order', async () => {
+      const headers = page.getByTestId('sample-data-table').locator('thead th');
+
+      for (const [
+        index,
+        columnName,
+      ] of RESERVED_SAMPLE_COLUMN_NAMES.entries()) {
+        await expect(headers.nth(index)).toContainText(columnName);
       }
     });
 
-    await test.step('Verify every reserved column shows its own cell values', async () => {
-      for (const [index] of RESERVED_SAMPLE_COLUMN_NAMES.entries()) {
-        await expect(
-          page
-            .getByTestId('sample-data-table')
-            .getByText(`sample_value_${index}_0`)
-        ).toBeVisible();
-        await expect(
-          page
-            .getByTestId('sample-data-table')
-            .getByText(`sample_value_${index}_2`)
-        ).toBeVisible();
+    await test.step('Verify each cell value sits under its own column', async () => {
+      const rows = page
+        .getByTestId('sample-data-table')
+        .locator('tbody tr.ant-table-row');
+
+      for (const [columnIndex] of RESERVED_SAMPLE_COLUMN_NAMES.entries()) {
+        for (const rowIndex of [0, 2]) {
+          await expect(
+            rows.nth(rowIndex).locator('td').nth(columnIndex)
+          ).toContainText(`sample_value_${columnIndex}_${rowIndex}`);
+        }
       }
     });
   });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataTableOperations.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataTableOperations.spec.ts
@@ -20,7 +20,9 @@ import {
 } from '../../utils/entity';
 import {
   addSampleDataViaApi,
+  buildReservedNameColumns,
   navigateToSampleDataTab,
+  RESERVED_SAMPLE_COLUMN_NAMES,
 } from '../../utils/sampleData';
 import { test } from '../fixtures/pages';
 
@@ -28,17 +30,26 @@ test.describe('Sample Data Tab - Download and Delete Functionality', () => {
   const tableWithData = new TableClass();
   const tableForDelete = new TableClass();
   const tableEmpty = new TableClass();
+  const tableWithReservedColumns = new TableClass();
 
   test.beforeAll('Setup tables with sample data', async ({ browser }) => {
     test.slow();
     const { apiContext, afterAction } = await performAdminLogin(browser);
 
+    tableWithReservedColumns.entity.columns = buildReservedNameColumns();
+
     await tableWithData.create(apiContext);
     await tableForDelete.create(apiContext);
     await tableEmpty.create(apiContext);
+    await tableWithReservedColumns.create(apiContext);
 
     await addSampleDataViaApi(apiContext, tableWithData);
     await addSampleDataViaApi(apiContext, tableForDelete);
+    await addSampleDataViaApi(
+      apiContext,
+      tableWithReservedColumns,
+      RESERVED_SAMPLE_COLUMN_NAMES
+    );
 
     await afterAction();
   });
@@ -50,6 +61,7 @@ test.describe('Sample Data Tab - Download and Delete Functionality', () => {
     await tableWithData.delete(apiContext);
     await tableForDelete.delete(apiContext);
     await tableEmpty.delete(apiContext);
+    await tableWithReservedColumns.delete(apiContext);
 
     await afterAction();
   });
@@ -73,6 +85,47 @@ test.describe('Sample Data Tab - Download and Delete Functionality', () => {
       await expect(
         page.getByTestId('sample-data-table').getByRole('row').nth(1)
       ).toBeVisible();
+    });
+  });
+
+  test('should render sample data for columns with reserved names', async ({
+    page,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to sample data tab', async () => {
+      await navigateToSampleDataTab(page, tableWithReservedColumns);
+    });
+
+    await test.step('Verify the tab renders instead of crashing', async () => {
+      await expect(page.getByTestId('sample-data')).toBeVisible();
+      await expect(page.getByTestId('sample-data-table')).toBeVisible();
+    });
+
+    await test.step('Verify every reserved column header is rendered', async () => {
+      for (const columnName of RESERVED_SAMPLE_COLUMN_NAMES) {
+        await expect(
+          page.getByTestId('sample-data-table').getByRole('columnheader', {
+            name: columnName,
+            exact: false,
+          })
+        ).toBeVisible();
+      }
+    });
+
+    await test.step('Verify every reserved column shows its own cell values', async () => {
+      for (const [index] of RESERVED_SAMPLE_COLUMN_NAMES.entries()) {
+        await expect(
+          page
+            .getByTestId('sample-data-table')
+            .getByText(`sample_value_${index}_0`)
+        ).toBeVisible();
+        await expect(
+          page
+            .getByTestId('sample-data-table')
+            .getByText(`sample_value_${index}_2`)
+        ).toBeVisible();
+      }
     });
   });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/sampleData.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/sampleData.ts
@@ -12,9 +12,25 @@
  */
 
 import { APIRequestContext, expect, Page } from '@playwright/test';
+import { Column, DataType } from '../../src/generated/entity/data/table';
 import { TableClass } from '../support/entity/TableClass';
 import { redirectToHomePage } from './common';
 import { waitForAllLoadersToDisappear } from './entity';
+
+/**
+ * `children` is Ant Design's reserved nested-rows field and `name` was the
+ * table's former row key, so a table carrying both is the regression case for
+ * a sample data payload that used to crash the tab.
+ */
+export const RESERVED_SAMPLE_COLUMN_NAMES = ['children', 'name', 'label'];
+
+export const buildReservedNameColumns = (): Column[] =>
+  RESERVED_SAMPLE_COLUMN_NAMES.map((name) => ({
+    name,
+    dataType: DataType.Varchar,
+    dataLength: 100,
+    dataTypeDisplay: 'varchar',
+  }));
 
 export const navigateToSampleDataTab = async (
   page: Page,
@@ -39,11 +55,14 @@ export const navigateToSampleDataTab = async (
 
 export const addSampleDataViaApi = async (
   apiContext: APIRequestContext,
-  table: TableClass
+  table: TableClass,
+  columnNames?: string[]
 ) => {
-  const columns = (table.entityResponseData.columns ?? [])
-    .map((col) => col.name ?? '')
-    .filter(Boolean);
+  const columns =
+    columnNames ??
+    (table.entityResponseData.columns ?? [])
+      .map((col) => col.name ?? '')
+      .filter(Boolean);
 
   const rows = Array.from({ length: 3 }, (_, rowIdx) =>
     columns.map((_, colIdx) => `sample_value_${colIdx}_${rowIdx}`)

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/sampleData.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/sampleData.ts
@@ -55,14 +55,11 @@ export const navigateToSampleDataTab = async (
 
 export const addSampleDataViaApi = async (
   apiContext: APIRequestContext,
-  table: TableClass,
-  columnNames?: string[]
+  table: TableClass
 ) => {
-  const columns =
-    columnNames ??
-    (table.entityResponseData.columns ?? [])
-      .map((col) => col.name ?? '')
-      .filter(Boolean);
+  const columns = (table.entityResponseData.columns ?? [])
+    .map((col) => col.name ?? '')
+    .filter(Boolean);
 
   const rows = Array.from({ length: 3 }, (_, rowIdx) =>
     columns.map((_, colIdx) => `sample_value_${colIdx}_${rowIdx}`)

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
@@ -31,7 +31,6 @@ type RecordProps = Record<string, SampleDataType>;
  */
 export type SampleDataColumn = ColumnsType<RecordProps>[number] & {
   name: string;
-  dataType?: string;
 };
 
 export interface SampleData {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnType } from 'antd/lib/table';
+import { ColumnsType } from 'antd/lib/table';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../../../enums/entity.enum';
 import { EntityReference } from '../../../generated/tests/testCase';
@@ -29,10 +29,10 @@ type RecordProps = Record<string, SampleDataType>;
  * from `key`/`dataIndex` because those address the row record, which cannot be
  * keyed by a raw column name (see SampleDataTable.component).
  */
-export interface SampleDataColumn extends ColumnType<RecordProps> {
+export type SampleDataColumn = ColumnsType<RecordProps>[number] & {
   name: string;
-  dataType: string;
-}
+  dataType?: string;
+};
 
 export interface SampleData {
   columns?: SampleDataColumn[];

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleData.interface.ts
@@ -10,7 +10,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { ColumnsType } from 'antd/lib/table';
+import { ColumnType } from 'antd/lib/table';
 import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
 import { EntityType } from '../../../enums/entity.enum';
 import { EntityReference } from '../../../generated/tests/testCase';
@@ -24,8 +24,18 @@ export type SampleDataType =
 
 type RecordProps = Record<string, SampleDataType>;
 
+/**
+ * `name` is the column name as the source system reports it. It is kept apart
+ * from `key`/`dataIndex` because those address the row record, which cannot be
+ * keyed by a raw column name (see SampleDataTable.component).
+ */
+export interface SampleDataColumn extends ColumnType<RecordProps> {
+  name: string;
+  dataType: string;
+}
+
 export interface SampleData {
-  columns?: ColumnsType<RecordProps>;
+  columns?: SampleDataColumn[];
   rows?: RecordProps[];
 }
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -58,6 +58,18 @@ import {
   ROW_LIMIT_OPTIONS,
 } from './SampleDataTable.utils';
 
+/**
+ * Ant Design treats `children` on a row record as nested rows and reads the row
+ * key off a record field, so raw column names cannot be used as record keys: a
+ * column named `children` crashes the table, and a repeated cell value collides
+ * as a row key. Addressing every cell by column index keeps record keys unique
+ * and clear of both reserved names.
+ */
+const ROW_KEY = '__rowKey';
+
+const getSampleDataColumnKey = (index: number, column: string) =>
+  `${index}-${column}`;
+
 const SampleDataTable: FC<SampleDataProps> = ({
   isTableDeleted,
   tableId,
@@ -101,9 +113,8 @@ const SampleDataTable: FC<SampleDataProps> = ({
     if (!sampleData?.rows || !sampleData?.columns) {
       return;
     }
-    const columnNames = sampleData.columns.map((col) => String(col.key ?? ''));
     const csvContent = buildSampleDataCSVContent(
-      columnNames,
+      sampleData.columns,
       sampleData.rows,
       rowLimit
     );
@@ -120,8 +131,9 @@ const SampleDataTable: FC<SampleDataProps> = ({
     const columns =
       'columns' in entity ? entity.columns : entity.dataModel?.columns ?? [];
 
-    const updatedColumns = sampleData?.columns?.map((column) => {
+    const updatedColumns = sampleData?.columns?.map((column, index) => {
       const matchedColumn = columns.find((col) => col.name === column);
+      const columnKey = getSampleDataColumnKey(index, column);
 
       return {
         name: column,
@@ -136,17 +148,19 @@ const SampleDataTable: FC<SampleDataProps> = ({
             )}
           </div>
         ),
-        dataIndex: column,
-        key: column,
+        dataIndex: columnKey,
+        key: columnKey,
         width: 250,
         render: (data: SampleDataType) => <RowData data={data} />,
       };
     });
 
-    const data = (sampleData?.rows ?? []).map((item) => {
-      const dataObject: Record<string, SampleDataType> = {};
+    const data = (sampleData?.rows ?? []).map((item, rowIndex) => {
+      const dataObject: Record<string, SampleDataType> = {
+        [ROW_KEY]: rowIndex,
+      };
       (sampleData?.columns ?? []).forEach((col, index) => {
-        dataObject[col] = item[index];
+        dataObject[getSampleDataColumnKey(index, col)] = item[index];
       });
 
       return dataObject;
@@ -346,7 +360,7 @@ const SampleDataTable: FC<SampleDataProps> = ({
         data-testid="sample-data-table"
         dataSource={slicedRows}
         pagination={false}
-        rowKey="name"
+        rowKey={ROW_KEY}
         scroll={{ y: 'calc(100vh - 160px)' }}
         size="small"
       />

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.component.tsx
@@ -137,7 +137,6 @@ const SampleDataTable: FC<SampleDataProps> = ({
 
       return {
         name: column,
-        dataType: matchedColumn?.dataType ?? '',
         title: (
           <div className="d-flex flex-column">
             <Typography.Text> {column}</Typography.Text>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Deliberately does not mock components/common/Table/Table: what the real Ant
+// Design table renders is one half of the display-matches-export assertion.
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
+import { Table } from '../../../generated/entity/data/table';
+import { getSampleDataByTableId } from '../../../rest/tableAPI';
+import { downloadFile } from '../../../utils/Export/ExportUtils';
+import SampleDataTable from './SampleDataTable.component';
+
+const mockProps = {
+  tableId: 'id',
+  owners: [{ type: 'user', id: 'ownerId' }],
+  permissions: {
+    ViewAll: true,
+    EditAll: true,
+  } as OperationPermission,
+};
+
+// A query projection can repeat a name (a self-join re-introduces the join
+// keys), and each occurrence carries its own value.
+const SAMPLE_COLUMNS = ['dup', 'dup', 'other'];
+const SAMPLE_ROWS = [['first-dup', 'second-dup', 'other-value']];
+
+const MOCK_TABLE_WITH_DUPLICATE_COLUMNS = {
+  id: 'table-id',
+  name: 'duplicate_columns_table',
+  columns: SAMPLE_COLUMNS.map((name) => ({ name, dataType: 'STRING' })),
+  sampleData: {
+    columns: SAMPLE_COLUMNS,
+    rows: SAMPLE_ROWS,
+  },
+} as unknown as Table;
+
+jest.mock('react-router-dom', () => ({
+  Link: jest.fn().mockImplementation(({ children }) => <span>{children}</span>),
+}));
+
+jest.mock('../../../rest/tableAPI', () => ({
+  getSampleDataByTableId: jest.fn(),
+  deleteSampleDataByTableId: jest.fn(),
+}));
+
+jest.mock('../../common/ErrorWithPlaceholder/ErrorPlaceHolder', () => {
+  return jest
+    .fn()
+    .mockReturnValue(
+      <div data-testid="error-placeholder">ErrorPlaceholder</div>
+    );
+});
+
+jest.mock('../../common/DeleteModal/DeleteModal', () => {
+  return jest.fn().mockReturnValue(<p>DeleteModal</p>);
+});
+
+jest.mock('../../../utils/Export/ExportUtils', () => ({
+  downloadFile: jest.fn(),
+}));
+
+describe('SampleDataTable with duplicate column names', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSampleDataByTableId as jest.Mock).mockResolvedValue(
+      MOCK_TABLE_WITH_DUPLICATE_COLUMNS
+    );
+  });
+
+  it('should render a cell per occurrence, each with its own value', async () => {
+    const { container } = await act(async () =>
+      render(<SampleDataTable {...mockProps} />)
+    );
+
+    const cellTexts = Array.from(
+      container.querySelectorAll('tbody tr.ant-table-row td')
+    ).map((cell) => cell.textContent);
+
+    expect(cellTexts).toEqual(SAMPLE_ROWS[0]);
+  });
+
+  it('should export exactly what the table renders', async () => {
+    const { container } = await act(async () =>
+      render(<SampleDataTable {...mockProps} />)
+    );
+
+    fireEvent.click(screen.getByTestId('sample-data-manage-button'));
+    fireEvent.click(screen.getByTestId('export-button-details-container'));
+
+    const cellTexts = Array.from(
+      container.querySelectorAll('tbody tr.ant-table-row td')
+    ).map((cell) => cell.textContent);
+    const csvContent = (downloadFile as jest.Mock).mock.calls[0][0] as string;
+    const [header, firstDataLine] = csvContent.split('\n');
+
+    expect(header).toBe(SAMPLE_COLUMNS.join(','));
+    expect(firstDataLine).toBe(cellTexts.join(','));
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
@@ -1,0 +1,139 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+// Deliberately does not mock components/common/Table/Table: the real Ant Design
+// Table is what reserves `children` on a record and what derives the row key.
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { OperationPermission } from '../../../context/PermissionProvider/PermissionProvider.interface';
+import { Table } from '../../../generated/entity/data/table';
+import { getSampleDataByTableId } from '../../../rest/tableAPI';
+import { downloadFile } from '../../../utils/Export/ExportUtils';
+import SampleDataTable from './SampleDataTable.component';
+
+const mockProps = {
+  tableId: 'id',
+  owners: [{ type: 'user', id: 'ownerId' }],
+  permissions: {
+    ViewAll: true,
+    EditAll: true,
+  } as OperationPermission,
+};
+
+// `children` is Ant Design's default `childrenColumnName`; `name` is what the
+// table was previously handed as its `rowKey`. Both are legal column names.
+const SAMPLE_COLUMNS = ['name', 'children', 'label'];
+const SAMPLE_ROWS = [
+  ['shared-name', 'first-child-value', 'first-label'],
+  ['shared-name', 'second-child-value', 'second-label'],
+];
+
+const MOCK_TABLE_WITH_RESERVED_COLUMNS = {
+  id: 'table-id',
+  name: 'reserved_columns_table',
+  columns: SAMPLE_COLUMNS.map((name) => ({ name, dataType: 'STRING' })),
+  sampleData: {
+    columns: SAMPLE_COLUMNS,
+    rows: SAMPLE_ROWS,
+  },
+} as unknown as Table;
+
+jest.mock('react-router-dom', () => ({
+  Link: jest.fn().mockImplementation(({ children }) => <span>{children}</span>),
+}));
+
+jest.mock('../../../rest/tableAPI', () => ({
+  getSampleDataByTableId: jest.fn(),
+  deleteSampleDataByTableId: jest.fn(),
+}));
+
+jest.mock('../../common/ErrorWithPlaceholder/ErrorPlaceHolder', () => {
+  return jest
+    .fn()
+    .mockReturnValue(
+      <div data-testid="error-placeholder">ErrorPlaceholder</div>
+    );
+});
+
+jest.mock('../../common/DeleteModal/DeleteModal', () => {
+  return jest.fn().mockReturnValue(<p>DeleteModal</p>);
+});
+
+jest.mock('../../../utils/Export/ExportUtils', () => ({
+  downloadFile: jest.fn(),
+}));
+
+describe('SampleDataTable with reserved column names', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSampleDataByTableId as jest.Mock).mockResolvedValue(
+      MOCK_TABLE_WITH_RESERVED_COLUMNS
+    );
+  });
+
+  it('should render the table when a column is named children', async () => {
+    await act(async () => {
+      render(<SampleDataTable {...mockProps} />);
+    });
+
+    expect(screen.getByTestId('sample-data-table')).toBeInTheDocument();
+    expect(screen.getByText('children')).toBeInTheDocument();
+  });
+
+  it('should render every cell of a column named children', async () => {
+    await act(async () => {
+      render(<SampleDataTable {...mockProps} />);
+    });
+
+    expect(screen.getByText('first-child-value')).toBeInTheDocument();
+    expect(screen.getByText('second-child-value')).toBeInTheDocument();
+  });
+
+  it('should render one row per sample row without extra flattened rows', async () => {
+    const { container } = await act(async () =>
+      render(<SampleDataTable {...mockProps} />)
+    );
+
+    expect(container.querySelectorAll('tbody tr.ant-table-row')).toHaveLength(
+      SAMPLE_ROWS.length
+    );
+  });
+
+  it('should give each row a distinct row key even when cell values repeat', async () => {
+    const { container } = await act(async () =>
+      render(<SampleDataTable {...mockProps} />)
+    );
+
+    const rowKeys = Array.from(
+      container.querySelectorAll('tbody tr.ant-table-row')
+    ).map((row) => row.getAttribute('data-row-key'));
+
+    expect(rowKeys).not.toContain(null);
+    expect(new Set(rowKeys).size).toBe(rowKeys.length);
+  });
+
+  it('should export a CSV headed by the raw column names', async () => {
+    await act(async () => {
+      render(<SampleDataTable {...mockProps} />);
+    });
+
+    fireEvent.click(screen.getByTestId('sample-data-manage-button'));
+    fireEvent.click(screen.getByTestId('export-button-details-container'));
+
+    const csvContent = (downloadFile as jest.Mock).mock.calls[0][0] as string;
+    const [header, ...dataLines] = csvContent.split('\n');
+
+    expect(header).toBe(SAMPLE_COLUMNS.join(','));
+    expect(dataLines).toContain(SAMPLE_ROWS[0].join(','));
+    expect(dataLines).toContain(SAMPLE_ROWS[1].join(','));
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
@@ -117,6 +117,7 @@ describe('SampleDataTable with reserved column names', () => {
       container.querySelectorAll('tbody tr.ant-table-row')
     ).map((row) => row.getAttribute('data-row-key'));
 
+    expect(rowKeys.length).toBeGreaterThan(1);
     expect(rowKeys).not.toContain(null);
     expect(new Set(rowKeys).size).toBe(rowKeys.length);
   });

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.test.ts
@@ -94,6 +94,22 @@ describe('buildSampleDataCSVContent', () => {
     expect(lines[1]).toBe('child-value,label-value');
   });
 
+  it('keeps one column per occurrence when column names repeat', () => {
+    const csv = buildSampleDataCSVContent(
+      [
+        { key: '0-dup', name: 'dup' },
+        { key: '1-dup', name: 'dup' },
+        { key: '2-x', name: 'x' },
+      ],
+      [{ '0-dup': 'A', '1-dup': 'B', '2-x': 'C' }],
+      10
+    );
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('dup,dup,x');
+    expect(lines[1]).toBe('A,B,C');
+  });
+
   it('handles null cell values as empty strings', () => {
     const csv = buildSampleDataCSVContent(
       toColumns(['a', 'b']),

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.test.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.test.ts
@@ -47,7 +47,10 @@ describe('stringifySampleDataValue', () => {
 });
 
 describe('buildSampleDataCSVContent', () => {
-  const columns = ['id', 'name', 'age'];
+  const toColumns = (names: string[]) =>
+    names.map((name) => ({ key: name, name }));
+
+  const columns = toColumns(['id', 'name', 'age']);
   const rows = [
     { id: 1, name: 'Alice', age: 30 },
     { id: 2, name: 'Bob', age: 25 },
@@ -76,9 +79,24 @@ describe('buildSampleDataCSVContent', () => {
     expect(lines).toHaveLength(3); // header + 2 data rows
   });
 
+  it('reads cells by column key while writing the column name as the header', () => {
+    const csv = buildSampleDataCSVContent(
+      [
+        { key: '0-children', name: 'children' },
+        { key: '1-label', name: 'label' },
+      ],
+      [{ '0-children': 'child-value', '1-label': 'label-value' }],
+      10
+    );
+    const lines = csv.split('\n');
+
+    expect(lines[0]).toBe('children,label');
+    expect(lines[1]).toBe('child-value,label-value');
+  });
+
   it('handles null cell values as empty strings', () => {
     const csv = buildSampleDataCSVContent(
-      ['a', 'b'],
+      toColumns(['a', 'b']),
       [{ a: null, b: null }],
       10
     );
@@ -89,7 +107,7 @@ describe('buildSampleDataCSVContent', () => {
 
   it('quotes values that contain commas', () => {
     const csv = buildSampleDataCSVContent(
-      ['col'],
+      toColumns(['col']),
       [{ col: 'hello, world' }],
       10
     );
@@ -98,14 +116,18 @@ describe('buildSampleDataCSVContent', () => {
   });
 
   it('quotes values that contain double quotes, escaping them', () => {
-    const csv = buildSampleDataCSVContent(['col'], [{ col: 'say "hi"' }], 10);
+    const csv = buildSampleDataCSVContent(
+      toColumns(['col']),
+      [{ col: 'say "hi"' }],
+      10
+    );
 
     expect(csv).toContain('"say ""hi"""');
   });
 
   it('quotes values that contain newlines', () => {
     const csv = buildSampleDataCSVContent(
-      ['col'],
+      toColumns(['col']),
       [{ col: 'line1\nline2' }],
       10
     );
@@ -115,7 +137,7 @@ describe('buildSampleDataCSVContent', () => {
 
   it('serializes object values as JSON in RFC 4180 encoding', () => {
     const csv = buildSampleDataCSVContent(
-      ['meta'],
+      toColumns(['meta']),
       [{ meta: { nested: true } }],
       10
     );

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.ts
@@ -13,7 +13,7 @@
 
 import { isObject, toString as lodashToString } from 'lodash';
 import { unparse } from 'papaparse';
-import { SampleDataType } from './SampleData.interface';
+import { SampleDataColumn, SampleDataType } from './SampleData.interface';
 
 export const ROW_LIMIT_OPTIONS = [10, 100, 1000];
 
@@ -21,15 +21,19 @@ export const stringifySampleDataValue = (value: SampleDataType): string =>
   isObject(value) ? JSON.stringify(value) : lodashToString(value);
 
 export const buildSampleDataCSVContent = (
-  columnNames: string[],
+  columns: Pick<SampleDataColumn, 'key' | 'name'>[],
   rows: Record<string, SampleDataType>[],
   rowLimit: number
 ): string => {
   const limitedRows = rows.slice(0, rowLimit);
+  const columnNames = columns.map(({ name }) => name);
 
   const data = limitedRows.map((row) =>
     Object.fromEntries(
-      columnNames.map((col) => [col, stringifySampleDataValue(row[col])])
+      columns.map(({ key, name }) => [
+        name,
+        stringifySampleDataValue(row[String(key ?? '')]),
+      ])
     )
   );
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import { isObject, toString as lodashToString } from 'lodash';
+import { isEmpty, isObject, toString as lodashToString } from 'lodash';
 import { unparse } from 'papaparse';
 import { SampleDataColumn, SampleDataType } from './SampleData.interface';
 
@@ -26,20 +26,25 @@ export const buildSampleDataCSVContent = (
   rowLimit: number
 ): string => {
   const limitedRows = rows.slice(0, rowLimit);
-  const columnNames = columns.map(({ name }) => name);
 
-  const data = limitedRows.map((row) =>
-    Object.fromEntries(
-      columns.map(({ key, name }) => [
-        name,
-        stringifySampleDataValue(row[String(key ?? '')]),
-      ])
-    )
+  // papaparse emits a header-only document when handed fields with no data,
+  // whereas exporting nothing has always produced an empty file.
+  if (isEmpty(limitedRows)) {
+    return '';
+  }
+
+  // Rows are emitted positionally rather than as name-keyed records: sample
+  // columns can repeat a name, and a keyed record would collapse them to one
+  // value while the table still renders each occurrence separately.
+  return unparse(
+    {
+      fields: columns.map(({ name }) => name),
+      data: limitedRows.map((row) =>
+        columns.map(({ key }) =>
+          stringifySampleDataValue(row[String(key ?? '')])
+        )
+      ),
+    },
+    { newline: '\n' }
   );
-
-  return unparse(data, {
-    columns: columnNames,
-    header: true,
-    newline: '\n',
-  });
 };


### PR DESCRIPTION
### Describe your changes:

Fixes #28585

I worked on the **Sample Data** tab because a table with a column named `children` blanked the whole page instead of rendering, and while fixing that I found two further defects on the same lines.

The tab built each row record using the **raw user column name as the record key**:

```ts
(sampleData?.columns ?? []).forEach((col, index) => {
  dataObject[col] = item[index];   // raw column name becomes the key
});
```

Ant Design reserves `children` on a row record for nested rows. In antd 4.24.16, `useSelection.js` `flattenData` runs inside an **unconditional `useMemo`** — with or without `rowSelection` — and does `(data || []).forEach(...)` on `record[childrenColumnName]`. A `children` cell holding a **truthy non-array scalar** therefore throws `TypeError: (data || []).forEach is not a function` during initial paint, and the route's error boundary escalates it to a whole-page crash.

Three defects are fixed:

1. **The crash.** Every cell is now addressed by column index (`` `${index}-${column}` ``), so no record key can be an Ant Design reserved name.
2. **Broken `rowKey`.** The table was passed `rowKey="name"` against those same records, so each row's key was `record['name']` — `undefined` unless a column happened to be named `name`, and a duplicated *sample cell value* when one was. Rows now carry a dedicated `__rowKey`.
3. **CSV export contradicting the rendered table.** Namespacing the record keys fixes rendering for a projection that repeats a column name, but `buildSampleDataCSVContent` still keyed its intermediate record by the raw name, so duplicates collapsed last-wins — the table would show `first-dup` while the export wrote `second-dup`. The CSV is now emitted positionally via papaparse's `{ fields, data }` form.

**Defect 3 is load-bearing, not defensive.** Duplicate sample-data column names *are* reachable through the API: `TableRepository.addSampleData` only does a per-column existence check (`EntityRepository.validateColumn` → `columns.stream().anyMatch(...)`), and `DatabaseUtil.validateColumnNames` — the rule that does enforce uniqueness — guards the **table entity's own** column list, never the sample-data `columns` array. So this is accepted and stored:

```
PUT /api/v1/tables/{id}/sampleData
{"columns":["dup","dup","x"],"rows":[["A","B","C"]]}
```

#
### Type of change:
- [x] Bug fix

#
### High-level design:

**Namespaced record keys, not a `childrenColumnName` sentinel.**

The obvious alternative is to tell Ant Design to look elsewhere — set `childrenColumnName` to a sentinel. I rejected it for two reasons:

- **A sentinel is not provably collision-free.** The `rowKey` defect requires putting a synthesized key into the record anyway, so `__rowKey` (or any sentinel) becomes a name a user column could legally collide with. Namespacing every cell as `${index}-${column}` makes both `children` and `__rowKey` structurally unreachable — no user column name can ever produce a key of that shape.
- **Setting it on the shared wrapper has a large blast radius.** `src/components/common/Table/Table.tsx` merges `expandable` for every consumer, and `SchemaTable`, `TopicSchema`, `ModelTab`, `File`/`WorksheetColumnsTable`, `VersionTable`, `TeamHierarchy`, `ContainerDataModel`, `APIEndpointSchema`, `GlossaryTermTab` and `ContractSchemaFormTab` all rely on genuine nested `children` arrays. The fix is therefore kept local to `SampleDataTable`; the wrapper is untouched.

**This follows the pattern already merged in #31420** for the sibling `FailedTestCaseSampleData` component, which uses exactly this shape — `const ROW_KEY = '__rowKey'` plus `${index}-${column}` column ids — so the two sample-data tables now handle reserved and repeated column names the same way.

**On the test design — worth a reviewer's attention.** An earlier attempt at this fix, #28691, took the `childrenColumnName` sentinel route and was closed by the stale bot without merging. Its regression test used the issue's literal payload, which puts **`false`** in the `children` cell. `false` is falsy, so it survives antd's `(data || [])` guard — **that test would have passed without its own fix**. The crash is deterministic only for a *truthy* non-array value (`true`, a non-empty string, a non-zero number, an object). Every test here uses truthy values, and each was watched failing against the base commit before the fix was written.

The one type-level constraint worth noting: `SampleDataColumn` is derived as `ColumnsType<RecordProps>[number] & { name: string }` rather than importing `ColumnType` directly, because `scripts/tw-deprecation-guard.js` compares the *set of imported specifiers* per antd module and a new specifier on an existing import counts as new antd debt, failing `ui-checkstyle`.

#
### Tests:

#### Use cases covered

- A table whose sample data includes a column named `children` renders the Sample Data tab instead of crashing the page (truthy scalar values — the case that actually throws).
- Every cell of that `children` column displays its own value.
- No phantom rows are synthesized from a `children` cell.
- Rows get distinct keys even when a `name` column repeats the same value across rows.
- CSV export is headed by the raw column names, not the internal namespaced keys.
- A projection that repeats a column name renders one cell per occurrence, each with its own value.
- The exported CSV is exactly what the table renders, including for repeated column names.

#### Unit tests

- [x] I added unit tests for the new/changed logic.

Files added:
- `openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx` (5 tests)
- `openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx` (2 tests)

Files updated:
- `openmetadata-ui/src/main/resources/ui/src/components/Database/SampleDataTable/SampleDataTable.utils.test.ts` (+2 tests)

Both new specs deliberately **do not mock** `components/common/Table/Table` — the real Ant Design table is the thing that crashes, so mocking it would make the regression tests assert nothing. Assertions are on rendered DOM (`tbody tr.ant-table-row`, `data-row-key`, cell text) and on the CSV string actually handed to `downloadFile`.

Every test was verified RED against the base commit before the fix:

```
FAIL src/components/Database/SampleDataTable/SampleDataTable.reservedColumns.test.tsx
    ✕ should render the table when a column is named children
    ✕ should render every cell of a column named children
    ✕ should render one row per sample row without extra flattened rows
    ✕ should give each row a distinct row key even when cell values repeat
    ✕ should export a CSV headed by the raw column names
  TypeError: (data || []).forEach is not a function
      at flattenData (node_modules/antd/lib/table/hooks/useSelection.js:36:16)
      at useSelection (node_modules/antd/lib/table/hooks/useSelection.js:111:40)
      at InternalTable (node_modules/antd/lib/table/Table.js:272:53)

FAIL src/components/Database/SampleDataTable/SampleDataTable.duplicateColumns.test.tsx
  ● should render a cell per occurrence, each with its own value
      Array [
    -   "first-dup",
    +   "second-dup",
        "second-dup",
        "other-value",
```

The `rowKey` defect was RED-checked in isolation (record keys namespaced, `rowKey="name"` still in place), since at base the crash prevents any row from rendering:

```
  ● should give each row a distinct row key even when cell values repeat
    Expected value: not null
    Received array:     [null, null]
```

GREEN:

```
$ yarn test src/components/Database/SampleDataTable
Test Suites: 5 passed, 5 total
Tests:       37 passed, 37 total
```

Coverage on changed files (`yarn test src/components/Database/SampleDataTable --coverage`):

```
File                           | % Stmts | % Branch | % Funcs | % Lines
All files                      |   88.35 |    82.94 |    90.9 |   88.97
 SampleDataTable.component.tsx |   85.71 |    81.57 |   91.66 |   85.98
 SampleDataTable.utils.ts      |     100 |    85.71 |     100 |     100
 RowData.tsx                   |   94.73 |      100 |      75 |     100
```

`SampleData.interface.ts` is type-only. The uncovered component lines are the delete-sample-data flow and the tour branch, neither touched here.

Wider suite, to show nothing regressed (baselined at the base commit first — 10 suites / 82 tests, no pre-existing failures):

```
$ yarn test src/components/Database/SampleDataTable \
            src/components/DataQuality/IncidentManager/FailedTestCaseSampleData \
            src/components/common/Table src/components/Modals/SchemaModal \
            src/pages/TableDetailsPageV1
Test Suites: 16 passed, 16 total
Tests:       111 passed, 111 total
```

#### Backend integration tests

- [x] Not applicable (no backend changes — this PR is UI-only).

#### Ingestion integration tests

- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests

- [x] I added a Playwright E2E test for the UI change.

Files updated:
- `openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SampleDataTableOperations.spec.ts` — new test `should render sample data for columns with reserved names`, seeding a table whose columns are `children`, `name`, `label` and asserting the tab renders, that the *n*-th header contains the *n*-th column name, and that the cell at (row, column) holds `sample_value_<column>_<row>` so a column-ordering regression fails.
- `openmetadata-ui/src/main/resources/ui/playwright/utils/sampleData.ts` — `RESERVED_SAMPLE_COLUMN_NAMES` and `buildReservedNameColumns()`.

> ⚠️ **The Playwright spec was NOT executed. There is no browser-level verification of this fix.**
>
> This is not a hedge — the spec has never been run, and the fix has not been observed working in a browser. The only OpenMetadata stack available while developing this served a UI bundle built from a **different checkout**, so running the spec against it would have exercised code without the fix and proved nothing. The spec was checked statically only: ESLint clean, and `tsc:playwright` adds no new errors.
>
> A reviewer with a server built from this branch should run:
> ```bash
> cd openmetadata-ui/src/main/resources/ui
> yarn playwright:run --grep "should render sample data for columns with reserved names"
> ```

#### Manual testing performed

> ⚠️ **Also not performed, for the same reason.** No manual browser verification of this fix has been done. The steps below are written to be reproducible by a reviewer, not reported as completed.

1. **Create a table with a column literally named `children`.** The backend validates sample-data column names against the table schema, so the column must exist first:
   ```bash
   curl -s -X POST http://localhost:8585/api/v1/tables \
     -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
     -d '{
       "name": "reserved_columns_table",
       "databaseSchema": "sample_data.ecommerce_db.shopify",
       "columns": [
         {"name": "children", "dataType": "VARCHAR", "dataLength": 100},
         {"name": "name",     "dataType": "VARCHAR", "dataLength": 100},
         {"name": "label",    "dataType": "VARCHAR", "dataLength": 100}
       ]
     }'
   ```
   Expected: HTTP 201. Save the returned `id` as `$TABLE_ID`.

2. **Attach sample data with a truthy value in `children`** and a repeated value in `name` (which also exercises the row-key defect):
   ```bash
   curl -s -X PUT http://localhost:8585/api/v1/tables/$TABLE_ID/sampleData \
     -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
     -d '{
       "columns": ["children", "name", "label"],
       "rows": [
         ["child-value-1", "shared-name", "label-1"],
         ["child-value-2", "shared-name", "label-2"],
         ["child-value-3", "shared-name", "label-3"]
       ]
     }'
   ```
   Expected: HTTP 200. Note a `false` or `0` value will **not** reproduce the bug — it is falsy and survives antd's `|| []` guard.

3. Open the table in the UI and click the **Sample Data** tab. Expected: the tab renders with headers `children (varchar)`, `name (varchar)`, `label (varchar)` and three rows; the page does not go blank.

4. Keep devtools **Console** open throughout step 3. Expected: no `TypeError: (data || []).forEach is not a function`, and no React duplicate-key warning for the sample-data rows.

5. Inspect the rows in the Elements panel. Expected: each `<tr class="ant-table-row">` has a distinct `data-row-key` (`0`, `1`, `2`) — not a missing attribute, and not three identical `shared-name` values.

6. Change the **Row Limit** selector (10 / 100 / 1000). Expected: re-renders each time without crashing.

7. **Manage (⋮) → Export.** Expected: `sample_data_<limit>_rows.csv` downloads with header row exactly `children,name,label` — the raw names, **not** `0-children,1-name,2-label` — and the three seeded rows.

8. **Regression sweep on nested-children tables**: open the **Columns** tab of a table with struct/array columns (e.g. `sample_data.ecommerce_db.shopify.dim_address`), a Topic's **Schema** tab, and *Settings → Teams*. Expected: expand arrows still present, expanding still reveals nested rows.

9. Clean up: `curl -X DELETE "http://localhost:8585/api/v1/tables/$TABLE_ID?hardDelete=true&recursive=true" -H "Authorization: Bearer $TOKEN"`.

#
### UI screen recording / screenshots:

**OUTSTANDING — not attached.** This PR changes the UI and the template requires a recording; I was unable to produce one, for the same reason the Playwright spec could not run (no stack serving a build of this branch). Please treat this as an open item before merge.

Frames to capture, in one ~45–60s take:

1. Start with devtools **Console** docked and cleared.
2. Show the seeded table's **Sample Data** tab loading — headers `children`, `name`, `label` and three rows — and pan the console to show it free of the `forEach is not a function` error and of duplicate-key warnings.
3. Briefly open the **Elements** panel on one `<tr>` to show distinct `data-row-key` values.
4. Change **Row Limit** to 10 and back to 100, showing repeated re-renders are stable.
5. **Manage → Export**, then open the downloaded CSV and show the header row reads `children,name,label`.
6. Finish on the **Columns** tab of a table with nested struct columns, expanding one row, to show nested-children tables are unaffected.

A "before" clip on a build without the fix — blank page plus the console `TypeError` — would make the contrast obvious for reviewers.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema changes.
- [ ] For UI changes: I attached a screen recording and/or screenshots above. — **NOT DONE**, see the section above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
