### PR TITLE
fix(playwright): use getByRole('textbox') for MUI TextField name field in tag tests on 1.13

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/tag.ts
@@ -277,8 +277,11 @@ export async function validateForm(page: Page) {
 
   // min length validation
   await page.locator('[data-testid="name"]').scrollIntoViewIfNeeded();
-  await page.locator('[data-testid="name"]').clear();
-  await page.locator('[data-testid="name"]').fill(TAG_INVALID_NAMES.MIN_LENGTH);
+  await page.getByTestId('name').getByRole('textbox').clear();
+  await page
+    .getByTestId('name')
+    .getByRole('textbox')
+    .fill(TAG_INVALID_NAMES.MIN_LENGTH);
   await page.waitForLoadState('domcontentloaded');
 
   await expect(
@@ -286,8 +289,11 @@ export async function validateForm(page: Page) {
   ).toBeVisible();
 
   // max length validation
-  await page.locator('[data-testid="name"]').clear();
-  await page.locator('[data-testid="name"]').fill(TAG_INVALID_NAMES.MAX_LENGTH);
+  await page.getByTestId('name').getByRole('textbox').clear();
+  await page
+    .getByTestId('name')
+    .getByRole('textbox')
+    .fill(TAG_INVALID_NAMES.MAX_LENGTH);
   await page.waitForLoadState('domcontentloaded');
 
   await expect(
@@ -295,9 +301,10 @@ export async function validateForm(page: Page) {
   ).toBeVisible();
 
   // with special char validation
-  await page.locator('[data-testid="name"]').clear();
+  await page.getByTestId('name').getByRole('textbox').clear();
   await page
-    .locator('[data-testid="name"]')
+    .getByTestId('name')
+    .getByRole('textbox')
     .fill(TAG_INVALID_NAMES.WITH_SPECIAL_CHARS);
   await page.waitForLoadState('domcontentloaded');
 
@@ -516,7 +523,7 @@ export const LIMITED_USER_RULES: PolicyRulesType[] = [
 ];
 
 export const fillTagForm = async (adminPage: Page, domain: Domain) => {
-  await adminPage.fill('[data-testid="name"]', NEW_TAG.name);
+  await adminPage.getByTestId('name').getByRole('textbox').fill(NEW_TAG.name);
   await adminPage.fill('[data-testid="displayName"]', NEW_TAG.displayName);
   await adminPage.locator(descriptionBox).fill(NEW_TAG.description);
   await adminPage.getByTestId('icon-picker-btn').click();


### PR DESCRIPTION
## Problem

Two E2E tests were failing on the 1.13 branch with:

```
Error: locator.clear: Error: Element is not an <input>, <textarea>, <select> or
[contenteditable] and does not have a role allowing [aria-readonly]

  locator resolved to <div data-testid="name" aria-invalid="true"
  class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-sb9nqm">
```

Failing tests:
- `[chromium] › playwright/e2e/Pages/Tag.spec.ts:229 › Tag Page with Admin Roles › Create tag with domain`
- `[chromium] › playwright/e2e/Pages/Tags.spec.ts:113 › Classification Page › Create classification with validation checks`

CI run: https://github.com/open-metadata/OpenMetadata/actions/runs/31779313588/job/94701398981

## Root Cause

Commit `50e961f` (`fix(ui): move data-testid to MUI TextField wrapper in tag form fields on 1.13`) moved `data-testid="name"` from `inputProps` to the outer `props` in `tagFormFields.tsx`.

Before `50e961f`:
```tsx
// inputProps — attribute lands on the inner <input>
inputProps: {
  'data-testid': 'name',
},
```

After `50e961f`:
```tsx
// props — attribute lands on the MuiFormControl-root wrapper <div>
props: {
  'data-testid': 'name',
  disabled,
},
```

When `data-testid="name"` sits on the MUI wrapper `<div>`, Playwright's `.clear()` and `.fill()` fail because those actions require an editable element (`<input>`, `<textarea>`, or `[contenteditable]`). The playwright test wasn't updated alongside the component change, causing both tests to break.

## Fix

Scope all `.clear()` / `.fill()` calls in `playwright/utils/tag.ts` to the inner `<textbox>` via `.getByTestId('name').getByRole('textbox')` instead of directly targeting `locator('[data-testid="name"]')`:

**`validateForm` function** — 6 call sites (min-length, max-length, special-char validation checks):
```ts
// Before
await page.locator('[data-testid="name"]').clear();
await page.locator('[data-testid="name"]').fill(TAG_INVALID_NAMES.MIN_LENGTH);

// After
await page.getByTestId('name').getByRole('textbox').clear();
await page.getByTestId('name').getByRole('textbox').fill(TAG_INVALID_NAMES.MIN_LENGTH);
```

**`fillTagForm` function** — 1 call site:
```ts
// Before
await adminPage.fill('[data-testid="name"]', NEW_TAG.name);

// After
await adminPage.getByTestId('name').getByRole('textbox').fill(NEW_TAG.name);
```

> Note: The `.scrollIntoViewIfNeeded()` call is intentionally left targeting the wrapper div (`locator('[data-testid="name"]')`) — scrolling the container element is correct and works regardless of whether it is a div or an input.

## Test Plan

- [ ] `playwright/e2e/Pages/Tag.spec.ts › Create tag with domain` passes on chromium
- [ ] `playwright/e2e/Pages/Tags.spec.ts › Create classification with validation checks` passes on chromium

🤖 Generated with [Claude Code](https://claude.com/claude-code)