### PR TITLE
fix(ingestion): quote the Snowflake session query tag as a string literal

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/metadata.py
@@ -111,7 +111,7 @@ from metadata.ingestion.source.database.snowflake.queries import (
     SNOWFLAKE_GET_STORED_PROCEDURES_AND_FUNCTIONS,
     SNOWFLAKE_GET_STREAM,
     SNOWFLAKE_LIFE_CYCLE_QUERY,
-    SNOWFLAKE_SESSION_TAG_QUERY,
+    set_session_tag_query,
 )
 from metadata.ingestion.source.database.snowflake.semantic_view_metrics import (
     build_metric_request,
@@ -324,7 +324,7 @@ class SnowflakeSource(
             @event.listens_for(self.engine, "connect")
             def _set_query_tag(dbapi_connection, connection_record):
                 cursor = dbapi_connection.cursor()
-                cursor.execute(SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag))
+                cursor.execute(set_session_tag_query(query_tag))
                 cursor.close()
 
     def set_partition_details(self) -> None:

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
@@ -83,9 +83,10 @@ SNOWFLAKE_SESSION_TAG_QUERY = "ALTER SESSION SET QUERY_TAG='{query_tag}'"
 
 def set_session_tag_query(query_tag: str) -> str:
     """Return the ALTER SESSION statement setting QUERY_TAG to the given value."""
-    # ALTER SESSION SET takes several space-separated pairs, so an unescaped quote
-    # in the tag does not just truncate the value, it starts a new assignment.
-    return SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag.replace("'", "''"))
+    # Snowflake reads backslash escapes inside the literal, so those double first;
+    # an unescaped quote would otherwise start a further ALTER SESSION assignment.
+    escaped = query_tag.replace("\\", "\\\\").replace("'", "''")
+    return SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=escaped)
 
 
 SNOWFLAKE_FETCH_TABLE_TAGS = textwrap.dedent(

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/queries.py
@@ -78,7 +78,15 @@ SNOWFLAKE_SQL_STATEMENT = textwrap.dedent(
     """
 )
 
-SNOWFLAKE_SESSION_TAG_QUERY = 'ALTER SESSION SET QUERY_TAG="{query_tag}"'
+SNOWFLAKE_SESSION_TAG_QUERY = "ALTER SESSION SET QUERY_TAG='{query_tag}'"
+
+
+def set_session_tag_query(query_tag: str) -> str:
+    """Return the ALTER SESSION statement setting QUERY_TAG to the given value."""
+    # ALTER SESSION SET takes several space-separated pairs, so an unescaped quote
+    # in the tag does not just truncate the value, it starts a new assignment.
+    return SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag.replace("'", "''"))
+
 
 SNOWFLAKE_FETCH_TABLE_TAGS = textwrap.dedent(
     """

--- a/ingestion/src/metadata/ingestion/source/database/snowflake/query_parser.py
+++ b/ingestion/src/metadata/ingestion/source/database/snowflake/query_parser.py
@@ -29,7 +29,7 @@ from metadata.ingestion.api.steps import InvalidSourceException
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.database.query_parser_source import QueryParserSource
 from metadata.ingestion.source.database.snowflake.queries import (
-    SNOWFLAKE_SESSION_TAG_QUERY,
+    set_session_tag_query,
 )
 from metadata.utils.logger import ingestion_logger
 
@@ -98,7 +98,7 @@ class SnowflakeQueryParserSource(QueryParserSource, ABC):
             @event.listens_for(self.engine, "connect")
             def _set_query_tag(dbapi_connection, connection_record):
                 cursor = dbapi_connection.cursor()
-                cursor.execute(SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag))
+                cursor.execute(set_session_tag_query(query_tag))
                 cursor.close()
 
     def get_table_query(self) -> Iterable[TableQuery]:

--- a/ingestion/src/metadata/mixins/sqalchemy/sqa_mixin.py
+++ b/ingestion/src/metadata/mixins/sqalchemy/sqa_mixin.py
@@ -38,7 +38,7 @@ from metadata.ingestion.models.custom_pydantic import BaseModel
 from metadata.ingestion.ometa.ometa_api import OpenMetadata
 from metadata.ingestion.source.connections import get_connection
 from metadata.ingestion.source.database.snowflake.queries import (
-    SNOWFLAKE_SESSION_TAG_QUERY,
+    set_session_tag_query,
 )
 from metadata.profiler.orm.converter.base import ometa_to_sqa_orm
 from metadata.utils.collaborative_super import Root
@@ -77,7 +77,7 @@ class SQAInterfaceMixin(Root):
             and self.service_connection_config.queryTag
         ):
             query_tag = self.service_connection_config.queryTag  # pyright: ignore[reportAttributeAccessIssue]
