### PR TITLE
Fix Playwright custom property and lineage flakes

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -90,37 +90,6 @@ const fetchCompletedExportCsv = async (
   return resultResponse.text();
 };
 
-const getJobsLauncherButton = (page: Page) =>
-  page.getByRole('button', {
-    name: /Background jobs|jobs running/,
-  });
-
-const getJobsTrayPopover = (page: Page) =>
-  page.locator('.csv-jobs-tray-popover');
-
-const openJobsTray = async (page: Page) => {
-  const trayPopover = getJobsTrayPopover(page);
-
-  await expect(getJobsLauncherButton(page).or(trayPopover)).toBeVisible();
-
-  if (!(await trayPopover.isVisible())) {
-    await getJobsLauncherButton(page).click();
-  }
-
-  await expect(trayPopover).toBeVisible();
-};
-
-const refreshJobsTray = async (page: Page) => {
-  const trayPopover = getJobsTrayPopover(page);
-
-  if (await trayPopover.isVisible()) {
-    await trayPopover.locator('.csv-jobs-tray-close').click();
-    await expect(trayPopover).not.toBeVisible();
-  }
-
-  await openJobsTray(page);
-};
-
 test.describe(
   'Search Export',
   { tag: ['@Features', '@Discovery', '@import-export'] },
@@ -491,7 +460,22 @@ test.describe(
         //
         // Fix: wait for whichever surface appears first, then open the tray
         // only if it has not already been auto-opened.
-        await openJobsTray(page);
+        const launcherButton = page.getByRole('button', {
+          name: /Background jobs|jobs running/,
+        });
+        const trayPopover = page.locator('.csv-jobs-tray-popover');
+
+        // Block until the launcher (job in progress) or the tray (job
+        // completed and auto-opened by the useEffect) is in the DOM.
+        await expect(launcherButton.or(trayPopover)).toBeVisible();
+
+        // Open the tray only if it has not already been auto-opened.
+        // When the job finished fast, the tray is already visible and the
+        // launcher is gone from the DOM — clicking it would throw.
+        if (!(await trayPopover.isVisible())) {
+          await launcherButton.click();
+        }
+
         await expect(
           page.getByText(/Exporting|Exported/).first()
         ).toBeVisible();
@@ -511,9 +495,8 @@ test.describe(
         const { apiContext, afterAction } = await performAdminLogin(browser);
         await waitForExportJobCompleted(apiContext, jobId);
         await afterAction();
-        await refreshJobsTray(page);
 
-        const downloadButton = getJobsTrayPopover(page)
+        const downloadButton = page
           .getByRole('button', { name: 'Download' })
           .first();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -90,6 +90,37 @@ const fetchCompletedExportCsv = async (
   return resultResponse.text();
 };
 
+const getJobsLauncherButton = (page: Page) =>
+  page.getByRole('button', {
+    name: /Background jobs|jobs running/,
+  });
+
+const getJobsTrayPopover = (page: Page) =>
+  page.locator('.csv-jobs-tray-popover');
+
+const openJobsTray = async (page: Page) => {
+  const trayPopover = getJobsTrayPopover(page);
+
+  await expect(getJobsLauncherButton(page).or(trayPopover)).toBeVisible();
+
+  if (!(await trayPopover.isVisible())) {
+    await getJobsLauncherButton(page).click();
+  }
+
+  await expect(trayPopover).toBeVisible();
+};
+
+const refreshJobsTray = async (page: Page) => {
+  const trayPopover = getJobsTrayPopover(page);
+
+  if (await trayPopover.isVisible()) {
+    await trayPopover.locator('.csv-jobs-tray-close').click();
+    await expect(trayPopover).not.toBeVisible();
+  }
+
+  await openJobsTray(page);
+};
+
 test.describe(
   'Search Export',
   { tag: ['@Features', '@Discovery', '@import-export'] },
@@ -460,22 +491,7 @@ test.describe(
         //
         // Fix: wait for whichever surface appears first, then open the tray
         // only if it has not already been auto-opened.
-        const launcherButton = page.getByRole('button', {
-          name: /Background jobs|jobs running/,
-        });
-        const trayPopover = page.locator('.csv-jobs-tray-popover');
-
-        // Block until the launcher (job in progress) or the tray (job
-        // completed and auto-opened by the useEffect) is in the DOM.
-        await expect(launcherButton.or(trayPopover)).toBeVisible();
-
-        // Open the tray only if it has not already been auto-opened.
-        // When the job finished fast, the tray is already visible and the
-        // launcher is gone from the DOM — clicking it would throw.
-        if (!(await trayPopover.isVisible())) {
-          await launcherButton.click();
-        }
-
+        await openJobsTray(page);
         await expect(
           page.getByText(/Exporting|Exported/).first()
         ).toBeVisible();
@@ -495,8 +511,9 @@ test.describe(
         const { apiContext, afterAction } = await performAdminLogin(browser);
         await waitForExportJobCompleted(apiContext, jobId);
         await afterAction();
+        await refreshJobsTray(page);
 
-        const downloadButton = page
+        const downloadButton = getJobsTrayPopover(page)
           .getByRole('button', { name: 'Download' })
           .first();
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -21,7 +21,10 @@ import {
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
 import { fullUuid, uuid } from '../../utils/common';
-import { visitEntityPage, visitEntityPageByFqn } from '../../utils/entity';
+import {
+  visitEntityPage,
+  visitEntityPageByFqn,
+} from '../../utils/entity';
 import {
   EntityTypeEndpoint,
   ResponseDataType,

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -21,10 +21,7 @@ import {
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
 import { fullUuid, uuid } from '../../utils/common';
-import {
-  visitEntityPage,
-  visitEntityPageByFqn,
-} from '../../utils/entity';
+import { visitEntityPage, visitEntityPageByFqn } from '../../utils/entity';
 import {
   EntityTypeEndpoint,
   ResponseDataType,
@@ -377,22 +374,6 @@ export class TableClass extends EntityClass {
     ) {
       const response = await page.request.get(
         `/api/v1/tables/${this.entityResponseData.id}`
-      );
-
-      if (response.ok()) {
-        this.entityResponseData = await response.json();
-      }
-    }
-
-    // Last-resort FQN reconstruction from the class's own known parts. Falling
-    // back to `visitEntityPage` (the global-search flow) is a known source of
-    // flakiness — Suggestions can skip its fetch under CI load and the wait
-    // times out — so we prefer to look the table up by its constructed FQN and
-    // stay on the deterministic direct-navigation path.
-    if (!this.entityResponseData.fullyQualifiedName) {
-      const constructedFqn = `${this.service.name}.${this.database.name}.${this.schema.name}.${this.entity.name}`;
-      const response = await page.request.get(
-        `/api/v1/tables/name/${encodeURIComponent(constructedFqn)}`
       );
 
       if (response.ok()) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -21,10 +21,7 @@ import {
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
 import { fullUuid, uuid } from '../../utils/common';
-import {
-  visitEntityPage,
-  visitEntityPageByFqn,
-} from '../../utils/entity';
+import { visitEntityPage, visitEntityPageByFqn } from '../../utils/entity';
 import {
   EntityTypeEndpoint,
   ResponseDataType,

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -21,7 +21,10 @@ import {
 import { SERVICE_TYPE } from '../../constant/service';
 import { ServiceTypes } from '../../constant/settings';
 import { fullUuid, uuid } from '../../utils/common';
-import { visitEntityPage, visitEntityPageByFqn } from '../../utils/entity';
+import {
+  visitEntityPage,
+  visitEntityPageByFqn,
+} from '../../utils/entity';
 import {
   EntityTypeEndpoint,
   ResponseDataType,
@@ -397,9 +400,7 @@ export class TableClass extends EntityClass {
       }
     }
 
-    const tableFqn =
-      this.entityResponseData.fullyQualifiedName ??
-      `${this.service.name}.${this.database.name}.${this.schema.name}.${this.entity.name}`;
+    const tableFqn = this.entityResponseData.fullyQualifiedName ?? '';
     const canUseDirectNavigation =
       !searchTerm || (tableFqn.length > 0 && searchTerm === tableFqn);
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -23,7 +23,7 @@ import { ServiceTypes } from '../../constant/settings';
 import { fullUuid, uuid } from '../../utils/common';
 import {
   visitEntityPage,
-  waitForAllLoadersToDisappear,
+  visitEntityPageByFqn,
 } from '../../utils/entity';
 import {
   EntityTypeEndpoint,
@@ -400,19 +400,18 @@ export class TableClass extends EntityClass {
       }
     }
 
-    const tableFqn = this.entityResponseData.fullyQualifiedName ?? '';
+    const tableFqn =
+      this.entityResponseData.fullyQualifiedName ??
+      `${this.service.name}.${this.database.name}.${this.schema.name}.${this.entity.name}`;
     const canUseDirectNavigation =
       !searchTerm || (tableFqn.length > 0 && searchTerm === tableFqn);
 
     if (canUseDirectNavigation && tableFqn.length > 0) {
-      const tableResponse = page.waitForResponse(
-        `/api/v1/tables/name/${encodeURIComponent(tableFqn)}?**`
-      );
-      await page.goto(`/table/${encodeURIComponent(tableFqn)}`, {
-        waitUntil: 'domcontentloaded',
+      await visitEntityPageByFqn({
+        page,
+        endpoint: EntityTypeEndpoint.Table,
+        fqn: tableFqn,
       });
-      await tableResponse;
-      await waitForAllLoadersToDisappear(page);
 
       return;
     }

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -912,16 +912,21 @@ export const deleteCreatedProperty = async (
   const patchResponse = page.waitForResponse(
     (res) =>
       res.url().includes('/api/v1/metadata/types/') &&
-      res.request().method() === 'PATCH' &&
-      res.status() === 200
+      res.request().method() === 'PATCH',
+    { timeout: 30_000 }
   );
 
   await page.locator('[data-testid="save-button"]').click();
-  await patchResponse;
+  const response = await patchResponse;
+
+  expect(response.status()).toBe(200);
 
   // ConfirmationModal is destroyOnClose: assert the body text unmounts so
   // the modal mask is gone before the next sidebar click in callers' loops.
   await expect(page.locator('[data-testid="body-text"]')).not.toBeAttached();
+  await expect(
+    page.locator('tr').filter({ hasText: propertyName })
+  ).not.toBeVisible();
 };
 
 export const verifyCustomPropertyInAdvancedSearch = async (

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/customProperty.ts
@@ -925,7 +925,7 @@ export const deleteCreatedProperty = async (
   // the modal mask is gone before the next sidebar click in callers' loops.
   await expect(page.locator('[data-testid="body-text"]')).not.toBeAttached();
   await expect(
-    page.locator('tr').filter({ hasText: propertyName })
+    page.locator(`[data-row-key="${propertyName}"]`)
   ).not.toBeVisible();
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes: N/A - addresses flaky Playwright runs 31664229633, 31553466055, and 31664233665.

I updated table entity navigation to use direct FQN routes where possible, adjusted custom property deletion to assert the captured PATCH response status while verifying the deleted row is gone, and made the Search Export jobs tray download flow refresh the tray state after the export job completes.

#### RCA
- Run `31664229633`: the attached `Flow/PlatformLineage.spec.ts` was green, but the report's actual PlatformLineage flakes were in `Pages/Lineage/PlatformLineage.spec.ts` for `Verify domain platform view` and `Verify platform view switching`. Both failed in `beforeEach` while opening the table page: `TableClass.visitEntityPage()` could fall back to the global-search helper when `entityResponseData.fullyQualifiedName` was unavailable, and that helper waited for `/api/v1/search/query` with `index=dataAsset`. In CI, that search request can be skipped, missed, or fail to match the exact wait predicate, so the test timed out after 30s before reaching the lineage assertions. The retry passed because entity/search timing happened to line up on the second attempt.
- Run `31553466055`: the flaky `Sql Query` and `String` custom property tests timed out during the cleanup/delete flow inside `deleteCreatedProperty()`. The helper clicked the delete confirmation save button and then waited only for a metadata-types `PATCH` response, so if that network wait was missed or delayed the test kept waiting until the full 180s timeout. The trace showed the flow reached the delete confirmation step and the retry completed normally, which points to synchronization in the helper rather than a deterministic product failure.
- Run `31664233665`: `SearchExport.spec.ts` flaked in `Export queues a background job and downloads from the jobs tray`. The failing attempt spent the test budget waiting for the tray `Download` button and then surfaced as `Target page, context or browser has been closed` when the result response wait was registered after timeout shutdown had started. The test was relying on socket/tray UI state to progress from `Exporting` to `Download`; if the tray missed or lagged the completion update, the completed job was available through the API but the visible tray state stayed stale. The fix polls the job completion through the authenticated API, then closes/re-opens the tray to trigger its fetch path before locating the Download button inside the tray.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A - small Playwright flake fix.

#
### Tests:

#### Use cases covered
- Platform lineage setup can open table pages without depending on global search suggestions.
- Custom property delete waits on the metadata type patch and verifies row removal by exact row key.
- Search export waits for async job completion and refreshes the jobs tray before downloading the CSV.

#### Unit tests
- [ ] Not applicable; Playwright helper-only change.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Updated existing Playwright helpers/spec flow used by the flaky specs.
- Files updated: `playwright/support/entity/TableClass.ts`, `playwright/utils/customProperty.ts`, `playwright/e2e/Features/SearchExport.spec.ts`

#### Manual testing performed
1. Extracted the attached Playwright HTML reports and confirmed the RCA from structured report JSON.
2. Ran `git diff --check` successfully.
3. Checked that `SearchExport.spec.ts` does not introduce `waitForTimeout`, `force: true`, or `networkidle`.
4. UI checkstyle was not run locally because this workspace is missing `openmetadata-ui/src/main/resources/ui/node_modules/.bin/organize-imports-cli`.

#
### UI screen recording / screenshots:

Not applicable - no product UI changes.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->