### PR TITLE
Fixes #31574: stop the stale redirect cookie navigating users away mid-session

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.test.tsx
@@ -13,6 +13,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { AxiosResponse } from 'axios';
 import { act } from 'react-test-renderer';
+import { REDIRECT_PATHNAME } from '../../../constants/router.constants';
 import { AuthProvider as AuthProviderProps } from '../../../generated/configuration/authenticationConfiguration';
 import axiosClient from '../../../rest';
 import TokenService from '../../../utils/Auth/TokenService/TokenServiceUtil';
@@ -30,6 +31,17 @@ Object.defineProperty(globalThis, 'localStorage', {
 });
 
 const mockOnLogoutHandler = jest.fn();
+const mockSetCookie = jest.fn();
+
+jest.mock('cookie-storage', () => ({
+  CookieStorage: jest.fn().mockImplementation(() => ({
+    getItem: jest.fn(),
+    // Lazily forwarded: the class is constructed at module-import time, before
+    // mockSetCookie's initializer has run
+    setItem: (...args: unknown[]) => mockSetCookie(...args),
+    removeItem: jest.fn(),
+  })),
+}));
 
 jest.mock('../../../hooks/useCustomLocation/useCustomLocation', () => {
   return jest.fn().mockImplementation(() => ({ pathname: 'pathname' }));
@@ -283,6 +295,64 @@ describe('Test axios response interceptor', () => {
     expect(result).toEqual({ data: 'success' });
     expect(mockRefreshToken).toHaveBeenCalled();
     expect(mockAxios).toHaveBeenCalledWith(mockError.config);
+  });
+
+  it('should not store a redirect path for a 401 that the refresh heals', async () => {
+    globalThis.history.pushState({}, '', '/explore/tables');
+    const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
+    jest
+      .spyOn(axiosClient, 'request')
+      .mockImplementation(jest.fn().mockResolvedValue({ data: 'success' }));
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+
+    mockSetCookie.mockClear();
+
+    const [, errorHandler] = mockUse.mock.calls[0];
+    await errorHandler?.({
+      response: { status: 401, data: { message: 'Token expired' } },
+      config: { url: '/api/test' },
+    });
+
+    // The user never leaves the page, so no redirect hint may be armed —
+    // a stale one would later yank them off whatever page they are browsing
+    expect(mockSetCookie).not.toHaveBeenCalledWith(
+      REDIRECT_PATHNAME,
+      expect.anything(),
+      expect.anything()
+    );
+
+    globalThis.history.pushState({}, '', '/');
+  });
+
+  it('should store the current path when the session is dropped to signin', async () => {
+    globalThis.history.pushState({}, '', '/explore/tables?quickFilter=abc');
+    mockRefreshToken.mockResolvedValueOnce(undefined);
+    const mockUse = jest.spyOn(axiosClient.interceptors.response, 'use');
+
+    await act(async () => {
+      render(<WrapperComponent />);
+    });
+
+    mockSetCookie.mockClear();
+
+    const [, errorHandler] = mockUse.mock.calls[0];
+    await act(async () => {
+      await errorHandler?.({
+        response: { status: 401, data: { message: 'Token expired' } },
+        config: { url: '/api/test' },
+      }).catch(() => undefined);
+    });
+
+    expect(mockSetCookie).toHaveBeenCalledWith(
+      REDIRECT_PATHNAME,
+      '/explore/tables?quickFilter=abc',
+      expect.objectContaining({ path: '/' })
+    );
+
+    globalThis.history.pushState({}, '', '/');
   });
 
   it('should queue request when refresh is already in progress', async () => {

--- a/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Auth/AuthProviders/AuthProvider.tsx
@@ -412,7 +412,26 @@ export const AuthProvider = ({
     });
   }, []);
 
+  /**
+   * Stores the current location so the user can be returned to it after login
+   */
+  const handleStoreProtectedRedirectPath = useCallback(() => {
+    // Read the location at call time, not from the closure: the axios
+    // interceptors are registered once on mount, so a closed-over pathname
+    // would be whatever page the app booted on.
+    const { pathname, search } = globalThis.location;
+    if (applicationRoutesClass.isProtectedRoute(pathname)) {
+      storeRedirectPath(`${pathname}${search}`);
+    }
+  }, [storeRedirectPath]);
+
   const resetUserDetails = (forceLogout = false) => {
+    // The user is about to be bounced to /signin — remember where they were so
+    // PermissionProvider can put them back once they authenticate. This is the
+    // only moment the redirect hint is valid; storing it on a 401 that the
+    // silent refresh then heals leaves a stale path armed that later yanks the
+    // user out of whatever page they are on.
+    handleStoreProtectedRedirectPath();
     setCurrentUser({} as User);
     clearOidcToken();
     setIsAuthenticated(false);
@@ -508,18 +527,6 @@ export const AuthProvider = ({
       try {
         const token = await getOidcToken();
         const { isExpired, timeoutExpiry } = extractDetailsFromToken(token);
-
-        // eslint-disable-next-line no-console
-        console.debug(
-          '[VisibilityHandler] token length:',
-          token?.length,
-          'isExpired:',
-          isExpired,
-          'timeoutExpiry:',
-          timeoutExpiry,
-          'hasTokenService:',
-          !!tokenService.current
-        );
 
         if (isExpired || timeoutExpiry <= 0) {
           tokenService.current?.refreshToken();
@@ -619,15 +626,6 @@ export const AuthProvider = ({
     ]
   );
 
-  /**
-   * Stores redirect URL for successful login
-   */
-  const handleStoreProtectedRedirectPath = useCallback(() => {
-    if (applicationRoutesClass.isProtectedRoute(location.pathname)) {
-      storeRedirectPath(location.pathname);
-    }
-  }, [location.pathname, storeRedirectPath]);
-
   const updateAuthInstance = async (
     configJson: AuthenticationConfiguration
   ) => {
@@ -702,7 +700,10 @@ export const AuthProvider = ({
             ) {
               throw error;
             }
-            handleStoreProtectedRedirectPath();
+            // Note: the redirect path is deliberately NOT stored here. Most
+            // 401s are healed by the refresh below and the user never leaves
+            // the page; resetUserDetails() stores it on the paths that do end
+            // in a bounce to /signin.
 
             // Queue the failed request, then ensure exactly one refresh drives
             // the queue in THIS tab. Every 401 lands in pendingRequests; the

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/ErrorBoundary/ErrorBoundary.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/ErrorBoundary/ErrorBoundary.tsx
@@ -13,8 +13,7 @@
 
 import React from 'react';
 import { ErrorBoundary as ErrorBoundaryWrapper } from 'react-error-boundary';
-import { useNavigate } from 'react-router-dom';
-import { ROUTES } from '../../../constants/constants';
+import { useLocation } from 'react-router-dom';
 import ErrorFallback from './ErrorFallback';
 
 interface Props {
@@ -22,16 +21,18 @@ interface Props {
 }
 
 const ErrorBoundary: React.FC<Props> = ({ children }) => {
-  const navigate = useNavigate();
+  const location = useLocation();
 
-  const onErrorReset = () => {
-    navigate(ROUTES.HOME);
-  };
-
+  /*
+   * Retry renders the URL the user is actually on — sending them to the landing
+   * page instead silently discarded whatever they were looking at. `resetKeys`
+   * additionally clears a stuck boundary on any route change, so a failure on
+   * one page does not swallow the rest of the app.
+   */
   return (
     <ErrorBoundaryWrapper
       FallbackComponent={ErrorFallback}
-      onReset={onErrorReset}>
+      resetKeys={[location.pathname, location.search]}>
       {children}
     </ErrorBoundaryWrapper>
   );

--- a/openmetadata-ui/src/main/resources/ui/src/constants/router.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/router.constants.ts
@@ -44,3 +44,11 @@ export const UNPROTECTED_ROUTES: Set<string> = new Set([
 ]);
 
 export const REDIRECT_PATHNAME = 'redirectUrlPath';
+
+/**
+ * Lifetime of the {@link REDIRECT_PATHNAME} cookie. It only has to survive the
+ * round-trip through the identity provider, so it is deliberately short — a
+ * long-lived hint gets replayed later and drops the user on a page they left
+ * minutes ago.
+ */
+export const REDIRECT_PATHNAME_EXPIRY_MS = 5 * 60 * 1000;

--- a/openmetadata-ui/src/main/resources/ui/src/context/PermissionProvider/PermissionProvider.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/PermissionProvider/PermissionProvider.test.tsx
@@ -10,7 +10,8 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { REDIRECT_PATHNAME } from '../../constants/router.constants';
 import {
   getEntityPermissionByFqn,
   getEntityPermissionById,
@@ -19,8 +20,19 @@ import {
 } from '../../rest/permissionAPI';
 import PermissionProvider from './PermissionProvider';
 
+const mockNavigate = jest.fn();
+const mockGetCookie = jest.fn().mockReturnValue(null);
+const mockRemoveCookie = jest.fn();
+
 jest.mock('react-router-dom', () => ({
-  useNavigate: jest.fn().mockImplementation(() => jest.fn()),
+  useNavigate: jest.fn().mockImplementation(() => mockNavigate),
+}));
+
+jest.mock('cookie-storage', () => ({
+  CookieStorage: jest.fn().mockImplementation(() => ({
+    getItem: mockGetCookie,
+    removeItem: mockRemoveCookie,
+  })),
 }));
 
 jest.mock('../../rest/permissionAPI', () => ({
@@ -38,7 +50,11 @@ jest.mock('../../rest/permissionAPI', () => ({
     .mockImplementation(() => Promise.resolve({})),
 }));
 
-let currentUser: { id: string; name: string } | null = {
+let currentUser: {
+  id: string;
+  name: string;
+  teams?: { id: string }[];
+} | null = {
   id: '123',
   name: 'Test User',
 };
@@ -56,6 +72,12 @@ jest.mock('../../components/common/Loader/Loader', () => {
 });
 
 describe('PermissionProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCookie.mockReturnValue(null);
+    currentUser = { id: '123', name: 'Test User' };
+  });
+
   it('Should render loader and call getLoggedInUserPermissions', async () => {
     render(
       <PermissionProvider>
@@ -101,5 +123,57 @@ describe('PermissionProvider', () => {
 
     expect(screen.queryByText('Loader')).not.toBeInTheDocument();
     expect(await screen.findByTestId('children')).toBeInTheDocument();
+  });
+
+  it('Should consume the stored redirect path only once and delete the cookie', async () => {
+    mockGetCookie.mockReturnValue('/glossary/sample');
+
+    const { rerender } = render(
+      <PermissionProvider>
+        <div data-testid="children">Children</div>
+      </PermissionProvider>
+    );
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/glossary/sample')
+    );
+
+    expect(mockRemoveCookie).toHaveBeenCalledWith(REDIRECT_PATHNAME, {
+      path: '/',
+    });
+
+    // A later permission refetch — triggered by a teams/roles identity change,
+    // e.g. a persona save — must not replay the redirect
+    currentUser = { id: '123', name: 'Test User', teams: [] };
+
+    rerender(
+      <PermissionProvider>
+        <div data-testid="children">Children</div>
+      </PermissionProvider>
+    );
+
+    await waitFor(() =>
+      expect(getLoggedInUserPermissions).toHaveBeenCalledTimes(2)
+    );
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should not navigate when the stored path is the current location', async () => {
+    // jsdom's default location is http://localhost/
+    mockGetCookie.mockReturnValue('/');
+
+    render(
+      <PermissionProvider>
+        <div data-testid="children">Children</div>
+      </PermissionProvider>
+    );
+
+    await waitFor(() => expect(getLoggedInUserPermissions).toHaveBeenCalled());
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockRemoveCookie).toHaveBeenCalledWith(REDIRECT_PATHNAME, {
+      path: '/',
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/context/PermissionProvider/PermissionProvider.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/context/PermissionProvider/PermissionProvider.tsx
@@ -33,7 +33,6 @@ import {
   getLoggedInUserPermissions,
   getResourcePermission,
 } from '../../rest/permissionAPI';
-import { setUrlPathnameExpiryAfterRoute } from '../../utils/AuthProvider.util';
 import {
   getOperationPermissions,
   getUIPermission,
@@ -102,13 +101,32 @@ const PermissionProvider: FC<PermissionProviderProps> = ({ children }) => {
     Map<ResourceEntity, Promise<ReturnType<typeof getOperationPermissions>>>
   >(new Map());
 
+  // Latches the one-shot post-login redirect, see redirectToStoredPath below
+  const hasConsumedRedirectPath = useRef(false);
+
+  /*
+   * The redirect cookie is a ONE-SHOT "resume where you left off" hint, written
+   * only when the app is about to bounce the user through login. Permissions
+   * are re-fetched whenever currentUser's teams/roles identity changes (persona
+   * save, team update, profile edit), so consuming the cookie on every fetch
+   * used to yank a user who was quietly browsing to a page they left minutes
+   * ago. The ref latches consumption for this session and the cookie is deleted
+   * on read — resetPermissions() re-arms it across a logout/login boundary.
+   */
   const redirectToStoredPath = useCallback(() => {
+    if (hasConsumedRedirectPath.current) {
+      return;
+    }
+    hasConsumedRedirectPath.current = true;
+
     const urlPathname = cookieStorage.getItem(REDIRECT_PATHNAME);
-    if (urlPathname) {
-      setUrlPathnameExpiryAfterRoute(urlPathname);
+    cookieStorage.removeItem(REDIRECT_PATHNAME, { path: '/' });
+
+    const { pathname, search } = globalThis.location;
+    if (urlPathname && urlPathname !== `${pathname}${search}`) {
       navigate(urlPathname);
     }
-  }, [history]);
+  }, [navigate]);
 
   /**
    * Fetch permission for logged in user
@@ -236,6 +254,8 @@ const PermissionProvider: FC<PermissionProviderProps> = ({ children }) => {
     entityPermissionByIdInflight.current.clear();
     entityPermissionByFqnInflight.current.clear();
     resourcePermissionInflight.current.clear();
+    // Re-arm the post-login redirect for the next principal
+    hasConsumedRedirectPath.current = false;
   }, [setEntitiesPermission, setPermissions, setResourcesPermission]);
 
   useEffect(() => {

--- a/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/SignUpPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/SignUp/SignUpPage.tsx
@@ -25,10 +25,7 @@ import { ClientType } from '../../generated/configuration/authenticationConfigur
 import { EntityReference } from '../../generated/entity/type';
 import { useApplicationStore } from '../../hooks/useApplicationStore';
 import { createUser } from '../../rest/userAPI';
-import {
-  getNameFromUserData,
-  setUrlPathnameExpiryAfterRoute,
-} from '../../utils/AuthProvider.util';
+import { getNameFromUserData } from '../../utils/AuthProvider.util';
 import brandClassBase from '../../utils/BrandData/BrandClassBase';
 import { Transi18next } from '../../utils/i18next/LocalUtil';
 import { showErrorToast } from '../../utils/ToastUtils';
@@ -64,10 +61,9 @@ const SignUp = () => {
         },
       });
       updateCurrentUser(res);
-      const urlPathname = cookieStorage.getItem(REDIRECT_PATHNAME);
-      if (urlPathname) {
-        setUrlPathnameExpiryAfterRoute(urlPathname);
-      }
+      // A brand new user has no page to resume — drop the redirect hint so it
+      // cannot fire later while they are browsing.
+      cookieStorage.removeItem(REDIRECT_PATHNAME, { path: '/' });
       setIsSigningUp(false);
       navigate(ROUTES.HOME);
     } catch (error) {

--- a/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/AuthProvider.util.ts
@@ -12,7 +12,6 @@
  */
 
 import type { AuthenticationResult, Configuration } from '@azure/msal-browser';
-import { CookieStorage } from 'cookie-storage';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 import { first, get, isEmpty, isNil } from 'lodash';
 import { WebStorageStateStore } from 'oidc-client';
@@ -23,7 +22,7 @@ import {
 } from '../components/Auth/AuthProviders/AuthProvider.interface';
 import { ROUTES } from '../constants/constants';
 import { EMAIL_REG_EX } from '../constants/regex.constants';
-import { REDIRECT_PATHNAME } from '../constants/router.constants';
+import { REDIRECT_PATHNAME_EXPIRY_MS } from '../constants/router.constants';
 import {
   AuthenticationConfiguration,
   ClientType,
@@ -35,8 +34,6 @@ import { t } from './i18next/LocalUtil';
 import { oidcTokenStorage } from './OidcTokenStorage';
 import { SSO_TEST_LOGIN_STORE_PREFIX } from './SsoTestLoginPopup';
 import { setOidcToken } from './SwTokenStorageUtils';
-
-const cookieStorage = new CookieStorage();
 
 // 1 minutes for client auth approach
 export const EXPIRY_THRESHOLD_MILLES = 1 * 60 * 1000;
@@ -418,7 +415,7 @@ export const isTourRoute = (pathname: string) => {
 };
 
 export const getUrlPathnameExpiry = () => {
-  return new Date(Date.now() + 60 * 60 * 1000);
+  return new Date(Date.now() + REDIRECT_PATHNAME_EXPIRY_MS);
 };
 
 /**
@@ -463,14 +460,6 @@ export const extractDetailsFromToken = (token: string) => {
     isExpired: true,
     timeoutExpiry: 0,
   };
-};
-
-export const setUrlPathnameExpiryAfterRoute = (pathname: string) => {
-  cookieStorage.setItem(REDIRECT_PATHNAME, pathname, {
-    // 1 second expiry
-    expires: new Date(Date.now() + 1000),
-    path: '/',
-  });
 };
 
 /**


### PR DESCRIPTION
### Describe your changes:

Fixes #31574

Users browsing the app — most visibly clicking service aggregations / filters in Explore — were intermittently thrown onto the landing page, Glossary or Connections. The click was never the cause.

**Root cause.** The `redirectUrlPath` cookie is meant to be a one-shot "resume where you were after login" hint. Today:

- `AuthProvider` writes it on **every refreshable 401** with a **1-hour** TTL, including 401s the silent refresh heals and the user never notices.
- The axios interceptors are registered once in a `useEffect` with an empty dep array, so `handleStoreProtectedRedirectPath` closes over `location.pathname` **from app boot** — the stored path is not where the user actually is.
- `PermissionProvider.redirectToStoredPath()` runs on **every** permission fetch and navigates unconditionally. That effect is keyed on `currentUser?.teams` / `?.roles` — **array identities** — so every `setCurrentUser` (persona save, team update, profile edit, boot) replays it.
- Consumption never deleted the cookie; it re-wrote it with a 1-second expiry, which is a race, not a clear.

So: a token expiry while browsing armed a stale path, and an unrelated user-state update minutes later navigated there. The same cookie also explains "I hit refresh on the upgrade screen and landed somewhere else" — on boot the permission fetch replays an hour-old path and discards the URL that was reloaded.

**Changes**

- `PermissionProvider.tsx` — consume the hint **once per session** (ref latch, re-armed by `resetPermissions()` across a logout/login boundary), **delete** the cookie on read, skip the navigate when the stored path already equals `pathname + search`, and fix the `[history]` dep to `[navigate]`.
- `AuthProvider.tsx` — read the location **at call time** (`globalThis.location`) so the boot-time closure cannot write a stale path, store `pathname + search`, and store **only from `resetUserDetails`** (the paths that really bounce to `/signin`) instead of from every 401.
- `router.constants.ts` / `AuthProvider.util.ts` — cookie TTL 1 hour → 5 minutes via `REDIRECT_PATHNAME_EXPIRY_MS`; removed `setUrlPathnameExpiryAfterRoute` (the 1-second-expiry pseudo-delete).
- `SignUpPage.tsx` — a brand-new user has nothing to resume, so the cookie is deleted outright.
- `ErrorBoundary.tsx` — retry now re-renders the URL that failed instead of `navigate(ROUTES.HOME)`, and `resetKeys` on the location clears a stuck boundary on route change.
- Removed a leftover `[VisibilityHandler]` `console.debug`.

#
### Type of change:

- [x] Bug fix

#
### Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/open-metadata/OpenMetadata/blob/main/CONTRIBUTING.md) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

#
### Tests

New unit tests (all green, `yarn test`, 4 suites / 40 tests):

`PermissionProvider.test.tsx`
- consumes the stored redirect path **once**, deletes the cookie, and does not replay it on a second permission fetch triggered by a `teams`/`roles` identity change;
- does not navigate when the stored path is already the current location.

`AuthProvider.test.tsx`
- a 401 that the refresh heals writes **no** `redirectUrlPath` cookie;
- a session drop to `/signin` stores the **current** path (`/explore/tables?quickFilter=abc`), not the boot-time one.

Also verified: `eslint` 0 errors on the changed files, `prettier --check` clean, `tsc --noEmit` reports nothing new for them.

### Manual test steps

1. `document.cookie = "redirectUrlPath=/glossary; path=/"` while sitting on `/explore`.
2. Trigger a `currentUser` update (save a persona preference on My Data) or reload.
3. Before: yanked to `/glossary`. After: stays put.
4. Token-expiry path: shorten the JWT expiry, sit on `/explore`, let the token expire and keep clicking aggregations — no navigation away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)