### PR TITLE
MINOR - docs: correct CLAUDE.md license-header guidance (ingestion is Collate, not Apache; only the UI is enforced)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,8 +100,8 @@ but the code is wrong?" — if the answer is "nothing", rewrite it. Assert on ob
 (API responses, DB state), not internal `verify()` calls.
 
 **License headers are per-module — copy one from a sibling file, never assume Apache.** UI TS/TSX:
-Apache-2.0 (`yarn license-header-fix`). Python under `ingestion/` and `openmetadata-airflow-apis/`:
-**Collate Community License 1.0** (`ingestion/LICENSE`). Java: Apache-2.0, most files carry none.
+Apache-2.0 (`yarn license-header-fix`). Python: `ingestion/` is **Collate Community License 1.0** (`ingestion/LICENSE`); `openmetadata-airflow-apis/` Python files use the same Collate header template.
+Java: Apache-2.0, most files carry none.
 Only the UI is enforced — the `ui-license-header` pre-commit hook and CI `ui-checkstyle`; spotless
 and `py_format_check` never look at headers, so a wrong Python or Java header ships silently.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,8 +99,11 @@ for boundaries (HTTP clients, third-party APIs), not internals. Ask "what breaks
 but the code is wrong?" — if the answer is "nothing", rewrite it. Assert on observable outcomes
 (API responses, DB state), not internal `verify()` calls.
 
-**Apache-2.0 license header** on every new source file (Java, Python, TS). UI files:
-`yarn license-header-fix`. CI enforces it.
+**License headers are per-module — copy one from a sibling file, never assume Apache.** UI TS/TSX:
+Apache-2.0 (`yarn license-header-fix`). Python under `ingestion/` and `openmetadata-airflow-apis/`:
+**Collate Community License 1.0** (`ingestion/LICENSE`). Java: Apache-2.0, most files carry none.
+Only the UI is enforced — the `ui-license-header` pre-commit hook and CI `ui-checkstyle`; spotless
+and `py_format_check` never look at headers, so a wrong Python or Java header ships silently.
 
 **Schema-first.** JSON Schemas in `openmetadata-spec/` are the single source of truth; all generated
 code (Java POJOs, Pydantic models, TS types) is derived. **Edit the schema, then regenerate — never


### PR DESCRIPTION
### Describe your changes:

Not applicable — no linked issue. This is a documentation-only correction to `CLAUDE.md`; the defect was found and measured directly in the repo rather than reported as an issue.

`CLAUDE.md` told contributors and coding agents:

> **Apache-2.0 license header** on every new source file (Java, Python, TS). UI files: `yarn license-header-fix`. CI enforces it.

**Both halves are false.**

1. Python under `ingestion/` and `openmetadata-airflow-apis/` is not Apache-2.0 — it is the **Collate Community License 1.0** (`ingestion/LICENSE`). Most Java files carry no header at all.
2. Nothing enforces a header on Python or Java. The only license enforcement in the repo is UI-scoped: the `ui-license-header` pre-commit hook and the "Licence Header Check" step in `ui-checkstyle`.

The rule was contradicted by the script sitting right next to it — `scripts/check-ui-license.sh` says so in its own header comment:

> `# The UI is Apache-2.0; ingestion/ uses the Collate Community License and is deliberately out of this hook's scope.`

**This is not hypothetical.** The wrong guidance was followed during real work on this repo: an Apache-2.0 header was written onto a new `ingestion/` file, and a review round was spent correcting it. Because nothing checks Python headers, neither pre-commit nor CI caught it — the doc was the only control, and it was wrong.

This PR replaces the claim with per-module guidance and states precisely what is and is not enforced:

```
**License headers are per-module — copy one from a sibling file, never assume Apache.** UI TS/TSX:
Apache-2.0 (`yarn license-header-fix`). Python under `ingestion/` and `openmetadata-airflow-apis/`:
**Collate Community License 1.0** (`ingestion/LICENSE`). Java: Apache-2.0, most files carry none.
Only the UI is enforced — the `ui-license-header` pre-commit hook and CI `ui-checkstyle`; spotless
and `py_format_check` never look at headers, so a wrong Python or Java header ships silently.
```

**No source-file license header was changed.** This PR is documentation only — one file, `CLAUDE.md`, +5/-2.

#### Evidence

Measured on this branch at `b1ba2b0` (rebased onto `main` @ `0525d0b4575`):

