### PR TITLE
config: drop tenant-default appMode yaml knob from openmetadata.yaml

### DIFF
--- a/conf/openmetadata.yaml
+++ b/conf/openmetadata.yaml
@@ -858,15 +858,6 @@ rdf:
   dataset: ${RDF_DATASET:-"openmetadata"}
   inferenceEnabled: ${RDF_INFERENCE_ENABLED:-false}
 
-# App Configuration
-# Tenant-wide "first impression" UI default, seeded into the DB-backed appConfiguration
-# setting on first boot only. After that, admins mutate it at runtime via
-# /v1/system/settings/appConfiguration and this yaml value is ignored.
-appConfiguration:
-  # Non-null seeds the app mode for users who have not chosen one (e.g. "ai" or "classic");
-  # user preference and persona-level app mode still win over this default.
-  defaultAppMode: ${APP_DEFAULT_MODE:-null}
-
 # Cache Configuration
 # Caching layer for entity metadata, relationships, and tag usage to reduce database load
 # Default: none (no external dependency). Set CACHE_PROVIDER=redis to enable the


### PR DESCRIPTION
## Summary

Removes the `appConfiguration.defaultAppMode: \${APP_DEFAULT_MODE:-null}` block from `conf/openmetadata.yaml` (originally added by #31099). It's not a knob OSS operators are expected to reach for directly — the resolver's precedence chain (session > hint > user pref > persona > tenant default > `DEFAULT_APP_MODE`) already gives a sensible Classic default without any yaml override, and admins that genuinely need to force a tenant-wide default can still PUT `/v1/system/settings/appConfiguration` at runtime once the DB row is seeded.

## What still works

- `SettingsCache.seedAppConfiguration` (lines 510–522) reads `applicationConfig.getAppConfiguration()`. `OpenMetadataApplicationConfig` initializes that field to `new AppConfiguration()` by default, so on first boot the DB row is still seeded — just with `defaultAppMode = null` regardless of environment.
- The `AppConfiguration` schema (`openmetadata-spec/.../appConfiguration.json`), the settings-cache entry, `SystemResource`'s PUT endpoint, `AppConfigurationSettingTest`, and every UI reference to `appConfig?.defaultAppMode` are untouched.
- No OSS shell scripts, Dockerfiles, Helm charts, or docs reference `APP_DEFAULT_MODE` — the yaml line was the only mention. Verified via repo-wide grep.

## Test plan

- [ ] `mvn -pl openmetadata-service test` — SettingsCache seed + PUT/GET flows still green.
- [ ] Fresh docker boot on `main` with this change — `GET /v1/system/settings/appConfiguration` returns `{ defaultAppMode: null }` and Classic mode resolves for a fresh user.
- [ ] Admin PUT `/v1/system/settings` with `configType: appConfiguration` still writes and takes effect at boot for new users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)