### PR TITLE
fix(ingestion): apply AUTOCOMMIT via create_engine so releasing a connection cannot assert

### DIFF
--- a/ingestion/src/metadata/ingestion/connections/builders.py
+++ b/ingestion/src/metadata/ingestion/connections/builders.py
@@ -90,23 +90,40 @@ def create_generic_db_connection(
     Returns:
         SQLAlchemy Engine
     """
-    engine = create_engine(
-        get_connection_url_fn(connection),
-        connect_args=get_connection_args_fn(connection),
-        poolclass=QueuePool,
-        pool_reset_on_return=None,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#reset-on-return
-        echo=False,
-        max_overflow=-1,
-        **kwargs,
-    )
+    url = get_connection_url_fn(connection)
+    connect_args = get_connection_args_fn(connection)
+
+    def build_engine(**extra) -> Engine:
+        return create_engine(
+            url,
+            connect_args=connect_args,
+            poolclass=QueuePool,
+            pool_reset_on_return=None,  # https://docs.sqlalchemy.org/en/14/core/pooling.html#reset-on-return
+            echo=False,
+            max_overflow=-1,
+            **extra,
+            **kwargs,
+        )
+
+    engine = build_engine()
 
     # Read-only metadata/profiler ingestion must not hold a transaction open for
     # the whole run. On Redshift/Postgres that pins AccessShareLock on every
     # crawled table and blocks other users' DDL for hours (issue #29092).
     # AUTOCOMMIT releases locks after each statement. Skip dialects that do not
     # support it (non-transactional engines do not hold these locks anyway).
+    #
+    # It has to be a create_engine kwarg rather than engine.update_execution_options:
+    # only the kwarg records the level on the dialect, and that is what SQLAlchemy
+    # restores to when a connection returns to the pool. Supplied as an execution
+    # option that field stays unset and the restore falls back to the dialect's
+    # default_isolation_level, which Dialect.initialize leaves as None on any dialect
+    # that cannot read its level back (Azure Synapse cannot query sys.dm_exec_sessions),
+    # so releasing the connection asserts in reset_isolation_level. Dialect support can
+    # only be probed once the engine has resolved it, and building an engine opens no
+    # connection, so discarding the first one costs nothing.
     if "isolation_level" not in kwargs and _dialect_supports_autocommit(engine.dialect):
-        engine.update_execution_options(isolation_level="AUTOCOMMIT")
+        engine = build_engine(isolation_level="AUTOCOMMIT")
 
     attach_query_tracker(engine)
 

--- a/ingestion/tests/unit/test_connection_builders.py
+++ b/ingestion/tests/unit/test_connection_builders.py
@@ -14,6 +14,8 @@ Validate connection builder utilities
 
 from unittest import TestCase
 
+from sqlalchemy import text
+
 from metadata.generated.schema.entity.services.connections.database.common.basicAuth import (
     BasicAuth,
 )
@@ -109,13 +111,47 @@ def test_dialect_supports_autocommit_false_when_raises():
     assert _dialect_supports_autocommit(FakeDialectRaises()) is False
 
 
-def test_create_generic_db_connection_applies_autocommit():
+def test_create_generic_db_connection_applies_autocommit(tmp_path):
+    """
+    Statements must land without an explicit commit, so a read-only crawl does not
+    hold a transaction -- and therefore locks -- open for the whole run (issue #29092).
+    """
+    engine = create_generic_db_connection(
+        connection=object(),
+        get_connection_url_fn=lambda _conn: f"sqlite:///{tmp_path / 'autocommit.db'}",
+        get_connection_args_fn=lambda _conn: {},
+    )
+
+    with engine.connect() as writer:
+        writer.execute(text("create table t (id integer)"))
+        writer.execute(text("insert into t values (1)"))
+        # deliberately no commit: another connection must already see the row
+        with engine.connect() as reader:
+            assert reader.execute(text("select count(*) from t")).scalar() == 1
+
+
+def test_create_generic_db_connection_autocommit_survives_pool_checkin():
+    """
+    Releasing a connection must not blow up on a dialect that cannot read its own
+    isolation level back. SQLAlchemy restores the level on checkin, and only falls
+    back to ``default_isolation_level`` -- which ``Dialect.initialize`` leaves as
+    ``None`` whenever ``get_isolation_level`` raises ``NotImplementedError`` -- when
+    the level was not recorded on the dialect. Azure Synapse hits exactly that: it
+    cannot query ``sys.dm_exec_sessions``, so the fallback tripped an
+    ``AssertionError`` in ``reset_isolation_level`` and every test connection failed
+    with a misleading "validate the credentials".
+    """
     engine = create_generic_db_connection(
         connection=object(),
         get_connection_url_fn=lambda _conn: "sqlite://",
         get_connection_args_fn=lambda _conn: {},
     )
-    assert engine.get_execution_options().get("isolation_level") == "AUTOCOMMIT"
+
+    with engine.connect() as conn:
+        # initialize() has run; emulate a dialect that could not read the level back
+        engine.dialect.default_isolation_level = None
+        assert conn.execute(text("select 1")).scalar() == 1
+    # the release above is what used to raise
 
 
 def test_create_generic_db_connection_respects_explicit_isolation_level():


### PR DESCRIPTION
## Describe your changes

Ingestion engines opt into `AUTOCOMMIT` so read-only crawls stop pinning `AccessShareLock` for the length of a run (#29092, #29658). It was applied with `engine.update_execution_options(isolation_level="AUTOCOMMIT")`, which makes it a **per-connection execution option**. SQLAlchemy then tracks it as an `IsolationLevelCharacteristic` and restores the level when the connection returns to the pool.

Only the `create_engine(isolation_level=...)` **kwarg** records the level on the dialect (`_on_connect_isolation_level`), and that is what the restore path reads. Supplied as an execution option, the field stays unset and `reset_isolation_level` falls back to `dialect.default_isolation_level` — which `Dialect.initialize` leaves as `None` on any dialect whose `get_isolation_level` raises `NotImplementedError`.

`MSDialect.get_isolation_level` raises exactly that whenever its opening probe returns no row or errors:

```sql
SELECT name FROM sys.system_views
WHERE name IN ('dm_exec_sessions', 'dm_pdw_nodes_exec_sessions')
```

That is the reported state on Azure Synapse. Every `mssql+pyodbc` connection then died on release:

```
File ".../sqlalchemy/engine/characteristics.py", line 103, in reset_characteristic
    dialect.reset_isolation_level(dbapi_conn)
File ".../sqlalchemy/engine/default.py", line 1015, in reset_isolation_level
    assert self.default_isolation_level is not None
AssertionError
```

The probe query had already succeeded, so the user-facing result was `Failed to connect, please validate the credentials` on perfectly good credentials, and metadata ingestion never got past `CheckAccess`. This affects any `mssql+pyodbc` target where the isolation level cannot be read back.

Dialect support for `AUTOCOMMIT` can only be probed once the engine has resolved the dialect, so the engine is built twice when it applies. `create_engine` opens no connection, so discarding the first one costs nothing; the call itself is unchanged, just moved behind a local `build_engine(**extra)`.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document
- [x] My PR title is following the [naming convention](https://docs.open-metadata.org/developers/contribute/build-code-and-run-tests#pull-request-guidelines)
- [x] I have added tests around the new logic
- [x] Existing unit tests pass locally with my changes

## Verification

### Against a live SQL Server 2022 over ODBC Driver 18

Three logins on the same instance, differing only in whether the isolation-level probe succeeds, each driven through the real `create_generic_db_connection`:

| login | probe result | `default_isolation_level` | `main` | this PR |
|---|---|---|---|---|
| `GRANT VIEW SERVER STATE` | `['dm_exec_sessions']` | `'READ COMMITTED'` | OK | OK |
| `db_datareader` only | `['dm_exec_sessions']` | `'READ COMMITTED'` | OK | OK |
| probe errors (msg 229) | `ProgrammingError` → `NotImplementedError` | `None` | **AssertionError** | OK |

The third row is the field failure, reproduced on a real dialect and driver, and fixed.

Note rows 1–2: **permissions are not the trigger.** A principal without `VIEW SERVER STATE` still reads its own session row from `sys.dm_exec_sessions`, so granting it is not a workaround. What matters is only whether the probe resolves at all.

### Unit tests

The new test fails on `main` at the same frame and passes with the fix:

```
# without the fix
FAILED test_create_generic_db_connection_autocommit_survives_pool_checkin
  .../sqlalchemy/engine/default.py:1015: AssertionError
1 failed, 8 passed

# with the fix
9 passed
```

Wider sweep — `ingestion/tests/unit/{test_connection_builders.py,source/database,topology/database}`: `1566 passed`, with the same 7 failures and 31 collection errors (missing optional drivers) present on `main` before the change.

`ruff check` / `ruff format --check` / `basedpyright` clean on both files.

### Test change worth a look

`test_create_generic_db_connection_applies_autocommit` asserted `engine.get_execution_options()["isolation_level"] == "AUTOCOMMIT"` — the exact plumbing this PR deliberately moves. It now asserts the behaviour #29092 actually asked for: a second connection sees a write that was never committed. That assertion passes both before and after this change, so it still guards the original fix.

## Backport

The regression is in every branch carrying #29658, including `1.13`.