| Tree | Files | Collate Community License | Apache-2.0 |
|---|---:|---:|---:|
| `ingestion/src/metadata` (`*.py`) | 1425 | **1114** | 5 |
| `ingestion/tests/unit` (`*.py`) | 798 | **599** | 6 |
| `openmetadata-airflow-apis` (`*.py`) | 69 | **54** | 0 |
| UI `src` (`*.ts`/`*.tsx`, non-generated) | 3947 | 0 | **3947** |
| Java repo-wide (excl. `target/`) | 3444 | 0 | **1277** — the other **2167 (63%) carry no header at all** |

```bash
# Collate vs Apache, per tree
grep -rl  'Collate Community License'               <tree> --include='*.py' | wc -l
grep -rlEi 'apache license|apache-2\.0|apache 2\.0' <tree> --include='*.py' | wc -l
```

Enforcement, verified by reading the config rather than assuming:

- `.pre-commit-config.yaml` — the only license hook is `ui-license-header`, whose `files:` regex is scoped to `openmetadata-ui/.../ui/(src|playwright)` and `openmetadata-ui-core-components/.../src`.
- `.github/workflows/ui-checkstyle.yml` — "Licence Header Check" runs `yarn license-header-fix` over changed **UI** files only, and gates on the result.
- `grep -rn 'licenseHeader|apache-rat|license-maven-plugin' --include='pom.xml' .` → **0 hits**. Spotless is configured with `googleJavaFormat` + `removeUnusedImports` only; no license goal anywhere.
- `.github/workflows/py-checkstyle.yml` runs `make py_format_check`, which is `ruff check` + `ruff format --check` (`ingestion/Makefile:59-61`) — neither looks at headers.
- Root `LICENSE` is Apache-2.0; `ingestion/LICENSE` is the Collate Community License Agreement 1.0.

#

### Type of change:

- [x] Documentation

#

### High-level design:

N/A — single-file documentation correction.

#

### Tests:

#### Use cases covered

- A contributor or coding agent adding a new file under `ingestion/` is told to use the Collate Community License, not Apache-2.0.
- A reader is told which checks actually run, so they do not assume CI will catch a wrong Python or Java header.

#### Unit tests

Not applicable — no code changed.

#### Backend integration tests

Not applicable — no backend API changes.

#### Ingestion integration tests

Not applicable — no ingestion code changes. No license header in any source file was modified.

#### Playwright (UI) tests

Not applicable — no UI changes.

#### Manual testing performed

1. Re-ran every count in the evidence table above against the rebased tree and confirmed the numbers cited.
2. Read `.pre-commit-config.yaml`, `scripts/check-ui-license.sh`, `.github/workflows/ui-checkstyle.yml`, `.github/workflows/py-checkstyle.yml`, `ingestion/Makefile`, and the root `pom.xml` spotless block to confirm the enforcement claims.
3. `make harness-check` — output is byte-identical to the pre-edit baseline on the same commit (5 pre-existing warnings, none in `CLAUDE.md`); no new dead reference introduced by the new `ingestion/LICENSE`, `openmetadata-airflow-apis/`, and `yarn license-header-fix` references.
4. `CLAUDE.md` is 173 lines, within the 200-line doc-size budget enforced by `scripts/harness/check_harness.py`.
5. `git diff --stat upstream/main HEAD` touches exactly one file. `AGENTS.md` is still a symlink to `CLAUDE.md` and is untouched.

#

### UI screen recording / screenshots:

Not applicable — no UI changes.

#

### Observations for maintainers (not fixed by this PR)

Two things surfaced while verifying the above. Both are out of scope here and are left for maintainers to judge:

1. **`make harness-check` mutates tracked files.** `scripts/harness/check_harness.py`'s `generated-fresh` check regenerates `docs/generated/api-reference.md` **in place** and leaves it dirty in the working tree, so a "check" command has a write side effect. On this tree it produces a real diff (`1760 → 1761` endpoints; adds `GET /v1/audit/logs/export/{jobId}`), so the staleness warning is legitimate — but anyone running `make harness-check` before `git add -A` will silently sweep that regeneration into an unrelated PR. Comparing into a temp file would avoid it. I reverted it each time it appeared.
2. **~2167 Java files (63%) carry no license header, and nothing in the build enforces one.** If Apache-2.0 on Java is intended, Spotless's `licenseHeader` step is the natural place to enforce it; it is currently absent from every pom.

#

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, no linked issue (docs-only correction).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A, see above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema changes.
- [x] For UI changes: N/A — no UI changes.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above — N/A, documentation-only change with no code paths to test; verification evidence is listed under Manual testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
