### PR TITLE
fix(playwright): use getByRole('textbox') for MUI TextField name field in tag tests on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -277,8 +277,11 @@ export async function validateForm(page: Page) {
 
   // min length validation
   await page.locator('[data-testid="name"]').scrollIntoViewIfNeeded();
-  await page.locator('[data-testid="name"]').clear();
-  await page.locator('[data-testid="name"]').fill(TAG_INVALID_NAMES.MIN_LENGTH);
+  await page.getByTestId('name').getByRole('textbox').clear();
+  await page
+    .getByTestId('name')
+    .getByRole('textbox')
+    .fill(TAG_INVALID_NAMES.MIN_LENGTH);
   await page.waitForLoadState('domcontentloaded');
 
   await expect(
@@ -286,8 +289,11 @@ export async function validateForm(page: Page) {
   ).toBeVisible();
 
   // max length validation
-  await page.locator('[data-testid="name"]').clear();
-  await page.locator('[data-testid="name"]').fill(TAG_INVALID_NAMES.MAX_LENGTH);
+  await page.getByTestId('name').getByRole('textbox').clear();
+  await page
+    .getByTestId('name')
+    .getByRole('textbox')
+    .fill(TAG_INVALID_NAMES.MAX_LENGTH);
   await page.waitForLoadState('domcontentloaded');
 
   await expect(
@@ -295,9 +301,10 @@ export async function validateForm(page: Page) {
   ).toBeVisible();
 
   // with special char validation
-  await page.locator('[data-testid="name"]').clear();
+  await page.getByTestId('name').getByRole('textbox').clear();
   await page
-    .locator('[data-testid="name"]')
+    .getByTestId('name')
+    .getByRole('textbox')
     .fill(TAG_INVALID_NAMES.WITH_SPECIAL_CHARS);
   await page.waitForLoadState('domcontentloaded');
 
@@ -516,7 +523,7 @@ export const LIMITED_USER_RULES: PolicyRulesType[] = [
 ];
 
 export const fillTagForm = async (adminPage: Page, domain: Domain) => {
-  await adminPage.fill('[data-testid="name"]', NEW_TAG.name);
+  await adminPage.getByTestId('name').getByRole('textbox').fill(NEW_TAG.name);
   await adminPage.fill('[data-testid="displayName"]', NEW_TAG.displayName);
   await adminPage.locator(descriptionBox).fill(NEW_TAG.description);
   await adminPage.getByTestId('icon-picker-btn').click();


### PR DESCRIPTION
## Root Cause

Commit `50e961f` moved `data-testid="name"` from `inputProps` (placed on the inner `<input>`) to the top-level `props` (placed on the MUI `FormControl` wrapper `<div>`) in `tagFormFields.tsx`. 

After that change, `page.locator('[data-testid="name"]')` resolves to the wrapper `<div class="MuiFormControl-root ...">` — not the actual `<input>`. Playwright's `.clear()` and `.fill()` require an editable element, so they threw:

```
Error: Element is not an <input>, <textarea>, <select> or [contenteditable]
  locator resolved to <div data-testid="name" class="MuiFormControl-root MuiTextField-root ...">
```

## Fix

Scope the locator to the inner `<input>` via `.getByTestId('name').getByRole('textbox')` in two functions:

- **`validateForm`** — all six `.clear()` / `.fill()` calls on the name field (min-length, max-length, special-char validations)  
- **`fillTagForm`** — the `adminPage.fill('[data-testid="name"]', ...)` call

The `.scrollIntoViewIfNeeded()` call is intentionally left targeting the wrapper div — scrolling the container is correct behaviour.

## Failing Tests Fixed

- `[chromium] › playwright/e2e/Pages/Tag.spec.ts:229:3 › Tag Page with Admin Roles › Create tag with domain`
- `[chromium] › playwright/e2e/Pages/Tags.spec.ts:113:5 › Classification Page › Create classification with validation checks`

CI: https://github.com/open-metadata/OpenMetadata/actions/runs/31779313588/job/94701398981

## Test plan

- [ ] `Tag.spec.ts - Create tag with domain` passes on chromium
- [ ] `Tags.spec.ts - Create classification with validation checks` passes on chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)