### PR TITLE
fix(auth): serve persisted responseType & publicKeyUrls from /config/auth (#29597)

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ConfigResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/ConfigResourceIT.java
@@ -18,6 +18,7 @@ import org.openmetadata.it.util.TestNamespaceExtension;
 import org.openmetadata.schema.api.configuration.LoginConfiguration;
 import org.openmetadata.schema.api.security.AuthenticationConfiguration;
 import org.openmetadata.schema.api.security.AuthorizerConfiguration;
+import org.openmetadata.schema.configuration.SecurityConfiguration;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.network.HttpMethod;
 import org.openmetadata.service.clients.pipeline.PipelineServiceAPIClientConfig;
@@ -56,9 +57,44 @@ public class ConfigResourceIT {
 
     assertNull(auth.getLdapConfiguration(), "LDAP configuration should be excluded");
     assertNull(auth.getOidcConfiguration(), "OIDC configuration should be excluded");
-    assertTrue(
-        auth.getPublicKeyUrls() == null || auth.getPublicKeyUrls().isEmpty(),
-        "Public key URLs should be empty or null");
+  }
+
+  /**
+   * The public /config/auth endpoint must mirror the persisted authentication configuration for the
+   * fields the login flow depends on — it must not fall back to schema defaults. Regression guard
+   * for #29597, where a configured responseType of 'code' was served back as the default 'id_token'
+   * (and populated publicKeyUrls as an empty list). Cross-checks the public endpoint against the
+   * admin /security/config endpoint, which returns the true persisted configuration.
+   */
+  @Test
+  void testAuthConfigMirrorsPersistedLoginFields(TestNamespace ns) throws Exception {
+    OpenMetadataClient client = SdkClients.adminClient();
+
+    String publicResponse =
+        client.getHttpClient().executeForString(HttpMethod.GET, "/v1/system/config/auth", null);
+    AuthenticationConfiguration publicAuth =
+        OBJECT_MAPPER.readValue(publicResponse, AuthenticationConfiguration.class);
+
+    String securityResponse =
+        client.getHttpClient().executeForString(HttpMethod.GET, "/v1/system/security/config", null);
+    AuthenticationConfiguration persistedAuth =
+        OBJECT_MAPPER
+            .readValue(securityResponse, SecurityConfiguration.class)
+            .getAuthenticationConfiguration();
+
+    assertNotNull(persistedAuth, "Persisted authentication configuration should be present");
+    assertEquals(
+        persistedAuth.getResponseType(),
+        publicAuth.getResponseType(),
+        "Public /config/auth responseType must match the persisted configuration");
+    assertEquals(
+        persistedAuth.getPublicKeyUrls(),
+        publicAuth.getPublicKeyUrls(),
+        "Public /config/auth publicKeyUrls must match the persisted configuration");
+    assertEquals(
+        persistedAuth.getTokenValidationAlgorithm(),
+        publicAuth.getTokenValidationAlgorithm(),
+        "Public /config/auth tokenValidationAlgorithm must match the persisted configuration");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/system/ConfigResource.java
@@ -103,6 +103,9 @@ public class ConfigResource {
       responseAuthConfig.setClientId(yamlConfig.getClientId());
       responseAuthConfig.setAuthority(yamlConfig.getAuthority());
       responseAuthConfig.setCallbackUrl(yamlConfig.getCallbackUrl());
+      responseAuthConfig.setResponseType(yamlConfig.getResponseType());
+      responseAuthConfig.setPublicKeyUrls(yamlConfig.getPublicKeyUrls());
+      responseAuthConfig.setTokenValidationAlgorithm(yamlConfig.getTokenValidationAlgorithm());
       if (responseAuthConfig.getProvider().equals(AuthProvider.SAML)
           && yamlConfig.getSamlConfiguration() != null) {
         // Remove Saml Fields

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/ConfigResourceTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/system/ConfigResourceTest.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2025 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.openmetadata.service.resources.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mockStatic;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmetadata.schema.api.security.AuthenticationConfiguration;
+import org.openmetadata.schema.api.security.ClientType;
+import org.openmetadata.schema.api.security.ResponseType;
+import org.openmetadata.schema.services.connections.metadata.AuthProvider;
+import org.openmetadata.service.security.auth.SecurityConfigurationManager;
+
+/**
+ * Unit tests for {@link ConfigResource#getAuthConfig()} — the public, unauthenticated endpoint the
+ * login page consumes. It must reflect the persisted authentication configuration for the fields the
+ * login flow depends on (regression guard for #29597, where AWS Cognito's configured {@code code}
+ * response type was served back as the schema default {@code id_token}).
+ */
+class ConfigResourceTest {
+
+  private static final List<String> PUBLIC_KEY_URLS =
+      List.of("https://cognito-idp.us-east-1.amazonaws.com/pool/.well-known/jwks.json");
+
+  private AuthenticationConfiguration persistedCognitoConfig() {
+    return new AuthenticationConfiguration()
+        .withProvider(AuthProvider.AWS_COGNITO)
+        .withProviderName("aws-cognito")
+        .withClientType(ClientType.PUBLIC)
+        .withResponseType(ResponseType.CODE)
+        .withPublicKeyUrls(PUBLIC_KEY_URLS)
+        .withTokenValidationAlgorithm(AuthenticationConfiguration.TokenValidationAlgorithm.RS_384)
+        .withClientId("client-id")
+        .withAuthority("https://cognito-idp.us-east-1.amazonaws.com/pool");
+  }
+
+  @Test
+  void getAuthConfigReflectsPersistedResponseType() {
+    try (MockedStatic<SecurityConfigurationManager> managerMock =
+        mockStatic(SecurityConfigurationManager.class)) {
+      managerMock
+          .when(SecurityConfigurationManager::getCurrentAuthConfig)
+          .thenReturn(persistedCognitoConfig());
+
+      AuthenticationConfiguration response = new ConfigResource().getAuthConfig();
+
+      assertEquals(
+          ResponseType.CODE,
+          response.getResponseType(),
+          "Persisted responseType 'code' must not be replaced by the schema default 'id_token'");
+    }
+  }
+
+  @Test
+  void getAuthConfigReflectsPersistedPublicKeyUrls() {
+    try (MockedStatic<SecurityConfigurationManager> managerMock =
+        mockStatic(SecurityConfigurationManager.class)) {
+      managerMock
+          .when(SecurityConfigurationManager::getCurrentAuthConfig)
+          .thenReturn(persistedCognitoConfig());
+
+      AuthenticationConfiguration response = new ConfigResource().getAuthConfig();
+
+      assertEquals(
+          PUBLIC_KEY_URLS,
+          response.getPublicKeyUrls(),
+          "Persisted publicKeyUrls must be served, not reset to the empty schema default");
+    }
+  }
+
+  @Test
+  void getAuthConfigReflectsPersistedTokenValidationAlgorithm() {
+    try (MockedStatic<SecurityConfigurationManager> managerMock =
+        mockStatic(SecurityConfigurationManager.class)) {
+      managerMock
+          .when(SecurityConfigurationManager::getCurrentAuthConfig)
+          .thenReturn(persistedCognitoConfig());
+
+      AuthenticationConfiguration response = new ConfigResource().getAuthConfig();
+
+      assertEquals(
+          AuthenticationConfiguration.TokenValidationAlgorithm.RS_384,
+          response.getTokenValidationAlgorithm(),
+          "Persisted tokenValidationAlgorithm must be served, not reset to the RS256 default");
+    }
+  }
+
+  @Test
+  void getAuthConfigStillExcludesSensitiveNestedConfigs() {
+    try (MockedStatic<SecurityConfigurationManager> managerMock =
+        mockStatic(SecurityConfigurationManager.class)) {
+      managerMock
+          .when(SecurityConfigurationManager::getCurrentAuthConfig)
+          .thenReturn(persistedCognitoConfig());
+
+      AuthenticationConfiguration response = new ConfigResource().getAuthConfig();
+
+      assertNull(response.getOidcConfiguration(), "OIDC configuration must stay excluded");
+      assertNull(response.getLdapConfiguration(), "LDAP configuration must stay excluded");
+    }
+  }
+}


### PR DESCRIPTION
### Describe your changes:

Fixes #29597

**What / why:** The public, unauthenticated `GET /api/v1/system/config/auth` endpoint (consumed by the login page) was serving `responseType: "id_token"` and `publicKeyUrls: []` regardless of the persisted configuration.

Root cause: `ConfigResource.getAuthConfig()` builds a **fresh** `AuthenticationConfiguration` POJO and hand-copies only a subset of fields from the persisted config (`SecurityConfigurationManager.getCurrentAuthConfig()`). It never copied `responseType`, `publicKeyUrls`, or `tokenValidationAlgorithm`, so those kept their JSON-schema POJO defaults (`responseType` defaults to `"id_token"` in `authenticationConfiguration.json`; a list field serializes as `[]`).

For AWS Cognito configured with `responseType: "code"`, the endpoint therefore returned `"id_token"`, pushing the browser onto the implicit grant flow instead of authorization-code. No server-side session is established, the user bounces back to `/signin`, and login never completes — a production-blocking SSO failure. This is a field-drop bug, **not** the config-caching issue the title of #29597 hypothesizes: `getCurrentAuthConfig()` returns the correct persisted value; the endpoint simply discards it.

The fix copies the three login-relevant public (non-secret) fields onto the response object. Present on both `main` and `1.13`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — 3-line change in `ConfigResource.getAuthConfig()`.

#
### Tests:

#### Use cases covered
- AWS Cognito (public client) configured with `responseType: code` → `/config/auth` returns `code`, not `id_token`.
- Configured `publicKeyUrls` / `tokenValidationAlgorithm` are served, not reset to schema defaults.
- Sensitive nested configs (`oidcConfiguration`, `ldapConfiguration`) remain excluded.

#### Unit tests
- [x] `ConfigResourceTest` — mocks the config singleton and asserts `getAuthConfig()` reflects the persisted `responseType`, `publicKeyUrls`, and `tokenValidationAlgorithm`. Verified **RED before the fix** (`expected: <code> but was: <id_token>`, `expected: [url] but was: []`) and **GREEN after** (4/4 pass).

#### Integration tests
- [x] `ConfigResourceIT.testAuthConfigMirrorsPersistedLoginFields` — real-server invariant cross-checking the public `/config/auth` response against the admin `/security/config` (which returns the true persisted config). Also removed the now-incorrect assertion that required `publicKeyUrls` to be empty (it encoded the buggy behavior).

#### Manual test
```
GET /api/v1/system/config/auth
# before: { "responseType": "id_token", "publicKeyUrls": [] ... }
# after:  { "responseType": "code",     "publicKeyUrls": ["https://.../jwks.json"] ... }
```

> Note: a companion frontend PR ensures the OIDC `UserManager` forwards this `responseType` (it was previously dropped, defaulting to `id_token` in the browser). Both are required for the end-to-end Cognito `code` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)