### PR TITLE
test(ui): stop the CSV jobs tray from blocking the test-case import/export E2E

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -76,15 +76,63 @@ const scrollIntoViewCenter = async (locator: Locator) => {
     .catch(() => undefined);
 };
 
-// The CSV jobs tray is position:fixed at bottom-right and can appear at any
-// moment during a test (mid-fill, mid-modal, mid-drag) as background jobs
-// complete. Injecting pointer-events:none once disables click interception for
-// the entire page session — no need to poll or dismiss at every step.
-const disableCsvJobsTrayInterception = async (page: Page) => {
-  await page.addStyleTag({
-    content:
-      '.csv-jobs-tray-popover, .csv-jobs-tray-launcher-wrap { pointer-events: none !important; }',
-  });
+const CSV_JOBS_TRAY_INERT_CSS =
+  '.csv-jobs-tray-popover, .csv-jobs-tray-launcher-wrap { pointer-events: none !important; }';
+
+// Pages that already carry the suppression. addInitScript stacks, so without
+// this guard a page routed through several import helpers would grow one style
+// tag per call.
+const csvJobsTraySuppressedPages = new WeakSet<Page>();
+
+/**
+ * Make the CSV background-jobs tray click-through for the rest of this page's
+ * life.
+ *
+ * The tray is a position:fixed panel anchored at bottom:88px that auto-expands
+ * whenever a job it is watching reaches a terminal status. Because the anchor
+ * pins its lower edge just above the viewport bottom, it lands on the profiler's
+ * Manage button (measured at 1280x720: button y 596-636, tray bottom y 632), and
+ * a single job is enough — extra rows only push the top edge higher.
+ *
+ * A spec's own export therefore triggers this. Jobs from other workers make it
+ * worse rather than causing it: `/api/v1/csvAsyncJobs` is scoped per *user* and
+ * every worker shares the admin identity, so unrelated jobs both grow the panel
+ * and keep re-expanding it mid-test.
+ *
+ * addStyleTag alone is not enough — it lives on the current document and dies on
+ * the next hard navigation. addInitScript re-applies the rule to every document
+ * the page loads afterwards, so one call at the start of a flow holds for the
+ * whole flow.
+ *
+ * pointer-events (not display) so the tray stays in the DOM: specs that assert
+ * on it still see it, they just must not route through this helper.
+ */
+export const suppressCsvJobsTray = async (page: Page) => {
+  if (csvJobsTraySuppressedPages.has(page)) {
+    return;
+  }
+
+  csvJobsTraySuppressedPages.add(page);
+
+  await page.addInitScript((css: string) => {
+    const applyStyle = () => {
+      const style = document.createElement('style');
+      style.textContent = css;
+      document.head.appendChild(style);
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyStyle);
+    } else {
+      applyStyle();
+    }
+  }, CSV_JOBS_TRAY_INERT_CSS);
+
+  // addInitScript only reaches documents loaded from now on, so the document
+  // already on screen needs the rule injected directly.
+  await page
+    .addStyleTag({ content: CSV_JOBS_TRAY_INERT_CSS })
+    .catch(() => undefined);
 };
 
 const getTextEditorCandidates = (page: Page) => {
@@ -1001,7 +1049,7 @@ export const startCsvPreviewAndWaitForGrid = async (
   // Disable the CSV jobs tray's click interception for the entire page session.
   // The tray can appear at any moment (mid-fill, mid-modal, mid-drag) so a
   // one-shot CSS injection is more robust than polling at specific steps.
-  await disableCsvJobsTrayInterception(page);
+  await suppressCsvJobsTray(page);
 
   if (
     !(await waitForVisibleLocator(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
@@ -29,6 +29,7 @@ import {
   fillTagDetails,
   pressKeyXTimes,
   startCsvPreviewAndWaitForGrid,
+  suppressCsvJobsTray,
 } from './importUtils';
 
 export const getFailedRowsData = (table: TableClass) => {
@@ -708,6 +709,25 @@ export const addTestCaseValidationRows = async (
   );
 };
 
+const IMPORT_LOAD_MASK_SELECTOR =
+  '.inovua-react-toolkit-load-mask__background-layer';
+
+/**
+ * Click the import preview's Update button once nothing is covering it.
+ *
+ * This used to pass { force: true } for an "element obscured by overlay" that
+ * was never pinned down. There are two real obstructions: the grid's load mask,
+ * which this waits out, and the background-jobs tray, which suppressCsvJobsTray
+ * makes click-through at the start of the flow. With both handled the click can
+ * go through Playwright's actionability checks, so a future overlay regression
+ * surfaces here instead of being forced past.
+ */
+const clickImportUpdateButton = async (page: Page) => {
+  await page.locator(IMPORT_LOAD_MASK_SELECTOR).waitFor({ state: 'detached' });
+
+  await page.click('[type="button"] >> text="Update"');
+};
+
 /**
  * Perform complete E2E export-import-validate flow
  * @param page - Playwright page object
@@ -721,6 +741,12 @@ export const performE2EExportImportFlow = async (
 ) => {
   const { validateImportStatus } = await import('./importUtils');
   const { test } = await import('@playwright/test');
+
+  // Step 1's export finishes mid-flow and auto-expands the background-jobs tray
+  // over the profiler's Manage button, so every later clickManageButton retries
+  // until the test times out. Neutralise the tray before the first export rather
+  // than inside the import helpers, which run after the first blocked click.
+  await suppressCsvJobsTray(page);
 
   // Step 1: Export test case details
   await test.step('Export test case details to downloads folder', async () => {
@@ -789,11 +815,10 @@ export const performE2EExportImportFlow = async (
         response.url().includes('recursive=true')
     );
 
-    // eslint-disable-next-line playwright/no-force-option -- element obscured by overlay
-    await page.click('[type="button"] >> text="Update"', { force: true });
+    await clickImportUpdateButton(page);
     await updateButtonResponse;
     await page
-      .locator('.inovua-react-toolkit-load-mask__background-layer')
+      .locator(IMPORT_LOAD_MASK_SELECTOR)
       .waitFor({ state: 'detached' });
     await toastNotification(page, /updated successfully/);
   });
@@ -866,11 +891,10 @@ export const performE2EExportImportFlow = async (
         response.url().includes('dryRun=false')
     );
 
-    // eslint-disable-next-line playwright/no-force-option -- element obscured by overlay
-    await page.click('[type="button"] >> text="Update"', { force: true });
+    await clickImportUpdateButton(page);
     await bulkEditUpdateResponse;
     await page
-      .locator('.inovua-react-toolkit-load-mask__background-layer')
+      .locator(IMPORT_LOAD_MASK_SELECTOR)
       .waitFor({ state: 'detached' });
     await toastNotification(page, /updated successfully/);
 


### PR DESCRIPTION
## Describe your changes

`TestCaseImportExportE2eFlow` times out after 300s inside `clickManageButton`, retrying a click Playwright reports as `<div class="csv-jobs-tray"> subtree intercepts pointer events`.

The background-jobs tray is a `position: fixed` panel anchored at `bottom: 88px` that auto-expands when a job it is watching turns terminal. That anchor pins its lower edge just above the viewport bottom — exactly where the profiler's Manage button sits. Measured at 1280x720: button `y 596-636`, tray bottom `y 632`. **A single job is enough to cover it**; extra rows only push the top edge higher. Step 1's own export triggers this. Jobs from other workers make it worse rather than cause it, since `/api/v1/csvAsyncJobs` is scoped per *user* and every worker shares the admin identity.

A guard for this already existed, but it could neither fire in time nor survive:

- it was installed inside `startCsvPreviewAndWaitForGrid`, which runs **after** the first blocked click; and
- it used `page.addStyleTag`, which lives on the current document and is destroyed by the next hard navigation (`visitDataQualityTab`), leaving the later steps unprotected — which is why the two `{ force: true }` escapes were still needed.

### Changes

- `suppressCsvJobsTray` installs the rule via `addInitScript`, so it re-applies to every document the page loads, plus `addStyleTag` for the document already on screen. Re-entry is guarded by a `WeakSet<Page>` so repeated calls don't stack style tags.
- Called before the first export in `performE2EExportImportFlow`, not after the first blocked click.
- Both `{ force: true }` escapes on the Update button removed. `force` does **not** click through a covering overlay — it skips the actionability checks but still dispatches at the element's coordinates, so the overlay receives the event and the button never fires. Waiting the grid's load mask out makes the click real, and lets a future overlay regression surface instead of being forced past.

`pointer-events: none` rather than `display: none`, so the tray stays in the DOM. Verified the three specs that assert on the tray — `CsvJobsTray`, `MetricBulkImportExportEdit`, `SearchExport` — never route through the suppressed helpers, and that every download in a suppressed spec goes through the API (`fetchCompletedCsvAsyncJobResult`), never the tray's Download button.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Verified against a running stack with the tray expanded over the Manage button:

| | Result |
|---|---|
| Tray expanded, no guard | fails with `intercepts pointer events` — same error as CI |
| Same tray, guard applied | click succeeds, Manage dropdown opens |

The intercepting elements in the reproduction match the CI trace, including the `Download` span and `csv-jobs-tray-item-success`.

Also confirmed separately that `addStyleTag` works on the current document but is lost across a hard navigation, while `addInitScript` survives — the specific reason the previous guard did not protect the later steps.

> [!NOTE]
> This is a test-side guard. Auto-expanding the tray is intended product behaviour, so the panel will keep appearing during any spec that touches CSV export/import. Worth considering separately whether it should collapse on outside click, or cap its row count, so a user's click on the page isn't swallowed — a real user who exports and then reaches for Manage hits the same wall.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the test-case CSV import/export E2E flow by making the background-jobs tray click-through across page navigations and removing forced Update clicks.

- Adds persistent, per-Page CSV tray suppression using an initialization script and current-document style injection.
- Applies suppression before the first export can expand the tray over subsequent controls.
- Waits for the import grid load mask before performing normal actionable Update clicks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable regression identified in the changed E2E utilities.

The suppression is installed before the tray-producing export, persists across subsequent documents, remains isolated from tray-interaction specs, and the Update-click refactoring preserves the existing load-mask wait behavior while restoring Playwright actionability checks.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts | Adds idempotent, navigation-persistent tray suppression and reuses it when starting CSV previews; no actionable defect identified. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts | Activates tray suppression before export and replaces forced Update clicks with load-mask-aware normal clicks; no actionable defect identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): stop the CSV jobs tray from bl..."](https://github.com/open-metadata/openmetadata/commit/4c44575fd5efcb0a495d7760486139957484f81f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53733775)</sub>

<!-- /greptile_comment -->