### PR TITLE
fix(agents): distinguish loading from an unreachable pipeline service

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentCardSkeleton.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentCardSkeleton.component.tsx
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { Box, Card, Skeleton } from '@openmetadata/ui-core-components';
+import { FC } from 'react';
+
+/**
+ * Placeholder row for {@link AgentCard}. The outer chrome and the three column
+ * widths are copied from the real card so the list does not reflow when the
+ * agents arrive.
+ */
+const AgentCardSkeleton: FC = () => (
+  <Card
+    className="tw:rounded-2xl tw:border tw:border-secondary tw:bg-primary tw:px-4.5 tw:py-4 tw:shadow-xs"
+    data-testid="agent-card-skeleton"
+    variant="ghost">
+    <Box align="center" className="tw:gap-3.5">
+      {/* identity */}
+      <Box
+        align="start"
+        className="tw:w-[30%] tw:min-w-[300px] tw:max-w-[520px] tw:shrink-0 tw:gap-3">
+        <Skeleton
+          className="tw:size-9.5 tw:shrink-0 tw:rounded-xl"
+          variant="rectangular"
+        />
+        <div className="tw:min-w-0 tw:flex-1">
+          <Skeleton height={14} width="60%" />
+          <Skeleton className="tw:mt-1.5" height={10} width="35%" />
+        </div>
+      </Box>
+
+      {/* live status zone */}
+      <div className="tw:min-w-0 tw:flex-1">
+        <Skeleton height={22} variant="rounded" width={96} />
+        <Skeleton className="tw:mt-2" height={10} width={180} />
+      </div>
+
+      {/* actions */}
+      <Box align="center" className="tw:shrink-0 tw:gap-2">
+        <Skeleton height={32} variant="rounded" width={88} />
+        <Skeleton className="tw:size-8" variant="rounded" />
+      </Box>
+    </Box>
+  </Card>
+);
+
+export default AgentCardSkeleton;

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentCardSkeleton.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentCardSkeleton.test.tsx
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import AgentCardSkeleton from './AgentCardSkeleton.component';
+
+describe('AgentCardSkeleton', () => {
+  it('should render a placeholder card', () => {
+    render(<AgentCardSkeleton />);
+
+    expect(screen.getByTestId('agent-card-skeleton')).toBeInTheDocument();
+  });
+
+  it('should expose no text content to assistive tech', () => {
+    render(<AgentCardSkeleton />);
+
+    expect(screen.getByTestId('agent-card-skeleton')).toHaveTextContent('');
+  });
+});

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentGroup.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentGroup.component.tsx
@@ -25,6 +25,9 @@ import { ReactComponent as ReloadIcon } from '../../../assets/svg/reload.svg';
 import Loader from '../../common/Loader/Loader';
 import { Agent, AgentActionPermissions } from '../AgentsPage.interface';
 import AgentCard from './AgentCard.component';
