### PR TITLE
test(ui): use test.use admin.json storageState in InputOutputPorts spec

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
@@ -11,7 +11,7 @@
  *  limitations under the License.
  */
 
-import base, { expect, Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { get } from 'lodash';
 import { SidebarItem } from '../../constant/sidebar';
 import { DataProduct } from '../../support/domain/DataProduct';
@@ -45,19 +45,9 @@ import {
 } from '../../utils/inputOutputPorts';
 import { sidebarClick } from '../../utils/sidebar';
 
-const domain = new Domain();
+test.use({ storageState: 'playwright/.auth/admin.json' });
 
-const test = base.extend<{
-  page: Page;
-}>({
-  page: async ({ browser }, setPage) => {
-    const { page, afterAction } = await performAdminLogin(browser, {
-      navigate: true,
-    });
-    await setPage(page);
-    await afterAction();
-  },
-});
+const domain = new Domain();
 
 test.describe('Input Output Ports', () => {
   const tables: TableClass[] = [];
@@ -998,7 +988,6 @@ test.describe('Input Output Ports', () => {
       await test.step('Open and cancel removal dialog', async () => {
         const portId = tables[0].entityResponseData.id;
 
-        await waitForPortRow(page, portId);
         await page.getByTestId(`port-actions-${portId}`).click();
         await page.getByRole('menuitem', { name: 'Remove' }).click();
 


### PR DESCRIPTION
## What
`InputOutputPorts.spec.ts` rolled its own admin `page` fixture via `base.extend` + `performAdminLogin(browser, { navigate: true })`, running a full UI login per worker. Switched to the repo-standard `test.use({ storageState: 'playwright/.auth/admin.json' })`, which reuses the pre-authenticated admin session created by `auth.setup.ts`.

## Changes
- `import { test } from '@playwright/test'` + `test.use({ storageState: 'playwright/.auth/admin.json' })`, matching existing specs (VersionPages, Features, nightly).
- Removed the local `base.extend` admin-login fixture and now-unused `base`/`Page` imports.
- Kept `performAdminLogin(browser)` (API-only, `navigate: false`) in `beforeAll`/`afterAll` for entity seeding/cleanup — that path returns an `apiContext` and never opens a page.
- Dropped one redundant `waitForPortRow` call.

## Why
Avoids a per-worker interactive login, less bespoke fixture code, aligns with the handbook's shared-auth pattern.

## Tests
Playwright-only change; `ui-checkstyle` (eslint + prettier + organize-imports) run clean on the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the spec’s custom interactive admin-login fixture with the shared Playwright admin storage state while retaining API authentication for entity setup and cleanup.
- Uses `playwright/.auth/admin.json` for the page fixture.
- Removes the bespoke `base.extend` fixture and associated imports.
- Removes port-row recovery from the cancellation scenario.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because the cancellation test can still time out when the ports API returns the documented transient empty-row response.

The direct action-button click remains reachable without `waitForPortRow`, while the helper documents that this backend response cannot recover without remounting the list through a reload.

**Files Needing Attention:** openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/InputOutputPorts.spec.ts | Adopts shared admin storage state correctly, but the cancellation test still lacks the previously reported reload-based recovery for transiently missing port rows. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into playwright-fixt..."](https://github.com/open-metadata/openmetadata/commit/8487c1d56f535219222f828195400e9c4a56a4ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53890359)</sub>

<!-- /greptile_comment -->