### PR TITLE
Backport #30703 to 2.0: gate distributed reindex completion on promotion so every staged index is promoted

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/DistributedIndexingStrategy.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/DistributedIndexingStrategy.java
@@ -20,7 +20,6 @@ import org.openmetadata.schema.system.StepStats;
 import org.openmetadata.schema.type.Include;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.apps.bundles.searchIndex.distributed.DistributedSearchIndexExecutor;
-import org.openmetadata.service.apps.bundles.searchIndex.distributed.IndexJobStatus;
 import org.openmetadata.service.apps.bundles.searchIndex.distributed.SearchIndexJob;
 import org.openmetadata.service.apps.bundles.searchIndex.promotion.RatioPromotionPolicy;
 import org.openmetadata.service.jdbi3.CollectionDAO;
@@ -167,6 +166,10 @@ public class DistributedIndexingStrategy {
             stagedIndexContext,
             !stopped.get() && !hasIncompleteProcessing(stats));
 
+    // Promotion sweep is done; flip the job from PROMOTING to its terminal status. The job stayed
+    // non-terminal until now, so the pod was not torn down mid-promotion.
+    distributedExecutor.markPromotionComplete(distributedJob.getId(), allPromoted);
+
     ExecutionResult.Status resultStatus = determineStatus(stats);
     if (!allPromoted && resultStatus == ExecutionResult.Status.COMPLETED) {
       LOG.error(
@@ -241,12 +244,11 @@ public class DistributedIndexingStrategy {
                 return;
               }
 
-              IndexJobStatus status = job.getStatus();
-              if (status == IndexJobStatus.COMPLETED
-                  || status == IndexJobStatus.COMPLETED_WITH_ERRORS
-                  || status == IndexJobStatus.FAILED
-                  || status == IndexJobStatus.STOPPED) {
-                LOG.info("Distributed job {} completed with status: {}", jobId, status);
+              // PROMOTING counts as processing-complete: stop monitoring and let the strategy run
+              // the
+              // promotion sweep, then flip the job terminal via markPromotionComplete().
+              if (job.isProcessingComplete()) {
+                LOG.info("Distributed job {} reached status: {}", jobId, job.getStatus());
                 completionLatch.countDown();
                 return;
               }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexApp.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexApp.java
@@ -24,6 +24,7 @@ public class SearchIndexApp extends AbstractNativeApplication {
   private static final List<String> ACTIVE_DISTRIBUTED_JOB_STATUSES =
       List.of(
           IndexJobStatus.RUNNING.name(),
+          IndexJobStatus.PROMOTING.name(),
           IndexJobStatus.READY.name(),
           IndexJobStatus.INITIALIZING.name());
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedJobStatsAggregator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedJobStatsAggregator.java
@@ -627,7 +627,7 @@ public class DistributedJobStatsAggregator {
   private AppRunRecord.Status convertStatus(IndexJobStatus status) {
     return switch (status) {
       case INITIALIZING, READY -> AppRunRecord.Status.PENDING;
-      case RUNNING -> AppRunRecord.Status.RUNNING;
+      case RUNNING, PROMOTING -> AppRunRecord.Status.RUNNING;
       case COMPLETED -> AppRunRecord.Status.SUCCESS;
       case COMPLETED_WITH_ERRORS -> AppRunRecord.Status.ACTIVE_ERROR;
       case FAILED -> AppRunRecord.Status.FAILED;

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinator.java
@@ -1016,49 +1016,99 @@ public class DistributedSearchIndexCoordinator {
         partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PENDING.name());
     List<SearchIndexPartitionRecord> processing =
         partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.PROCESSING.name());
-    List<SearchIndexPartitionRecord> failed =
-        partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.FAILED.name());
-    List<SearchIndexPartitionRecord> cancelled =
-        partitionDAO.findByJobIdAndStatus(jobId.toString(), PartitionStatus.CANCELLED.name());
-
     if (pending.isEmpty() && processing.isEmpty()) {
-      // All partitions are done
-      IndexJobStatus newStatus;
-      if (job.getStatus() == IndexJobStatus.STOPPING) {
-        newStatus = IndexJobStatus.STOPPED;
-      } else if (!failed.isEmpty() || !cancelled.isEmpty()) {
-        newStatus = IndexJobStatus.COMPLETED_WITH_ERRORS;
-      } else {
-        newStatus = IndexJobStatus.COMPLETED;
-      }
+      // All partitions finished. A stop request terminates immediately; every other job hands off
+      // to
+      // the promotion phase instead of completing. PROMOTING is non-terminal, so the coordinator
+      // and
+      // its pod stay alive until markPromotionComplete() runs after every staged index is promoted.
+      // This closes the race where the pod was torn down on COMPLETED mid-promotion, leaving the
+      // tail
+      // of entities on stale pre-reindex indexes (fielddata/nested mapping errors after an
+      // upgrade).
+      boolean stopping = job.getStatus() == IndexJobStatus.STOPPING;
+      IndexJobStatus newStatus = stopping ? IndexJobStatus.STOPPED : IndexJobStatus.PROMOTING;
 
-      // Get final aggregated stats
-      AggregatedStatsRecord stats = partitionDAO.getAggregatedStats(jobId.toString());
+      writeJobStatusWithStats(jobDAO, job, newStatus, stopping);
 
-      SearchIndexJob completed =
-          job.toBuilder()
-              .status(newStatus)
-              .processedRecords(stats != null ? stats.processedRecords() : 0)
-              .successRecords(stats != null ? stats.successRecords() : 0)
-              .failedRecords(stats != null ? stats.failedRecords() : 0)
-              .completedAt(System.currentTimeMillis())
-              .updatedAt(System.currentTimeMillis())
-              .build();
-
-      updateJob(jobDAO, completed);
-
-      // Drop the precomputed cursor cache for this job — once terminal it can never be
-      // re-claimed, and long-running servers would otherwise leak ~one entry per reindex
-      // run for the lifetime of the process.
+      // Partitions are all terminal now, so the precomputed cursor cache can never be re-claimed;
+      // drop it to avoid leaking ~one entry per reindex run for the process lifetime.
       partitionStartCursors.remove(jobId);
 
-      LOG.info(
-          "Job {} completed with status {} (success: {}, failed: {})",
-          jobId,
-          newStatus,
-          completed.getSuccessRecords(),
-          completed.getFailedRecords());
+      LOG.info("Job {} finished processing, status -> {}", jobId, newStatus);
     }
+  }
+
+  /**
+   * Flip a job from PROMOTING to its terminal status once the strategy has finished promoting every
+   * staged index: COMPLETED when everything promoted cleanly, COMPLETED_WITH_ERRORS when a partition
+   * failed/was cancelled or some staged index could not be promoted. No-op unless the job is still
+   * PROMOTING, so it is idempotent and safe if another server already terminalized the job.
+   */
+  public void markPromotionComplete(UUID jobId, boolean allPromoted) {
+    SearchIndexJobDAO jobDAO = collectionDAO.searchIndexJobDAO();
+    SearchIndexJobRecord jobRecord = jobDAO.findById(jobId.toString());
+    if (jobRecord == null || recordToJob(jobRecord).getStatus() != IndexJobStatus.PROMOTING) {
+      return;
+    }
+
+    IndexJobStatus finalStatus =
+        allPromoted && !hasFailedOrCancelledPartitions(jobId)
+            ? IndexJobStatus.COMPLETED
+            : IndexJobStatus.COMPLETED_WITH_ERRORS;
+
+    writeJobStatusWithStats(jobDAO, recordToJob(jobRecord), finalStatus, true);
+    LOG.info(
+        "Job {} promotion finished, status -> {} (allPromoted={})",
+        jobId,
+        finalStatus,
+        allPromoted);
+  }
+
+  /**
+   * Terminalize a finished-but-orphaned job (RUNNING with all partitions terminal, or stuck
+   * PROMOTING) as COMPLETED_WITH_ERRORS: it processed its data, but a cold recovery cannot confirm
+   * its staged indexes were promoted, so the run is not treated as a clean rebuild. No-op if the job
+   * is already terminal.
+   */
+  public void markOrphanedJobCompletedWithErrors(UUID jobId) {
+    SearchIndexJobDAO jobDAO = collectionDAO.searchIndexJobDAO();
+    SearchIndexJobRecord jobRecord = jobDAO.findById(jobId.toString());
+    if (jobRecord == null || recordToJob(jobRecord).isTerminal()) {
+      return;
+    }
+    writeJobStatusWithStats(
+        jobDAO, recordToJob(jobRecord), IndexJobStatus.COMPLETED_WITH_ERRORS, true);
+    partitionStartCursors.remove(jobId);
+    LOG.info(
+        "Job {} terminalized as COMPLETED_WITH_ERRORS (orphaned before promotion was confirmed)",
+        jobId);
+  }
+
+  private boolean hasFailedOrCancelledPartitions(UUID jobId) {
+    SearchIndexPartitionDAO partitionDAO = collectionDAO.searchIndexPartitionDAO();
+    return !partitionDAO
+            .findByJobIdAndStatus(jobId.toString(), PartitionStatus.FAILED.name())
+            .isEmpty()
+        || !partitionDAO
+            .findByJobIdAndStatus(jobId.toString(), PartitionStatus.CANCELLED.name())
+            .isEmpty();
+  }
+
+  private void writeJobStatusWithStats(
+      SearchIndexJobDAO jobDAO, SearchIndexJob job, IndexJobStatus status, boolean terminal) {
+    AggregatedStatsRecord stats =
+        collectionDAO.searchIndexPartitionDAO().getAggregatedStats(job.getId().toString());
+    SearchIndexJob updated =
+        job.toBuilder()
+            .status(status)
+            .processedRecords(stats != null ? stats.processedRecords() : 0)
+            .successRecords(stats != null ? stats.successRecords() : 0)
+            .failedRecords(stats != null ? stats.failedRecords() : 0)
+            .completedAt(terminal ? System.currentTimeMillis() : null)
+            .updatedAt(System.currentTimeMillis())
+            .build();
+    updateJob(jobDAO, updated);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexExecutor.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexExecutor.java
@@ -89,6 +89,9 @@ public class DistributedSearchIndexExecutor {
   /** Interval for checking stale partitions */
   private static final long STALE_CHECK_INTERVAL_MS = 30000;
 
+  /** Poll cadence while waiting for participant partitions to drain, so finishers reconcile promptly */
+  private static final long DRAIN_WAIT_POLL_INTERVAL_MS = 2000;
+
   /** Interval for refreshing the distributed lock */
   private static final long LOCK_REFRESH_INTERVAL_MS = 60000;
 
@@ -97,6 +100,17 @@ public class DistributedSearchIndexExecutor {
 
   /** Default cadence the orchestrator re-checks job state while waiting for workers to finish */
   private static final long DEFAULT_LATCH_POLL_INTERVAL_SECONDS = 15;
+
+  private static final long DEFAULT_PARTICIPANT_DRAIN_TIMEOUT_MS = TimeUnit.MINUTES.toMillis(30);
+
+  // Generous backstop on how long this coordinator waits for participant-claimed partitions to
+  // finish after it has drained its own, so every entity is promoted with a fully-built index
+  // instead of being left on its stale pre-reindex index. The wait returns the moment the job goes
+  // terminal, so a large value is free in the common case; it only bounds a wedged job (a dead
+  // participant whose reclaimed partition no surviving worker re-claims), which is then left
+  // in-flight for the orphan-job monitor to finalize rather than force-cancelled. Overridable in
+  // tests.
+  private volatile long participantDrainTimeoutMs = DEFAULT_PARTICIPANT_DRAIN_TIMEOUT_MS;
 
   private final CollectionDAO collectionDAO;
   private final DistributedSearchIndexCoordinator coordinator;
@@ -481,8 +495,9 @@ public class DistributedSearchIndexExecutor {
             .name("reindex-stale-reclaimer-" + jobId.toString().substring(0, 8))
             .start(() -> runStaleReclaimerLoop(jobId));
 
+    boolean drained = false;
     try {
-      boolean drained = awaitWorkers(workerLatch, jobId);
+      drained = awaitWorkers(workerLatch, jobId);
       if (drained) {
         LOG.info("All workers completed for job {}", jobId);
       } else {
@@ -512,14 +527,13 @@ public class DistributedSearchIndexExecutor {
       Thread.currentThread().interrupt();
       LOG.warn("Execution interrupted for job {}", jobId);
     } finally {
-      // If the job is stopping, force-complete any partitions still stuck in PROCESSING
-      // so the job can transition to a terminal state
+      // Drive the job to a terminal state before the coordinator unwinds, so the strategy's
+      // monitor returns and the finalizer promotes every staged index. Without this, a slow or
+      // dead participant server's still-PROCESSING partition leaves the job RUNNING forever — the
+      // finalizer never runs and the participant's entities silently keep serving their stale
+      // pre-reindex indexes (surfacing as fielddata/nested mapping errors after an upgrade).
       try {
-        SearchIndexJob currentState = coordinator.getJob(jobId).orElse(null);
-        if (currentState != null && currentState.getStatus() == IndexJobStatus.STOPPING) {
-          coordinator.forceCompleteProcessingPartitions(jobId);
-        }
-        coordinator.checkAndUpdateJobCompletion(jobId);
+        driveJobToTerminalState(jobId, drained);
       } catch (Exception e) {
         LOG.warn("Error during job cleanup for job {}", jobId, e);
       }
@@ -581,15 +595,8 @@ public class DistributedSearchIndexExecutor {
       try {
         if (metrics != null && timerSample != null) {
           SearchIndexJob finalJob = coordinator.getJob(jobId).orElse(null);
-          IndexJobStatus finalStatus = finalJob != null ? finalJob.getStatus() : null;
-          if (finalStatus == IndexJobStatus.COMPLETED
-              || finalStatus == IndexJobStatus.COMPLETED_WITH_ERRORS) {
-            metrics.recordJobCompleted(timerSample);
-          } else if (finalStatus == IndexJobStatus.STOPPED) {
-            metrics.recordJobStopped(timerSample);
-          } else {
-            metrics.recordJobFailed(timerSample);
-          }
+          recordTerminalMetric(
+              metrics, timerSample, finalJob != null ? finalJob.getStatus() : null);
         }
       } catch (Exception e) {
         LOG.debug("Error recording metrics", e);
@@ -814,6 +821,86 @@ public class DistributedSearchIndexExecutor {
       } catch (Exception e) {
         LOG.error("Error in stale reclaimer for job {}", jobId, e);
       }
+    }
+  }
+
+  /**
+   * Ensures the job reaches a terminal state as the coordinator unwinds. A STOPPING job force-cancels
+   * its PROCESSING partitions (the user asked to stop). Otherwise, once this coordinator has drained
+   * its own partitions ({@code drained}), any still-PROCESSING partitions belong to participant
+   * servers: wait for them to finish so every entity completes and is promoted with a fully-built
+   * index, never force-cancelling in-flight work (which would promote a partial index). The
+   * stale-reclaimer runs alongside this wait, reconciling finished entities as their partitions land
+   * and re-queuing stragglers a crashed participant abandoned. If the wait is exhausted - a wedged
+   * job whose reclaimed work no surviving worker picks up - the partitions are left in-flight for the
+   * orphan-job monitor to finalize rather than cancelled.
+   */
+  private void driveJobToTerminalState(UUID jobId, boolean drained) {
+    SearchIndexJob state = coordinator.getJob(jobId).orElse(null);
+    if (state != null && state.getStatus() == IndexJobStatus.STOPPING) {
+      coordinator.forceCompleteProcessingPartitions(jobId);
+    } else if (drained
+        && !coordinator.getPartitions(jobId, PartitionStatus.PROCESSING).isEmpty()
+        && !awaitProcessingComplete(jobId, participantDrainTimeoutMs)) {
+      LOG.warn(
+          "Job {} still has PROCESSING partitions after waiting {}ms for participant servers to "
+              + "finish; leaving them in-flight rather than cancelling, so entities are promoted "
+              + "with complete indexes once their partitions actually finish",
+          jobId,
+          participantDrainTimeoutMs);
+    }
+    coordinator.checkAndUpdateJobCompletion(jobId);
+  }
+
+  /**
+   * Waits up to {@code timeoutMs} for the job's partitions to all finish processing (the job reaching
+   * PROMOTING or a terminal state), reconciling entity completion each cycle so partitions finished
+   * by participant servers are promoted as they land. Returns whether processing completed in time.
+   */
+  private boolean awaitProcessingComplete(UUID jobId, long timeoutMs) {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    boolean processingComplete = isJobProcessingComplete(jobId);
+    while (!processingComplete && !Thread.currentThread().isInterrupted()) {
+      if (entityTracker != null) {
+        entityTracker.reconcileFromDatabase(coordinator.getPartitions(jobId, null));
+      }
+      if (System.currentTimeMillis() >= deadline) {
+        break;
+      }
+      sleepQuietly(Math.min(STALE_CHECK_INTERVAL_MS, DRAIN_WAIT_POLL_INTERVAL_MS));
+      processingComplete = isJobProcessingComplete(jobId);
+    }
+    return processingComplete;
+  }
+
+  private boolean isJobProcessingComplete(UUID jobId) {
+    SearchIndexJob job = coordinator.getJob(jobId).orElse(null);
+    return job == null || job.isProcessingComplete();
+  }
+
+  private void sleepQuietly(long millis) {
+    try {
+      Thread.sleep(millis);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Records the timing metric for the run based on the job's status when {@code execute()} unwinds.
+   * PROMOTING is the normal drained end-state - the strategy's promotion sweep flips it terminal
+   * afterwards, outside this timer scope - so it counts as a completed run rather than a failure.
+   */
+  private void recordTerminalMetric(
+      ReindexingMetrics metrics, Timer.Sample timerSample, IndexJobStatus finalStatus) {
+    if (finalStatus == IndexJobStatus.COMPLETED
+        || finalStatus == IndexJobStatus.COMPLETED_WITH_ERRORS
+        || finalStatus == IndexJobStatus.PROMOTING) {
+      metrics.recordJobCompleted(timerSample);
+    } else if (finalStatus == IndexJobStatus.STOPPED) {
+      metrics.recordJobStopped(timerSample);
+    } else {
+      metrics.recordJobFailed(timerSample);
     }
   }
 
@@ -1114,6 +1201,14 @@ public class DistributedSearchIndexExecutor {
    */
   public EntityCompletionTracker getEntityTracker() {
     return entityTracker;
+  }
+
+  /**
+   * Flip the job from PROMOTING to its terminal status after the strategy's promotion sweep. Thin
+   * delegate to the coordinator so the strategy does not reach past the executor.
+   */
+  public void markPromotionComplete(UUID jobId, boolean allPromoted) {
+    coordinator.markPromotionComplete(jobId, allPromoted);
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/IndexJobStatus.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/IndexJobStatus.java
@@ -24,6 +24,13 @@ public enum IndexJobStatus {
   /** Job is actively being processed by servers */
   RUNNING,
 
+  /**
+   * All partitions processed; staged indexes are being promoted onto their aliases. Deliberately
+   * non-terminal so the coordinator and its pod stay alive (and external watchers do not tear the
+   * pod down) until every staged index is promoted. Only then does the job move to COMPLETED.
+   */
+  PROMOTING,
+
   /** Job completed successfully */
   COMPLETED,
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryManager.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryManager.java
@@ -136,6 +136,7 @@ public class JobRecoveryManager {
                 IndexJobStatus.INITIALIZING,
                 IndexJobStatus.READY,
                 IndexJobStatus.RUNNING,
+                IndexJobStatus.PROMOTING,
                 IndexJobStatus.STOPPING),
             1);
 
@@ -165,6 +166,7 @@ public class JobRecoveryManager {
                     IndexJobStatus.INITIALIZING,
                     IndexJobStatus.READY,
                     IndexJobStatus.RUNNING,
+                    IndexJobStatus.PROMOTING,
                     IndexJobStatus.STOPPING),
                 1);
 
@@ -227,6 +229,7 @@ public class JobRecoveryManager {
                 IndexJobStatus.INITIALIZING,
                 IndexJobStatus.READY,
                 IndexJobStatus.RUNNING,
+                IndexJobStatus.PROMOTING,
                 IndexJobStatus.STOPPING),
             10);
 
@@ -293,18 +296,69 @@ public class JobRecoveryManager {
     long now = System.currentTimeMillis();
     long jobAge = now - (job.getStartedAt() != null ? job.getStartedAt() : job.getCreatedAt());
 
-    // Decide whether to recover or fail based on job state and age
-    boolean shouldRecover = shouldRecoverJob(job, jobAge);
-
-    if (shouldRecover) {
+    if (shouldRecoverJob(job, jobAge)) {
       if (recoverJob(job)) {
         resultBuilder.incrementRecovered();
         LOG.info("Job {} has been marked for recovery (will resume processing)", job.getId());
       }
+    } else if (hasFinishedProcessing(job)) {
+      terminalizeUnpromotedJob(job, resultBuilder);
     } else {
       failJob(job, "Job abandoned due to server crash or shutdown");
       resultBuilder.incrementFailed();
       LOG.info("Job {} has been marked as FAILED", job.getId());
+    }
+  }
+
+  /**
+   * True when an orphaned job finished processing every partition but is not yet terminal — either
+   * left RUNNING (the coordinator exited between the last partition completing and the completion
+   * check) or stuck PROMOTING (the coordinator died during the promotion sweep). Such a job did its
+   * work and must be terminalized, not failed as an abandoned crash. A RUNNING job must have at least
+   * one partition, so one that never created any is not mistaken for finished.
+   */
+  private boolean hasFinishedProcessing(SearchIndexJob job) {
+    boolean finished = job.getStatus() == IndexJobStatus.PROMOTING;
+    if (job.getStatus() == IndexJobStatus.RUNNING) {
+      List<SearchIndexPartition> partitions = coordinator.getPartitions(job.getId(), null);
+      finished =
+          !partitions.isEmpty() && partitions.stream().noneMatch(this::isPartitionOutstanding);
+    }
+    return finished;
+  }
+
+  private boolean isPartitionOutstanding(SearchIndexPartition partition) {
+    PartitionStatus status = partition.getStatus();
+    return status == PartitionStatus.PENDING || status == PartitionStatus.PROCESSING;
+  }
+
+  /**
+   * Terminalize an orphaned job that finished processing but whose coordinator died before promotion
+   * was confirmed. Takes the reindex lock, drives the job through the completion check (RUNNING ->
+   * PROMOTING) and then marks it COMPLETED_WITH_ERRORS: promotion could not be verified from cold
+   * recovery, so the staged indexes may not have been swapped onto their aliases and the run is not a
+   * clean rebuild. This never marks a fully-processed job FAILED and it unblocks future reindexes.
+   *
+   * <p>It does not itself re-run promotion; recovering the staged indexes is a follow-up (rebuild the
+   * context from {@code job.getStagedIndexMapping()} and run the finalizer).
+   */
+  private void terminalizeUnpromotedJob(SearchIndexJob job, RecoveryResult.Builder resultBuilder) {
+    if (coordinator.tryAcquireReindexLock(job.getId())) {
+      try {
+        coordinator.markOrphanedJobCompletedWithErrors(job.getId());
+        resultBuilder.incrementRecovered();
+        LOG.info(
+            "Job {} finished processing but its coordinator died before promotion completed; "
+                + "terminalized as COMPLETED_WITH_ERRORS (staged indexes may be stale - re-run "
+                + "reindex to refresh) instead of failing it as abandoned",
+            job.getId());
+      } finally {
+        coordinator.releaseReindexLock(job.getId());
+      }
+    } else {
+      LOG.warn(
+          "Could not acquire lock to finalize orphaned job {}; another server may hold it",
+          job.getId());
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/SearchIndexJob.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/SearchIndexJob.java
@@ -113,6 +113,15 @@ public class SearchIndexJob {
     return status == IndexJobStatus.RUNNING;
   }
 
+  /**
+   * Whether all partitions have finished processing, i.e. the job is either promoting its staged
+   * indexes or already terminal. Waiters that only care that processing is done (not that promotion
+   * has finished) stop once the job reaches this point.
+   */
+  public boolean isProcessingComplete() {
+    return isTerminal() || status == IndexJobStatus.PROMOTING;
+  }
+
   /** Statistics for a specific entity type */
   @Data
   @Builder

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexAppTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/SearchIndexAppTest.java
@@ -286,7 +286,7 @@ class SearchIndexAppTest {
             null,
             System.currentTimeMillis(),
             1);
-    when(jobDAO.findByStatuses(List.of("RUNNING", "READY", "INITIALIZING")))
+    when(jobDAO.findByStatuses(List.of("RUNNING", "PROMOTING", "READY", "INITIALIZING")))
         .thenReturn(List.of(activeJob));
 
     App appEntity = new App();
@@ -367,7 +367,7 @@ class SearchIndexAppTest {
             null,
             System.currentTimeMillis(),
             1);
-    when(jobDAO.findByStatuses(List.of("RUNNING", "READY", "INITIALIZING")))
+    when(jobDAO.findByStatuses(List.of("RUNNING", "PROMOTING", "READY", "INITIALIZING")))
         .thenReturn(List.of(activeJob));
     doThrow(new RuntimeException("DB error"))
         .when(jobDAO)

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexCoordinatorTest.java
@@ -1322,6 +1322,147 @@ class DistributedSearchIndexCoordinatorTest {
   }
 
   @Test
+  void testCheckAndUpdateJobCompletion_MovesToPromotingNotCompleted() {
+    UUID jobId = UUID.randomUUID();
+    when(jobDAO.findById(jobId.toString()))
+        .thenReturn(createJobRecord(jobId, IndexJobStatus.RUNNING, null, "{}"));
+    when(partitionDAO.findByJobIdAndStatus(eq(jobId.toString()), anyString()))
+        .thenReturn(List.of());
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(100, 100, 100, 0, 1, 1, 0, 0, 0));
+
+    coordinator.checkAndUpdateJobCompletion(jobId);
+
+    // All partitions are done, but the job must go to PROMOTING (non-terminal), NOT COMPLETED — the
+    // coordinator/pod must stay alive for the promotion sweep. Pre-fix this wrote COMPLETED and the
+    // pod could be torn down mid-promotion, orphaning the tail of entities on stale pre-reindex
+    // indexes.
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.PROMOTING.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+    verify(jobDAO, never())
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
+  void testMarkPromotionComplete_PromotingToCompleted() {
+    UUID jobId = UUID.randomUUID();
+    when(jobDAO.findById(jobId.toString()))
+        .thenReturn(createJobRecord(jobId, IndexJobStatus.PROMOTING, null, "{}"));
+    when(partitionDAO.findByJobIdAndStatus(eq(jobId.toString()), anyString()))
+        .thenReturn(List.of());
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(100, 100, 100, 0, 1, 1, 0, 0, 0));
+
+    coordinator.markPromotionComplete(jobId, true);
+
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
+  void testMarkPromotionComplete_NotAllPromotedGivesCompletedWithErrors() {
+    UUID jobId = UUID.randomUUID();
+    when(jobDAO.findById(jobId.toString()))
+        .thenReturn(createJobRecord(jobId, IndexJobStatus.PROMOTING, null, "{}"));
+    when(partitionDAO.findByJobIdAndStatus(eq(jobId.toString()), anyString()))
+        .thenReturn(List.of());
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(100, 100, 100, 0, 1, 1, 0, 0, 0));
+
+    coordinator.markPromotionComplete(jobId, false);
+
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED_WITH_ERRORS.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
+  void testMarkPromotionComplete_NoOpWhenNotPromoting() {
+    UUID jobId = UUID.randomUUID();
+    when(jobDAO.findById(jobId.toString()))
+        .thenReturn(createJobRecord(jobId, IndexJobStatus.RUNNING, null, "{}"));
+
+    coordinator.markPromotionComplete(jobId, true);
+
+    // Only a PROMOTING job is terminalized; a RUNNING job is left untouched (idempotent guard).
+    verify(jobDAO, never())
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
+  void testMarkOrphanedJobCompletedWithErrors_TerminalizesPromotingJob() {
+    UUID jobId = UUID.randomUUID();
+    when(jobDAO.findById(jobId.toString()))
+        .thenReturn(createJobRecord(jobId, IndexJobStatus.PROMOTING, null, "{}"));
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(100, 100, 100, 0, 1, 1, 0, 0, 0));
+
+    coordinator.markOrphanedJobCompletedWithErrors(jobId);
+
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED_WITH_ERRORS.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
   void testGetJob_Found() {
     UUID jobId = UUID.randomUUID();
     EventPublisherJob jobConfig = new EventPublisherJob().withEntities(Set.of("table"));

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexExecutorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/DistributedSearchIndexExecutorTest.java
@@ -97,6 +97,8 @@ class DistributedSearchIndexExecutorTest {
     executor = new DistributedSearchIndexExecutor(collectionDAO);
     setField("coordinator", coordinator);
     setField("recoveryManager", recoveryManager);
+    // Unit tests exercise the force-cancel logic, not the participant-drain grace timing.
+    setField("participantDrainTimeoutMs", 0L);
   }
 
   @AfterEach
@@ -971,6 +973,61 @@ class DistributedSearchIndexExecutorTest {
   }
 
   @Test
+  void driveJobToTerminalStateWaitsForParticipantsInsteadOfForceCancelling() throws Exception {
+    UUID jobId = UUID.randomUUID();
+    // A non-STOPPING job whose workers drained, but a participant's partition is still PROCESSING
+    // and the job has not reached a terminal state yet.
+    when(coordinator.getJob(jobId))
+        .thenReturn(
+            Optional.of(SearchIndexJob.builder().id(jobId).status(IndexJobStatus.RUNNING).build()));
+    when(coordinator.getPartitions(jobId, PartitionStatus.PROCESSING))
+        .thenReturn(List.of(partition(jobId, "table", PartitionStatus.PROCESSING)));
+
+    invokePrivate(
+        "driveJobToTerminalState", new Class<?>[] {UUID.class, boolean.class}, jobId, true);
+
+    // We wait for the participant to finish so the entity is promoted with a fully-built index; the
+    // in-flight partition must NOT be force-cancelled (that would promote a partial index). The
+    // completion check still runs so the job terminalizes once the partition actually finishes.
+    verify(coordinator, never()).forceCompleteProcessingPartitions(jobId);
+    verify(coordinator).checkAndUpdateJobCompletion(jobId);
+  }
+
+  @Test
+  void driveJobToTerminalStateForceCancelsProcessingPartitionsWhenStopping() throws Exception {
+    UUID jobId = UUID.randomUUID();
+    when(coordinator.getJob(jobId))
+        .thenReturn(
+            Optional.of(
+                SearchIndexJob.builder().id(jobId).status(IndexJobStatus.STOPPING).build()));
+
+    invokePrivate(
+        "driveJobToTerminalState", new Class<?>[] {UUID.class, boolean.class}, jobId, true);
+
+    // A user-requested stop force-cancels in-flight partitions so the job can reach STOPPED.
+    verify(coordinator).forceCompleteProcessingPartitions(jobId);
+    verify(coordinator).checkAndUpdateJobCompletion(jobId);
+  }
+
+  @Test
+  void driveJobToTerminalStateDoesNotForceCancelWhenNoProcessingPartitionsRemain()
+      throws Exception {
+    UUID jobId = UUID.randomUUID();
+    when(coordinator.getJob(jobId))
+        .thenReturn(
+            Optional.of(SearchIndexJob.builder().id(jobId).status(IndexJobStatus.RUNNING).build()));
+    when(coordinator.getPartitions(jobId, PartitionStatus.PROCESSING)).thenReturn(List.of());
+
+    invokePrivate(
+        "driveJobToTerminalState", new Class<?>[] {UUID.class, boolean.class}, jobId, true);
+
+    // Nothing is still processing, so there is nothing to force-cancel; the completion check alone
+    // takes the job terminal.
+    verify(coordinator, never()).forceCompleteProcessingPartitions(jobId);
+    verify(coordinator).checkAndUpdateJobCompletion(jobId);
+  }
+
+  @Test
   void runWorkerLoopAggregatesPartitionResults() throws Exception {
     UUID jobId = UUID.randomUUID();
     SearchIndexJob runningJob =
@@ -1353,6 +1410,23 @@ class DistributedSearchIndexExecutorTest {
         entityType,
         List.of());
     return context;
+  }
+
+  @Test
+  void recordTerminalMetricCountsPromotingAsCompletedNotFailed() throws Exception {
+    ReindexingMetrics metrics = mock(ReindexingMetrics.class);
+    Timer.Sample sample = mock(Timer.Sample.class);
+    Class<?>[] sig = {ReindexingMetrics.class, Timer.Sample.class, IndexJobStatus.class};
+
+    // PROMOTING is the drained hand-off state execute() ends on (the strategy promotes and flips it
+    // terminal afterwards). It must record a COMPLETED run — pre-fix it fell through to
+    // recordJobFailed, misreporting every successful distributed reindex as a failure.
+    invokePrivate("recordTerminalMetric", sig, metrics, sample, IndexJobStatus.PROMOTING);
+    verify(metrics).recordJobCompleted(sample);
+    verify(metrics, never()).recordJobFailed(sample);
+
+    invokePrivate("recordTerminalMetric", sig, metrics, sample, IndexJobStatus.FAILED);
+    verify(metrics).recordJobFailed(sample);
   }
 
   private Object invokePrivate(String methodName, Class<?>[] parameterTypes, Object... args)

--- a/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryManagerTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/apps/bundles/searchIndex/distributed/JobRecoveryManagerTest.java
@@ -179,6 +179,96 @@ class JobRecoveryManagerTest {
   }
 
   @Test
+  void testStartupRecovery_TerminalizesFinishedOrphanAsCompletedWithErrors() {
+    UUID jobId = UUID.randomUUID();
+
+    // A RUNNING job whose partitions all finished but whose coordinator died before promotion was
+    // confirmed. It must be terminalized as COMPLETED_WITH_ERRORS (data processed, promotion
+    // unverified), never failed as "abandoned due to server crash or shutdown".
+    SearchIndexJobRecord jobRecord = createJobRecord(jobId, IndexJobStatus.RUNNING);
+    when(jobDAO.findByStatusesWithLimit(any(), eq(10))).thenReturn(List.of(jobRecord));
+    when(jobDAO.findById(jobId.toString())).thenReturn(jobRecord);
+
+    when(lockDAO.cleanupExpiredLocks(anyLong())).thenReturn(0);
+    when(lockDAO.getLockInfo(anyString())).thenReturn(null); // no live lock -> orphaned
+    when(lockDAO.tryAcquireLock(anyString(), anyString(), anyString(), anyLong(), anyLong()))
+        .thenReturn(true); // finalizer takes the lock
+
+    SearchIndexPartitionRecord completed =
+        createPartitionRecord(jobId, UUID.randomUUID(), PartitionStatus.COMPLETED);
+    when(partitionDAO.findByJobId(jobId.toString())).thenReturn(List.of(completed));
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(226306, 226306, 226306, 0, 1, 1, 0, 0, 0));
+
+    JobRecoveryManager.RecoveryResult result = recoveryManager.performStartupRecovery();
+
+    assertEquals(1, result.orphanedJobsFound());
+    assertEquals(0, result.jobsMarkedFailed());
+    assertEquals(1, result.jobsRecovered());
+
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED_WITH_ERRORS.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any());
+    verify(jobDAO, never())
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.FAILED.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any());
+  }
+
+  @Test
+  void testStartupRecovery_TerminalizesOrphanedPromotingJob() {
+    UUID jobId = UUID.randomUUID();
+
+    // A job stuck in PROMOTING (its coordinator died during the promotion sweep). It finished
+    // processing, so it must be terminalized as COMPLETED_WITH_ERRORS to unblock future reindexes -
+    // never left hanging non-terminal and never failed as abandoned.
+    SearchIndexJobRecord jobRecord = createJobRecord(jobId, IndexJobStatus.PROMOTING);
+    when(jobDAO.findByStatusesWithLimit(any(), eq(10))).thenReturn(List.of(jobRecord));
+    when(jobDAO.findById(jobId.toString())).thenReturn(jobRecord);
+
+    when(lockDAO.cleanupExpiredLocks(anyLong())).thenReturn(0);
+    when(lockDAO.getLockInfo(anyString())).thenReturn(null);
+    when(lockDAO.tryAcquireLock(anyString(), anyString(), anyString(), anyLong(), anyLong()))
+        .thenReturn(true);
+    when(partitionDAO.getAggregatedStats(jobId.toString()))
+        .thenReturn(new AggregatedStatsRecord(945, 945, 945, 0, 1, 1, 0, 0, 0));
+
+    JobRecoveryManager.RecoveryResult result = recoveryManager.performStartupRecovery();
+
+    assertEquals(1, result.orphanedJobsFound());
+    assertEquals(0, result.jobsMarkedFailed());
+    verify(jobDAO)
+        .update(
+            eq(jobId.toString()),
+            eq(IndexJobStatus.COMPLETED_WITH_ERRORS.name()),
+            anyLong(),
+            anyLong(),
+            anyLong(),
+            any(),
+            any(),
+            any(),
+            anyLong(),
+            any());
+  }
+
+  @Test
   void testStartupRecovery_FailInitializingJob() {
     UUID jobId = UUID.randomUUID();
 


### PR DESCRIPTION
### Describe your changes:

Backport of #30703 to `2.0`. Clean cherry-pick of `f1978141a9` — no conflicts, patch-id identical to main (`0e9e977…`), all 12 files byte-identical to main's tree.

`2.0` already has #30519 (promotion **reports** failure: `promoteEntityIndex`/`finalizeReindex` return `boolean`, `EntityCompletionTracker` only marks promoted on a real alias swap) but is missing this follow-up, which makes the promotion sweep actually **run to completion**. Without it, `checkAndUpdateJobCompletion` flips the distributed reindex job to `COMPLETED` from partition doc-counts *while* `finalizeAllEntityReindex` / `reconcileFromDatabase` still have entities to promote. Ephemeral pods (nightly AUT reindex) are torn down the instant the job reports `COMPLETED`, cutting the sweep off partway — and because iteration order is stable, **the same tail of entities is orphaned on every run**, left serving their stale pre-reindex indexes while the run reports success. That surfaces post-upgrade as `illegal_argument_exception: fielddata on text [ownerDisplayName]` / `[nested] … is not of nested type`. `git grep PROMOTING origin/2.0` returns zero hits today.

Separately, `2.0`'s `JobRecoveryManager` still reaps a *fully finished* orphaned `RUNNING` job as `"Job abandoned due to server crash or shutdown"` and marks it `FAILED`, discarding a successful rebuild on a live server.

What the change does (as merged on `main`):
- **`PROMOTING`, a new non-terminal state** gates completion on promotion. `checkAndUpdateJobCompletion` moves a drained job to `PROMOTING` (a user STOP still goes straight to `STOPPED`); the pod stays alive because the job is not terminal; after `finalizeAllEntityReindex` the strategy calls `markPromotionComplete`, flipping `PROMOTING` → `COMPLETED` or `COMPLETED_WITH_ERRORS`. Internal waits treat `PROMOTING` as processing-complete; app-run/active-job views treat it as still running.
- **The coordinator waits for participant-claimed partitions** instead of force-cancelling in-flight work, reconciling as they land so each entity is promoted with a fully-built index. A user-requested STOP still force-cancels. If the wait is exhausted, partitions are left in-flight for the orphan-job monitor rather than cancelled.
- **`JobRecoveryManager` finalizes instead of failing**: an orphaned `RUNNING` job whose partitions are all terminal is driven to its real status via the coordinator's own completion check; an orphaned `PROMOTING` job (hard kill mid-promotion) is terminalized as `COMPLETED_WITH_ERRORS` so it unblocks future reindexes. Genuinely-incomplete or never-started jobs still fail as before.
- Reindex timing metrics count `PROMOTING` as a completed run.

No schema or DB migration: `PROMOTING` is persisted as a JSON string, not a SQL enum.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

No design delta from #30703 — this is a verbatim cherry-pick, reviewed and merged on `main` as PR #30703. Interaction with what is already on `2.0`:

- **#30519** (already on `2.0` as `497ffe7f99`) shares `DistributedIndexingStrategy.java` and `DistributedSearchIndexExecutor.java` with this commit. Pick order matches `main`, hence the clean apply. #30519 makes a failed swap *visible*; this PR makes sure the sweep is not cut off before those swaps happen — the two are halves of one fix on any ephemeral/distributed deployment.
- **#30965** (already on `2.0` as `0826d8c413`) has **no file overlap**. Semantically safe: `HeapBackpressure`'s max reader pause is 30s, well under this PR's `PARTITION_CLAIM_TIMEOUT_MS` (3 min stale reclaim) and the 30 min participant drain, so a backpressure-paused reader cannot be misread as a straggler.
- **#29108** (`index_total` staged-index rescue) predates the `2.0` branch point and is an independent layer (the promote-vs-delete decision).

#
### Tests:

#### Use cases covered
- A drained distributed reindex moves to `PROMOTING`, stays non-terminal through the promotion sweep, then flips to `COMPLETED` / `COMPLETED_WITH_ERRORS` — no entity is left on a stale index by an early teardown.
- A coordinator that drains its own partitions waits for participant-claimed partitions instead of force-cancelling them; a user STOP still force-cancels.
- An orphaned `RUNNING` job whose partitions are all terminal is finalized to its real status instead of failed as abandoned; an orphaned `PROMOTING` job terminalizes as `COMPLETED_WITH_ERRORS`.

#### Unit tests
- [x] Cherry-picked with the commit (4 test files: `DistributedSearchIndexCoordinatorTest`, `DistributedSearchIndexExecutorTest`, `JobRecoveryManagerTest`, `SearchIndexAppTest`).
- Run on this branch against `2.0`: **207 tests, 0 failures, 0 errors** —
  `DistributedSearchIndexCoordinatorTest` 55, `DistributedSearchIndexExecutorTest` 42,
  `DistributedJobStatsAggregatorTest` 28, `JobRecoveryManagerTest` 23,
  `DistributedIndexingStrategyTest` 17, `EntityCompletionTrackerTest` 14,
  `SearchIndexAppTest` 12, `JobRecoveryOrphanDetectionTest` 10, `HeapBackpressureTest` 6.
- `mvn test-compile` BUILD SUCCESS (0 errors); `mvn spotless:check` clean.

#### Backend integration tests
- [x] Not applicable (no API changes; ITs unchanged from #30703).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed
Verified as a backport rather than re-diagnosed: `git cherry origin/2.0` flagged the commit as absent, `git grep` on `origin/2.0` returns zero hits for `PROMOTING` / `straggler` / `forceCancel` / `FORCE_CANCELLED`, and no prior backport PR exists. The pick, compile, unit-test and spotless runs above were executed on this branch. Original RCA (Grafana/Loki + `opensearch` container logs on the failing migration nightly `aut-30510489255`) is in #30703.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable — no schema change (`PROMOTING` is a Java enum persisted as a JSON string).
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.
