### PR TITLE
fix(security): pin httpcore5 (core) to 5.4.3 for CVE-2026-54399 (1.13 backport)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -756,10 +756,20 @@
         <artifactId>flyway-mysql</artifactId>
         <version>${flyway.version}</version>
       </dependency>
+      <!-- CVE-2026-54399 — HTTP/1.1 parser DoS via excessive headers / header length.
+           Affects httpcore5 <= 5.4.2 and 5.5-alpha..5.5-beta1. h2 pin alone leaves the
+           core artifact unmanaged; calcite-core -> avatica -> httpclient5 5.5 pulls
+           httpcore5 5.3.5, and elasticsearch-java / opensearch-java shading picks up
+           httpcore5 5.3.4 the same way. Pin both artifacts on the 5.4.3 line. -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>5.4.3</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5-h2</artifactId>
-        <version>5.3.5</version>
+        <version>5.4.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Backport of #31442 to `1.13`.

## Summary

- CVE-2026-54399 — HTTP/1.1 parser DoS via excessive headers / header length. Affects `httpcore5 <= 5.4.2` and `5.5-alpha..5.5-beta1` (CVSS 3.1 base score 7.5, HIGH).
- `main` (#31442) only needed to add the `httpcore5` (core) pin because `httpcore5-h2` was already at 5.4.3 there. `1.13` still had `httpcore5-h2` pinned at 5.3.5, so this PR bumps both artifacts to 5.4.3.
- Flagged by AWS Inspector on the 1.13 nightly `#290` `collate/server` image (`sha256:c1cd7c48…`) with vulnerable versions surfacing at three paths inside `/opt/openmetadata/libs/`:
  - `httpcore5-5.3.5.jar` — standalone (calcite-core → avatica-core → httpclient5 5.5)
  - `elasticsearch-deps-1.13.4.jar` — shaded 5.3.4 (via elasticsearch-java → httpclient5 5.4.4)
  - `opensearch-deps-1.13.4.jar` — shaded 5.3.4 (via opensearch-java → httpclient5 5.5)

## Verification (local `mvn dependency:tree` with pin applied)

```
elasticsearch-deps: httpcore5 5.4.3, httpcore5-h2 5.4.3
opensearch-deps:    httpcore5 5.4.3, httpcore5-h2 5.4.3
openmetadata-service (calcite path): httpcore5 5.4.3, httpcore5-h2 5.4.3
```

Shaded uber-jars produced by the reactor build embed `version=5.4.3` in `META-INF/maven/org.apache.httpcomponents.core5/httpcore5/pom.properties` (was 5.3.4). Full `mvn clean install -DskipTests` on `:openmetadata-service` and reactor succeeds.

## Follow-up

Collate root pom on `1.13` has its own restated `httpcore5-h2 = 5.3.5` pin (OSS dep-management does not propagate to Collate consumers). A companion Collate PR is needed for the standalone `httpcore5-*.jar` under `/opt/openmetadata/libs/` — filing separately.

## Test plan

- [ ] CI build on `1.13`
- [ ] Nightly rebuild of `openmetadata/ingestion-slim:1.13-*` + `collate/server:1.13-*` picks up the pin
- [ ] AWS Inspector rescan clears the two shaded-jar paths (standalone jar cleared by companion Collate PR)