### PR TITLE
Fixes 31518: Stabilize Data Quality and Incident Manager tests

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1458,20 +1458,17 @@ test.describe(
         });
 
         await test.step('Test page size dropdown', async () => {
-          await expect(
-            page.locator('[data-testid="page-size-selection-dropdown"]')
-          ).toBeVisible();
+          const pageSizeDropdown = page.getByTestId(
+            'page-size-selection-dropdown'
+          );
+          const pageSizeMenu = page.locator(
+            '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu'
+          );
 
-          await page.click('[data-testid="page-size-selection-dropdown"]');
-
-          // Wait for dropdown menu to be visible
-          await page.locator('.ant-dropdown-menu').waitFor({
-            state: 'visible',
-            timeout: 5000,
-          });
-
-          // Verify dropdown options are visible
-          await expect(page.locator('.ant-dropdown-menu-item')).toHaveCount(3);
+          await expect(pageSizeDropdown).toBeVisible();
+          await pageSizeDropdown.hover();
+          await expect(pageSizeMenu).toBeVisible();
+          await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);
         });
       } finally {
         await paginationTable.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1466,6 +1466,8 @@ test.describe(
           );
 
           await expect(pageSizeDropdown).toBeVisible();
+          // NextPrevious inherits Ant Dropdown's hover trigger; clicking this
+          // button only runs its preventDefault handler and may not open the menu.
           await pageSizeDropdown.hover();
           await expect(pageSizeMenu).toBeVisible();
           await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1082,7 +1082,56 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
     );
     await assigneeOption.click();
-    await assigneeFilterRes;
+    const assigneeFilterResponse = await assigneeFilterRes;
+    const assignedIncident = page.getByTestId(
+      `test-case-${assigneeTestCase.testCaseName}`
+    );
+
+    if (!(await assignedIncident.isVisible().catch(() => false))) {
+      await expect
+        .poll(
+          async () => {
+            const retryResponse = await page.request.get(
+              assigneeFilterResponse.url()
+            );
+
+            if (!retryResponse.ok()) {
+              return false;
+            }
+
+            const searchData = (await retryResponse.json()) as {
+              data?: Array<{
+                testCaseReference?: { name?: string };
+                testCaseResolutionStatusDetails?: {
+                  assignee?: { name?: string };
+                };
+              }>;
+            };
+
+            return Boolean(
+              searchData.data?.some(
+                (incident) =>
+                  incident.testCaseReference?.name ===
+                    assigneeTestCase.testCaseName &&
+                  incident.testCaseResolutionStatusDetails?.assignee?.name ===
+                    assigneeTestCase.username
+              )
+            );
+          },
+          {
+            message: `Wait for ${assigneeTestCase.testCaseName} assignee to be indexed`,
+            timeout: 60_000,
+            intervals: [1_000, 2_000, 5_000],
+          }
+        )
+        .toBe(true);
+
+      const indexedAssigneeFilterRes = page.waitForResponse(
+        `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
+      );
+      await page.reload();
+      await indexedAssigneeFilterRes;
+    }
 
     await expectIncidentTableRowsToContain(
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -24,6 +24,7 @@ import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { resetTokenFromBotPage } from '../../utils/bot';
 import { getApiContext, redirectToHomePage } from '../../utils/common';
+import { waitForIncidentToBeIndexed } from '../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   acknowledgeTask,
@@ -1050,6 +1051,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       username: user1.data.email.split('@')[0].toLocaleLowerCase(),
       userDisplayName: user1.getUserDisplayName(),
       testCaseName: table1.testCasesResponseData[2]?.['name'],
+      testCaseFqn: table1.testCasesResponseData[2]?.['fullyQualifiedName'],
     };
     const testCase1 = table1.testCasesResponseData[0]?.['name'];
     const incidentDetailsRes = page.waitForResponse(
@@ -1058,6 +1060,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
     await incidentDetailsRes;
 
+    const assignmentStartedAt = Date.now();
     await assignIncident({
       page,
       testCaseName: assigneeTestCase.testCaseName,
@@ -1067,6 +1070,13 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       },
       direct: true,
     });
+    await waitForIncidentToBeIndexed(
+      page.request,
+      assigneeTestCase.testCaseFqn,
+      assignmentStartedAt,
+      'Assigned',
+      assigneeTestCase.username
+    );
 
     await page.click('[data-testid="select-assignee"]');
     const assigneeOption = page.locator(
@@ -1082,60 +1092,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
     );
     await assigneeOption.click();
-    const assigneeFilterResponse = await assigneeFilterRes;
-    const assignedIncident = page.getByTestId(
-      `test-case-${assigneeTestCase.testCaseName}`
-    );
-
-    // The resolve API confirms the write before the search index necessarily
-    // exposes it, so wait on the exact filtered request the UI already issued.
-    if (!(await assignedIncident.isVisible().catch(() => false))) {
-      await expect
-        .poll(
-          async () => {
-            const retryResponse = await page.request.get(
-              assigneeFilterResponse.url()
-            );
-
-            if (!retryResponse.ok()) {
-              return false;
-            }
-
-            const searchData = (await retryResponse.json()) as {
-              data?: Array<{
-                testCaseReference?: { name?: string };
-                testCaseResolutionStatusDetails?: {
-                  assignee?: { name?: string };
-                };
-              }>;
-            };
-
-            return Boolean(
-              searchData.data?.some(
-                (incident) =>
-                  incident.testCaseReference?.name ===
-                    assigneeTestCase.testCaseName &&
-                  incident.testCaseResolutionStatusDetails?.assignee?.name ===
-                    assigneeTestCase.username
-              )
-            );
-          },
-          {
-            message: `Wait for ${assigneeTestCase.testCaseName} assignee to be indexed`,
-            timeout: 60_000,
-            intervals: [1_000, 2_000, 5_000],
-          }
-        )
-        .toBe(true);
-
-      const indexedAssigneeFilterRes = page.waitForResponse(
-        `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
-      );
-      // The assignee lives in the URL query, so reload preserves the filter and
-      // renders the indexed response without rebuilding UI state in the test.
-      await page.reload();
-      await indexedAssigneeFilterRes;
-    }
+    await assigneeFilterRes;
 
     await expectIncidentTableRowsToContain(
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1087,6 +1087,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `test-case-${assigneeTestCase.testCaseName}`
     );
 
