### PR TITLE
Fixes #28883: Backport any-language recognizer normalization to 1.13

### DIFF
--- a/ingestion/src/metadata/pii/tag_analyzer.py
+++ b/ingestion/src/metadata/pii/tag_analyzer.py
@@ -1,3 +1,4 @@
+import copy
 from itertools import groupby
 from typing import List, Optional, Sequence, Union, final
 
@@ -125,14 +126,35 @@ class TagAnalyzer:
     def _column_name(self) -> str:
         return self._column.name.root
 
+    def _normalize_recognizer_language(
+        self, recognizer_obj: EntityRecognizer, effective_language: str
+    ) -> EntityRecognizer:
+        """Return a recognizer compatible with the effective language."""
+        if recognizer_obj.supported_language != ClassificationLanguage.any.value:
+            return recognizer_obj
+        recognizer_copy = copy.copy(recognizer_obj)
+        recognizer_copy.supported_language = effective_language
+        return recognizer_copy
+
     def build_analyzer_with(
         self,
         recognizers: list[EntityRecognizer],
         nlp_engine: Optional[NlpEngine] = None,
+        effective_language: Optional[str] = None,
     ) -> AnalyzerEngine:
-        supported_languages = [rec.supported_language for rec in recognizers]
+        effective_lang = effective_language or self._language.value
+        if effective_lang == ClassificationLanguage.any.value:
+            raise ValueError(
+                "build_analyzer_with requires a concrete language when the analyzer language is 'any'. "
+                "Pass effective_language explicitly."
+            )
+        normalized_recs = [
+            self._normalize_recognizer_language(rec, effective_lang)
+            for rec in recognizers
+        ]
+        supported_languages = [rec.supported_language for rec in normalized_recs]
         recognizer_registry = RecognizerRegistry(
-            recognizers=recognizers, supported_languages=supported_languages
+            recognizers=normalized_recs, supported_languages=supported_languages
         )
         effective_nlp = nlp_engine if nlp_engine is not None else self._nlp_engine
         return AnalyzerEngine(
@@ -170,17 +192,27 @@ class TagAnalyzer:
         sorted_recs = sorted(recognizers, key=lambda r: r.supported_language)
         for lang, group in groupby(sorted_recs, key=lambda r: r.supported_language):
             lang_recognizers = list(group)
+            if lang == ClassificationLanguage.any.value:
+                effective_lang = ClassificationLanguage.en.value
+                effective_nlp = load_nlp_engine(
+                    classification_language=ClassificationLanguage.en
+                )
+            else:
+                effective_lang = lang
+                effective_nlp = load_nlp_engine(
+                    classification_language=ClassificationLanguage(lang)
+                )
+
             analyzer = self.build_analyzer_with(
                 lang_recognizers,
-                nlp_engine=load_nlp_engine(
-                    classification_language=ClassificationLanguage(lang)
-                ),
+                nlp_engine=effective_nlp,
+                effective_language=effective_lang,
             )
             for value in values:
                 results.extend(
                     analyzer.analyze(
                         value,
-                        language=lang,
+                        language=effective_lang,
                         context=context,
                         return_decision_process=True,
                     )

--- a/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
+++ b/ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from dirty_equals import Contains, HasAttributes, IsDict
+from presidio_analyzer import Pattern, PatternRecognizer
 
 from _openmetadata_testutils.factories.metadata.generated.schema.entity.classification.classification import (
     ClassificationFactory,
@@ -115,6 +116,31 @@ def _make_fr_tag(pii_classification):
     )
 
 
+def _make_any_language_tag(pii_classification):
+    """Tag with an any-language pattern recognizer (email regex)."""
+    pattern = PatternFactory.create(
+        name="any-email-pattern",
+        regex=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+        score=0.8,
+    )
+    recognizer_config = PatternRecognizerFactory.create(
+        patterns=[pattern],
+        context=[],
+        supportedLanguage=ClassificationLanguage.any,
+    )
+    rec = RecognizerFactory.create(
+        name="any-email",
+        recognizerConfig=recognizer_config,
+        target=recognizer.Target.content,
+    )
+    return TagFactory.create(
+        tag_name="AnyEmail",
+        tag_classification=pii_classification,
+        autoClassificationEnabled=True,
+        recognizers=[rec],
+    )
+
+
 class TestGetRecognizersByAnyLanguage:
     def test_any_language_includes_all_recognizers(
         self, pii_classification, column, mock_nlp_engine
@@ -173,6 +199,32 @@ class TestGetRecognizersByAnyLanguage:
         recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
         assert len(recognizers) == 1
 
+    def test_en_agent_includes_any_language_recognizer(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
+        assert len(recognizers) == 1
+
+    def test_fr_agent_includes_any_language_recognizer(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.fr,
+        )
+        recognizers = analyzer.get_recognizers_by(recognizer.Target.content)
+        assert len(recognizers) == 1
+
 
 class TestAnalyzeWithAnyLanguage:
     def test_any_language_content_analysis_dispatches_per_language_group(
@@ -189,9 +241,13 @@ class TestAnalyzeWithAnyLanguage:
         build_calls = []
         original_build = analyzer.build_analyzer_with
 
-        def tracking_build(recs, nlp_engine=None):
+        def tracking_build(recs, nlp_engine=None, effective_language=None):
             build_calls.append((recs, nlp_engine))
-            return original_build(recs, nlp_engine=nlp_engine)
+            return original_build(
+                recs,
+                nlp_engine=nlp_engine,
+                effective_language=effective_language,
+            )
 
         analyzer.build_analyzer_with = tracking_build
 
@@ -237,6 +293,21 @@ class TestAnalyzeWithAnyLanguage:
         assert result.score == 0
         assert result.recognizer_results == []
 
+    def test_build_analyzer_with_raises_when_language_is_any_without_effective_language(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        """build_analyzer_with must raise ValueError when the analyzer language is 'any'
+        and no effective_language is provided, to prevent silent 'any' propagation to Presidio."""
+        tag = _make_any_language_tag(pii_classification)
+        analyzer = TagAnalyzer(
+            tag=tag,
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.any,
+        )
+        with pytest.raises(ValueError, match="concrete language"):
+            analyzer.build_analyzer_with([])
+
     def test_any_language_analyze_column_no_exception(
         self, pii_classification, column, mock_nlp_engine
     ):
@@ -269,3 +340,181 @@ class TestAnalyzeWithAnyLanguage:
         )
         result = analyzer.analyze(str_values=[], run_column_analysis=True)
         assert result is not None
+
+
+class TestNormalizeRecognizerLanguage:
+    """Unit tests for the _normalize_recognizer_language helper."""
+
+    def test_any_language_replaced_by_effective_language(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        """A recognizer with supported_language='any' must be updated to the effective language."""
+        analyzer = TagAnalyzer(
+            tag=_make_any_language_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="any",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "en")
+        assert result.supported_language == "en"
+
+    def test_specific_language_not_changed(
+        self, pii_classification, column, mock_nlp_engine
+    ):
+        """A recognizer with an explicit language must not be overwritten."""
+        analyzer = TagAnalyzer(
+            tag=_make_en_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="en",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "fr")
+        assert result.supported_language == "en"
+
+    def test_original_not_mutated(self, pii_classification, column, mock_nlp_engine):
+        """_normalize_recognizer_language must not mutate the original recognizer."""
+        analyzer = TagAnalyzer(
+            tag=_make_any_language_tag(pii_classification),
+            column=column,
+            nlp_engine=mock_nlp_engine,
+            language=ClassificationLanguage.en,
+        )
+        rec = PatternRecognizer(
+            supported_entity="EMAIL",
+            supported_language="any",
+            patterns=[Pattern(name="p", regex=r"@", score=0.5)],
+        )
+        result = analyzer._normalize_recognizer_language(rec, "en")
+        assert result.supported_language == "en"
+        assert rec.supported_language == "any"
+
+
+def _make_presidio_nlp_mock_for(language: str):
+    """NLP mock for a specific language that satisfies AnalyzerEngine without real spaCy models."""
+    nlp = MagicMock()
+    nlp.is_loaded.return_value = True
+    nlp.get_supported_languages.return_value = [language]
+    return nlp
+
+
+def _make_presidio_nlp_mock():
+    """NLP mock that satisfies AnalyzerEngine without requiring real spaCy models.
+
+    PatternRecognizers are regex-only and don't invoke the NLP engine, so this
+    lightweight mock is sufficient to exercise the real Presidio registry/analysis
+    path end-to-end.
+    """
+    return _make_presidio_nlp_mock_for("en")
+
+
+class TestAnalyzeWithAnyLanguageRecognizerRealPresidia:
+    """Regression tests: any-language pattern recognizers must fire through the real
+    Presidio AnalyzerEngine when the agent is configured with a specific language.
+
+    These tests use a real AnalyzerEngine (not a full mock) to catch the ValueError
+    "No matching recognizers were found" that occurs when build_analyzer_with passes
+    supported_languages=["any"] to Presidio and then calls analyze(language="en").
+    """
+
+    @pytest.fixture
+    def any_language_email_tag(self, pii_classification):
+        return _make_any_language_tag(pii_classification)
+
+    def test_any_language_recognizer_does_not_raise_with_specific_language_agent(
+        self, any_language_email_tag, column
+    ):
+        """When agent language is 'en' and recognizer is 'any', analysis must
+        not raise ValueError from Presidio's registry."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze(str_values=["user@example.com", "not-an-email"])
+        assert result is not None
+
+    def test_any_language_recognizer_matches_content_with_specific_language_agent(
+        self, any_language_email_tag, column
+    ):
+        """An any-language pattern recognizer must actually score > 0 when data matches."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze(str_values=["user@example.com"])
+        assert result.score > 0
+
+    def test_any_language_recognizer_no_match_scores_zero(
+        self, any_language_email_tag, column
+    ):
+        """When data doesn't match, score must be 0 regardless of language."""
+        nlp = _make_presidio_nlp_mock()
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.en,
+        )
+        result = analyzer.analyze(str_values=["no-match-here", "also-not-an-email"])
+        assert result.score == 0
+
+    def test_any_language_recognizer_with_fr_agent_does_not_raise(
+        self, any_language_email_tag, column
+    ):
+        """Agent=fr, Recognizer=any: must not raise; 'any' normalized to 'fr' before Presidio sees it."""
+        nlp = _make_presidio_nlp_mock_for("fr")
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.fr,
+        )
+        result = analyzer.analyze(str_values=["user@example.com", "not-an-email"])
+        assert result is not None
+
+    def test_any_language_recognizer_matches_content_with_fr_agent(
+        self, any_language_email_tag, column
+    ):
+        """Agent=fr, Recognizer=any: pattern must still fire when data matches."""
+        nlp = _make_presidio_nlp_mock_for("fr")
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=nlp,
+            language=ClassificationLanguage.fr,
+        )
+        result = analyzer.analyze(str_values=["user@example.com"])
+        assert result.score > 0
+
+    def test_any_agent_with_any_recognizer_scores_on_match(
+        self, any_language_email_tag, column
+    ):
+        """Agent=any, Recognizer=any: 'any' group must be dispatched as 'en', not 'any'.
+
+        If _analyze_with calls analyze(language='any') instead of 'en', Presidio raises
+        ValueError because the recognizer is normalized to supported_language='en' but
+        the registry finds no recognizer for 'any'.
+        """
+        analyzer = TagAnalyzer(
+            tag=any_language_email_tag,
+            column=column,
+            nlp_engine=MagicMock(),
+            language=ClassificationLanguage.any,
+        )
+        result = analyzer.analyze(str_values=["user@example.com"])
+        assert result.score > 0


### PR DESCRIPTION
### Describe your changes:

Fixes #28883

Backports #28549 to `1.13`.

Presidio matches recognizer languages by exact equality. OpenMetadata admitted recognizers configured with `supportedLanguage: any`, then passed `any` unchanged while requesting analysis with a concrete language such as `en`, causing `No matching recognizers were found to serve the request`.

This change copies `any` recognizers with the effective concrete language before building Presidio's registry. It also maps the `any` recognizer group to English when the pipeline itself is configured for all languages.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — targeted two-file backport of #28549, adapted to the `1.13` combined `TagAnalyzer.analyze()` API.

#
### Tests:

#### Use cases covered

- An `any` recognizer is analyzed by English and French pipelines without raising.
- An `any` recognizer produces a positive score for matching content.
- An all-language pipeline dispatches an `any` recognizer through a concrete English registry.
- Explicit recognizer languages remain unchanged.
- Normalization does not mutate the original recognizer.

#### Unit tests

- [x] Added regression coverage using the real Presidio `AnalyzerEngine`.
- Updated: `ingestion/tests/unit/metadata/pii/test_tag_analyzer_any_language.py`
- Focused result: 20 passed
- Full PII result: 102 passed
- Changed-module coverage: 96% on `metadata.pii.tag_analyzer`

#### Backend integration tests

- [x] Not applicable — no backend API changes.

#### Ingestion integration tests

- [x] Not applicable — no connector boundary changes; the affected Presidio adapter is covered directly.

#### Playwright (UI) tests

- [x] Not applicable — no UI changes.

#### Manual testing performed

1. Reproduced the 1.13.4 failure with an enabled `any`-language recognizer and an English auto-classification pipeline.
2. Disabled only that recognizer and reran the same pipeline.
3. Confirmed the pipeline completed successfully, isolating the language mismatch as the trigger.

#
### UI screen recording / screenshots:

Not applicable — no UI changes.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`.
- [x] My PR is linked to a GitHub issue via `Fixes #28883`.
- [x] Comments/docstrings are limited to the non-obvious language-normalization contract.
- [x] JSON Schema migration is not applicable.
- [x] UI recording is not applicable.
- [x] I added tests covering the exact failure scenario.