-            session.execute(text(SNOWFLAKE_SESSION_TAG_QUERY.format(query_tag=query_tag)))
+            session.execute(text(set_session_tag_query(query_tag)))
 
     def set_catalog(self, session) -> None:
         """Set the catalog or database for the session.

--- a/ingestion/tests/unit/metadata/mixins/sqalchemy/test_sqa_mixin.py
+++ b/ingestion/tests/unit/metadata/mixins/sqalchemy/test_sqa_mixin.py
@@ -46,7 +46,17 @@ def test_set_session_tag_statement_is_accepted_by_sqlalchemy_2x():
 
     snowflake_interface(query_tag="my_tag").set_session_tag(session)
 
-    assert [str(statement) for statement in session.statements] == ['ALTER SESSION SET QUERY_TAG="my_tag"']
+    assert [str(statement) for statement in session.statements] == ["ALTER SESSION SET QUERY_TAG='my_tag'"]
+
+
+def test_set_session_tag_does_not_break_on_a_json_query_tag():
+    session = RecordingSession()
+
+    snowflake_interface(query_tag='{"app":"OpenMetadata"}').set_session_tag(session)
+
+    assert [str(statement) for statement in session.statements] == [
+        'ALTER SESSION SET QUERY_TAG=\'{"app":"OpenMetadata"}\''
+    ]
 
 
 def test_set_session_tag_is_skipped_without_a_query_tag():

--- a/ingestion/tests/unit/source/database/snowflake/test_queries.py
+++ b/ingestion/tests/unit/source/database/snowflake/test_queries.py
@@ -25,12 +25,21 @@ from metadata.ingestion.source.database.snowflake.queries import set_session_tag
             'ALTER SESSION SET QUERY_TAG=\'{"app":"OpenMetadata"}\'',
         ),
         ("it's a tag", "ALTER SESSION SET QUERY_TAG='it''s a tag'"),
+        ("C:\\temp", "ALTER SESSION SET QUERY_TAG='C:\\\\temp'"),
+        ("tag\\", "ALTER SESSION SET QUERY_TAG='tag\\\\'"),
         (
             "x' STATEMENT_TIMEOUT_IN_SECONDS=1 Y='",
             "ALTER SESSION SET QUERY_TAG='x'' STATEMENT_TIMEOUT_IN_SECONDS=1 Y='''",
         ),
     ],
-    ids=["plain", "json", "apostrophe", "parameter-injection"],
+    ids=[
+        "plain",
+        "json",
+        "apostrophe",
+        "backslash-escape",
+        "trailing-backslash",
+        "parameter-injection",
+    ],
 )
 def test_set_session_tag_query_keeps_the_tag_inside_one_string_literal(query_tag, expected):
     assert set_session_tag_query(query_tag) == expected

--- a/ingestion/tests/unit/source/database/snowflake/test_queries.py
+++ b/ingestion/tests/unit/source/database/snowflake/test_queries.py
@@ -1,0 +1,36 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Unit tests for the Snowflake session query tag statement"""
+
+import pytest
+
+from metadata.ingestion.source.database.snowflake.queries import set_session_tag_query
+
+
+@pytest.mark.parametrize(
+    "query_tag,expected",
+    [
+        ("my_tag", "ALTER SESSION SET QUERY_TAG='my_tag'"),
+        (
+            '{"app":"OpenMetadata"}',
+            'ALTER SESSION SET QUERY_TAG=\'{"app":"OpenMetadata"}\'',
+        ),
+        ("it's a tag", "ALTER SESSION SET QUERY_TAG='it''s a tag'"),
+        (
+            "x' STATEMENT_TIMEOUT_IN_SECONDS=1 Y='",
+            "ALTER SESSION SET QUERY_TAG='x'' STATEMENT_TIMEOUT_IN_SECONDS=1 Y='''",
+        ),
+    ],
+    ids=["plain", "json", "apostrophe", "parameter-injection"],
+)
+def test_set_session_tag_query_keeps_the_tag_inside_one_string_literal(query_tag, expected):
+    assert set_session_tag_query(query_tag) == expected


### PR DESCRIPTION
Fixes #31509

Snowflake ingestion fails for any `queryTag` containing a double quote, including JSON — the form Snowflake's own docs suggest for `QUERY_TAG`.

## What

The tag was emitted inside double quotes, which Snowflake parses as a *delimited identifier*, not a string literal. The first inner quote closes it, and because `ALTER SESSION SET` accepts several space-separated `param = value` pairs, the parser reads the remainder as further assignments rather than stopping:

```
ALTER SESSION SET QUERY_TAG="{"app":"OpenMetadata"}"
                            └┬┘└─┬─┘└┬┘
                            "{"  app  ":"   <- syntax error, and 4 more after it
```

Any tag *without* a `"` parses fine, which is why this has shipped unnoticed.

Test Connection passes throughout: `snowflake/connection.py` never sets the tag. It is applied by a `@event.listens_for(engine, "connect")` listener registered on the per-database engine the workflow builds, so only real ingestion connections raise — the run ends with 0 processed records and a `WorkflowExecutionError`.

## How

Emit a single-quoted string literal and double any embedded `'`, behind `set_session_tag_query()` so the escaping is applied exactly once at each of the three call sites (`snowflake/metadata.py`, `snowflake/query_parser.py`, `mixins/sqalchemy/sqa_mixin.py`).

Inside a single-quoted literal `"` carries no syntactic meaning, so JSON tags pass through untouched. The escape covers tags containing `'`, which would otherwise reproduce the same class of bug with the other quote character.

Verified against a live Snowflake account on a 1.13.3 stack: the same pipeline went from `Processed records: 0 | Errors: 1` to `Processed records: 9` with no SQL compilation errors, and `QUERY_HISTORY` shows the `ALTER SESSION` succeeding with the tag round-tripping as valid JSON.

Needs backporting to `2.0` and `1.13` — both carry the identical template and call sites.
