### PR TITLE
fix(test): drop getByRole chain in EditClassification — testid is on input

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EditClassification.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/EditClassification.spec.ts
@@ -57,7 +57,7 @@ test('Edit a user classification from the manage button', async ({ page }) => {
     'Edit Classification'
   );
 
-  const nameField = page.getByTestId('name').getByRole('textbox');
+  const nameField = page.getByTestId('name');
 
   await expect(nameField).toHaveValue(userClassification.responseData.name);
   // Name is editable for a user (non-system) classification
@@ -96,7 +96,7 @@ test('System classification name is disabled in the edit drawer', async ({
 
   await expect(page.getByTestId('tags-form')).toBeVisible();
   // System-provided classification name must not be editable
-  await expect(page.getByTestId('name').getByRole('textbox')).toBeDisabled();
+  await expect(page.getByTestId('name')).toBeDisabled();
 
   await page.click('[data-testid="cancel-button"]');
 


### PR DESCRIPTION
## Summary

- `getByTestId('name').getByRole('textbox')` timed out with **element(s) not found** in both `EditClassification` tests
- Root cause: Playwright's `getByRole` searches **descendants only** — the `<input data-testid="name">` element has no children, so the chained `getByRole('textbox')` finds nothing
- Fix: drop the redundant `.getByRole('textbox')` chain — the testid is already on the `<input>` element, and `toHaveValue` / `toBeDisabled` work directly on it

Backport of #31504

🤖 Generated with [Claude Code](https://claude.com/claude-code)