### PR TITLE
fix(mcp): let create tools set custom properties

### DIFF
--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CommonUtils.java
@@ -59,6 +59,22 @@ public class CommonUtils {
     return teamsOrUsers;
   }
 
+  /**
+   * Custom properties for the entity being created, as {@code {propertyName: value}}, or null when
+   * the caller supplied none. Returned rather than set on the request because {@code CreateEntity}
+   * exposes no {@code setExtension}; each tool assigns it on its own concrete request type.
+   */
+  public static Object extension(Map<String, Object> params) {
+    Object raw = params.get("extension");
+    if (raw != null && !(raw instanceof Map)) {
+      throw new IllegalArgumentException(
+          "Parameter 'extension' must be an object mapping custom property names to values."
+              + " Received: "
+              + raw);
+    }
+    return raw;
+  }
+
   public static String principal(CatalogSecurityContext securityContext) {
     return securityContext.getUserPrincipal().getName();
   }

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDataProductTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDataProductTool.java
@@ -62,6 +62,7 @@ public class CreateDataProductTool implements McpTool {
     if (params.containsKey("tags")) {
       create.setTags(CommonUtils.buildTagLabels(params.get("tags")));
     }
+    create.setExtension(CommonUtils.extension(params));
 
     final DataProductMapper mapper = new DataProductMapper();
     final DataProduct entity =

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDomainTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/CreateDomainTool.java
@@ -63,6 +63,7 @@ public class CreateDomainTool implements McpTool {
     if (params.containsKey("tags")) {
       create.setTags(CommonUtils.buildTagLabels(params.get("tags")));
     }
+    create.setExtension(CommonUtils.extension(params));
 
     final DomainMapper mapper = new DomainMapper();
     final Domain entity = mapper.createToEntity(create, CommonUtils.principal(securityContext));

--- a/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
+++ b/openmetadata-mcp/src/main/java/org/openmetadata/mcp/tools/GlossaryTermTool.java
@@ -43,6 +43,7 @@ public class GlossaryTermTool implements McpTool {
     if (params.containsKey("reviewers")) {
       createGlossaryTerm.setReviewers(CommonUtils.getTeamsOrUsers(params.get("reviewers")));
     }
+    createGlossaryTerm.setExtension(CommonUtils.extension(params));
 
     GlossaryTerm glossaryTerm =
         glossaryTermMapper.createToEntity(

--- a/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
+++ b/openmetadata-mcp/src/main/resources/json/data/mcp/tools.json
@@ -566,6 +566,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "extension": {
+            "type": "object",
+            "description": "Custom properties to set on the glossary term, as an object mapping each custom property name to its value (e.g. {\"costCenter\": \"CC-1234\"}). Each property must already be defined for this entity type. A property the organisation's intake form marks as required must be supplied here, or creation is rejected.",
+            "additionalProperties": true
           }
         },
         "required": [
@@ -1172,6 +1177,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "extension": {
+            "type": "object",
+            "description": "Custom properties to set on the domain, as an object mapping each custom property name to its value (e.g. {\"costCenter\": \"CC-1234\"}). Each property must already be defined for this entity type. A property the organisation's intake form marks as required must be supplied here, or creation is rejected.",
+            "additionalProperties": true
           }
         },
         "required": [
@@ -1238,6 +1248,11 @@
             "items": {
               "type": "string"
             }
+          },
+          "extension": {
+            "type": "object",
+            "description": "Custom properties to set on the data product, as an object mapping each custom property name to its value (e.g. {\"costCenter\": \"CC-1234\"}). Each property must already be defined for this entity type. A property the organisation's intake form marks as required must be supplied here, or creation is rejected.",
+            "additionalProperties": true
           }
         },
         "required": [

--- a/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateDataProductToolTest.java
+++ b/openmetadata-mcp/src/test/java/org/openmetadata/mcp/tools/CreateDataProductToolTest.java
@@ -1,5 +1,6 @@
 package org.openmetadata.mcp.tools;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,11 +22,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.openmetadata.schema.api.domains.CreateDataProduct;
 import org.openmetadata.schema.entity.domains.DataProduct;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.schema.type.EventType;
@@ -92,6 +95,52 @@ class CreateDataProductToolTest {
       assertNotNull(result);
       verify(repo).prepareInternal(any(DataProduct.class), eq(false));
     }
+  }
+
+  @Test
+  void testExtensionIsPassedToCreateRequest() {
+    DataProductRepository repo = mock(DataProductRepository.class);
+    DataProduct dataProduct = new DataProduct();
+    dataProduct.setId(UUID.randomUUID());
+    dataProduct.setName("CustomerInsights");
+
+    RestUtil.PutResponse<DataProduct> putResponse =
+        new RestUtil.PutResponse<>(Response.Status.CREATED, dataProduct, EventType.ENTITY_CREATED);
+    when(repo.createOrUpdate(isNull(), any(DataProduct.class), anyString(), any()))
+        .thenReturn(putResponse);
+
+    ArgumentCaptor<CreateDataProduct> captor = ArgumentCaptor.forClass(CreateDataProduct.class);
+    Map<String, Object> extension = Map.of("testTable", Map.of("rows", List.of()));
+
+    try (MockedStatic<Entity> entityMock = mockStatic(Entity.class);
+        MockedConstruction<DataProductMapper> mapperMock =
+            mockConstruction(
+                DataProductMapper.class,
+                (mapper, context) ->
+                    when(mapper.createToEntity(any(), anyString())).thenReturn(dataProduct))) {
+
+      entityMock.when(() -> Entity.getEntityRepository(Entity.DATA_PRODUCT)).thenReturn(repo);
+      entityMock
+          .when(() -> Entity.getEntityReferenceByName(anyString(), anyString(), any()))
+          .thenReturn(new EntityReference());
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("name", "CustomerInsights");
+      params.put("description", "Customer insights data product");
+      params.put("domains", List.of("Finance"));
+      params.put("extension", extension);
+
+      new CreateDataProductTool().execute(authorizer, limits, securityContext, params);
+
+      verify(mapperMock.constructed().getFirst()).createToEntity(captor.capture(), anyString());
+      assertEquals(extension, captor.getValue().getExtension());
+    }
+  }
+
+  @Test
+  void testNonObjectExtensionThrows() {
+    Map<String, Object> params = Map.of("extension", "not-an-object");
+    assertThrows(IllegalArgumentException.class, () -> CommonUtils.extension(params));
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormValidator.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/IntakeFormValidator.java
@@ -75,13 +75,25 @@ public final class IntakeFormValidator {
       if (!Boolean.TRUE.equals(field.getRequired())) continue;
       if (field.getFieldPath() == null || field.getFieldPath().isBlank()) continue;
       if (!isFieldSet(entity, field)) {
-        missing.add(
-            field.getErrorMessage() != null && !field.getErrorMessage().isBlank()
-                ? field.getErrorMessage()
-                : (field.getFieldLabel() != null ? field.getFieldLabel() : field.getFieldPath()));
+        missing.add(describe(field));
       }
     }
     return missing;
+  }
+
+  /**
+   * How a missing field is named in the error. Falls through to the field path when the label is
+   * blank as well as when it is absent: a form field configured with an empty label would otherwise
+   * contribute an empty entry, leaving the caller an error that names nothing.
+   */
+  private static String describe(IntakeFormField field) {
+    String described = field.getFieldPath();
+    if (field.getErrorMessage() != null && !field.getErrorMessage().isBlank()) {
+      described = field.getErrorMessage();
+    } else if (field.getFieldLabel() != null && !field.getFieldLabel().isBlank()) {
+      described = field.getFieldLabel();
+    }
+    return described;
   }
 
   private static boolean isFieldSet(EntityInterface entity, IntakeFormField field) {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormValidatorTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/util/IntakeFormValidatorTest.java
@@ -302,6 +302,26 @@ class IntakeFormValidatorTest {
   // ---------------------------------------------------------------------------
 
   @Test
+  void validate_namesTheFieldWhenItsLabelIsBlank() {
+    IntakeFormRequiredField unlabelled =
+        new IntakeFormRequiredField()
+            .withFieldPath("extension.testTable")
+            .withFieldLabel("")
+            .withFieldKind(FieldKind.CUSTOM_PROPERTY);
+    IntakeForm form = newEnabledForm(List.of(unlabelled));
+    when(mockRepo.findEnabledForEntityType(Entity.DATA_PRODUCT)).thenReturn(form);
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> IntakeFormValidator.validate(validDataProduct(), Entity.DATA_PRODUCT));
+
+    assertTrue(
+        thrown.getMessage().contains("extension.testTable"),
+        "an unlabelled required field must still be named: " + thrown.getMessage());
+  }
+
+  @Test
   void validate_skipsRequiredFieldEntryWithBlankFieldPath() {
     IntakeFormRequiredField blank =
         new IntakeFormRequiredField()


### PR DESCRIPTION
- Adds an `extension` parameter to the MCP tools that create Data Products, Domains and Glossary Terms, so custom properties can be set at creation time.
- Without it, an organisation with a required custom property on its intake form could not create these entities through MCP at all — the tool had no parameter that could satisfy the requirement, and the same payload worked fine over REST.
- Also names the field in the rejection message when its intake-form label is blank, instead of leaving an empty entry the caller cannot act on.

Fixes #31520
