### PR TITLE
fix(e2e): use SSO-provider token for security-config restore in afterAll

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/OktaSessionRenewalPublic.spec.ts
@@ -48,7 +48,7 @@ test.describe('Okta Public Session Renewal', { tag: OKTA_PUBLIC_TAGS }, () => {
   );
 
   let helper: ProviderHelper;
-  let restoreSecurity: (() => Promise<void>) | undefined;
+  let restoreSecurity: ((ssoToken?: string) => Promise<void>) | undefined;
   let userContext: BrowserContext | undefined;
   let userPage: Page | undefined;
 
@@ -69,11 +69,32 @@ test.describe('Okta Public Session Renewal', { tag: OKTA_PUBLIC_TAGS }, () => {
     }
   );
 
-  test.afterAll('Restore original security configuration', async () => {
-    await userPage?.close();
-    await userContext?.close();
-    await restoreSecurity?.();
-  });
+  test.afterAll(
+    'Restore original security configuration',
+    async ({ browser }) => {
+      test.setTimeout(SSO_LOGIN_HOOK_TIMEOUT_MS);
+
+      await userPage?.close();
+      await userContext?.close();
+
+      // The last test leaves the page in an uncertain navigation state after
+      // unrouting Okta endpoints.  Do a fresh SSO login so the restore PUT uses
+      // a token valid under the current provider.
+      let ssoToken: string | undefined;
+      const tempCtx = await browser.newContext();
+      const tempPage = await tempCtx.newPage();
+
+      try {
+        await loginViaSso(tempPage, helper, { username, password });
+        ssoToken = await getToken(tempPage);
+      } finally {
+        await tempPage.close();
+        await tempCtx.close();
+      }
+
+      await restoreSecurity?.(ssoToken);
+    }
+  );
 
   test('should silently renew the token once the stored token has expired', async () => {
     const page = userPage!;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOLogin.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOLogin.spec.ts
@@ -18,6 +18,8 @@ import {
   swapSecurityConfig,
   verifyLoggedInUserMatches,
 } from '../../utils/ssoAuth';
+import { loginViaSso, SSO_LOGIN_HOOK_TIMEOUT_MS } from '../../utils/ssoLogin';
+import { getToken } from '../../utils/tokenStorage';
 
 const providerType = process.env[SSO_ENV.PROVIDER_TYPE] ?? '';
 const username = process.env[SSO_ENV.USERNAME] ?? '';
@@ -34,7 +36,7 @@ test.describe('SSO Login', { tag: ['@sso', '@Platform'] }, () => {
   test.describe.configure({ mode: 'serial' });
 
   let helper: ProviderHelper;
-  let restoreSecurity: (() => Promise<void>) | undefined;
+  let restoreSecurity: ((ssoToken?: string) => Promise<void>) | undefined;
   let userContext: BrowserContext | undefined;
   let userPage: Page | undefined;
 
@@ -52,11 +54,32 @@ test.describe('SSO Login', { tag: ['@sso', '@Platform'] }, () => {
     }
   );
 
-  test.afterAll('Restore original security configuration', async () => {
-    await userPage?.close();
-    await userContext?.close();
-    await restoreSecurity?.();
-  });
+  test.afterAll(
+    'Restore original security configuration',
+    async ({ browser }) => {
+      test.setTimeout(SSO_LOGIN_HOOK_TIMEOUT_MS);
+
+      await userPage?.close();
+      await userContext?.close();
+
+      // The pre-swap basic-auth token is rejected once the server is in SSO mode
+      // (JwtFilter.validateSessionProviderIsCurrent).  Do a fresh SSO login to
+      // obtain a token the current provider will accept.
+      let ssoToken: string | undefined;
+      const tempCtx = await browser.newContext();
+      const tempPage = await tempCtx.newPage();
+
+      try {
+        await loginViaSso(tempPage, helper, { username, password });
+        ssoToken = await getToken(tempPage);
+      } finally {
+        await tempPage.close();
+        await tempCtx.close();
+      }
+
+      await restoreSecurity?.(ssoToken);
+    }
+  );
 
   test('should display SSO sign-in button on /signin', async ({ page }) => {
     await page.goto('/signin');

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSORenewal.spec.ts
@@ -77,7 +77,7 @@ for (const scenario of SCENARIOS) {
       );
 
       let helper: ProviderHelper;
-      let restoreSecurity: (() => Promise<void>) | undefined;
+      let restoreSecurity: ((ssoToken?: string) => Promise<void>) | undefined;
       let userContext: BrowserContext | undefined;
       let userPage: Page | undefined;
 
@@ -98,11 +98,31 @@ for (const scenario of SCENARIOS) {
         }
       );
 
-      test.afterAll('Restore original security configuration', async () => {
-        await userPage?.close();
-        await userContext?.close();
-        await restoreSecurity?.();
-      });
+      test.afterAll(
+        'Restore original security configuration',
+        async ({ browser }) => {
+          test.setTimeout(SSO_LOGIN_HOOK_TIMEOUT_MS);
+
+          await userPage?.close();
+          await userContext?.close();
+
+          // The server session was cleared by the last test; re-login via SSO to
+          // obtain a token valid under the current provider for the restore PUT.
+          let ssoToken: string | undefined;
+          const tempCtx = await browser.newContext();
+          const tempPage = await tempCtx.newPage();
+
+          try {
+            await loginViaSso(tempPage, helper, { username, password });
+            ssoToken = await getToken(tempPage);
+          } finally {
+            await tempPage.close();
+            await tempCtx.close();
+          }
+
+          await restoreSecurity?.(ssoToken);
+        }
+      );
 
       test('should silently refresh the access token after expiry', async () => {
         const page = userPage!;

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSessionLimit.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Auth/SSOSessionLimit.spec.ts
@@ -16,6 +16,7 @@ import { withMaxActiveSessions } from '../../utils/sessionRenewal';
 import { getProviderHelper, ProviderHelper } from '../../utils/sso-providers';
 import { swapSecurityConfig } from '../../utils/ssoAuth';
 import { loginViaSso, SSO_LOGIN_HOOK_TIMEOUT_MS } from '../../utils/ssoLogin';
+import { getToken } from '../../utils/tokenStorage';
 
 // maxActiveSessionsPerUser is enforced server-side (SessionService.applySessionLimit)
 // only when OpenMetadata mints its own session, i.e. a session-bound JWT carrying a
@@ -43,7 +44,7 @@ test.describe('SSO Session Limit', { tag: SESSION_LIMIT_TAGS }, () => {
   );
 
   let helper: ProviderHelper;
-  let restoreSecurity: (() => Promise<void>) | undefined;
+  let restoreSecurity: ((ssoToken?: string) => Promise<void>) | undefined;
   const sessions: { context: BrowserContext; page: Page }[] = [];
 
   test.beforeAll(
@@ -63,11 +64,19 @@ test.describe('SSO Session Limit', { tag: SESSION_LIMIT_TAGS }, () => {
   );
 
   test.afterAll('Restore original security configuration', async () => {
+    // The survivor (last) session is still authenticated — capture its token
+    // before closing so we have a valid SSO token for the restore PUT.
+    const survivor = sessions.at(-1);
+    const ssoToken = survivor
+      ? await getToken(survivor.page).catch(() => undefined)
+      : undefined;
+
     for (const { page, context } of sessions) {
       await page.close();
       await context.close();
     }
-    await restoreSecurity?.();
+
+    await restoreSecurity?.(ssoToken);
   });
 
   test('should evict the least-recently-used session once the cap is exceeded', async ({

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/ssoAuth.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/ssoAuth.ts
@@ -117,13 +117,17 @@ export const restoreSecurityConfig = async (
 
 /**
  * Applies `override` for the lifetime of a suite; returns the restore function.
- * The admin JWT must be captured before the swap — afterwards the admin can no
- * longer authenticate.
+ *
+ * The server rejects a pre-swap basic-auth session token once the provider is
+ * switched to SSO (JwtFilter.validateSessionProviderIsCurrent).  Callers must
+ * pass an `ssoToken` — a JWT minted by the active SSO provider — so the restore
+ * PUT is authenticated under the current provider.  Obtain it by doing a fresh
+ * SSO login in afterAll before calling the restore function.
  */
 export const swapSecurityConfig = async (
   browser: Browser,
   override: ProviderConfigOverride
-): Promise<() => Promise<void>> => {
+): Promise<(ssoToken?: string) => Promise<void>> => {
   const { apiContext, afterAction, token } = await performAdminLogin(browser);
 
   try {
@@ -137,8 +141,8 @@ export const swapSecurityConfig = async (
 
     await applyProviderConfig(apiContext, snapshot, override);
 
-    return async () => {
-      const adminContext = await getAuthContext(token);
+    return async (ssoToken?: string) => {
+      const adminContext = await getAuthContext(ssoToken ?? token);
 
       try {
         await restoreSecurityConfig(adminContext, snapshot);


### PR DESCRIPTION
## Root Cause

`da80689696` added `JwtFilter.validateSessionProviderIsCurrent`, which correctly rejects a basic-auth session token when the server is configured with an SSO provider (the SSO-27 security fix).

`swapSecurityConfig` was storing the **pre-swap basic-auth token** in its restore closure and using it to call `PUT /api/v1/system/security/config` after the server had already switched to SSO mode. The restore PUT returned **401**, leaving the server stuck in SSO mode. Every subsequent SSO test file then tried `POST /api/v1/auth/login` against an SSO-mode server, received an HTML redirect instead of JSON, and crashed with `SyntaxError: Unexpected token '<'`.

## What Changed

**`ssoAuth.ts`** — `swapSecurityConfig` now returns `(ssoToken?: string) => Promise<void>` instead of `() => Promise<void>`. The restore closure uses the caller-supplied `ssoToken` (a JWT minted by the current SSO provider) when provided, and falls back to the pre-swap token otherwise.

**Four spec `afterAll` hooks** — each now obtains a valid SSO-provider token before calling restore:

| Spec | Strategy |
|---|---|
| `SSOSessionLimit` | Captures the still-live **survivor session** token before closing the sessions array |
| `SSOLogin` | Does a fresh `loginViaSso` in a temp context (the user was logged out by test 5) |
| `SSORenewal` | Does a fresh `loginViaSso` (the last test explicitly clears the server session + waits for token expiry) |
| `OktaSessionRenewalPublic` | Does a fresh `loginViaSso` (the last test leaves the page mid-redirect after unrouting) |

## Test Plan

- [ ] SSO nightly CI jobs pass (Keycloak SAML, Okta, cross-site legs)
- [ ] `SSOLogin`, `SSORenewal`, `SSOSessionLimit`, `OktaSessionRenewalPublic` all show green restore in afterAll
- [ ] No regression in non-SSO tests (static admin token path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)