### PR TITLE
fix(ui): AI-mode marketplace list layout + Add-form table height & label weight

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DataProduct/DataProductListPage.tsx
@@ -383,7 +383,7 @@ const DataProductListPage = ({
         className={classNames('tw:flex tw:min-h-0 tw:flex-1 tw:flex-col', {
           'tw:mb-5': !isAiMode,
         })}
-        variant="elevated">
+        variant={isAiMode ? 'default' : 'elevated'}>
         <Box
           className="tw:px-6 tw:py-4 tw:border-b tw:border-secondary"
           direction="col"
@@ -413,6 +413,7 @@ const DataProductListPageWithLayout: FC<DataProductListPageProps> = (props) => {
 
   return (
     <PageLayoutV1
+      className={isAiMode ? 'tw:h-auto!' : undefined}
       fullHeight={isAiMode}
       pageTitle={props.pageTitle}
       variant={isAiMode ? 'compact' : 'default'}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainForm.component.tsx
@@ -1039,7 +1039,7 @@ const AddDomainForm = ({
 
   return (
     <HookForm
-      className="tw:flex tw:flex-col tw:gap-6"
+      className="tw:flex tw:flex-col tw:gap-6 tw:**:data-[testid=form-item-label]:font-medium"
       data-testid="add-domain-form"
       form={form}
       onSubmit={form.handleSubmit(handleSubmit)}>

--- a/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Domain/AddDomainForm/AddDomainFormExtensionFields.tsx
@@ -724,7 +724,7 @@ const TableExtensionInput = ({
   return (
     <Box
       aria-invalid={error ? true : undefined}
-      className="tw:gap-1.5"
+      className="tw:gap-1.5 tw:[&_.rdg]:h-64!"
       data-testid={dataTestId}
       direction="col">
       <Box align="center" justify="between">

--- a/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/DomainListing/DomainListPage.tsx
@@ -285,7 +285,7 @@ const DomainListPage = ({ renderPageHeader }: DomainListPageProps) => {
         className={classNames('tw:flex tw:min-h-0 tw:flex-1 tw:flex-col', {
           'tw:mb-5': !isAiMode,
         })}
-        variant="elevated">
+        variant={isAiMode ? 'default' : 'elevated'}>
         <Box
           className="tw:px-6 tw:py-4 tw:border-b tw:border-secondary"
           direction="col"
@@ -319,6 +319,7 @@ const DomainListPageWithLayout: FC<DomainListPageProps> = (props) => {
 
   return (
     <PageLayoutV1
+      className={isAiMode ? 'tw:h-auto!' : undefined}
       fullHeight={isAiMode}
       pageTitle={props.pageTitle}
       variant={isAiMode ? 'compact' : 'default'}>


### PR DESCRIPTION
## Summary

UI polish for the **Data Marketplace (AI mode)** Domains / Data Products list pages and the **Add Domain / Add Data Product** intake form. Four small, targeted fixes — all gated to AI mode / the intake form so classic (non-AI) screens and the full-screen custom-property editor are unaffected.

## Fixes

### 1. AI-mode list pages no longer clip the table/content
`DomainListPage` / `DataProductListPage` (`*WithLayout`) now pass `className={isAiMode ? 'tw:h-auto!' : undefined}` to `PageLayoutV1`.

- **Why:** in `fullHeight` mode `PageLayoutV1` pins the page to `height: var(--om-page-height)` = `calc(100vh - var(--ant-navbar-height))`. The AI shell content pane has no classic top navbar, so that fixed height overflows the pane and the bottom of the table/list gets cut off.
- `tw:h-auto!` lets the page size to its actual flex parent instead. The `!` is required because `.page-layout-v1-full-height { height: … }` is an **unlayered LESS** rule, which beats a plain (layered) Tailwind utility.

<img width="1512" height="804" alt="Screenshot 2026-08-14 at 2 10 15 PM" src="https://github.com/user-attachments/assets/ef4e2ae4-793f-4f67-a541-0b60c07b749b" />

<img width="1512" height="798" alt="Screenshot 2026-08-14 at 2 10 51 PM" src="https://github.com/user-attachments/assets/749646ec-8a2f-40ab-9e8c-f8f8c62c870b" />

### 2. AI-mode card loses the grey shadow haze
The list `Card` uses `variant={isAiMode ? 'default' : 'elevated'}`.

- **Why:** the `elevated` variant renders `shadow-md` (`rgba(10,13,18,0.1)`), which read as a grey haze around the card in the AI shell. `default` keeps the same border + white background without the shadow, matching the flat look of the Data Access Requests page.

<img width="1512" height="798" alt="Screenshot 2026-08-14 at 2 10 51 PM" src="https://github.com/user-attachments/assets/c689f2af-28eb-4549-8840-f140963e446f" />


### 3. Intake TABLE custom-property field is compact
In `AddDomainFormExtensionFields` (the `TABLE`-type field), the grid wrapper adds `tw:[&_.rdg]:h-64!` (256px).

- **Why:** the shared `.om-rdg .rdg` style uses `height: calc(100vh - 280px)` — meant for the full-screen custom-property editor. Inside the Add-form modal that left a huge empty void. Scoped Tailwind override caps it to a compact height (grid still scrolls internally as rows are added). `!` is required to beat the unlayered LESS height. The full-screen editor is untouched (it doesn't get this class).

<img width="708" height="538" alt="Screenshot 2026-08-14 at 2 03 10 PM" src="https://github.com/user-attachments/assets/93815e04-0d99-4466-85d1-2daa643cf810" />


### 4. Consistent form label weight (500)
The Add form root (`HookForm`) adds `tw:**:data-[testid=form-item-label]:font-medium`.

- **Why:** `FormItemLabel` carries no font-weight of its own, so labels rendered inconsistently. This one rule sets **every** field label in the form to 500 — regular fields (via `getField`) and custom-property / intake fields (via `ExtensionFieldContainer`) — without editing the shared `ui-core-components` label component. No `!` needed (nothing else sets a weight on that span).

<img width="702" height="810" alt="Screenshot 2026-08-14 at 2 13 40 PM" src="https://github.com/user-attachments/assets/b4f3297e-3fb1-4c67-a20b-1cd75c542d98" />
