### PR TITLE
test(ui): de-flake Data Quality toast assertions against cross-worker toast leakage (#31576) [2.0]

### DIFF
--- a/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx
+++ b/openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx
@@ -81,6 +81,7 @@ export const Toast = ({ toast }: ToastProps) => {
         'tw:animate-in tw:fade-in tw:slide-in-from-bottom-2 tw:duration-150'
       )}
       data-testid="alert-bar"
+      data-variant={variant}
       toast={toast}>
       <span className="tw:mt-0.5 tw:flex tw:shrink-0" data-testid="alert-icon">
         <Icon

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -32,6 +32,7 @@ import {
   redirectToHomePage,
   toastNotification,
   uuid,
+  waitForToastToDisappear,
 } from '../../../utils/common';
 import {
   dismissTagSuggestions,
@@ -319,10 +320,9 @@ test.describe(
 
         await page.getByTestId('create-btn').click();
         await updateTestCaseResponse;
-        await toastNotification(page, 'Test case updated successfully.');
-        await page.getByTestId('alert-bar').waitFor({
-          state: 'detached',
-        });
+        const updateSuccessMessage = 'Test case updated successfully.';
+        await toastNotification(page, updateSuccessMessage);
+        await waitForToastToDisappear(page, updateSuccessMessage);
 
         await page
           .getByTestId(`action-dropdown-${NEW_TABLE_TEST_CASE.name}`)

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts
@@ -23,7 +23,11 @@ import test, { expect } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { TableClass } from '../../../support/entity/TableClass';
 import { UserClass } from '../../../support/user/UserClass';
-import { createNewPage, redirectToHomePage } from '../../../utils/common';
+import {
+  createNewPage,
+  expectNoErrorToast,
+  redirectToHomePage,
+} from '../../../utils/common';
 import { sidebarClick } from '../../../utils/sidebar';
 
 type IncidentListResponse = {
@@ -193,10 +197,7 @@ test('Incident Manager renders after a test case owner change', async ({
     const response = await pageIncidentListResponse;
     expect(response.status()).toBe(200);
 
-    const errorToast = page
-      .locator('[data-testid="alert-bar"]')
-      .filter({ hasText: /Unrecognized field|owners/i });
-    await expect(errorToast).toHaveCount(0);
+    await expectNoErrorToast(page, /Unrecognized field|owners/i);
   } finally {
     await table.delete(apiContext).catch(() => undefined);
     if (owner.responseData.id) {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterSoftDelete.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterSoftDelete.spec.ts
@@ -28,7 +28,11 @@
 import test, { expect } from '@playwright/test';
 import { SidebarItem } from '../../../constant/sidebar';
 import { TableClass } from '../../../support/entity/TableClass';
-import { createNewPage, redirectToHomePage } from '../../../utils/common';
+import {
+  createNewPage,
+  expectNoErrorToast,
+  redirectToHomePage,
+} from '../../../utils/common';
 import { sidebarClick } from '../../../utils/sidebar';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -105,12 +109,10 @@ test('Incident Manager renders without Jackson error after a test case is soft-d
     expect(response.status()).toBe(200);
 
     // And the toast bar must not surface a Jackson "Unrecognized field"/"deleted" error.
-    // Scope to the toast container so we don't false-positive on legitimate page text
-    // (e.g. a table cell that happens to contain the word "deleted").
-    const errorToast = page
-      .locator('[data-testid="alert-bar"]')
-      .filter({ hasText: /Unrecognized field|deleted/i });
-    await expect(errorToast).toHaveCount(0);
+    // Scoped to error-variant toasts so we don't false-positive on legitimate page text
+    // (e.g. a table cell containing "deleted") nor on the background
+    // '"<entity>" deleted successfully!' notification a parallel worker can trigger.
+    await expectNoErrorToast(page, /Unrecognized field|deleted/i);
   } finally {
     await table.delete(apiContext);
     await afterAction();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts
@@ -343,6 +343,49 @@ export const toastNotification = async (
   await expect(toast.getByTestId('alert-icon')).toBeVisible();
 };
 
+/**
+ * Waits until the toast carrying `message` is gone.
+ *
+ * Always filter by message instead of waiting on a bare `alert-bar` locator: toasts
+ * are a stacking queue, and the backend fans async-delete/job notifications out to
+ * every socket of the logged-in user — so a parallel worker's cleanup can pop an
+ * unrelated toast into this page and turn an unfiltered locator into a strict-mode
+ * violation.
+ */
+export const waitForToastToDisappear = async (
+  page: Page,
+  message: string | RegExp,
+  timeout?: number
+) => {
+  await page
+    .getByTestId('alert-bar')
+    .filter({ hasText: message })
+    .first()
+    .waitFor({ state: 'detached', timeout });
+};
+
+/**
+ * Asserts that the page is showing no error toast, optionally narrowed to the
+ * ones carrying `message`.
+ *
+ * Scoped to the error variant on purpose — a bare `alert-bar` assertion also
+ * catches the background success notifications the backend fans out to every
+ * socket of the logged-in user (async delete, export jobs), which a parallel
+ * worker can trigger at any moment.
+ */
+export const expectNoErrorToast = async (
+  page: Page,
+  message?: string | RegExp
+) => {
+  const errorToast = page.locator(
+    '[data-testid="alert-bar"][data-variant="error"]'
+  );
+
+  await expect(
+    message ? errorToast.filter({ hasText: message }) : errorToast
+  ).toHaveCount(0);
+};
+
 export const clickOutside = async (page: Page) => {
   await page.locator('body').click({
     position: {


### PR DESCRIPTION
### Describe your changes:

Cherry-pick of #31576 (merged to `main` as `9d2c38e`) onto `2.0`.

I worked on **de-flaking the Data Quality Playwright toast assertions**, because
`Data Quality › Table test case` failed on both attempts in a nightly run with a strict-mode
violation, and the same root cause is latent in the Incident Manager regression specs.

**Root cause** (unchanged from #31576)

1. Toasts are a stacking react-aria queue and **every** entry carries `data-testid="alert-bar"`,
   so two visible toasts is normal product behaviour.
2. `AsyncDeleteProvider` shows `"{{entity}}" deleted successfully!` on the `deleteEntityChannel`,
   delivered by `WebSocketManager.sendToOne(userId, …)` — which loops over **all** sockets of that
   user.
3. Playwright runs `fullyParallel` with every worker on `playwright/.auth/admin.json`, so another
   worker's cleanup pops a toast into this test's page:

```
strict mode violation: getByTestId('alert-bar') resolved to 2 elements:
  1) …hasText: 'Test case updated'
  2) …hasText: '"pw-stored-procedure-0cb0e6e0'   ← retry 0
  2) …hasText: '"pw-search-index-413b57bb"'      ← retry 1
```

**Changes**

- `waitForToastToDisappear(page, message)` and `expectNoErrorToast(page, message?)` in
  `playwright/utils/common.ts`, both scoped so background toasts cannot interfere.
- `toast.tsx` emits `data-variant={variant}` — there was no DOM hook for the toast variant, so
  "no error toast" could not be expressed without also catching background success notifications.
  One additive attribute; no styling or behaviour change.
- `DataQuality.spec.ts` waits only for the toast the step itself produced.
- `IncidentManagerAfterSoftDelete` / `IncidentManagerAfterOwnerChange`: their
  `/Unrecognized field|deleted/i` and `/…|owners/i` filters matched the background
  `"pw-xxx" deleted successfully!` notification; now scoped to the error variant, so they still
  catch the Jackson regression they were written for and nothing else.

**Difference from the `main` PR**

#31576 also fixed `FailedTestCaseSampleData.spec.ts`. That hunk is **omitted here** — the
`Failed rows sample fetch gating` describe block it asserts in does not exist on `2.0`, and that
file has no toast assertion on this branch. 5 files instead of 6; everything else is identical.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — cherry-pick of an already-reviewed change.

#
### Tests:

#### Use cases covered
- `Data Quality › Table test case` survives an unrelated toast landing mid-step.
- Both Incident Manager regression specs still fail on an `Unrecognized field` error toast, and no
  longer fail on `"<entity>" deleted successfully!`.

#### Unit tests
Not applicable — no product logic changed; the single source change is a `data-*` test hook.

#### Backend integration tests
Not applicable — no backend API changes.

#### Ingestion integration tests
Not applicable — no ingestion changes.

#### Playwright (UI) tests
This PR *is* the Playwright change. Files updated on `2.0`:
- `playwright/utils/common.ts`
- `playwright/e2e/Features/DataQuality/DataQuality.spec.ts`
- `playwright/e2e/Features/DataQuality/IncidentManagerAfterSoftDelete.spec.ts`
- `playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts`

#### Manual testing performed
Verification run against the `2.0` tree after the cherry-pick:

1. `eslint` on the 4 changed playwright files → 0 messages.
2. `prettier --check` on those 4 → clean; `prettier --check` on `toast.tsx` with the
   core-components config → clean.
3. Conflict resolution reviewed by hand: the only conflict was `FailedTestCaseSampleData.spec.ts`,
   resolved to `2.0`'s content because the block being patched does not exist there.

The specs themselves were not executed locally — they need a live stack with ingestion. Asking for
a CI run on this branch.

#
### UI screen recording / screenshots:

Not applicable — no user-visible UI change. `data-variant` is an inert test attribute.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>` — N/A, cherry-pick of #31576
      (a CI de-flake with no linked issue, following #31528 / #31533 / #31541).
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above — N/A, same reason.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: N/A — no schema changes.
- [x] For UI changes: N/A — no visual change.
- [x] I have added tests (unit / integration / Playwright as applicable) and listed them above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR de-flakes Data Quality Playwright checks by scoping toast assertions to their message and variant.
- Adds an inert `data-variant` hook to the shared toast component.
- Adds helpers for waiting on a specific toast and excluding only matching error toasts.
- Updates the Data Quality and Incident Manager regression specs to ignore unrelated cross-worker success notifications.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the toast selectors consistently narrowed to the notifications each test intends to observe.

The production change only exposes an existing variant as a test attribute, and the Playwright helpers preserve their assertions while preventing unrelated stacked success toasts from causing strict-locator failures.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui-core-components/src/main/resources/ui/src/components/application/toast/toast.tsx | Exposes the existing toast variant through a data attribute without changing rendering behavior. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts | Adds message-scoped disappearance and error-variant absence helpers for stacked toast queues. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts | Waits for only the update-success toast to disappear before continuing. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterOwnerChange.spec.ts | Restricts the owner-change regression assertion to matching error toasts. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/IncidentManagerAfterSoftDelete.spec.ts | Restricts the soft-delete regression assertion to matching error toasts while ignoring background deletion successes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): de-flake Data Quality toast as..."](https://github.com/open-metadata/openmetadata/commit/3725890b7df66ea036e71ff651904b461b954d88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53732961)</sub>

<!-- /greptile_comment -->