### PR TITLE
Fixes #31568: read logical-suite revisions back through the DAO that wrote them

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -1365,14 +1365,20 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
             List.of(testSuiteId),
             TestSuiteRepository.TESTS_REVISION_EXTENSION,
             TestSuiteRepository.getTestsRevisionSchema());
-    Map<UUID, Long> testCaseRevisions = getTestSuiteRelationshipRevisions(testCaseIds);
+    Map<UUID, Long> testCaseRevisions =
+        getTestSuiteRelationshipRevisions(daoCollection, testCaseIds);
     if (testCaseRevisions.size() != testCaseIds.size()) {
-      throw new IllegalStateException("Failed to persist every test suite relationship revision");
+      throw new IllegalStateException(
+          String.format(
+              "Read back %d of %d test suite relationship revisions for test suite '%s'",
+              testCaseRevisions.size(), testCaseIds.size(), testSuiteId));
     }
     Long relationshipRevision =
-        TestSuiteRepository.getTestsRelationshipRevisions(List.of(testSuiteId)).get(testSuiteId);
+        TestSuiteRepository.getTestsRelationshipRevisions(daoCollection, List.of(testSuiteId))
+            .get(testSuiteId);
     if (relationshipRevision == null) {
-      throw new IllegalStateException("Failed to persist the test suite tests revision");
+      throw new IllegalStateException(
+          String.format("Read back no tests revision for test suite '%s'", testSuiteId));
     }
 
     return new LogicalSuiteRelationshipChange(
@@ -1380,10 +1386,26 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
   }
 
   public static Map<UUID, Long> getTestSuiteRelationshipRevisions(List<UUID> testCaseIds) {
+    return getTestSuiteRelationshipRevisions(Entity.getCollectionDAO(), testCaseIds);
+  }
+
+  /**
+   * Reads the revisions through the caller's own DAO, so a caller that has just written them reads
+   * them back over the same connection and therefore inside the same transaction.
+   *
+   * <p>The no-DAO overload resolves {@link Entity#getCollectionDAO()}, which is a mutable global that
+   * the application and the integration-test bootstrap each set to an on-demand DAO over their own
+   * {@link org.jdbi.v3.core.Jdbi}. A repository captures {@code daoCollection} once at construction,
+   * so the two can name different instances — and then a write made on one connection is read back on
+   * another. MySQL pins a REPEATABLE READ snapshot at the transaction's first read and so cannot see
+   * the other connection's later commit at all, which surfaced as this method reporting rows it had
+   * just written as missing. Postgres re-snapshots per statement and hid the same bug.
+   */
+  public static Map<UUID, Long> getTestSuiteRelationshipRevisions(
+      CollectionDAO collectionDAO, List<UUID> testCaseIds) {
     if (nullOrEmpty(testCaseIds)) {
       return Map.of();
     }
-    CollectionDAO collectionDAO = Entity.getCollectionDAO();
     if (collectionDAO == null || collectionDAO.entityExtensionDAO() == null) {
       return Map.of();
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestSuiteRepository.java
@@ -156,10 +156,20 @@ public class TestSuiteRepository extends EntityRepository<TestSuite> {
   }
 
   public static Map<UUID, Long> getTestsRelationshipRevisions(List<UUID> testSuiteIds) {
+    return getTestsRelationshipRevisions(Entity.getCollectionDAO(), testSuiteIds);
+  }
+
+  /**
+   * Reads the revisions through the caller's own DAO, so a caller that has just written them reads
+   * them back over the same connection and therefore inside the same transaction. See {@link
+   * TestCaseRepository#getTestSuiteRelationshipRevisions(CollectionDAO, List)} for why resolving the
+   * mutable global instead lets a write and its read-back land on two different connections.
+   */
+  public static Map<UUID, Long> getTestsRelationshipRevisions(
+      CollectionDAO collectionDAO, List<UUID> testSuiteIds) {
     if (nullOrEmpty(testSuiteIds)) {
       return Map.of();
     }
-    CollectionDAO collectionDAO = Entity.getCollectionDAO();
     if (collectionDAO == null || collectionDAO.entityExtensionDAO() == null) {
       return Map.of();
     }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
@@ -63,6 +64,36 @@ class TestCaseRepositoryTest {
       assertEquals(
           Map.of(firstId, 7L, secondId, 11L),
           TestCaseRepository.getTestSuiteRelationshipRevisions(List.of(firstId, secondId)));
+    }
+  }
+
+  @Test
+  void readsRevisionsThroughTheCallersDaoRatherThanTheGlobalOne() {
+    // A repository writes revisions through the daoCollection it captured at construction and then
+    // reads them straight back. Resolving the mutable Entity.getCollectionDAO() for that read can
+    // land on a different Jdbi's connection, and MySQL pins its REPEATABLE READ snapshot at the
+    // transaction's first read, so the rows just written come back missing.
+    UUID testCaseId = UUID.randomUUID();
+    CollectionDAO callerDAO = mock(CollectionDAO.class);
+    CollectionDAO.EntityExtensionDAO extensionDAO = mock(CollectionDAO.EntityExtensionDAO.class);
+    when(callerDAO.entityExtensionDAO()).thenReturn(extensionDAO);
+    when(extensionDAO.getExtensionBatch(
+            List.of(testCaseId.toString()), TestCaseRepository.TEST_SUITES_REVISION_EXTENSION))
+        .thenReturn(
+            List.of(
+                new CollectionDAO.ExtensionRecordWithId(
+                    testCaseId,
+                    TestCaseRepository.TEST_SUITES_REVISION_EXTENSION,
+                    "{\"revision\":4}")));
+    CollectionDAO globalDAO = mock(CollectionDAO.class);
+
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+      entity.when(Entity::getCollectionDAO).thenReturn(globalDAO);
+
+      assertEquals(
+          Map.of(testCaseId, 4L),
+          TestCaseRepository.getTestSuiteRelationshipRevisions(callerDAO, List.of(testCaseId)));
+      verifyNoInteractions(globalDAO);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestSuiteRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestSuiteRepositoryTest.java
@@ -2,6 +2,7 @@ package org.openmetadata.service.jdbi3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -61,6 +62,35 @@ class TestSuiteRepositoryTest {
       assertEquals(
           Map.of(firstId, 5L, secondId, 13L),
           TestSuiteRepository.getTestsRelationshipRevisions(List.of(firstId, secondId)));
+    }
+  }
+
+  @Test
+  void readsRevisionsThroughTheCallersDaoRatherThanTheGlobalOne() {
+    // The suite revision is written and read back inside one transaction, so the read has to use
+    // the caller's DAO. Going through the mutable Entity.getCollectionDAO() can pick a different
+    // Jdbi's connection, which under MySQL's REPEATABLE READ snapshot cannot see that write.
+    UUID testSuiteId = UUID.randomUUID();
+    CollectionDAO callerDAO = mock(CollectionDAO.class);
+    CollectionDAO.EntityExtensionDAO extensionDAO = mock(CollectionDAO.EntityExtensionDAO.class);
+    when(callerDAO.entityExtensionDAO()).thenReturn(extensionDAO);
+    when(extensionDAO.getExtensionBatch(
+            List.of(testSuiteId.toString()), TestSuiteRepository.TESTS_REVISION_EXTENSION))
+        .thenReturn(
+            List.of(
+                new CollectionDAO.ExtensionRecordWithId(
+                    testSuiteId,
+                    TestSuiteRepository.TESTS_REVISION_EXTENSION,
+                    "{\"revision\":9}")));
+    CollectionDAO globalDAO = mock(CollectionDAO.class);
+
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+      entity.when(Entity::getCollectionDAO).thenReturn(globalDAO);
+
+      assertEquals(
+          Map.of(testSuiteId, 9L),
+          TestSuiteRepository.getTestsRelationshipRevisions(callerDAO, List.of(testSuiteId)));
+      verifyNoInteractions(globalDAO);
     }
   }
 }