+import AgentCardSkeleton from './AgentCardSkeleton.component';
+
+const DEFAULT_SKELETON_COUNT = 3;
 
 interface AgentGroupProps {
   addAgentSlot?: ReactNode;
@@ -36,8 +39,15 @@ interface AgentGroupProps {
   descKey: string;
   emptyPlaceholder?: ReactNode;
   icon: ReactNode;
+  /**
+   * First load only. The list is empty until the caller knows whether there are
+   * any agents, and rendering `emptyPlaceholder` in that window claims "none
+   * exist" before that is known — show placeholder cards instead.
+   */
+  isLoading?: boolean;
   /** Disables the refresh button and swaps its icon for a spinner while a refetch is in flight. */
   isRefreshing?: boolean;
+  skeletonCount?: number;
   titleKey: string;
   onAction: (action: string, agent: Agent) => void | Promise<void>;
   onLogs: (agent: Agent) => void;
@@ -57,7 +67,9 @@ const AgentGroup: FC<AgentGroupProps> = ({
   descKey,
   emptyPlaceholder,
   icon,
+  isLoading = false,
   isRefreshing,
+  skeletonCount = DEFAULT_SKELETON_COUNT,
   onAction,
   onLogs,
   onRefresh,
@@ -67,6 +79,51 @@ const AgentGroup: FC<AgentGroupProps> = ({
 }) => {
   const { t } = useTranslation();
   const runningCount = agents.filter((a) => a.status === 'running').length;
+
+  const renderAgents = () => {
+    if (isLoading) {
+      return (
+        <div
+          aria-busy
+          aria-label={t('label.loading')}
+          aria-live="polite"
+          className="tw:grid tw:gap-2.5"
+          data-testid="agent-group-skeleton"
+          role="status">
+          {Array.from({ length: skeletonCount }, (_, index) => (
+            <AgentCardSkeleton key={`agent-card-skeleton-${index}`} />
+          ))}
+        </div>
+      );
+    }
+
+    if (agents.length === 0 && emptyPlaceholder) {
+      return (
+        <Box
+          className="tw:relative tw:min-h-80 tw:w-full"
+          data-testid="agent-group-empty-placeholder">
+          {emptyPlaceholder}
+        </Box>
+      );
+    }
+
+    return (
+      <div className="tw:grid tw:gap-2.5">
+        {agents.map((agent) => (
+          <AgentCard
+            agent={agent}
+            allowedActions={allowedActions}
+            key={agent.id}
+            permissions={agentPermissions?.[agent.fqn]}
+            onAction={onAction}
+            onLogs={onLogs}
+            onRun={onRun}
+            onRunDetails={onRunDetails}
+          />
+        ))}
+      </div>
+    );
+  };
 
   return (
     <Card
@@ -131,28 +188,7 @@ const AgentGroup: FC<AgentGroupProps> = ({
             </Button>
           ))}
       </Box>
-      {agents.length === 0 && emptyPlaceholder ? (
-        <Box
-          className="tw:relative tw:min-h-80 tw:w-full"
-          data-testid="agent-group-empty-placeholder">
-          {emptyPlaceholder}
-        </Box>
-      ) : (
-        <div className="tw:grid tw:gap-2.5">
-          {agents.map((agent) => (
-            <AgentCard
-              agent={agent}
-              allowedActions={allowedActions}
-              key={agent.id}
-              permissions={agentPermissions?.[agent.fqn]}
-              onAction={onAction}
-              onLogs={onLogs}
-              onRun={onRun}
-              onRunDetails={onRunDetails}
-            />
-          ))}
-        </div>
-      )}
+      {renderAgents()}
     </Card>
   );
 };

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentGroup.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/AgentGroup.test.tsx
@@ -21,6 +21,10 @@ jest.mock('./AgentCard.component', () =>
   jest.fn().mockImplementation(() => <p>AgentCard</p>)
 );
 
+jest.mock('./AgentCardSkeleton.component', () =>
+  jest.fn().mockImplementation(() => <p>AgentCardSkeleton</p>)
+);
+
 const mockOnAction = jest.fn();
 const mockOnLogs = jest.fn();
 const mockOnRun = jest.fn();
@@ -146,5 +150,35 @@ describe('AgentGroup', () => {
     );
 
     expect(slotFollowsRefresh).toBe(true);
+  });
+
+  it('should render skeleton cards instead of the empty placeholder while loading', () => {
+    renderGroup([], <p>no agents</p>, { isLoading: true });
+
+    expect(screen.getByTestId('agent-group-skeleton')).toBeInTheDocument();
+    expect(screen.getAllByText('AgentCardSkeleton')).toHaveLength(3);
+    expect(
+      screen.queryByTestId('agent-group-empty-placeholder')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('no agents')).not.toBeInTheDocument();
+  });
+
+  it('should keep the group header rendered while loading', () => {
+    renderGroup([], <p>no agents</p>, { isLoading: true });
+
+    expect(screen.getByTestId('agent-group')).toBeInTheDocument();
+  });
+
+  it('should honour skeletonCount', () => {
+    renderGroup([], undefined, { isLoading: true, skeletonCount: 5 });
+
+    expect(screen.getAllByText('AgentCardSkeleton')).toHaveLength(5);
+  });
+
+  it('should prefer the skeleton over already-loaded agents while loading', () => {
+    renderGroup([baseAgent], undefined, { isLoading: true });
+
+    expect(screen.getByTestId('agent-group-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('AgentCard')).not.toBeInTheDocument();
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.component.tsx
@@ -36,6 +36,7 @@ import {
 import serviceUtilClassBase from '../../../utils/ServiceUtilClassBase';
 import { showErrorToast } from '../../../utils/ToastUtils';
 import DeleteModal from '../../common/DeleteModal/DeleteModal';
+import ErrorPlaceHolderIngestion from '../../common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion';
 import LogViewerModal from '../../common/LogViewerModal/LogViewerModal.component';
 import AddIngestionButton from '../../Settings/Services/Ingestion/AddIngestionButton.component';
 import '../agents-preview.css';
@@ -46,10 +47,15 @@ import { useAgentPermissions } from '../hooks/useAgentPermissions';
 import AgentGroup from './AgentGroup.component';
 import RunHistoryDrawer from './RunHistoryDrawer.component';
 
+const AGENTS_EMPTY_CARD_CLASS =
+  'tw:bg-primary tw:border tw:border-secondary tw:rounded-xl';
+
 interface MetadataAgentsViewProps {
   addAgentSlot?: ReactNode;
   agents: Agent[];
   ingestionPipelineList: IngestionPipeline[];
+  /** First load — spans the airflow status call and the pipeline fetch it gates. */
+  isLoading?: boolean;
   serviceCategory: ServiceCategory;
   serviceDetails: ServicesType;
   serviceName: string;
@@ -63,6 +69,7 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
   addAgentSlot: addAgentSlotProp,
   agents,
   ingestionPipelineList,
+  isLoading,
   isRefreshing,
   serviceCategory,
   serviceDetails,
@@ -72,7 +79,7 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { platform } = useAirflowStatus();
+  const { isAirflowAvailable, isFetchingStatus, platform } = useAirflowStatus();
   const { theme } = useApplicationStore();
   const { runAgent, redeployAgent, killAgent, toggleAgent } =
     useAgentActions(onRefresh);
@@ -200,17 +207,23 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
     }
   }, [logsFor, rawText]);
 
-  const emptyPlaceholder = useMemo(
-    () =>
-      getErrorPlaceHolder(
-        agents.length,
-        platform === DISABLED,
-        theme,
-        undefined,
-        'tw:bg-primary tw:border tw:border-secondary tw:rounded-xl'
-      ),
-    [agents.length, platform, theme]
-  );
+  const emptyPlaceholder = useMemo(() => {
+    // The pipeline fetch is skipped while the service is unreachable, so an empty list here means
+    // "could not load", not "none exist" — say which.
+    if (!isFetchingStatus && !isAirflowAvailable) {
+      return (
+        <ErrorPlaceHolderIngestion cardClassName={AGENTS_EMPTY_CARD_CLASS} />
+      );
+    }
+
+    return getErrorPlaceHolder(
+      agents.length,
+      platform === DISABLED,
+      theme,
+      undefined,
+      AGENTS_EMPTY_CARD_CLASS
+    );
+  }, [agents.length, isAirflowAvailable, isFetchingStatus, platform, theme]);
 
   const extraMenuItems = useMemo(
     () =>
@@ -258,6 +271,7 @@ const MetadataAgentsView: FC<MetadataAgentsViewProps> = ({
         descKey="message.metadata-agents-description"
         emptyPlaceholder={emptyPlaceholder}
         icon={<Code01 size={18} />}
+        isLoading={isLoading}
         isRefreshing={isRefreshing}
         titleKey="label.metadata-agent-plural"
         onAction={onAction}

--- a/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/ServiceAgents/components/MetadataAgentsView.test.tsx
@@ -46,52 +46,63 @@ const baseAgent: Agent = {
   enabled: true,
 };
 
+const mockAgentGroup = jest.fn();
+
 jest.mock('./AgentGroup.component', () => ({
   __esModule: true,
-  default: ({
-    agents,
-    isRefreshing,
-    onAction,
-    onRefresh,
-    onRunDetails,
-  }: {
+  default: (props: {
     agents: Agent[];
+    emptyPlaceholder?: React.ReactNode;
     isRefreshing?: boolean;
     onAction: (action: string, agent: Agent) => void;
     onRefresh?: () => void;
     onRunDetails: (agent: Agent) => void;
-  }) => (
-    <div>
-      {onRefresh && (
-        <button
-          data-testid="group-refresh"
-          disabled={isRefreshing}
-          onClick={onRefresh}>
-          refresh
-        </button>
-      )}
-      {['run', 'redeploy', 'kill', 'pause', 'resume', 'edit', 'delete'].map(
-        (action) => (
+  }) => {
+    const {
+      agents,
+      emptyPlaceholder,
+      isRefreshing,
+      onAction,
+      onRefresh,
+      onRunDetails,
+    } = props;
+
+    mockAgentGroup(props);
+
+    return (
+      <div>
+        {agents.length === 0 && emptyPlaceholder}
+        {onRefresh && (
           <button
-            data-testid={`dispatch-${action}`}
-            key={action}
-            onClick={() => onAction(action, baseAgent)}>
-            {action}
+            data-testid="group-refresh"
+            disabled={isRefreshing}
+            onClick={onRefresh}>
+            refresh
           </button>
-        )
-      )}
-      <button
-        data-testid="dispatch-unknown"
-        onClick={() => onAction('unknown', baseAgent)}>
-        unknown
-      </button>
-      <button
-        data-testid="dispatch-run-details"
-        onClick={() => onRunDetails(agents[0])}>
-        run details
-      </button>
-    </div>
-  ),
+        )}
+        {['run', 'redeploy', 'kill', 'pause', 'resume', 'edit', 'delete'].map(
+          (action) => (
+            <button
+              data-testid={`dispatch-${action}`}
+              key={action}
+              onClick={() => onAction(action, baseAgent)}>
+              {action}
+            </button>
+          )
+        )}
+        <button
+          data-testid="dispatch-unknown"
+          onClick={() => onAction('unknown', baseAgent)}>
+          unknown
+        </button>
+        <button
+          data-testid="dispatch-run-details"
+          onClick={() => onRunDetails(agents[0])}>
+          run details
+        </button>
+      </div>
+    );
+  },
 }));
 
 const mockRunHistoryDrawer = jest.fn();
@@ -140,11 +151,17 @@ jest.mock('../hooks/useAgentPermissions', () => ({
   useAgentPermissions: () => ({ agentPermissions: {} }),
 }));
 
+const mockAirflowStatus = jest.fn();
+
 jest.mock(
   '../../../context/AirflowStatusProvider/AirflowStatusProvider',
   () => ({
-    useAirflowStatus: () => ({ platform: 'Airflow' }),
+    useAirflowStatus: () => mockAirflowStatus(),
   })
+);
+
+jest.mock('../../common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion', () =>
+  jest.fn().mockImplementation(() => <p>ErrorPlaceHolderIngestion</p>)
 );
 
 jest.mock('../../../hooks/useApplicationStore', () => ({
@@ -175,11 +192,12 @@ jest.mock('../../../utils/IngestionUtils', () => ({
   getLogViewerStatusFromAgentStatus: jest.fn(),
 }));
 
-const viewWithAgents = (agents: Agent[]) => (
+const viewWithAgents = (agents: Agent[], isLoading?: boolean) => (
   <MetadataAgentsView
     showAddAgent
     agents={agents}
     ingestionPipelineList={[]}
+    isLoading={isLoading}
     serviceCategory={ServiceCategory.DATABASE_SERVICES}
     serviceDetails={{ name: 'service' } as ServicesType}
     serviceName="service"
@@ -207,6 +225,11 @@ describe('MetadataAgentsView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDeleteIngestionPipelineById.mockResolvedValue({});
+    mockAirflowStatus.mockReturnValue({
+      isAirflowAvailable: true,
+      isFetchingStatus: false,
+      platform: 'Airflow',
+    });
   });
 
   it('should request the empty placeholder with the agents card styling', () => {
@@ -217,6 +240,32 @@ describe('MetadataAgentsView', () => {
     expect(lastCall?.[4]).toBe(
       'tw:bg-primary tw:border tw:border-secondary tw:rounded-xl'
     );
+  });
+
+  it('should explain the unreachable pipeline service instead of claiming there are no agents', () => {
+    mockAirflowStatus.mockReturnValue({
+      isAirflowAvailable: false,
+      isFetchingStatus: false,
+      platform: 'Airflow',
+    });
+
+    renderView([]);
+
+    expect(screen.getByText('ErrorPlaceHolderIngestion')).toBeInTheDocument();
+    expect(getErrorPlaceHolder).not.toHaveBeenCalled();
+  });
+
+  it('should not claim the pipeline service is unreachable while its status is still being fetched', () => {
+    mockAirflowStatus.mockReturnValue({
+      isAirflowAvailable: false,
+      isFetchingStatus: true,
+      platform: 'Airflow',
+    });
+
+    renderView([]);
+
+    expect(screen.queryByText('ErrorPlaceHolderIngestion')).toBeNull();
+    expect(getErrorPlaceHolder).toHaveBeenCalled();
   });
 
   it('should toggle the agent when the pause action is dispatched', () => {
@@ -303,6 +352,22 @@ describe('MetadataAgentsView', () => {
       expect.objectContaining({
         agent: expect.objectContaining({ status: 'queued' }),
       })
+    );
+  });
+
+  it('should forward the loading flag to the agent group', () => {
+    render(viewWithAgents([], true));
+
+    expect(mockAgentGroup).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isLoading: true })
+    );
+  });
+
+  it('should not report loading once the agents have arrived', () => {
+    renderView();
+
+    expect(mockAgentGroup).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isLoading: undefined })
     );
   });
 

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/Ingestion.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/Ingestion.component.tsx
@@ -40,12 +40,12 @@ const Ingestion: React.FC<IngestionProps> = ({
   serviceDetails,
   ingestionPipelineList,
   airflowInformation,
+  isLoading,
   isCollateAgentLoading,
   collateAgentsList,
   collateAgentPagingInfo,
   onCollateAgentPageChange,
   agentCounts,
-  isLoading,
   refreshAgentsList,
   workflowStartAt,
 }: IngestionProps) => {
@@ -86,10 +86,15 @@ const Ingestion: React.FC<IngestionProps> = ({
 
   const isCollateSubTabSelected = subTab === ServiceAgentSubTabs.COLLATE_AI;
 
-  const { isAirflowAvailable, platform } = useMemo(
+  const { isAirflowAvailable, isFetchingStatus, platform } = useMemo(
     () => airflowInformation,
     [airflowInformation]
   );
+
+  // The pipeline fetch is gated on the airflow status, so the agent list is only meaningful
+  // once both have settled. Until then the widgets show placeholder cards rather than an
+  // empty state that would read as "this service has no agents".
+  const isAgentsLoading = isFetchingStatus || Boolean(isLoading);
 
   const showAddAgent = useMemo(
     () =>
@@ -151,17 +156,22 @@ const Ingestion: React.FC<IngestionProps> = ({
     });
   }, [agentCounts, t]);
 
-  if (!isAirflowAvailable) {
+  // Only once the status call has answered — `isAirflowAvailable` is seeded `false`, so
+  // checking it alone flashes the setup guide on every load.
+  if (!isFetchingStatus && !isAirflowAvailable) {
     return <ErrorPlaceHolderIngestion />;
   }
 
   return (
     <div className="agents-tab" data-testid="ingestion-details-container">
-      {/* `agents` is one page of the list; the Metadata badge count is the service's real total. */}
-      <DeploymentSummaryCard
-        agents={agents}
-        totalAgents={agentCounts?.[ServiceAgentSubTabs.METADATA]}
-      />
+      {/* `agents` is one page of the list; the Metadata badge count is the service's real total.
+          Held back until that list is real — its counts read as "0 agents" otherwise. */}
+      {!isAgentsLoading && (
+        <DeploymentSummaryCard
+          agents={agents}
+          totalAgents={agentCounts?.[ServiceAgentSubTabs.METADATA]}
+        />
+      )}
 
       {isCollateAIWidgetSupported && (
         <Tabs
@@ -178,6 +188,7 @@ const Ingestion: React.FC<IngestionProps> = ({
           collateAgentPagingInfo={collateAgentPagingInfo}
           collateAgentsList={collateAgentsList}
           isCollateAgentLoading={isCollateAgentLoading}
+          isLoading={isFetchingStatus}
           serviceCategory={serviceCategory}
           serviceDetails={serviceDetails}
           workflowStartAt={workflowStartAt}
@@ -188,6 +199,7 @@ const Ingestion: React.FC<IngestionProps> = ({
         <MetadataAgentsView
           agents={agents}
           ingestionPipelineList={ingestionPipelineList}
+          isLoading={isAgentsLoading}
           isRefreshing={isLoading}
           serviceCategory={serviceCategory}
           serviceDetails={serviceDetails}

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/Ingestion.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/Ingestion.test.tsx
@@ -57,6 +57,11 @@ jest.mock('../../../../hoc/LimitWrapper', () => {
     .mockImplementation(({ children }) => <>LimitWrapper{children}</>);
 });
 
+jest.mock(
+  '../../../ServiceAgents/components/DeploymentSummaryCard.component',
+  () => jest.fn().mockImplementation(() => <div>DeploymentSummaryCard</div>)
+);
+
 describe('Ingestion', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -77,6 +82,50 @@ describe('Ingestion', () => {
     });
 
     expect(screen.getByText('ErrorPlaceHolderIngestion')).toBeInTheDocument();
+  });
+
+  it('should not render the error placeHolder while the airflow status is still being fetched', async () => {
+    await act(async () => {
+      render(
+        <Ingestion
+          {...ingestionProps}
+          airflowInformation={{
+            ...ingestionProps.airflowInformation,
+            isAirflowAvailable: false,
+            isFetchingStatus: true,
+          }}
+        />,
+        { wrapper: MemoryRouter }
+      );
+    });
+
+    expect(screen.queryByText('ErrorPlaceHolderIngestion')).toBeNull();
+    expect(screen.getByTestId('agent-group-skeleton')).toBeInTheDocument();
+  });
+
+  it('should hide the deployment summary card while the agents are loading', async () => {
+    await act(async () => {
+      render(
+        <Ingestion
+          {...ingestionProps}
+          airflowInformation={{
+            ...ingestionProps.airflowInformation,
+            isFetchingStatus: true,
+          }}
+        />,
+        { wrapper: MemoryRouter }
+      );
+    });
+
+    expect(screen.queryByText('DeploymentSummaryCard')).toBeNull();
+  });
+
+  it('should render the deployment summary card once the status has settled', async () => {
+    await act(async () => {
+      render(<Ingestion {...ingestionProps} />, { wrapper: MemoryRouter });
+    });
+
+    expect(screen.getByText('DeploymentSummaryCard')).toBeInTheDocument();
   });
 
   it('should render the AddIngestionButton when create permission is granted', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.test.tsx
@@ -15,6 +15,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import { AirflowStatusContextType } from '../../../../../context/AirflowStatusProvider/AirflowStatusProvider.interface';
 import { usePermissionProvider } from '../../../../../context/PermissionProvider/PermissionProvider';
 import { mockIngestionData } from '../../../../../mocks/Ingestion.mock';
 import {
@@ -58,6 +59,11 @@ jest.mock('../../../../../utils/IngestionUtils', () => ({
       <div data-testid="error-placeholder">ErrorPlaceholder</div>
     )),
 }));
+
+jest.mock(
+  '../../../../common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion',
+  () => jest.fn().mockImplementation(() => <div>ErrorPlaceHolderIngestion</div>)
+);
 
 jest.mock('./PipelineActions/PipelineActions', () =>
   jest.fn().mockImplementation(({ handleDeleteSelection }) => (
@@ -184,6 +190,58 @@ describe('Ingestion', () => {
     const lastCall = (getErrorPlaceHolder as jest.Mock).mock.calls.at(-1);
 
     expect(lastCall?.[4]).toBe('tw:relative tw:py-8');
+  });
+
+  it('should explain the unreachable pipeline service instead of claiming there are no pipelines', async () => {
+    (getErrorPlaceHolder as jest.Mock).mockClear();
+
+    await act(async () => {
+      render(
+        <IngestionListTable
+          {...mockIngestionListTableProps}
+          airflowInformation={
+            {
+              isAirflowAvailable: false,
+              isFetchingStatus: false,
+              platform: 'Airflow',
+            } as AirflowStatusContextType
+          }
+          extraTableProps={{ scroll: undefined }}
+          ingestionData={[]}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.getByText('ErrorPlaceHolderIngestion')).toBeInTheDocument();
+    expect(getErrorPlaceHolder).not.toHaveBeenCalled();
+  });
+
+  it('should not claim the pipeline service is unreachable while its status is still being fetched', async () => {
+    await act(async () => {
+      render(
+        <IngestionListTable
+          {...mockIngestionListTableProps}
+          airflowInformation={
+            {
+              isAirflowAvailable: false,
+              isFetchingStatus: true,
+              platform: 'Airflow',
+            } as AirflowStatusContextType
+          }
+          extraTableProps={{ scroll: undefined }}
+          ingestionData={[]}
+        />,
+        {
+          wrapper: MemoryRouter,
+        }
+      );
+    });
+
+    expect(screen.queryByText('ErrorPlaceHolderIngestion')).toBeNull();
+    expect(screen.getByText('ErrorPlaceholder')).toBeInTheDocument();
   });
 
   it('should not show the description column if showDescriptionCol is false', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Services/Ingestion/IngestionListTable/IngestionListTable.tsx
@@ -50,6 +50,7 @@ import {
   showSuccessToast,
 } from '../../../../../utils/ToastUtils';
 import DeleteModal from '../../../../common/DeleteModal/DeleteModal';
+import ErrorPlaceHolderIngestion from '../../../../common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion';
 import RichTextEditorPreviewerNew from '../../../../common/RichTextEditor/RichTextEditorPreviewNew';
 import ButtonSkeleton from '../../../../common/Skeleton/CommonSkeletons/ControlElements/ControlElements.component';
 import Table from '../../../../common/Table/Table';
@@ -62,6 +63,8 @@ import {
 } from './IngestionListTable.interface';
 import IngestionStatusCount from './IngestionStatusCount/IngestionStatusCount';
 import PipelineActions from './PipelineActions/PipelineActions';
+
+const INGESTION_EMPTY_CARD_CLASS = 'tw:relative tw:py-8';
 
 function IngestionListTable({
   tableContainerClassName = '',
@@ -194,12 +197,37 @@ function IngestionListTable({
     });
   }, [ingestionData]);
 
-  const { isFetchingStatus, platform } = useMemo(
+  const { isAirflowAvailable, isFetchingStatus, platform } = useMemo(
     () => airflowInformation ?? ({} as AirflowStatusContextType),
     [airflowInformation]
   );
 
   const isPlatFormDisabled = useMemo(() => platform === DISABLED, [platform]);
+
+  const defaultEmptyPlaceholder = useMemo(() => {
+    // The pipeline list is never fetched while the service is unreachable, so an empty table here
+    // means "could not load", not "none exist" — say which.
+    if (!isFetchingStatus && !isAirflowAvailable) {
+      return (
+        <ErrorPlaceHolderIngestion cardClassName={INGESTION_EMPTY_CARD_CLASS} />
+      );
+    }
+
+    return getErrorPlaceHolder(
+      ingestionData.length,
+      isPlatFormDisabled,
+      theme,
+      pipelineType,
+      INGESTION_EMPTY_CARD_CLASS
+    );
+  }, [
+    ingestionData.length,
+    isAirflowAvailable,
+    isFetchingStatus,
+    isPlatFormDisabled,
+    pipelineType,
+    theme,
+  ]);
 
   const handleDeleteConfirm = useCallback(async () => {
     await handleDelete(deleteSelection.id, getEntityName(deleteSelection));
@@ -420,15 +448,7 @@ function IngestionListTable({
           dataSource={data}
           loading={isLoading}
           locale={{
-            emptyText:
-              emptyPlaceholder ??
-              getErrorPlaceHolder(
-                ingestionData.length,
-                isPlatFormDisabled,
-                theme,
-                pipelineType,
-                'tw:relative tw:py-8'
-              ),
+            emptyText: emptyPlaceholder ?? defaultEmptyPlaceholder,
           }}
           pagination={false}
           rowKey="fullyQualifiedName"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ErrorWithPlaceholder/ErrorPlaceHolderIngestion.tsx
@@ -78,7 +78,7 @@ const ErrorPlaceHolderIngestion = ({
   }, [isAirflowPlatform, cardClassName]);
 
   return (
-    <div className="m-t-lg text-base font-medium">
+    <div className="text-base font-medium">
       {isFetchingStatus ? <Loader /> : airflowSetupGuide}
     </div>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/context/AirflowStatusProvider/AirflowStatusProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/AirflowStatusProvider/AirflowStatusProvider.test.tsx
@@ -13,6 +13,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { AxiosError } from 'axios';
+import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { getAirflowStatus } from '../../rest/ingestionPipelineAPI';
 import AirflowStatusProvider, {
   useAirflowStatus,
@@ -174,5 +175,27 @@ describe('AirflowStatusProvider', () => {
     await waitFor(() => {
       expect(screen.getByTestId('reason').textContent).toBe('Refreshed status');
     });
+  });
+
+  // Consumers gate their "Airflow is unavailable" states on `isFetchingStatus`. Until the user
+  // resolves, the status endpoint has not been asked, so reporting a terminal status here makes
+  // every one of them render its error placeholder on first paint.
+  it('should keep reporting a fetch in progress until the user resolves', async () => {
+    (useApplicationStore as unknown as jest.Mock).mockReturnValue({
+      currentUser: undefined,
+    });
+
+    render(
+      <AirflowStatusProvider>
+        <TestComponent />
+      </AirflowStatusProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('isFetchingStatus').textContent).toBe('true');
+    });
+
+    expect(getAirflowStatus).not.toHaveBeenCalled();
+    expect(screen.getByTestId('isAirflowAvailable').textContent).toBe('false');
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/context/AirflowStatusProvider/AirflowStatusProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/AirflowStatusProvider/AirflowStatusProvider.tsx
@@ -34,7 +34,10 @@ interface Props {
 }
 
 const AirflowStatusProvider = ({ children }: Props) => {
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  // Seeded `true` so the status reads as "unknown", not "known and unavailable", for the paint
+  // before the effect fires. Consumers gate their error/empty states on this, and a `false` seed
+  // made them flash a terminal state (the Airflow setup guide, "no agents yet") every load.
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isAirflowAvailable, setIsAirflowAvailable] = useState<boolean>(false);
   const [error, setError] = useState<AxiosError>();
   const [reason, setReason] =
@@ -45,6 +48,8 @@ const AirflowStatusProvider = ({ children }: Props) => {
 
   const fetchAirflowStatus = useCallback(async () => {
     if (!currentUser?.id) {
+      // The status endpoint needs an authenticated caller, so this is "not asked yet", not
+      // "asked and got nothing" — stay loading. The effect re-runs once the user resolves.
       return;
     }
     setIsLoading(true);

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
@@ -295,8 +295,11 @@ const ServiceDetailsPage: FunctionComponent = () => {
   const [files, setFiles] = useState<Array<File>>([]);
   const [spreadsheets, setSpreadsheets] = useState<Array<Spreadsheet>>([]);
   const [isLoading, setIsLoading] = useState(!isOpenMetadataService);
-  const [isIngestionPipelineLoading, setIsIngestionPipelineLoading] =
-    useState(false);
+  // Seeded to match `isLoading` above: the fetch is kicked off from an effect that waits on the
+  // airflow status, so a `false` seed lets the agents tab read an empty list as "no agents".
+  const [isIngestionPipelineLoading, setIsIngestionPipelineLoading] = useState(
+    !isOpenMetadataService
+  );
   const [isServiceLoading, setIsServiceLoading] = useState(true);
   const [isFilesLoading, setIsFilesLoading] = useState(true);
   const [isSpreadsheetsLoading, setIsSpreadsheetsLoading] = useState(true);
@@ -321,7 +324,9 @@ const ServiceDetailsPage: FunctionComponent = () => {
   const [statusFilter, setStatusFilter] = useState<
     Array<{ key: string; label: string }>
   >([]);
-  const [isCollateAgentLoading, setIsCollateAgentLoading] = useState(false);
+  // Seeded true for the same reason as `isIngestionPipelineLoading`: the list is fetched from an
+  // effect, and a `false` seed shows the widget's "no agents" placeholder before the first fetch.
+  const [isCollateAgentLoading, setIsCollateAgentLoading] = useState(true);
   const [collateAgentsList, setCollateAgentsList] = useState<
     CollateAgentAutomation[]
   >([]);
@@ -559,6 +564,9 @@ const ServiceDetailsPage: FunctionComponent = () => {
       if (deleted) {
         setCollateAgentsList([]);
         handleCollateAgentPagingChange({ total: 0 });
+        // Nothing will be fetched, so release the seeded loading flag rather than
+        // leaving the widget on placeholder cards forever.
+        setIsCollateAgentLoading(false);
 
         return;
       }
@@ -1620,8 +1628,12 @@ const ServiceDetailsPage: FunctionComponent = () => {
       fetchCollateAgentsList({
         limit: collateAgentPagingCursor?.pageSize ?? collateAgentPageSize,
       });
+    } else {
+      // The widget is not rendered for this service category, so nothing will fetch —
+      // release the seeded loading flag.
+      setIsCollateAgentLoading(false);
     }
-  }, [collateAgentPageSize]);
+  }, [collateAgentPageSize, isCollateAIWidgetSupported]);
 
   useEffect(() => {
     fetchWorkflowInstanceStates();


### PR DESCRIPTION
### Describe your changes:

<!-- No linked issue: this surfaced while working on the Collate agents tab. Happy to open one if
maintainers prefer it tracked before review. -->

The agents lists are gated on `GET /services/ingestionPipelines/status`, but neither the window while
that call is in flight nor an unreachable pipeline service was represented in the UI. Both showed a
terminal state that was factually wrong.

**1. The status read as "known and unavailable" before it was ever fetched.**
`AirflowStatusProvider` seeded `isLoading = false` and `isAirflowAvailable = false`, so for the paint
before its effect fired, every consumer saw "not loading, Airflow is down" and rendered its error
state. It now seeds `isLoading = true`, and the `!currentUser?.id` branch stays loading rather than
reporting a status it never asked for — the effect re-runs once the user resolves.

**2. The whole agents tab was replaced by the Airflow setup guide during the status call.**
`Ingestion.component` returned `ErrorPlaceHolderIngestion` on `!isAirflowAvailable` with no
`isFetchingStatus` check, so the "Install Airflow API" guide flashed on every load — including over
the Collate AI sub-tab, which does not depend on Airflow at all. It now waits for the status to
actually answer before showing the guide, and hides `DeploymentSummaryCard` while the list is still
unknown (its counts otherwise read as "0 agents").

**3. An unreachable pipeline service was reported as "No agents set up yet".**
When the service is down the pipeline fetch is skipped entirely, so the list is empty because nothing
was fetched — not because the service has no agents. `MetadataAgentsView` and `IngestionListTable` now
render `ErrorPlaceHolderIngestion` in that case, which already branches on platform: the managed-Airflow
guide for Airflow deployments, and "The Ingestion Scheduler is unable to respond" for everything else.
Note `getErrorPlaceHolder`'s only signal was `platform === DISABLED`, and an unreachable Airflow reports
`'Airflow'` or `'unknown'`, so even its existing disabled-platform copy never fired for this case.

**4. First loads now show placeholder cards.**
`AgentGroup` gains `isLoading` / `skeletonCount` and renders `AgentCardSkeleton` rows in place of the
empty placeholder, keeping its header mounted so the refresh control cannot vanish mid-flight.
`ServiceDetailsPage` seeds its pipeline and Collate AI loading flags to match, and releases them on the
paths that never fetch (deleted service, non-DB service).

**No new i18n keys** — every string on the unavailable path already existed in `ErrorPlaceHolderIngestion`.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

The branch is deliberately kept inside the two existing empty-state call sites rather than extracted
into a shared component — it is three lines each, and both components already read the Airflow status
they need (`MetadataAgentsView` via `useAirflowStatus()`, `IngestionListTable` via its
`airflowInformation` prop).

Reusing `ErrorPlaceHolderIngestion` rather than adding new copy means the platform branch (Airflow vs.
Argo/other) lives in exactly one place and stays correct for both. `getErrorPlaceHolder` and
`ErrorPlaceHolderIngestion` keep their existing signatures, so no other caller is affected.

`Ingestion.component.tsx` intentionally keeps its whole-tab early return — it already handled the
unavailable case correctly; only the missing `isFetchingStatus` guard was added.

#
### Tests:

#### Use cases covered
- Loading a service's agents tab with the pipeline service reachable → placeholder cards, then the real list
- Loading it with the pipeline service unreachable → the scheduler/Airflow message, not "No agents set up yet"
- Airflow platform vs. Argo/other → the two branches of `ErrorPlaceHolderIngestion` copy
- Status call still in flight → neither the "no agents" nor the "unreachable" state is shown
- Service with no agents and a healthy pipeline service → the existing "No agents set up yet" copy, unchanged

#### Unit tests
- [x] Added/updated for the new logic.
- Files added: `AgentCardSkeleton.component.tsx` + `AgentCardSkeleton.test.tsx`
- Files updated: `AgentGroup.test.tsx`, `MetadataAgentsView.test.tsx`, `Ingestion.test.tsx`, `IngestionListTable.test.tsx`
- `npx jest src/components/ServiceAgents src/components/Settings/Services/Ingestion src/utils/IngestionUtils.test.tsx src/context/AirflowStatusProvider src/pages/ServiceDetailsPage src/components/common/ErrorWithPlaceholder src/components/common/AirflowMessageBanner`
  → **29 suites / 398 tests passing**

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- Not added. The change is a rendering branch on an existing API response and is fully covered by the
  unit tests above; reproducing it E2E needs the pipeline service stopped, which the Playwright stack
  does not currently model.

#### Manual testing performed
1. Throttled `GET /api/v1/services/ingestionPipelines/status` in DevTools and reloaded a service's
   agents tab — placeholder cards for the whole window, no "Install Airflow API" flash.
2. Stopped the pipeline service on a service that has agents — the agents tab now explains the
   scheduler is unreachable instead of claiming there are none.

#
### UI screen recording / screenshots:

Not attached — flagging this so a reviewer can ask for one. The visible deltas are: placeholder cards
during first load, and the scheduler/Airflow message replacing "No agents set up yet" when the pipeline
service is down.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: I updated the migration scripts or explained why it is not needed. (No schema changes.)
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
