### PR TITLE
Fixes 31564: pass the extended config when formatting a single-value rule

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.js
@@ -1058,7 +1058,17 @@ export function elasticSearchFormat(tree, config, syntax = ES_6_SYNTAX) {
           },
         };
       } else {
-        return buildEsRule(field, value, operator, config, valueSrc, syntax);
+        // extendedConfig, as in every other branch: buildEsRule resolves the field's widget
+        // through the config it is given, and a raw one resolves none — so a fully entered
+        // condition builds no clause at all when this runs on a rule node directly.
+        return buildEsRule(
+          field,
+          value,
+          operator,
+          extendedConfig,
+          valueSrc,
+          syntax
+        );
       }
     }
 

--- a/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/QueryBuilderElasticsearchFormatUtils.test.js
@@ -11,7 +11,10 @@
  *  limitations under the License.
  */
 
-import { AntdConfig } from '@react-awesome-query-builder/antd';
+import {
+  AntdConfig,
+  Utils as QbUtils,
+} from '@react-awesome-query-builder/antd';
 import {
   elasticSearchFormat,
   hasUnfinishedRule,
@@ -286,5 +289,87 @@ describe('hasUnfinishedRule', () => {
     const group = makeGroup([makeTree('equal', [7]), makeTree('equal', [9])]);
 
     expect(hasUnfinishedRule(group, configWithNumberType)).toBe(false);
+  });
+});
+
+// The cases above all use `extension.*` fields, which return from buildEsRule through
+// buildExtensionQuery before the widget is ever resolved. A plain field goes the other way and
+// needs the config the widget lookup expects, so it is the one that exposes issue #31564.
+const SELECT_FIELD = 'service.displayName.keyword';
+const SELECT_VALUE = 'banking-bigquery';
+
+const selectFieldConfig = {
+  ...AntdConfig,
+  fields: {
+    [SELECT_FIELD]: {
+      label: 'Service',
+      type: 'select',
+      fieldSettings: {
+        listValues: { [SELECT_VALUE]: SELECT_VALUE },
+      },
+    },
+  },
+};
+
+const loadSelectTree = (operator, value, valueType) =>
+  QbUtils.checkTree(
+    QbUtils.loadTree({
+      id: 'aaaaaaaa-1111-4111-8111-111111111111',
+      type: 'group',
+      properties: { conjunction: 'AND', not: false },
+      children1: {
+        'bbbbbbbb-2222-4222-8222-222222222222': {
+          type: 'rule',
+          id: 'bbbbbbbb-2222-4222-8222-222222222222',
+          properties: {
+            field: SELECT_FIELD,
+            operator,
+            value,
+            valueSrc: ['value'],
+            valueType: [valueType],
+          },
+        },
+      },
+    }),
+    selectFieldConfig
+  );
+
+const firstRuleOf = (tree) => tree.get('children1').valueSeq().toArray()[0];
+
+describe('elasticSearchFormat – rule node reached directly (Issue #31564)', () => {
+  it('should build the same clause for a rule whether it is reached through its group or on its own', () => {
+    const tree = loadSelectTree('select_equals', [SELECT_VALUE], 'select');
+    const clause = { term: { [SELECT_FIELD]: SELECT_VALUE } };
+
+    expect(
+      elasticSearchFormat(firstRuleOf(tree), selectFieldConfig)
+    ).toStrictEqual(clause);
+    expect(elasticSearchFormat(tree, selectFieldConfig)).toStrictEqual({
+      bool: { must: [clause] },
+    });
+  });
+});
+
+describe('hasUnfinishedRule – entered rules on plain fields (Issue #31564)', () => {
+  it('should accept an entered single-value select condition', () => {
+    const tree = loadSelectTree('select_equals', [SELECT_VALUE], 'select');
+
+    expect(hasUnfinishedRule(tree, selectFieldConfig)).toBe(false);
+  });
+
+  it('should accept an entered multiselect condition', () => {
+    const tree = loadSelectTree(
+      'select_any_in',
+      [[SELECT_VALUE]],
+      'multiselect'
+    );
+
+    expect(hasUnfinishedRule(tree, selectFieldConfig)).toBe(false);
+  });
+
+  it('should still report a single-value select condition with no value entered', () => {
+    const tree = loadSelectTree('select_equals', [undefined], 'select');
+
+    expect(hasUnfinishedRule(tree, selectFieldConfig)).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #31564

## Problem

In **Settings → Personas → \<persona\> → AI Context → Add Rule**, a filter condition that is fully
filled in is rejected on save:

> Finish or remove the unfinished condition before saving. An unfinished condition is ignored, which
> would widen this rule to match everything.

Nothing is unfinished. The match preview in the same drawer resolves the filter and reports the right
count, and "View in Explore" returns the same assets. The rule just cannot be saved from the UI.

It hits any condition using a single-value operator (`Is`, `Is not`, `Contains`, `Is null`,
`Between`, …) on a normal field. Two cases escape: multiselect operators (`Any in`, `Not any in`),
and custom-property (`extension.*`) fields.

## Root cause

`elasticSearchFormat` extends the incoming config once at the top and hands `extendedConfig` to every
branch — the group branch, and the multiselect half of the rule branch — except the single-value half,
which passed the raw `config` straight to `buildEsRule`.

`buildEsRule` resolves the field's widget through that config (`getWidgetForFieldOp` →
`config.widgets[widget]`). A raw config resolves no widget, so it returns `undefined`.

The difference is invisible while a whole tree is formatted, because a rule is then always reached
*through* its group and so always receives an extended config. It surfaces the moment
`elasticSearchFormat` is called on a rule node directly — which is exactly what `hasUnfinishedRule`
(added in #30716) does to decide whether a row was left unfinished. It saw `undefined`, concluded the
row constrained nothing, and blocked the save.

Same tree, same config, opposite answers before this change:

```js
elasticSearchFormat(tree, config)
// {"bool":{"must":[{"term":{"service.displayName.keyword":"banking-bigquery"}}]}}

elasticSearchFormat(firstRuleOf(tree), config)
// undefined

hasUnfinishedRule(tree, config)
// true
```

## Fix

Pass `extendedConfig` to `buildEsRule` in the single-value branch, matching what the multiselect
branch beside it and the group branch already do. Formatting a whole tree is unaffected — the config
reaching `buildEsRule` there was already extended.

## Tests

`QueryBuilderElasticsearchFormatUtils.test.js`, four new cases. The existing `hasUnfinishedRule`
coverage all used `extension.*` fields, which return through `buildExtensionQuery` before the widget
is ever resolved, so it could not see this; the new cases use a plain `select` field and a real
`QbUtils.loadTree`/`checkTree` tree.

- a rule builds the same clause whether reached through its group or on its own
- an entered single-value condition is accepted (fails without the fix)
- an entered multiselect condition is accepted (the path that already worked, pinned)
- a single-value condition with no value entered is still reported — the #30716 behaviour this must
  not regress

```
Tests: 22 passed, 22 total
```

Also green: `QueryBuilder*`, `AdvancedSearch*`, `ContextRule*`, `PersonaAIContext*`, `Explore*`,
`CuratedAssets*` — 487 tests. ESLint clean, no new warnings.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