+    // The resolve API confirms the write before the search index necessarily
+    // exposes it, so wait on the exact filtered request the UI already issued.
     if (!(await assignedIncident.isVisible().catch(() => false))) {
       await expect
         .poll(
@@ -1129,6 +1131,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       const indexedAssigneeFilterRes = page.waitForResponse(
         `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
       );
+      // The assignee lives in the URL query, so reload preserves the filter and
+      // renders the indexed response without rebuilding UI state in the test.
       await page.reload();
       await indexedAssigneeFilterRes;
     }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1070,13 +1070,22 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       },
       direct: true,
     });
-    await waitForIncidentToBeIndexed(
-      page.request,
-      assigneeTestCase.testCaseFqn,
-      assignmentStartedAt,
-      'Assigned',
-      assigneeTestCase.username
-    );
+    // Browser API calls read the JWT from local storage, which page.request
+    // does not inherit. Poll with an authenticated context so a 401 cannot be
+    // mistaken for search-index lag.
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await waitForIncidentToBeIndexed(
+        apiContext,
+        assigneeTestCase.testCaseFqn,
+        assignmentStartedAt,
+        'Assigned',
+        assigneeTestCase.username
+      );
+    } finally {
+      await afterAction();
+    }
 
     await page.click('[data-testid="select-assignee"]');
     const assigneeOption = page.locator(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -567,40 +567,68 @@ export async function applyDashboardCertificationFilter(
 }
 
 /**
- * Polls the incident status API until an incident for `testCaseFqn` appears
- * within the [failTs-60s, failTs+120s] window.
- * Call this immediately after `addTestCaseResult` to guarantee the incident
- * document is indexed before any UI assertions.
- * Pass `expectedStatus` to also wait until the incident reaches that resolution
- * status (e.g. "Resolved") — useful after posting a status transition.
+ * Polls the incident search API until an incident for `testCaseFqn` appears
+ * within the [eventTs-60s, eventTs+120s] window.
+ * Call this after creating or updating an incident to guarantee the search
+ * document contains the state required by subsequent UI assertions.
+ * Assignee transitions filter on `updatedAt` because they update an existing
+ * incident whose original `timestamp` remains unchanged.
  */
 export async function waitForIncidentToBeIndexed(
   apiContext: APIRequestContext,
   testCaseFqn: string,
-  failTs: number,
-  expectedStatus?: string
+  eventTs: number,
+  expectedStatus?: string,
+  expectedAssignee?: string
 ): Promise<void> {
   await expect
     .poll(
       async () => {
         const res = await apiContext.get(
-          `/api/v1/dataQuality/testCases/testCaseIncidentStatus?latest=true` +
-            `&startTs=${failTs - 60_000}` +
-            `&endTs=${failTs + 120_000}`
+          '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list',
+          {
+            params: {
+              latest: true,
+              startTs: eventTs - 60_000,
+              endTs: eventTs + 120_000,
+              dateField: expectedAssignee ? 'updatedAt' : 'timestamp',
+              testCaseFQN: testCaseFqn,
+              ...(expectedStatus && {
+                testCaseResolutionStatusType: expectedStatus,
+              }),
+              ...(expectedAssignee && { assignee: expectedAssignee }),
+            },
+          }
         );
+
+        if (!res.ok()) {
+          return false;
+        }
+
         const body = await res.json();
 
         return (body.data ?? []).some(
           (i: {
             testCaseReference?: { fullyQualifiedName?: string };
             testCaseResolutionStatusType?: string;
+            testCaseResolutionStatusDetails?: {
+              assignee?: { name?: string };
+            };
           }) => {
             if (i.testCaseReference?.fullyQualifiedName !== testCaseFqn) {
               return false;
             }
 
-            return expectedStatus
-              ? i.testCaseResolutionStatusType === expectedStatus
+            if (
+              expectedStatus &&
+              i.testCaseResolutionStatusType !== expectedStatus
+            ) {
+              return false;
+            }
+
+            return expectedAssignee
+              ? i.testCaseResolutionStatusDetails?.assignee?.name ===
+                  expectedAssignee
               : true;
           }
         );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -255,21 +255,22 @@ export const addAssigneeFromPopoverWidget = async (data: {
   await page.click(`.ant-popover [title="${user.displayName}"]`);
   await updateIncident;
 
-  await page
-    .getByTestId('assignee')
-    .getByTestId('owner-link')
-    .first()
-    .waitFor();
-
   const taskHeaderAssignee = page.getByTestId(
     'incident-manager-task-header-container'
   );
+  const incidentAssignee = testCaseName
+    ? page
+        .locator('tr')
+        .filter({ has: page.getByTestId(`test-case-${testCaseName}`) })
+        .first()
+        .getByTestId('assignee')
+    : page.getByTestId('assignee').first();
 
   await expect(
     (await taskHeaderAssignee.isVisible().catch(() => false))
       ? taskHeaderAssignee
-      : page.getByTestId('assignee').first()
-  ).toContainText(user.displayName);
+      : incidentAssignee
+  ).toContainText(user.displayName, { timeout: 30_000 });
 };
 
 export const assignIncident = async (data: {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -258,6 +258,8 @@ export const addAssigneeFromPopoverWidget = async (data: {
   const taskHeaderAssignee = page.getByTestId(
     'incident-manager-task-header-container'
   );
+  // List pages can contain several incidents, so a generic first() may assert
+  // against an unrelated unassigned row instead of the incident just updated.
   const incidentAssignee = testCaseName
     ? page
         .locator('tr')


### PR DESCRIPTION
### Describe your changes:

Fixes #31518

This PR stabilizes two independent Playwright flakes in the Data Quality and Incident Manager suites. Both failures came from synchronizing on an event weaker than the product state the test intended to verify:

1. The pagination test clicked a hover-triggered page-size control.
2. The Incident Manager test treated completion of the assignment write as proof that both the target row and the search-backed filtered listing had converged.

No product behavior or API contract changes. The patch only makes the existing tests interact with the real UI contract and wait for the exact observable state.

## Root cause analysis

### 1. Data Quality pagination page-size dropdown

#### Failure signature

```text
locator.waitFor: Timeout 5000ms exceeded
waiting for locator('.ant-dropdown-menu') to be visible
```

The failure happened after the page-size trigger was clicked. The captured DOM showed the page-size button as active, but no visible dropdown menu was mounted during the fixed five-second window.

#### Product interaction contract

The pagination component wraps the page-size button in Ant Design `Dropdown` without an explicit `trigger`: [NextPrevious.tsx lines 125-144](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/src/components/common/NextPrevious/NextPrevious.tsx#L125-L144).

- Without an explicit trigger, the component uses the hover interaction.
- The nested button's click handler only calls `preventDefault()`.
- A click therefore does not itself satisfy the component contract. It opens the menu only if the pointer movement around that click happens to produce the required hover state.

The original test clicked the trigger and then waited on the broad `.ant-dropdown-menu` selector with a hard five-second timeout: [original DataQuality.spec.ts lines 1460-1474](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1460-L1474).

This was flaky for two independent reasons:

- It relied on incidental pointer hover generated around a click instead of deliberately performing the configured interaction.
- `.ant-dropdown-menu` can match Ant menus that remain mounted but hidden, so it did not uniquely identify the popup associated with this trigger.

A controlled repetition reproduced the original failure after four successful iterations. That pass/pass/pass/pass/fail pattern is consistent with an input-event race, not a consistently slow render.

#### Fix

The corrected flow is at [DataQuality.spec.ts lines 1460-1474](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1460-L1474):

1. Assert that the page-size trigger is visible.
2. Use `hover()`, matching the component contract.
3. Scope the menu to `.ant-dropdown:not(.ant-dropdown-hidden)` so only the visible popup is considered.
4. Use Playwright's web-first visibility assertion instead of a manually constrained five-second `waitFor`.
5. Count semantic `menuitem` roles within the visible popup.

The explanatory comment for the non-obvious hover behavior is at [lines 1468-1471](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1468-L1471).

Increasing the original timeout would only give an incorrect click interaction more time; it would not guarantee that the hover-triggered menu opens.

### 2. Incident Manager assignee filter

This failure had two original synchronization defects, followed by one authentication defect exposed by the first version of the index-polling fix.

#### 2a. The post-assignment assertion targeted the wrong incident row

The assignment helper identifies the target row by test-case identifier before opening its editor: [incidentManager.ts lines 177-185](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L177-L185).

The original post-write assertion then discarded that identity and read `page.getByTestId('assignee').first()`: [original incidentManager.ts lines 254-272](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L254-L272).

On a multi-row Incident Manager listing, the first assignee is not necessarily the incident just updated. If the first unrelated row is unassigned, the assertion receives `No Assignee` even when the target assignment succeeded. The previous global `owner-link.first()` wait had the same problem: it proved only that some owner link existed somewhere on the page.

The helper now preserves target identity and reads the assignee within the exact incident row: [incidentManager.ts lines 258-275](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L258-L275). The 30-second web-first assertion permits that row to re-render after the acknowledged update without a blind sleep. The reason for row scoping is documented at [lines 261-269](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L261-L269).

#### 2b. The assignment write completed before the search listing converged

Assignment waits for the task-resolution POST response: [task.ts lines 60-65](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts#L60-L65), consumed at [incidentManager.ts lines 254-256](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L254-L256).

That response acknowledges the write side. The assignee filter reads from `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?assignee=...`, so it observes the asynchronously updated search document. A successful task transition does not guarantee that the updated assignee is already searchable.

The original filter flow waited for exactly one search response and immediately asserted its rows: [original IncidentManager.spec.ts lines 1081-1090](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1081-L1090). If that first request reached search before indexing completed, it returned a valid but stale result. Waiting longer on an already completed response cannot make its payload current.

#### Why the existing helper needed to be extended

`waitForIncidentToBeIndexed` already existed, but before this PR it called the database-backed incident endpoint: [original dataQuality.ts lines 577-611](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts#L577-L611).

The two server routes have different consistency boundaries:

- The non-search `GET /testCaseIncidentStatus` route ends in `repository.list(...)`: [TestCaseResolutionStatusResource.java lines 108-219](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java#L108-L219).
- Incident Manager uses `GET /testCaseIncidentStatus/search/list`, whose implementation builds a `SearchListFilter` and calls `repository.listLatestFromSearch(...)` or `repository.listFromSearchWithOffset(...)`: [TestCaseResolutionStatusResource.java lines 639-791](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java#L639-L791).

Therefore, the unchanged helper could return as soon as the database row existed while Incident Manager's search document still contained the prior assignee. A generic search-presence check would also be insufficient: document existence does not prove that the assignee transition has been indexed.

The extended helper polls the same search-backed route and verifies the exact FQN, status, and nested assignee: [dataQuality.ts lines 569-638](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts#L569-L638).

It now:

1. Calls `/testCaseIncidentStatus/search/list`.
2. Filters by the exact test-case FQN.
3. Retains the bounded event window and 60-second polling budget.
4. Optionally filters and verifies resolution status.
5. Optionally filters and verifies assignee.
6. Uses `updatedAt` for assignee transitions because they update an existing incident whose original `timestamp` remains unchanged.
7. Rejects non-success responses instead of trying to parse them as incident data.
8. Verifies the returned source rather than trusting query parameters alone.

#### 2c. Follow-up CI failure: the index poll was unauthenticated

The first implementation passed `page.request` to the extended helper. The subsequent ingestion CI failure timed out in `waitForIncidentToBeIndexed` with `Expected: true / Received: false`.

Inspection of the failed job's server diagnostics provided an artifact-level reproduction without rerunning the test: [failed ingestion job](https://github.com/open-metadata/OpenMetadata/actions/runs/31805883036/job/94792616971).

The relevant request sequence was:

```text
14:28:04 POST /api/v1/tasks/<task-id>/resolve                                      200
14:28:04 GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/stateId/<id>   200
14:28:04 GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?... 401
14:28:05 GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?... 401
...
14:29:02 GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?... 401
```

The retry repeated the same pattern from `14:31:50` through `14:32:49`. Every poll returned HTTP 401 with a 58-byte response. This rules out an index query mismatch as the cause of this particular timeout: the helper never reached the search read at all.

The application stores its JWT in browser local storage. Browser-originated API calls inject that bearer token, but the request made through `page.request` did not inherit it. The repository's authenticated context explicitly reads the page token and adds `Authorization: Bearer <token>`: [common.ts lines 58-76](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts#L58-L76), wrapped by `getApiContext(page)` at [common.ts lines 294-305](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts#L294-L305).

The corrected test now:

1. Completes the UI assignment.
2. Creates an authenticated API context from the current page token.
3. Reuses `waitForIncidentToBeIndexed` with `Assigned + <username>`.
4. Disposes the temporary context in `finally`.
5. Applies the UI assignee filter only after the exact indexed state is observable.

This sequence is at [IncidentManager.spec.ts lines 1063-1104](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1063-L1104). The authentication rationale is documented inline at [lines 1073-1076](https://github.com/open-metadata/OpenMetadata/blob/e3e0516832/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1073-L1076).

The original product race is still a search-index propagation issue, so the existing helper remains the right synchronization primitive after extending it to verify the indexed assignee. The follow-up CI failure was in how that helper was called, not evidence that the indexing diagnosis was wrong.

## Why these failures were flaky

| Failure | State that varied between runs | Incorrect synchronization |
|---|---|---|
| Data Quality page-size menu | Whether click/pointer processing incidentally produced Ant Dropdown's hover state | A click followed by a fixed five-second wait |
| Incident row assignee | Which incident appeared first and whether the target row had rerendered | A global `assignee.first()` assertion |
| Incident assignee filter | Whether search consumed the assignment before the first filtered GET | Waiting for one HTTP response regardless of its data |
| Follow-up index poll | Not an index race: every helper request lacked authorization | Retrying HTTP 401 as if it meant “not indexed yet” |

## Scope and risk

- Test-only changes; no production UI, API, database, or search behavior is modified.
- Existing expectations remain unchanged: three page-size options and the selected assignee must be visible.
- Index polling is bounded and scoped to the exact test case, status, and assignee.
- The poll now uses the same authenticated API-context pattern already established in the spec.
- The temporary context is always disposed.
- Locators are narrower and identify the visible menu or exact incident row.
- No new dependency is introduced.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

The tests synchronize on observable business state:

- UI interaction uses the component's configured trigger and visible popup.
- List assertions retain the target incident identity.
- Search-backed assertions wait through an authenticated request for the exact target-assignee association, then refetch the filtered UI.

#
### Tests:

#### Use cases covered

- Test-case pagination exposes all three page-size choices from the visible page-size menu.
- Incident assignment verifies the assignee on the incident actually updated.
- Incident Manager assignee filtering tolerates bounded search-index propagation delay.
- The helper returns immediately when the indexed assignment is already current.
- The helper call is authenticated using the current page's bearer token.

#### Unit tests

- [x] Not applicable — Playwright-only change.

#### Backend integration tests

- [x] Not applicable — no backend changes.

#### Ingestion integration tests

- [x] Not applicable — no ingestion changes.

#### Playwright (UI) tests

- [x] Updated existing Playwright scenarios.
- Initial investigation reproduced the pagination failure after four successful iterations.
- The follow-up Incident Manager failure was reproduced from CI request logs: assignment/state reads returned 200, while every helper poll returned 401.
- Post-fix Playwright execution was not run per request.

#### Static validation performed

- UI organize-imports completed for all changed Playwright files.
- ESLint completed with zero errors; two expected multi-user-login warnings are outside the changed lines.
- Prettier completed successfully.
- `git diff --check` passed.
- The repository-wide Playwright TypeScript check reports existing baseline errors in unrelated files; it produced no diagnostic for the changed files.

#
### UI screen recording / screenshots:

Not applicable — no product UI behavior changed.

#
### Checklist:

- [x] I have read the contribution guidelines.
- [x] My PR title follows the required format.
- [x] I have linked the related issue.
- [x] I have updated existing tests that prove the corrected synchronization behavior.

### Bug fix:

- [x] I have updated the tests to cover the corrected synchronization behavior.