### PR DESCRIPTION
### Describe your changes:

Fixes #31568

`TestCaseRepository.prepareLogicalSuiteRelationshipChange` writes the test case and test suite revision rows through the repository's own `daoCollection`, then reads them back through the static helpers, which resolve `Entity.getCollectionDAO()` instead.

That global is mutable: `OpenMetadataApplication.run()` and the integration-test `TestSuiteBootstrap` each set it to an on-demand DAO over **their own `Jdbi`**, while a repository captures `daoCollection` **once at construction** (`EntityRepository.java:666`). The two can therefore name different instances, and the write lands on one connection while the read-back runs on another. MySQL pins a REPEATABLE READ snapshot at the transaction's first read, so it cannot see the other connection's later commit at all and the rows just written come back missing. Postgres re-snapshots per statement — which is precisely why only the MySQL lanes ever failed.

I gave both helpers an overload that takes the caller's DAO and used it from the write path, so a read-back always shares the writer's connection. The four call sites that read *outside* a transaction — `ReindexingUtil`, `SearchIndexRetryWorker`, `TestCaseIndex` and `TestSuiteIndex` — keep resolving the global, which is correct for them.

I also put the counts and the suite id into the two messages. As written they asserted a cause that was never checked ("failed to persist"), which points an investigation at the persistence layer rather than at which connection is being read.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- Adding test cases to a logical test suite succeeds on MySQL when the mutable `Entity.getCollectionDAO()` global does not match the repository's captured `daoCollection`
- Reindexing and search-index builders, which read revisions outside any transaction, keep resolving the global DAO

#### Unit tests
- [x] Added `readsRevisionsThroughTheCallersDaoRatherThanTheGlobalOne` to both `TestCaseRepositoryTest` and `TestSuiteRepositoryTest`. Each points the global at a different DAO and asserts the revisions still come from the caller's DAO and that the global is never touched — so a revert to the global fails both the value assertion and `verifyNoInteractions`.

Local run — `mvn -pl openmetadata-service test -Dtest='*TestCase*Test,*TestSuite*Test,*DataQuality*Test'`:

```
Tests run: 47, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

That set includes `TestCaseIndexTest` and `TestSuiteIndexTest`, which exercise the unchanged single-argument overload.

#### Integration tests
The existing `TestCaseResourceIT` and `TestSuiteResourceIT` logical-suite tests are the real regression coverage — they are the ones failing today on the MySQL lanes. No new IT is added, because reproducing the divergence deterministically needs a second `Jdbi` mid-startup, which the unit tests model directly.

#
### UI Screen Recording:

N/A — no UI change.