### PR TITLE
Chore(UI): Ensure the runner selection to avoid flaky behaviour

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/constant/serviceForm.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/constant/serviceForm.ts
@@ -12,6 +12,8 @@
  */
 import { SupersetFormType } from '../support/interfaces/ServiceForm.interface';
 
+export const COLLATE_SAAS_RUNNER = 'Collate SaaS Runner';
+
 export const supersetFormDetails1: SupersetFormType = {
   hostPort: 'http://localhost:8088',
   connectionType: 'SupersetApiConnection',

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ApiServiceRest.spec.ts
@@ -13,6 +13,7 @@
 import { expect, Page, test } from '@playwright/test';
 import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { BIG_ENTITY_DELETE_TIMEOUT } from '../../constant/delete';
+import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
 import { GlobalSettingOptions } from '../../constant/settings';
 import {
   descriptionBox,
@@ -20,6 +21,7 @@ import {
   toastNotification,
   uuid,
 } from '../../utils/common';
+import { selectIngestionRunnerFromDropdown } from '../../utils/serviceFormUtils';
 import { testConnection } from '../../utils/serviceIngestion';
 import { settingClick } from '../../utils/sidebar';
 
@@ -134,6 +136,7 @@ test.describe('API service', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     await page.locator('#service-name').fill(apiServiceConfig.name);
     await page.getByTestId('add-description-button').click();
     await page.locator(descriptionBox).fill(apiServiceConfig.description);
+    await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 
     await page
       .locator('#root\\/openAPISchemaConnection\\/openAPISchemaURL')

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ConnectionConfigLayout.spec.ts
@@ -12,8 +12,10 @@
  */
 
 import { expect, Locator, Page, test } from '@playwright/test';
+import { COLLATE_SAAS_RUNNER } from '../../constant/serviceForm';
 import { redirectToHomePage } from '../../utils/common';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
+import { selectIngestionRunnerFromDropdown } from '../../utils/serviceFormUtils';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -574,6 +576,7 @@ test.describe('Connection config layout', () => {
     }
 
     await page.locator('#service-name').fill('pw-snowflake-auth-payload');
+    await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
     await expect(page.getByTestId('connection-schema-loader')).toBeHidden({
       timeout: 10000,
     });

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/ServiceForm.spec.ts
@@ -18,6 +18,7 @@ import { PLAYWRIGHT_INGESTION_TAG_OBJ } from '../../constant/config';
 import { SERVICE_TYPE } from '../../constant/service';
 import {
   CERT_FILE,
+  COLLATE_SAAS_RUNNER,
   lookerFormDetails,
   supersetFormDetails1,
   supersetFormDetails2,
@@ -32,6 +33,7 @@ import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import { visitServiceDetailsPage } from '../../utils/service';
 import {
   fillSupersetFormDetails,
+  selectIngestionRunnerFromDropdown,
   selectOneOfOption,
 } from '../../utils/serviceFormUtils';
 import {
@@ -315,6 +317,7 @@ test.describe(
         await page.locator('#service-name').click();
         await page.locator('#service-name').fill(`${SERVICE_NAMES.service2}`);
         await advanceToServiceConnectionStep(page);
+        await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 
         await page.locator(String.raw`#root\/clientId`).clear();
         await page.fill(

--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/BigQueryIngestionClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/ingestion/BigQueryIngestionClass.ts
@@ -23,16 +23,19 @@ import ServiceBaseClass from './ServiceBaseClass';
 class BigQueryIngestionClass extends ServiceBaseClass {
   name = '';
   filterPattern: string;
+  authOverrides: Record<string, string>;
 
   constructor(extraParams?: {
     shouldTestConnection?: boolean;
     shouldAddIngestion?: boolean;
     shouldAddDefaultFilters?: boolean;
+    authOverrides?: Record<string, string>;
   }) {
     const {
       shouldTestConnection = true,
       shouldAddIngestion = true,
       shouldAddDefaultFilters = false,
+      authOverrides,
     } = extraParams ?? {};
 
     super(
@@ -46,6 +49,7 @@ class BigQueryIngestionClass extends ServiceBaseClass {
     );
 
     this.filterPattern = 'testschema';
+    this.authOverrides = authOverrides ?? {};
   }
 
   async createService(page: Page) {
@@ -60,7 +64,10 @@ class BigQueryIngestionClass extends ServiceBaseClass {
     const clientEmail = process.env.PLAYWRIGHT_BQ_CLIENT_EMAIL ?? '';
     const projectId = process.env.PLAYWRIGHT_BQ_PROJECT_ID ?? '';
     const privateKeyId = process.env.PLAYWRIGHT_BQ_PRIVATE_KEY_ID ?? '';
-    const privateKey = process.env.PLAYWRIGHT_BQ_PRIVATE_KEY ?? '';
+    const privateKey =
+      this.authOverrides.privateKey ??
+      process.env.PLAYWRIGHT_BQ_PRIVATE_KEY ??
+      '';
     const clientId = process.env.PLAYWRIGHT_BQ_CLIENT_ID ?? '';
     const projectIdTaxonomy =
       process.env.PLAYWRIGHT_BQ_PROJECT_ID_TAXONOMY ?? '';

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/serviceFormUtils.ts
@@ -12,6 +12,7 @@
  */
 import { expect, Page } from '@playwright/test';
 import { startCase } from 'lodash';
+import { COLLATE_SAAS_RUNNER } from '../constant/serviceForm';
 import { FillSupersetFormProps } from '../support/interfaces/ServiceForm.interface';
 
 const escapeRegExp = (value: string) =>
@@ -76,6 +77,26 @@ export const selectOneOfOption = async (
   throw new Error(
     `Unable to select oneOf option "${optionName}" for field "${fieldId}"`
   );
+};
+
+export const selectIngestionRunnerFromDropdown = async (
+  page: Page,
+  runnerDisplayName: string
+) => {
+  // Select the ingestion runner if the selector is visible. The runner control
+  // migrated from an antd Select to a react-aria Select — clicking the trigger
+  // opens a role="listbox" of runner options instead of an `.ant-select-dropdown`.
+  const runnerSelector = page.getByTestId('select-widget-root/ingestionRunner');
+
+  if (await runnerSelector.isVisible()) {
+    await runnerSelector.click();
+
+    const runnerOption = page.getByRole('option').getByText(runnerDisplayName);
+    await runnerOption.waitFor({ state: 'visible' });
+    await runnerOption.click();
+
+    await expect(runnerSelector).toContainText(runnerDisplayName);
+  }
 };
 
 export const fillSupersetFormDetails = async ({
@@ -155,21 +176,5 @@ export const fillSupersetFormDetails = async ({
       { force: true } // eslint-disable-line playwright/no-force-option -- form field overlay covers input
     );
   }
-
-  // Select the ingestion runner if the selector is visible. The runner control
-  // migrated from an antd Select to a react-aria Select — clicking the trigger
-  // opens a role="listbox" of runner options instead of an `.ant-select-dropdown`.
-  const runnerSelector = page.getByTestId('select-widget-root/ingestionRunner');
-
-  if (await runnerSelector.isVisible()) {
-    await runnerSelector.click();
-
-    const runnerOption = page
-      .getByRole('option', { name: /Collate SaaS/i })
-      .first();
-    await runnerOption.waitFor({ state: 'visible' });
-    await runnerOption.click();
-
-    await expect(runnerSelector).toContainText('Collate SaaS');
-  }
+  await selectIngestionRunnerFromDropdown(page, COLLATE_SAAS_RUNNER);
 };


### PR DESCRIPTION
This pull request improves the Playwright test codebase by introducing a reusable utility for selecting the ingestion runner in service forms and updating tests to use this utility. It also adds support for authentication overrides in the BigQuery ingestion class. These changes enhance maintainability, reduce code duplication, and provide more flexibility for test configuration.

**Test utility improvements:**

* Added a new constant `COLLATE_SAAS_RUNNER` to `serviceForm.ts` for consistent reference to the runner display name.
* Introduced a reusable `selectIngestionRunnerFromDropdown` function in `serviceFormUtils.ts` to standardize the selection of the ingestion runner in forms, replacing duplicated logic in multiple tests. [[1]](diffhunk://#diff-82c257e9fa76a9cb54c3b6d79c88cd374af9547e98fe96ba91196a80e54fee53R82-R101) [[2]](diffhunk://#diff-82c257e9fa76a9cb54c3b6d79c88cd374af9547e98fe96ba91196a80e54fee53L158-R179)

**Test refactoring and usage:**

* Updated various test specs (`ServiceForm.spec.ts`, `ApiServiceRest.spec.ts`, `ConnectionConfigLayout.spec.ts`) to use the new utility and constant when selecting the ingestion runner, improving code clarity and reducing duplication. [[1]](diffhunk://#diff-36d5c4769185e5bc4698b44171a4da4b7d6a27edd6afac1e5adcecb2484f1da9R16-R24) [[2]](diffhunk://#diff-36d5c4769185e5bc4698b44171a4da4b7d6a27edd6afac1e5adcecb2484f1da9R139) [[3]](diffhunk://#diff-27c547da47dea0d682240bd5ff6aed5a372b69da1eea706ff94cdf87342593a6R15-R18) [[4]](diffhunk://#diff-27c547da47dea0d682240bd5ff6aed5a372b69da1eea706ff94cdf87342593a6R579) [[5]](diffhunk://#diff-53ebcb569c8451ed05612a7c9620d562e2a989aa50aa7de6026af6da2c08271eR21) [[6]](diffhunk://#diff-53ebcb569c8451ed05612a7c9620d562e2a989aa50aa7de6026af6da2c08271eR36) [[7]](diffhunk://#diff-53ebcb569c8451ed05612a7c9620d562e2a989aa50aa7de6026af6da2c08271eR320)

**BigQuery ingestion enhancements:**

* Added an `authOverrides` property to `BigQueryIngestionClass`, allowing test cases to override authentication parameters (such as `privateKey`) for greater flexibility in test configuration. [[1]](diffhunk://#diff-561129734a45846aa8a8a99b0a335e36754b955b0348760fe499701d1d1b10bdR26-R38) [[2]](diffhunk://#diff-561129734a45846aa8a8a99b0a335e36754b955b0348760fe499701d1d1b10bdR52) [[3]](diffhunk://#diff-561129734a45846aa8a8a99b0a335e36754b955b0348760fe499701d1d1b10bdL63-R70)

<img width="368" height="231" alt="Screenshot 2026-08-14 at 6 03 12 PM" src="https://github.com/user-attachments/assets/7620807b-1f3f-47c8-992f-93416c6789db" />
<img width="371" height="271" alt="Screenshot 2026-08-14 at 6 03 25 PM" src="https://github.com/user-attachments/assets/2c7b6bdf-3c45-4442-ab96-bc3aee0ca1f3" />
