### PR TITLE
fix(domain): scope REST lists by a global X-OpenMetadata-Domain header (server-side, central)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/ActiveDomainContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/ActiveDomainContext.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2026 Collate
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.openmetadata.service.security;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+/**
+ * Holds the global (navbar-selected) domain sent on the request via the {@code X-OpenMetadata-Domain}
+ * header, so code paths that don't have the {@link jakarta.ws.rs.core.SecurityContext} at hand can
+ * still read it. Mirrors {@link ActivePersonaContext}. The value is a single domain fully-qualified
+ * name; it is only ever used to NARROW a listing within the user's accessible domains, never for
+ * authorization.
+ */
+public final class ActiveDomainContext {
+  private static final ThreadLocal<String> ACTIVE_DOMAIN = new ThreadLocal<>();
+
+  private ActiveDomainContext() {}
+
+  public static void setActiveDomain(String activeDomain) {
+    if (nullOrEmpty(activeDomain)) {
+      ACTIVE_DOMAIN.remove();
+    } else {
+      ACTIVE_DOMAIN.set(activeDomain);
+    }
+  }
+
+  public static String getActiveDomain() {
+    return ACTIVE_DOMAIN.get();
+  }
+
+  public static void clear() {
+    ACTIVE_DOMAIN.remove();
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/CatalogOpenIdAuthorizationRequestFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/CatalogOpenIdAuthorizationRequestFilter.java
@@ -77,6 +77,7 @@ public class CatalogOpenIdAuthorizationRequestFilter implements ContainerRequest
       ContainerRequestContext requestContext, CatalogPrincipal catalogPrincipal) {
     String scheme = requestContext.getUriInfo().getRequestUri().getScheme();
     String activePersona = requestContext.getHeaderString(JwtFilter.ACTIVE_PERSONA_HEADER);
+    String activeDomain = requestContext.getHeaderString(JwtFilter.ACTIVE_DOMAIN_HEADER);
     CatalogSecurityContext catalogSecurityContext =
         new CatalogSecurityContext(
             catalogPrincipal,
@@ -85,8 +86,10 @@ public class CatalogOpenIdAuthorizationRequestFilter implements ContainerRequest
             new HashSet<>(),
             false,
             null,
-            activePersona);
+            activePersona,
+            activeDomain);
     requestContext.setSecurityContext(catalogSecurityContext);
     ActivePersonaContext.setActivePersona(activePersona);
+    ActiveDomainContext.setActiveDomain(activeDomain);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/JwtFilter.java
@@ -86,6 +86,7 @@ public class JwtFilter implements ContainerRequestFilter {
   public static final String IMPERSONATED_USER_CLAIM = "impersonatedUser";
   public static final String IMPERSONATE_USER_HEADER = "X-Impersonate-User";
   public static final String ACTIVE_PERSONA_HEADER = "X-OpenMetadata-Persona";
+  public static final String ACTIVE_DOMAIN_HEADER = "X-OpenMetadata-Domain";
   private static final Set<String> NATIVE_PASSWORD_PROVIDER_VALUES =
       Set.of(AuthProvider.BASIC.value(), AuthProvider.OPENMETADATA.value());
   @Getter private List<String> jwtPrincipalClaims;
@@ -181,6 +182,7 @@ public class JwtFilter implements ContainerRequestFilter {
     Timer.Sample authSample = RequestLatencyContext.startAuthOperation();
     ImpersonationContext.clear();
     ActivePersonaContext.clear();
+    ActiveDomainContext.clear();
 
     try {
       String tokenFromHeader = extractToken(requestContext.getHeaders());
@@ -197,6 +199,7 @@ public class JwtFilter implements ContainerRequestFilter {
 
       String impersonateUser = requestContext.getHeaderString(IMPERSONATE_USER_HEADER);
       String activePersona = requestContext.getHeaderString(ACTIVE_PERSONA_HEADER);
+      String activeDomain = requestContext.getHeaderString(ACTIVE_DOMAIN_HEADER);
       String impersonatedBy = null;
 
       if (impersonateUser != null && !impersonateUser.isEmpty()) {
@@ -228,7 +231,8 @@ public class JwtFilter implements ContainerRequestFilter {
               getUserRolesFromClaims(claims, isBotUser),
               isBotUser,
               impersonatedBy,
-              activePersona);
+              activePersona,
+              activeDomain);
       LOG.debug("SecurityContext {}", catalogSecurityContext);
       requestContext.setSecurityContext(catalogSecurityContext);
 
@@ -238,9 +242,11 @@ public class JwtFilter implements ContainerRequestFilter {
         ImpersonationContext.clear();
       }
       ActivePersonaContext.setActivePersona(activePersona);
+      ActiveDomainContext.setActiveDomain(activeDomain);
     } catch (Throwable t) {
       ImpersonationContext.clear();
       ActivePersonaContext.clear();
+      ActiveDomainContext.clear();
       throw t;
     } finally {
       RequestLatencyContext.endAuthOperation(authSample);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopFilter.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/NoopFilter.java
@@ -37,6 +37,7 @@ public class NoopFilter implements ContainerRequestFilter {
         new CatalogPrincipal("anonymous", "anonymous@openmetadata.org");
     String scheme = containerRequestContext.getUriInfo().getRequestUri().getScheme();
     String activePersona = containerRequestContext.getHeaderString(JwtFilter.ACTIVE_PERSONA_HEADER);
+    String activeDomain = containerRequestContext.getHeaderString(JwtFilter.ACTIVE_DOMAIN_HEADER);
     CatalogSecurityContext catalogSecurityContext =
         new CatalogSecurityContext(
             catalogPrincipal,
@@ -45,9 +46,11 @@ public class NoopFilter implements ContainerRequestFilter {
             new HashSet<>(),
             false,
             null,
-            activePersona);
+            activePersona,
+            activeDomain);
     LOG.debug("SecurityContext {}", catalogSecurityContext);
     containerRequestContext.setSecurityContext(catalogSecurityContext);
     ActivePersonaContext.setActivePersona(activePersona);
+    ActiveDomainContext.setActiveDomain(activeDomain);
   }
 }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/CatalogSecurityContext.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/auth/CatalogSecurityContext.java
@@ -30,7 +30,8 @@ public record CatalogSecurityContext(
     Set<String> userRoles,
     boolean isBot,
     String impersonatedUser,
-    String activePersona)
+    String activePersona,
+    String activeDomain)
     implements SecurityContext {
   public static final String OPENID_AUTH = "openid";
 
@@ -56,7 +57,7 @@ public record CatalogSecurityContext(
   // Backward compatibility constructors
   public CatalogSecurityContext(
       Principal principal, String scheme, String authenticationScheme, Set<String> userRoles) {
-    this(principal, scheme, authenticationScheme, userRoles, false, null, null);
+    this(principal, scheme, authenticationScheme, userRoles, false, null, null, null);
   }
 
   public CatalogSecurityContext(
@@ -65,7 +66,7 @@ public record CatalogSecurityContext(
       String authenticationScheme,
       Set<String> userRoles,
       boolean isBot) {
-    this(principal, scheme, authenticationScheme, userRoles, isBot, null, null);
+    this(principal, scheme, authenticationScheme, userRoles, isBot, null, null, null);
   }
 
   public CatalogSecurityContext(
@@ -75,7 +76,26 @@ public record CatalogSecurityContext(
       Set<String> userRoles,
       boolean isBot,
       String impersonatedUser) {
-    this(principal, scheme, authenticationScheme, userRoles, isBot, impersonatedUser, null);
+    this(principal, scheme, authenticationScheme, userRoles, isBot, impersonatedUser, null, null);
+  }
+
+  public CatalogSecurityContext(
+      Principal principal,
+      String scheme,
+      String authenticationScheme,
+      Set<String> userRoles,
+      boolean isBot,
+      String impersonatedUser,
+      String activePersona) {
+    this(
+        principal,
+        scheme,
+        authenticationScheme,
+        userRoles,
+        isBot,
+        impersonatedUser,
+        activePersona,
+        null);
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/EntityUtil.java
@@ -74,6 +74,7 @@ import org.openmetadata.service.jdbi3.CollectionDAO.UsageDAO;
 import org.openmetadata.service.jdbi3.EntityRepository;
 import org.openmetadata.service.jdbi3.ListFilter;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
+import org.openmetadata.service.security.ActiveDomainContext;
 import org.openmetadata.service.security.policyevaluator.ResourceContext;
 import org.openmetadata.service.security.policyevaluator.SubjectContext;
 
@@ -1085,14 +1086,42 @@ public final class EntityUtil {
     return result.stream().toList();
   }
 
+  // A domainId that matches nothing, used when a domain-restricted user filters on a domain they
+  // cannot access.
+  private static final String NO_MATCH_DOMAIN_ID = "'00000000-0000-0000-0000-000000000000'";
+
   public static void addDomainQueryParam(
       SecurityContext securityContext, ListFilter filter, String entityType) {
     SubjectContext subjectContext = getSubjectContext(securityContext);
-    // If the User is admin then no need to add domainId in the query param
-    // Also if there are domain restriction on the subject context via role
-    if (!subjectContext.isAdmin()
-        && !subjectContext.isBot()
-        && subjectContext.hasAnyRole(DOMAIN_ONLY_ACCESS_ROLE)) {
+    boolean restricted =
+        !subjectContext.isAdmin()
+            && !subjectContext.isBot()
+            && subjectContext.hasAnyRole(DOMAIN_ONLY_ACCESS_ROLE);
+
+    // The global (navbar) domain selection arrives on the X-OpenMetadata-Domain header (a domain
+    // id).
+    // Applied only to entity types that carry a domain; otherwise a strict filter would wrongly
+    // empty
+    // a non-domain list (users, teams, roles, ...).
+    String navDomainId = ActiveDomainContext.getActiveDomain();
+    if (!nullOrEmpty(navDomainId) && entitySupportsDomains(entityType)) {
+      String requested = "'" + navDomainId.replace("'", "") + "'";
+      // STRICT narrowing (no domainAccessControl -> un-domained assets are hidden), for admins and
+      // restricted users alike. For restricted users the selection is intersected with their
+      // accessible domains so it can only narrow, never widen (a domain they cannot access -> no
+      // match).
+      String domainId =
+          restricted
+              ? intersectWithAllowedDomains(
+                  requested, getCommaSeparatedIdsFromRefs(subjectContext.getUserDomains()))
+              : requested;
+      filter.addQueryParam("domainId", domainId);
+      return;
+    }
+
+    // No navbar selection (or a non-domain entity type): keep the existing RBAC-only scoping for
+    // domain-restricted users; admins/bots stay unfiltered.
+    if (restricted) {
       if (!nullOrEmpty(subjectContext.getUserDomains())) {
         filter.addQueryParam(
             "domainId", getCommaSeparatedIdsFromRefs(subjectContext.getUserDomains()));
@@ -1102,6 +1131,49 @@ public final class EntityUtil {
         filter.addQueryParam("entityType", entityType);
       }
     }
+  }
+
+  // Governance/administration entities carry a domains field but are not data assets, so the global
+  // (navbar) domain filter must not scope their list pages -- otherwise selecting a domain would
+  // empty the Users/Teams/Policies/etc. lists.
+  private static final Set<String> NAV_DOMAIN_FILTER_EXCLUDED_TYPES =
+      Set.of(Entity.USER, Entity.TEAM, Entity.ROLE, Entity.POLICY, Entity.PERSONA, Entity.BOT);
+
+  private static boolean entitySupportsDomains(String entityType) {
+    if (NAV_DOMAIN_FILTER_EXCLUDED_TYPES.contains(entityType)) {
+      return false;
+    }
+    try {
+      return Entity.getEntityRepository(entityType).isSupportsDomains();
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /**
+   * Intersect a requested domainId filter (from the navbar) with the domains a restricted user may
+   * access. A requested domain outside that set yields a no-match so the user never sees a domain
+   * they cannot access.
+   */
+  private static String intersectWithAllowedDomains(
+      String requestedDomainId, String allowedDomainIds) {
+    if (nullOrEmpty(requestedDomainId) || NULL_PARAM.equals(requestedDomainId)) {
+      return allowedDomainIds;
+    }
+    Set<String> allowed = splitDomainIds(allowedDomainIds);
+    List<String> narrowed =
+        splitDomainIds(requestedDomainId).stream()
+            .filter(allowed::contains)
+            .map(id -> "'" + id + "'")
+            .toList();
+    return narrowed.isEmpty() ? NO_MATCH_DOMAIN_ID : String.join(",", narrowed);
+  }
+
+  private static Set<String> splitDomainIds(String commaSeparatedQuotedIds) {
+    return Arrays.stream(commaSeparatedQuotedIds.replace("'", "").split(","))
+        .map(String::trim)
+        .filter(id -> !id.isEmpty())
+        .collect(Collectors.toSet());
   }
 
   /**

--- a/openmetadata-service/src/main/java/org/openmetadata/service/util/PerRequestContextCleaner.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/util/PerRequestContextCleaner.java
@@ -16,6 +16,7 @@ package org.openmetadata.service.util;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.jdbi3.ReadBundleContext;
 import org.openmetadata.service.resources.filters.ETagRequestFilter;
+import org.openmetadata.service.security.ActiveDomainContext;
 import org.openmetadata.service.security.ActivePersonaContext;
 import org.openmetadata.service.security.ImpersonationContext;
 
@@ -38,6 +39,7 @@ public final class PerRequestContextCleaner {
   public static void clear() {
     ImpersonationContext.clear();
     ActivePersonaContext.clear();
+    ActiveDomainContext.clear();
     ETagRequestFilter.clearIfMatchHeader();
     RequestEntityCache.clear();
     ReadBundleContext.clear();

--- a/openmetadata-ui/src/main/resources/ui/src/hoc/withDomainFilter.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/hoc/withDomainFilter.tsx
@@ -20,11 +20,16 @@ import {
 } from '../pages/ExplorePage/ExplorePage.interface';
 import { getPathNameFromWindowLocation } from '../utils/LocationUtils';
 
+// Global domain sent to the server so it can scope every REST list centrally (read in the auth
+// filters, applied in EntityUtil.addDomainQueryParam) -- mirrors the active-persona header. Carries
+// the domain id so the backend can intersect it with the user's accessible domains.
+export const ACTIVE_DOMAIN_HEADER = 'X-OpenMetadata-Domain';
+
 export const withDomainFilter = (
   config: InternalAxiosRequestConfig
 ): InternalAxiosRequestConfig => {
   const isGetRequest = config.method === 'get';
-  const activeDomain = useDomainStore.getState().activeDomain;
+  const { activeDomain, activeDomainEntityRef } = useDomainStore.getState();
   const hasActiveDomain = activeDomain !== DEFAULT_DOMAIN_VALUE;
   const currentPath = getPathNameFromWindowLocation();
 
@@ -102,11 +107,9 @@ export const withDomainFilter = (
         ...config.params,
         query_filter: JSON.stringify(filter),
       };
-    } else {
-      config.params = {
-        ...config.params,
-        domain: activeDomain,
-      };
+    } else if (activeDomainEntityRef?.id) {
+      // REST list endpoints: scope centrally on the server via the header (no per-API ?domain param).
+      config.headers[ACTIVE_DOMAIN_HEADER] = activeDomainEntityRef.id;
     }
   }
 


### PR DESCRIPTION
## Summary

Replaces the per-API `?domain=` approach to the global (navbar) domain filter with a single **`X-OpenMetadata-Domain` request header** applied **server-side and centrally**, mirroring how the active-persona header works. This is the scalable "right solution" to the gap that #31180 patched per-endpoint (glossary/metric/tag/classification/service/dataProduct): every REST list view is covered in one place, with no per-resource `?domain` handling.

> Phase 1 (REST list path). Opening as **draft** for approach review — see Scope below.

## Problem

The navbar domain filter didn't scope REST list endpoints: the UI stamped `?domain=<fqn>` on every list request, but each resource had to declare `@QueryParam("domain")` and apply it — only a handful did, so most lists ignored it. Adding the param to every API (and every future entity) doesn't scale, and the same gap shows up on entity-page child lists.

## Approach — mirror the active-persona header

- **Transport:** the UI (`withDomainFilter`) sends `X-OpenMetadata-Domain: <domainId>` on REST GETs instead of `?domain=`.
- **Read once:** the three auth filters (`JwtFilter`, `NoopFilter`, `CatalogOpenIdAuthorizationRequestFilter`) read the header into `CatalogSecurityContext.activeDomain` + an `ActiveDomainContext` ThreadLocal (cleared in `PerRequestContextCleaner`) — same shape as `X-OpenMetadata-Persona` / `ActivePersonaContext`.
- **Apply centrally:** `EntityUtil.addDomainQueryParam` (already the domain chokepoint for every `EntityResource.listInternal` list) reads the active domain and scopes the list.

## Semantics

- **Strict** narrowing: when a domain is selected, only that domain's assets are listed (un-domained hidden), for admins **and** `DomainOnlyAccessRole` users. When "All Domains" is selected (no header), behavior is unchanged (admins unfiltered; restricted users keep their RBAC scope incl. un-domained).
- **RBAC-safe (cannot bypass):** the accessible set always comes from `subjectContext.getUserDomains()` server-side; the header only *narrows* within it (intersection). A domain the user can't access → no-match. The header can only shrink the result set, never widen it.
- **Guarded:** applied only to entity types that carry a domain (`supportsDomains`), and a governance denylist (`user`, `team`, `role`, `policy`, `persona`, `bot`) is excluded even though those carry a `domains` field — otherwise selecting a domain would empty the Users/Teams/Policies lists.

## Scope

- **This PR — REST list path.** Search is intentionally **unchanged**: it already scopes domains securely server-side (`RBACConditionEvaluator.hasDomain` from `user.getDomains()`, non-bypassable), and the nav-domain narrowing stays client-side in `query_filter` (safe because RBAC bounds it). No server-side search change is needed.
- **Follow-up (Phase 2):** the few DB-list endpoints that bypass `listInternal` and would need the same central apply (`GlossaryTermResource`, custom-paging resources).

## Verification

Built into a stack and ran an API matrix with the header, for **admin** and a **DomainOnlyAccessRole user with domains [A,B]**; glossaries in A, in B, and un-domained:

| Context | Header | Result |
|---|---|---|
| admin | none | A + B + un-domained |
| admin | B | only B (A + un-domained hidden — strict) |
| restricted [A,B] | none | A + B + un-domained (RBAC lenient) |
| restricted [A,B] | B | only B |
| restricted [A,B] | A | only A |
| restricted [A,B] | C (inaccessible) | nothing (RBAC not bypassed) |
| any | B, on users/teams/policies/roles | unaffected (guard) |

All pass. The customer's original case (a Domain-A glossary hidden when Domain B is selected) works for both admin and the restricted user.

## Notes

- Replaces the per-API approach in #31180.
- UI change is a small interceptor swap; a full browser per-page pass is pending a UI build.
