### PR TITLE
fix(ui): move data-testid to MUI TextField wrapper in tag form fields on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.test.tsx
@@ -125,9 +125,7 @@ describe('tagFormFields', () => {
         placeholder: 'label.name',
         type: FieldTypes.TEXT_MUI,
         props: {
-          inputProps: {
-            'data-testid': 'name',
-          },
+          'data-testid': 'name',
           disabled: false,
         },
         formItemProps: {
@@ -149,8 +147,8 @@ describe('tagFormFields', () => {
     });
 
     it('should forward disabled prop', () => {
-      expect(getNameField(true, mockT).props?.isDisabled).toBe(true);
-      expect(getNameField(false, mockT).props?.isDisabled).toBe(false);
+      expect(getNameField(true).props?.disabled).toBe(true);
+      expect(getNameField(false).props?.disabled).toBe(false);
     });
   });
 
@@ -167,9 +165,7 @@ describe('tagFormFields', () => {
         placeholder: 'label.display-name',
         type: FieldTypes.TEXT_MUI,
         props: {
-          inputProps: {
-            'data-testid': 'displayName',
-          },
+          'data-testid': 'displayName',
           disabled: false,
         },
       });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TagsPage/tagFormFields.tsx
@@ -67,9 +67,7 @@ export const getNameField = (disabled: boolean): FieldProp => ({
   placeholder: 'label.name',
   type: FieldTypes.TEXT_MUI,
   props: {
-    inputProps: {
-      'data-testid': 'name',
-    },
+    'data-testid': 'name',
     disabled,
   },
   formItemProps: {
@@ -86,9 +84,7 @@ export const getDisplayNameField = (disabled: boolean): FieldProp => ({
   placeholder: 'label.display-name',
   type: FieldTypes.TEXT_MUI,
   props: {
-    inputProps: {
-      'data-testid': 'displayName',
-    },
+    'data-testid': 'displayName',
     disabled,
   },
 });


### PR DESCRIPTION
## Summary

- On **main**, `FieldTypes.TEXT` puts `data-testid` on a wrapper element, so `getByTestId('name').getByRole('textbox')` correctly finds the `<input>` within it → tests pass
- On **1.13**, `FieldTypes.TEXT_MUI` with `data-testid` inside `inputProps` places it on the `<input>` element directly (void element with no descendants), so `getByRole('textbox')` finds nothing → `Error: element(s) not found`
- Fix: move `data-testid` from `inputProps` to top-level props — this places it on the MUI `TextField` root `<div>`, matching the expected DOM structure

<img width="772" height="344" alt="Screenshot 2026-08-14 at 9 45 32 AM" src="https://github.com/user-attachments/assets/9271c21f-afc8-4fcd-a714-744dcacdc1f5" />
