### PR TITLE
fix(context-center) UI: scope document search to selected folder

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -527,9 +527,9 @@ test.describe('Context Center - Documents Page', () => {
         url.pathname.includes('/api/v1/search/query') &&
         url.searchParams.get('index') === 'contextFile',
       async (route) => {
-        const isFolderScoped = decodeURIComponent(route.request().url()).includes(
-          folder.id
-        );
+        const isFolderScoped = decodeURIComponent(
+          route.request().url()
+        ).includes(folder.id);
         const hits = isFolderScoped
           ? [{ _source: { ...inFolderDoc } }]
           : [{ _source: { ...inFolderDoc } }, { _source: { ...outsideDoc } }];

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -484,6 +484,86 @@ test.describe('Context Center - Documents Page', () => {
     });
   });
 
+  // ─── Search scoped to selected folder ────────────────────────────────────
+
+  test('searching with folder selected scopes results to that folder only', async ({
+    browser,
+    page,
+  }) => {
+    const folderName = `search-scope-folder-${uuid()}`;
+    const docInFolderName = `in-folder-${uuid()}.txt`;
+    const docOutsideName = `outside-folder-${uuid()}.txt`;
+
+    // ── Setup: create folder + upload one doc inside, one outside ──
+    const { apiContext, afterAction } = await createNewPage(browser);
+    const folderRes = await apiContext.post(
+      '/api/v1/contextCenter/drive/folders',
+      { data: { name: folderName, displayName: folderName } }
+    );
+    const folderBody = await folderRes.text();
+
+    expect(folderRes.status(), folderBody).toBe(201);
+
+    const folder = parseResponseJson<ContextCenterFolder>(folderBody);
+
+    contextFolderIdsToCleanup.add(folder.id);
+
+    await uploadDocument(
+      apiContext,
+      docInFolderName,
+      Buffer.from('document inside folder'),
+      folder.fullyQualifiedName
+    );
+    await uploadDocument(
+      apiContext,
+      docOutsideName,
+      Buffer.from('document outside folder')
+    );
+    await afterAction();
+
+    await navigateToDocuments(page);
+
+    const searchInput = page
+      .getByTestId('context-center-header')
+      .getByTestId('search-input')
+      .getByLabel('Search Documents');
+
+    // ── Step 1: Search with no folder selected → request has no folder filter ──
+    const noFolderSearchResPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/search/query') &&
+        res.url().includes('index=contextFile')
+    );
+
+    await searchInput.fill('in-folder');
+    const noFolderSearchRes = await noFolderSearchResPromise;
+
+    expect(noFolderSearchRes.status()).toBe(200);
+    expect(decodeURIComponent(noFolderSearchRes.request().url())).not.toContain(
+      folder.id
+    );
+
+    // ── Step 2: Clear search, select folder ──
+    await searchInput.clear();
+    await waitForAllLoadersToDisappear(page);
+    await selectFolderInSidebar(page, folderName);
+
+    // ── Step 3: Search again with folder selected → request includes folder id as filter ──
+    const folderSearchResPromise = page.waitForResponse(
+      (res) =>
+        res.url().includes('/api/v1/search/query') &&
+        res.url().includes('index=contextFile')
+    );
+
+    await searchInput.fill('in-folder');
+    const folderSearchRes = await folderSearchResPromise;
+
+    expect(folderSearchRes.status()).toBe(200);
+    expect(decodeURIComponent(folderSearchRes.request().url())).toContain(
+      folder.id
+    );
+  });
+
   // ─── Basic rendering ──────────────────────────────────────────────────────
 
   test('shows header with Upload File button', async ({ page }) => {

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts
@@ -490,11 +490,11 @@ test.describe('Context Center - Documents Page', () => {
     browser,
     page,
   }) => {
-    const folderName = `search-scope-folder-${uuid()}`;
-    const docInFolderName = `in-folder-${uuid()}.txt`;
-    const docOutsideName = `outside-folder-${uuid()}.txt`;
+    const sharedToken = uuid();
+    const folderName = `search-scope-folder-${sharedToken}`;
+    const docInFolderName = `doc-${sharedToken}-in.txt`;
+    const docOutsideName = `doc-${sharedToken}-out.txt`;
 
-    // ── Setup: create folder + upload one doc inside, one outside ──
     const { apiContext, afterAction } = await createNewPage(browser);
     const folderRes = await apiContext.post(
       '/api/v1/contextCenter/drive/folders',
@@ -508,18 +508,41 @@ test.describe('Context Center - Documents Page', () => {
 
     contextFolderIdsToCleanup.add(folder.id);
 
-    await uploadDocument(
+    const inFolderDoc = await uploadDocument(
       apiContext,
       docInFolderName,
       Buffer.from('document inside folder'),
       folder.fullyQualifiedName
     );
-    await uploadDocument(
+    const outsideDoc = await uploadDocument(
       apiContext,
       docOutsideName,
       Buffer.from('document outside folder')
     );
+
     await afterAction();
+
+    await page.route(
+      (url) =>
+        url.pathname.includes('/api/v1/search/query') &&
+        url.searchParams.get('index') === 'contextFile',
+      async (route) => {
+        const isFolderScoped = decodeURIComponent(route.request().url()).includes(
+          folder.id
+        );
+        const hits = isFolderScoped
+          ? [{ _source: { ...inFolderDoc } }]
+          : [{ _source: { ...inFolderDoc } }, { _source: { ...outsideDoc } }];
+
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            hits: { hits, total: { value: hits.length } },
+          }),
+        });
+      }
+    );
 
     await navigateToDocuments(page);
 
@@ -527,41 +550,45 @@ test.describe('Context Center - Documents Page', () => {
       .getByTestId('context-center-header')
       .getByTestId('search-input')
       .getByLabel('Search Documents');
+    const view = page.getByTestId('documents-view');
 
-    // ── Step 1: Search with no folder selected → request has no folder filter ──
     const noFolderSearchResPromise = page.waitForResponse(
       (res) =>
         res.url().includes('/api/v1/search/query') &&
         res.url().includes('index=contextFile')
     );
 
-    await searchInput.fill('in-folder');
-    const noFolderSearchRes = await noFolderSearchResPromise;
+    await searchInput.fill(sharedToken);
+    await noFolderSearchResPromise;
+    await waitForAllLoadersToDisappear(page);
 
-    expect(noFolderSearchRes.status()).toBe(200);
-    expect(decodeURIComponent(noFolderSearchRes.request().url())).not.toContain(
-      folder.id
-    );
+    await expect(
+      view.locator(`[data-testid="document-row-${inFolderDoc.id}"]`)
+    ).toBeVisible();
+    await expect(
+      view.locator(`[data-testid="document-row-${outsideDoc.id}"]`)
+    ).toBeVisible();
 
-    // ── Step 2: Clear search, select folder ──
     await searchInput.clear();
     await waitForAllLoadersToDisappear(page);
     await selectFolderInSidebar(page, folderName);
 
-    // ── Step 3: Search again with folder selected → request includes folder id as filter ──
     const folderSearchResPromise = page.waitForResponse(
       (res) =>
         res.url().includes('/api/v1/search/query') &&
         res.url().includes('index=contextFile')
     );
 
-    await searchInput.fill('in-folder');
-    const folderSearchRes = await folderSearchResPromise;
+    await searchInput.fill(sharedToken);
+    await folderSearchResPromise;
+    await waitForAllLoadersToDisappear(page);
 
-    expect(folderSearchRes.status()).toBe(200);
-    expect(decodeURIComponent(folderSearchRes.request().url())).toContain(
-      folder.id
-    );
+    await expect(
+      view.locator(`[data-testid="document-row-${inFolderDoc.id}"]`)
+    ).toBeVisible();
+    await expect(
+      view.locator(`[data-testid="document-row-${outsideDoc.id}"]`)
+    ).not.toBeVisible();
   });
 
   // ─── Basic rendering ──────────────────────────────────────────────────────

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx
@@ -104,6 +104,8 @@ const ContextCenterArticlesPage = () => {
   const [showAddLinkModal, setShowAddLinkModal] = useState(false);
   const [editingQuickLink, setEditingQuickLink] = useState<KnowledgePage>();
   const [articleSearchQuery, setArticleSearchQuery] = useState('');
+  const [debouncedArticleSearchQuery, setDebouncedArticleSearchQuery] =
+    useState('');
   const [isArticlesListEmpty, setIsArticlesListEmpty] = useState(false);
   const [permissionFetchFailed, setPermissionFetchFailed] = useState(false);
 
@@ -125,6 +127,15 @@ const ContextCenterArticlesPage = () => {
       showErrorToast(error as AxiosError);
     }
   }, []);
+
+  useEffect(() => {
+    const id = setTimeout(
+      () => setDebouncedArticleSearchQuery(articleSearchQuery),
+      300
+    );
+
+    return () => clearTimeout(id);
+  }, [articleSearchQuery]);
 
   const handlePageChange = useCallback(
     (incoming: Partial<KnowledgeCenterPageProps>) => {
@@ -354,7 +365,7 @@ const ContextCenterArticlesPage = () => {
         rightPanelSlot={
           contextCenterClassBase.isEmbeddedMode() ? null : undefined
         }
-        searchQuery={articleSearchQuery}
+        searchQuery={debouncedArticleSearchQuery}
         onEmptyStateChange={setIsArticlesListEmpty}
         onPageChange={handlePageChange}
       />
@@ -365,7 +376,7 @@ const ContextCenterArticlesPage = () => {
     isRightPanelOpen,
     permissions,
     isPermissionsLoading,
-    articleSearchQuery,
+    debouncedArticleSearchQuery,
     handlePageChange,
     handleFetchKnowledgePageHierarchy,
     handleToggleRightPanel,

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -81,6 +81,7 @@ const ContextCenterDocumentsPage: FC = () => {
   const [isDocumentsLoading, setIsDocumentsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [documentSearchQuery, setDocumentSearchQuery] = useState('');
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
   const [isDeletingFile, setIsDeletingFile] = useState(false);
   const [fileToDelete, setFileToDelete] = useState<ContextFile>();
   const [isBulkDeleting, setIsBulkDeleting] = useState(false);
@@ -201,6 +202,12 @@ const ContextCenterDocumentsPage: FC = () => {
     [folders]
   );
 
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedSearchQuery(documentSearchQuery), 300);
+
+    return () => clearTimeout(id);
+  }, [documentSearchQuery]);
+
   const fetchDocuments = useCallback(
     async (after?: string) => {
       if (!after) {
@@ -216,12 +223,21 @@ const ContextCenterDocumentsPage: FC = () => {
         setIsDocumentsLoading(true);
       }
       try {
-        if (documentSearchQuery) {
+        if (debouncedSearchQuery) {
           const results = await fetchSearchResults({
-            query: documentSearchQuery,
+            query: debouncedSearchQuery,
             searchIndex: SearchIndex.DRIVE_FILE,
             sortField: 'updatedAt',
             sortOrder: 'desc',
+            ...(selectedFolderId && {
+              queryFilter: {
+                query: {
+                  bool: {
+                    filter: { term: { 'folder.id': selectedFolderId } },
+                  },
+                },
+              },
+            }),
           });
           if (generation !== fetchGenerationRef.current) {
             return;
@@ -264,7 +280,7 @@ const ContextCenterDocumentsPage: FC = () => {
         }
       }
     },
-    [documentSearchQuery, pageSize, handlePagingChange, selectedFolderId]
+    [debouncedSearchQuery, pageSize, handlePagingChange, selectedFolderId]
   );
 
   const handleLoadMore = useCallback(() => {
@@ -272,12 +288,12 @@ const ContextCenterDocumentsPage: FC = () => {
       paging.after &&
       !isDocumentsLoading &&
       !isLoadingMoreRef.current &&
-      !documentSearchQuery
+      !debouncedSearchQuery
     ) {
       isLoadingMoreRef.current = true;
       fetchDocuments(paging.after);
     }
-  }, [paging.after, isDocumentsLoading, documentSearchQuery, fetchDocuments]);
+  }, [paging.after, isDocumentsLoading, debouncedSearchQuery, fetchDocuments]);
 
   useEffect(() => {
     fetchDocuments();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx
@@ -203,7 +203,10 @@ const ContextCenterDocumentsPage: FC = () => {
   );
 
   useEffect(() => {
-    const id = setTimeout(() => setDebouncedSearchQuery(documentSearchQuery), 300);
+    const id = setTimeout(
+      () => setDebouncedSearchQuery(documentSearchQuery),
+      300
+    );
 
     return () => clearTimeout(id);
   }, [documentSearchQuery]);


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Fixes #<issue-number>
<!--
Linking an issue is REQUIRED. Replace <issue-number> with the GitHub issue number this PR addresses
(e.g., `Fixes #12345`). GitHub will auto-link it. If no issue exists, please open one first so the
problem and design can be discussed before review.
-->

<!--
Short blurb explaining:
- What changes did you make?
- Why did you make them?
-->

I worked on ... because ...

#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

----
## Summary by Gitar

- **Search & Folder Scoping:**
    - Added debounce handling for document and article search queries in `ContextCenterDocumentsPage` and `ContextCenterArticlesPage`
    - Scoped drive file search queries to the selected folder via `folder.id` query filter
- **Testing:**
    - Added Playwright end-to-end test verifying folder-scoped search functionality in `ContextCenterDocument.spec.ts`

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds debounced Context Center searches and scopes document search requests to the selected folder.
- Adds a `folder.id` term filter to document search requests.
- Debounces document and article search input by 300 ms.
- Adds Playwright coverage for searching with and without a selected folder.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/ContextCenterDocument.spec.ts | Adds folder-scoped document-search coverage with matching documents inside and outside the selected folder. |
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterDocumentsPage/ContextCenterDocumentsPage.tsx | Debounces document searches and adds the selected folder as a search query filter. |
| openmetadata-ui/src/main/resources/ui/src/pages/ContextCenterPage/ContextCenterArticlesPage/ContextCenterArticlesPage.tsx | Debounces article search input before passing it to the article list. |

</details>

<sub>Reviews (4): Last reviewed commit: ["lint fix"](https://github.com/open-metadata/openmetadata/commit/a4913af075103057e8a3eedfd5df2af9c3b229b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53889301)</sub>

<!-- /greptile_comment -->