### PR TITLE
test(ui): stop the CSV jobs tray from blocking the test-case import/export E2E (#31589) [2.0]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts
@@ -42,7 +42,7 @@ import {
 import { selectActiveGlossary } from '../../utils/glossary';
 import {
   createGlossaryTermRowDetails,
-  disableCsvJobsTrayInterception,
+  suppressCsvJobsTray,
   fillGlossaryRowDetails,
   startCsvPreviewAndWaitForGrid,
   validateImportStatus,
@@ -144,7 +144,7 @@ test.describe('Glossary Bulk Import Export', () => {
     // the import preview begins, which is after the reviewer edit.
     // redirectToHomePage is the only hard navigation here, so injecting once at
     // this point covers the whole test.
-    await disableCsvJobsTrayInterception(page);
+    await suppressCsvJobsTray(page);
   });
 
   test('Glossary Bulk Import Export', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts
@@ -76,15 +76,63 @@ const scrollIntoViewCenter = async (locator: Locator) => {
     .catch(() => undefined);
 };
 
-// The CSV jobs tray is position:fixed at bottom-right and can appear at any
-// moment during a test (mid-fill, mid-modal, mid-drag) as background jobs
-// complete. Injecting pointer-events:none once disables click interception for
-// the entire page session — no need to poll or dismiss at every step.
-export const disableCsvJobsTrayInterception = async (page: Page) => {
-  await page.addStyleTag({
-    content:
-      '.csv-jobs-tray-popover, .csv-jobs-tray-launcher-wrap { pointer-events: none !important; }',
-  });
+const CSV_JOBS_TRAY_INERT_CSS =
+  '.csv-jobs-tray-popover, .csv-jobs-tray-launcher-wrap { pointer-events: none !important; }';
+
+// Pages that already carry the suppression. addInitScript stacks, so without
+// this guard a page routed through several import helpers would grow one style
+// tag per call.
+const csvJobsTraySuppressedPages = new WeakSet<Page>();
+
+/**
+ * Make the CSV background-jobs tray click-through for the rest of this page's
+ * life.
+ *
+ * The tray is a position:fixed panel anchored at bottom:88px that auto-expands
+ * whenever a job it is watching reaches a terminal status. Because the anchor
+ * pins its lower edge just above the viewport bottom, it lands on the profiler's
+ * Manage button (measured at 1280x720: button y 596-636, tray bottom y 632), and
+ * a single job is enough — extra rows only push the top edge higher.
+ *
+ * A spec's own export therefore triggers this. Jobs from other workers make it
+ * worse rather than causing it: `/api/v1/csvAsyncJobs` is scoped per *user* and
+ * every worker shares the admin identity, so unrelated jobs both grow the panel
+ * and keep re-expanding it mid-test.
+ *
+ * addStyleTag alone is not enough — it lives on the current document and dies on
+ * the next hard navigation. addInitScript re-applies the rule to every document
+ * the page loads afterwards, so one call at the start of a flow holds for the
+ * whole flow.
+ *
+ * pointer-events (not display) so the tray stays in the DOM: specs that assert
+ * on it still see it, they just must not route through this helper.
+ */
+export const suppressCsvJobsTray = async (page: Page) => {
+  if (csvJobsTraySuppressedPages.has(page)) {
+    return;
+  }
+
+  csvJobsTraySuppressedPages.add(page);
+
+  await page.addInitScript((css: string) => {
+    const applyStyle = () => {
+      const style = document.createElement('style');
+      style.textContent = css;
+      document.head.appendChild(style);
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', applyStyle);
+    } else {
+      applyStyle();
+    }
+  }, CSV_JOBS_TRAY_INERT_CSS);
+
+  // addInitScript only reaches documents loaded from now on, so the document
+  // already on screen needs the rule injected directly.
+  await page
+    .addStyleTag({ content: CSV_JOBS_TRAY_INERT_CSS })
+    .catch(() => undefined);
 };
 
 const getTextEditorCandidates = (page: Page) => {
@@ -1001,7 +1049,7 @@ export const startCsvPreviewAndWaitForGrid = async (
   // Disable the CSV jobs tray's click interception for the entire page session.
   // The tray can appear at any moment (mid-fill, mid-modal, mid-drag) so a
   // one-shot CSS injection is more robust than polling at specific steps.
-  await disableCsvJobsTrayInterception(page);
+  await suppressCsvJobsTray(page);
 
   if (
     !(await waitForVisibleLocator(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
@@ -29,6 +29,7 @@ import {
   fillTagDetails,
   pressKeyXTimes,
   startCsvPreviewAndWaitForGrid,
+  suppressCsvJobsTray,
 } from './importUtils';
 
 export const getFailedRowsData = (table: TableClass) => {
@@ -708,6 +709,25 @@ export const addTestCaseValidationRows = async (
   );
 };
 
+const IMPORT_LOAD_MASK_SELECTOR =
+  '.inovua-react-toolkit-load-mask__background-layer';
+
+/**
+ * Click the import preview's Update button once nothing is covering it.
+ *
+ * This used to pass { force: true } for an "element obscured by overlay" that
+ * was never pinned down. There are two real obstructions: the grid's load mask,
+ * which this waits out, and the background-jobs tray, which suppressCsvJobsTray
+ * makes click-through at the start of the flow. With both handled the click can
+ * go through Playwright's actionability checks, so a future overlay regression
+ * surfaces here instead of being forced past.
+ */
+const clickImportUpdateButton = async (page: Page) => {
+  await page.locator(IMPORT_LOAD_MASK_SELECTOR).waitFor({ state: 'detached' });
+
+  await page.click('[type="button"] >> text="Update"');
+};
+
 /**
  * Perform complete E2E export-import-validate flow
  * @param page - Playwright page object
@@ -721,6 +741,12 @@ export const performE2EExportImportFlow = async (
 ) => {
   const { validateImportStatus } = await import('./importUtils');
   const { test } = await import('@playwright/test');
+
+  // Step 1's export finishes mid-flow and auto-expands the background-jobs tray
+  // over the profiler's Manage button, so every later clickManageButton retries
+  // until the test times out. Neutralise the tray before the first export rather
+  // than inside the import helpers, which run after the first blocked click.
+  await suppressCsvJobsTray(page);
 
   // Step 1: Export test case details
   await test.step('Export test case details to downloads folder', async () => {
@@ -789,11 +815,10 @@ export const performE2EExportImportFlow = async (
         response.url().includes('recursive=true')
     );
 
-    // eslint-disable-next-line playwright/no-force-option -- element obscured by overlay
-    await page.click('[type="button"] >> text="Update"', { force: true });
+    await clickImportUpdateButton(page);
     await updateButtonResponse;
     await page
-      .locator('.inovua-react-toolkit-load-mask__background-layer')
+      .locator(IMPORT_LOAD_MASK_SELECTOR)
       .waitFor({ state: 'detached' });
     await toastNotification(page, /updated successfully/);
   });
@@ -866,11 +891,10 @@ export const performE2EExportImportFlow = async (
         response.url().includes('dryRun=false')
     );
 
-    // eslint-disable-next-line playwright/no-force-option -- element obscured by overlay
-    await page.click('[type="button"] >> text="Update"', { force: true });
+    await clickImportUpdateButton(page);
     await bulkEditUpdateResponse;
     await page
-      .locator('.inovua-react-toolkit-load-mask__background-layer')
+      .locator(IMPORT_LOAD_MASK_SELECTOR)
       .waitFor({ state: 'detached' });
     await toastNotification(page, /updated successfully/);
 


### PR DESCRIPTION
## Describe your changes

Cherry-pick of #31589 onto `2.0`.

`TestCaseImportExportE2eFlow` times out after 300s inside `clickManageButton`, retrying a click Playwright reports as `<div class="csv-jobs-tray"> subtree intercepts pointer events`.

The background-jobs tray is a `position: fixed` panel anchored at `bottom: 88px` that auto-expands when a job it is watching turns terminal. That anchor pins its lower edge just above the viewport bottom — exactly where the profiler's Manage button sits. Measured at 1280x720: button `y 596-636`, tray bottom `y 632`. **A single job is enough to cover it**; extra rows only push the top edge higher, so the spec's own Step 1 export triggers this. Jobs from other workers make it worse rather than cause it, since `/api/v1/csvAsyncJobs` is scoped per *user* and every worker shares the admin identity.

The existing guard could neither fire in time nor survive:

- it was installed inside `startCsvPreviewAndWaitForGrid`, which runs **after** the first blocked click; and
- it used `page.addStyleTag`, which lives on the current document and is destroyed by the next hard navigation (`visitDataQualityTab`) — which is why the two `{ force: true }` escapes were still needed.

### Changes

- `suppressCsvJobsTray` installs the rule via `addInitScript`, so it re-applies to every document the page loads, plus `addStyleTag` for the document already on screen. Re-entry guarded by a `WeakSet<Page>` so repeated calls don't stack style tags.
- Called before the first export in `performE2EExportImportFlow`.
- Both `{ force: true }` escapes on the Update button removed. `force` does **not** click through a covering overlay — it skips the actionability checks but still dispatches at the element's coordinates, so the overlay receives the event and the button never fires. Waiting the grid's load mask out makes the click real.

### Delta from the original commit

On `2.0` the helper is exported and has a second call site in `GlossaryImportExport.spec.ts`, which `main` does not have. That call site is renamed to `suppressCsvJobsTray` along with the helper — so this cherry-pick touches 3 files rather than 2. No behavioural difference for that spec beyond the guard now surviving navigation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Verified on `main` by the full Playwright suite — 34 shards, all green, including the 3 `import-export` shards that actually run this spec ([run 31936946562](https://github.com/open-metadata/OpenMetadata/actions/runs/31936946562)).

Also reproduced and fixed against a running stack: with the tray expanded over the Manage button the click fails with the same `intercepts pointer events` error as CI, and passes with the guard applied. The intercepting elements in the reproduction matched the CI trace, including the `Download` span and `csv-jobs-tray-item-success`.

> [!NOTE]
> `playwright/utils/**` maps to `sharedInfrastructure` in the impact map, which selects smoke + canary — neither includes the import/export specs. So a targeted PR run will **not** exercise this fix; it needs a `workflow_dispatch` with `full_suite=true`.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes the CSV jobs tray click-through throughout Playwright page navigations and applies that suppression before the first test-case export. It also replaces forced Update clicks with explicit load-mask synchronization, but the new pre-click synchronization waits for the wrong lifecycle state.
- Renames and extends the tray-suppression helper using a persistent page init script.
- Applies suppression earlier in test-case import/export and updates the glossary call site.
- Removes forced Update clicks and introduces a shared click helper.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The load-mask synchronization should be corrected before merging because it can make both changed import stages time out before clicking Update.

The new helper waits for load-mask detachment before the click, while the established lifecycle hides the mask before Update and detaches it afterward.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts | Adds navigation-persistent CSV tray suppression with current-document coverage and per-Page deduplication. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts | Applies tray suppression before export and replaces forced Update clicks, but the pre-click detached-state wait can stall after the mask is merely hidden. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/GlossaryImportExport.spec.ts | Updates the glossary setup to use the renamed persistent tray-suppression helper. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): stop the CSV jobs tray from bl..."](https://github.com/open-metadata/openmetadata/commit/13afdcabef40dc969a8628384fb4a3402ec622e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53872811)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->