### PR TITLE
fix(ui): use disabled prop for name field in tag form on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.tsx
@@ -70,7 +70,7 @@ export const getNameField = (disabled: boolean): FieldProp => ({
     inputProps: {
       'data-testid': 'name',
     },
-    isDisabled: disabled,
+    disabled,
   },
   formItemProps: {
     validateTrigger: ['onChange', 'onBlur'],


### PR DESCRIPTION
## Summary

- `getNameField` in `tagFormFields.tsx` was using `isDisabled: disabled` after the cherry-pick from main
- `MUITextField` extends MUI's `TextFieldProps` and spreads all props onto `<TextField>` — MUI uses the standard `disabled` prop, not `isDisabled`
- `isDisabled` was silently ignored, leaving system classification names editable when they should be read-only
- `getDisplayNameField` in the same file already used `disabled` correctly; only `getNameField` had the wrong key

## Test plan

- [ ] Open a system-generated classification (e.g. `PersonalData`) in edit mode
- [ ] Confirm the **Name** field is disabled and cannot be edited
- [ ] Open a user-created classification in edit mode
- [ ] Confirm the **Name** field is editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)