### PR TITLE
feat(contextCenter): support sortBy/sortOrder on page hierarchy search

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
@@ -172,7 +172,7 @@ public class KnowledgePageHierarchyIT {
         .untilAsserted(
             () -> {
               List<PageHierarchy> asc =
-                  listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=asc").getData();
+                  listSearchHierarchy(rest, "?limit=1000&sortBy=name&sortOrder=asc").getData();
               int a = indexOfId(asc, pageA.getId());
               int m = indexOfId(asc, pageM.getId());
               int z = indexOfId(asc, pageZ.getId());
@@ -182,7 +182,7 @@ public class KnowledgePageHierarchyIT {
             });
 
     List<PageHierarchy> desc =
-        listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=desc").getData();
+        listSearchHierarchy(rest, "?limit=1000&sortBy=name&sortOrder=desc").getData();
     int a = indexOfId(desc, pageA.getId());
     int m = indexOfId(desc, pageM.getId());
     int z = indexOfId(desc, pageZ.getId());

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java
@@ -12,6 +12,7 @@
  */
 package org.openmetadata.it.tests;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.ws.rs.core.Response;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import org.apache.http.client.HttpResponseException;
@@ -55,6 +57,7 @@ public class KnowledgePageHierarchyIT {
 
   private static final String KC_PATH = "v1/contextCenter/pages";
   private static final String KC_HIERARCHY_PATH = KC_PATH + "/hierarchy";
+  private static final String KC_SEARCH_HIERARCHY_PATH = KC_PATH + "/search/hierarchy";
   private static final String PARENT_FIELD = "parent";
   private static final String RELATED_ENTITIES_FIELD = "relatedEntities";
   private static final String ORGANIZATION_NAME = "Organization";
@@ -118,6 +121,72 @@ public class KnowledgePageHierarchyIT {
 
   private boolean containsTopLevelId(ResultList<PageHierarchy> hierarchy, UUID id) {
     return hierarchy.getData().stream().anyMatch(node -> id.equals(node.getId()));
+  }
+
+  private ResultList<PageHierarchy> listSearchHierarchy(RestClient rest, String query) {
+    String path = KC_SEARCH_HIERARCHY_PATH + query;
+    try (Response response = rest.rawGet(path)) {
+      assertEquals(
+          200, response.getStatus(), "Search hierarchy call failed: " + response.getStatus());
+      String body = response.readEntity(String.class);
+      return JsonUtils.readValue(body, new TypeReference<ResultList<PageHierarchy>>() {});
+    }
+  }
+
+  private int indexOfId(List<PageHierarchy> nodes, UUID id) {
+    for (int i = 0; i < nodes.size(); i++) {
+      if (id.equals(nodes.get(i).getId())) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortBy(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response = rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=notAField")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchyRejectsInvalidSortOrder(TestNamespace ns) {
+    RestClient rest = RestClient.admin();
+    try (Response response =
+        rest.rawGet(KC_SEARCH_HIERARCHY_PATH + "?sortBy=name&sortOrder=sideways")) {
+      assertEquals(400, response.getStatus(), response.readEntity(String.class));
+    }
+  }
+
+  @Test
+  void testSearchHierarchySortsByName(TestNamespace ns) throws HttpResponseException {
+    RestClient rest = RestClient.admin();
+    Page pageA = createPage(rest, buildCreateRequest(ns.prefix("aaa-sort"), null));
+    Page pageM = createPage(rest, buildCreateRequest(ns.prefix("mmm-sort"), null));
+    Page pageZ = createPage(rest, buildCreateRequest(ns.prefix("zzz-sort"), null));
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .untilAsserted(
+            () -> {
+              List<PageHierarchy> asc =
+                  listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=asc").getData();
+              int a = indexOfId(asc, pageA.getId());
+              int m = indexOfId(asc, pageM.getId());
+              int z = indexOfId(asc, pageZ.getId());
+              assertTrue(
+                  a >= 0 && m >= 0 && z >= 0, "All created pages must be indexed and returned");
+              assertTrue(a < m && m < z, "Ascending name sort must order aaa < mmm < zzz");
+            });
+
+    List<PageHierarchy> desc =
+        listSearchHierarchy(rest, "?limit=1000000&sortBy=name&sortOrder=desc").getData();
+    int a = indexOfId(desc, pageA.getId());
+    int m = indexOfId(desc, pageM.getId());
+    int z = indexOfId(desc, pageZ.getId());
+    assertTrue(z < m && m < a, "Descending name sort must order zzz < mmm < aaa");
   }
 
   @Test

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java
@@ -63,6 +63,7 @@ import org.openmetadata.service.governance.workflows.WorkflowHandler;
 import org.openmetadata.service.resources.feeds.MessageParser;
 import org.openmetadata.service.resources.knowledge.KnowledgePageResource;
 import org.openmetadata.service.search.PropagationDescriptor;
+import org.openmetadata.service.search.SearchSortFilter;
 import org.openmetadata.service.search.vector.PageBodyTextContributor;
 import org.openmetadata.service.security.AuthorizationException;
 import org.openmetadata.service.util.EntityUtil;
@@ -418,19 +419,19 @@ public class KnowledgePageRepository extends EntityRepository<Page> {
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearch(
-      String parent, PageType pageType, int offset, int limit) {
+      String parent, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchy(parent, pageTypeValue, offset, limit);
+        .listPageHierarchy(parent, pageTypeValue, sortFilter, offset, limit);
   }
 
   public ResultList<PageHierarchy> getHierarchyWithSearchForActivePage(
-      String activeFqn, PageType pageType, int offset, int limit) {
+      String activeFqn, PageType pageType, SearchSortFilter sortFilter, int offset, int limit) {
     String pageTypeValue = pageType != null ? pageType.value() : null;
     return searchRepository
         .getSearchClient()
-        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, offset, limit);
+        .listPageHierarchyForActivePage(activeFqn, pageTypeValue, sortFilter, offset, limit);
   }
 
   public List<PageHierarchy> listHierarchy(ListFilter filter, int limit) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
@@ -398,13 +398,37 @@ public class KnowledgePageResource extends EntityResource<Page, KnowledgePageRep
               description =
                   "FQN of the active page to show the active page correctly in  the hierarchy , while showing other root nodes at level 1.")
           @QueryParam("activeFqn")
-          String activeFqn) {
+          String activeFqn,
+      @Parameter(
+              description = "Field to sort by. Supported: name, createdAt, updatedAt.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"name", "createdAt", "updatedAt"}))
+          @QueryParam("sortBy")
+          String sortBy,
+      @Parameter(
+              description = "Sort order. Supported: asc, desc. Defaults to desc.",
+              schema =
+                  @Schema(
+                      type = "string",
+                      allowableValues = {"asc", "desc"}))
+          @QueryParam("sortOrder")
+          String sortOrder) {
+    SearchSortFilter sortFilter = buildHierarchySortFilter(sortBy, sortOrder);
     if (!CommonUtil.nullOrEmpty(activeFqn)) {
       return repository.getHierarchyWithSearchForActivePage(
-          activeFqn, knowledgePageType, offset, limit);
+          activeFqn, knowledgePageType, sortFilter, offset, limit);
     } else {
-      return repository.getHierarchyWithSearch(parent, knowledgePageType, offset, limit);
+      return repository.getHierarchyWithSearch(
+          parent, knowledgePageType, sortFilter, offset, limit);
     }
+  }
+
+  private static SearchSortFilter buildHierarchySortFilter(String sortBy, String sortOrder) {
+    String effectiveSortBy = CommonUtil.nullOrEmpty(sortBy) ? "updatedAt" : sortBy;
+    return new SearchSortFilter(
+        resolveSortField(effectiveSortBy), resolveSortOrder(sortOrder), null, null);
   }
 
   @GET

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java
@@ -400,11 +400,11 @@ public class KnowledgePageResource extends EntityResource<Page, KnowledgePageRep
           @QueryParam("activeFqn")
           String activeFqn,
       @Parameter(
-              description = "Field to sort by. Supported: name, createdAt, updatedAt.",
+              description = "Field to sort by. Supported: name, updatedAt.",
               schema =
                   @Schema(
                       type = "string",
-                      allowableValues = {"name", "createdAt", "updatedAt"}))
+                      allowableValues = {"name", "updatedAt"}))
           @QueryParam("sortBy")
           String sortBy,
       @Parameter(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java
@@ -797,7 +797,8 @@ public interface SearchClient
    Used for listing knowledge page hierarchy for a given parent and page type, used in Elastic/Open SearchClientExtension
   */
   @SuppressWarnings("unused")
-  default ResultList listPageHierarchy(String parent, String pageType, int offset, int limit) {
+  default ResultList listPageHierarchy(
+      String parent, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }
@@ -807,7 +808,7 @@ public interface SearchClient
   */
   @SuppressWarnings("unused")
   default ResultList listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
     throw new CustomExceptionMessage(
         Response.Status.NOT_IMPLEMENTED, NOT_IMPLEMENTED_ERROR_TYPE, NOT_IMPLEMENTED_METHOD);
   }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -103,6 +103,7 @@ public class ElasticSearchClient implements SearchClient {
 
   private volatile boolean isClientAvailable;
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
+  private static final String SORT_ORDER_DESC = "desc";
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
 
   private volatile boolean isNewClientAvailable;
@@ -1174,10 +1175,12 @@ public class ElasticSearchClient implements SearchClient {
     List<SortOptions> sortOptions = new ArrayList<>();
     if (sortFilter != null
         && sortFilter.getSortField() != null
-        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+        && !Entity.FIELD_FULLY_QUALIFIED_NAME.equals(sortFilter.getSortField())) {
       String field = sortFilter.getSortField();
       SortOrder order =
-          "desc".equalsIgnoreCase(sortFilter.getSortType()) ? SortOrder.Desc : SortOrder.Asc;
+          SORT_ORDER_DESC.equalsIgnoreCase(sortFilter.getSortType())
+              ? SortOrder.Desc
+              : SortOrder.Asc;
       sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
     }
     // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
@@ -1185,7 +1188,8 @@ public class ElasticSearchClient implements SearchClient {
     // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
     // indices.id_field_data.enabled=true at the cluster level.
     sortOptions.add(
-        SortOptions.of(so -> so.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc))));
+        SortOptions.of(
+            so -> so.field(f -> f.field(Entity.FIELD_FULLY_QUALIFIED_NAME).order(SortOrder.Asc))));
     return sortOptions;
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import es.co.elastic.clients.elasticsearch.ElasticsearchClient;
 import es.co.elastic.clients.elasticsearch._types.FieldValue;
 import es.co.elastic.clients.elasticsearch._types.Refresh;
+import es.co.elastic.clients.elasticsearch._types.SortOptions;
 import es.co.elastic.clients.elasticsearch._types.SortOrder;
 import es.co.elastic.clients.elasticsearch._types.aggregations.FiltersBucket;
 import es.co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
@@ -1158,20 +1159,41 @@ public class ElasticSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchy(
-      String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private List<SortOptions> buildPageHierarchySortOptions(SearchSortFilter sortFilter) {
+    List<SortOptions> sortOptions = new ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      SortOrder order =
+          "desc".equalsIgnoreCase(sortFilter.getSortType()) ? SortOrder.Desc : SortOrder.Asc;
+      sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is non-unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        SortOptions.of(so -> so.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc))));
+    return sortOptions;
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearch(
-      String parentFqn, String pageType, int offset, int limit) throws IOException {
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQuery(parentFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1181,13 +1203,7 @@ public class ElasticSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1203,8 +1219,10 @@ public class ElasticSearchClient implements SearchClient {
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearchForActivePage(
-      String activeFqn, String pageType, int offset, int limit) throws IOException {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     es.co.elastic.clients.elasticsearch.core.SearchRequest searchRequest =
         es.co.elastic.clients.elasticsearch.core.SearchRequest.of(
@@ -1214,9 +1232,7 @@ public class ElasticSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -75,6 +75,7 @@ import org.openmetadata.service.workflows.searchIndex.ReindexingUtil;
 import os.org.opensearch.client.json.JsonData;
 import os.org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import os.org.opensearch.client.opensearch._types.FieldValue;
+import os.org.opensearch.client.opensearch._types.SortOptions;
 import os.org.opensearch.client.opensearch._types.SortOrder;
 import os.org.opensearch.client.opensearch._types.aggregations.FiltersBucket;
 import os.org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -1180,20 +1181,41 @@ public class OpenSearchClient implements SearchClient {
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchy(
-      String parentFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearch(parentFqn, pageType, offset, limit);
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearch(parentFqn, pageType, sortFilter, offset, limit);
   }
 
   @Override
   @lombok.SneakyThrows
   public ResultList<PageHierarchy> listPageHierarchyForActivePage(
-      String activeFqn, String pageType, int offset, int limit) {
-    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, offset, limit);
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit) {
+    return getPageHierarchyFromSearchForActivePage(activeFqn, pageType, sortFilter, offset, limit);
+  }
+
+  private List<SortOptions> buildPageHierarchySortOptions(SearchSortFilter sortFilter) {
+    List<SortOptions> sortOptions = new ArrayList<>();
+    if (sortFilter != null
+        && sortFilter.getSortField() != null
+        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+      String field = sortFilter.getSortField();
+      SortOrder order =
+          "desc".equalsIgnoreCase(sortFilter.getSortType()) ? SortOrder.Desc : SortOrder.Asc;
+      sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
+    }
+    // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
+    // from/size pagination cannot miss/duplicate hits when the primary sort field is non-unique.
+    // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
+    // indices.id_field_data.enabled=true at the cluster level.
+    sortOptions.add(
+        SortOptions.of(so -> so.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc))));
+    return sortOptions;
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearch(
-      String parentFqn, String pageType, int offset, int limit) throws IOException {
+      String parentFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQuery(parentFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1203,13 +1225,7 @@ public class OpenSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort so from/size pagination cannot miss/duplicate hits.
-                    // fullyQualifiedName is a keyword field with doc_values and is unique per
-                    // page (name is unique within a parent's children), so no tiebreaker is
-                    // needed. _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x
-                    // without setting indices.id_field_data.enabled=true at the cluster level.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 
@@ -1225,8 +1241,10 @@ public class OpenSearchClient implements SearchClient {
   }
 
   private ResultList<PageHierarchy> getPageHierarchyFromSearchForActivePage(
-      String activeFqn, String pageType, int offset, int limit) throws IOException {
+      String activeFqn, String pageType, SearchSortFilter sortFilter, int offset, int limit)
+      throws IOException {
     Query boolQuery = buildPageHierarchyBoolQueryForActivePage(activeFqn, pageType);
+    List<SortOptions> sortOptions = buildPageHierarchySortOptions(sortFilter);
 
     os.org.opensearch.client.opensearch.core.SearchRequest searchRequest =
         os.org.opensearch.client.opensearch.core.SearchRequest.of(
@@ -1236,9 +1254,7 @@ public class OpenSearchClient implements SearchClient {
                             .getIndexOrAliasName(
                                 KnowledgePageRepository.KNOWLEDGE_PAGE_TERM_SEARCH_INDEX))
                     .query(boolQuery)
-                    // Stable sort by fqn (keyword, unique per page). See note above on _id.
-                    .sort(
-                        sort -> sort.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc)))
+                    .sort(sortOptions)
                     .from(offset)
                     .size(limit));
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -105,6 +105,7 @@ public class OpenSearchClient implements SearchClient {
 
   private volatile boolean isClientAvailable;
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
+  private static final String SORT_ORDER_DESC = "desc";
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
   private final RBACConditionEvaluator rbacConditionEvaluator;
 
@@ -1196,10 +1197,12 @@ public class OpenSearchClient implements SearchClient {
     List<SortOptions> sortOptions = new ArrayList<>();
     if (sortFilter != null
         && sortFilter.getSortField() != null
-        && !"fullyQualifiedName".equals(sortFilter.getSortField())) {
+        && !Entity.FIELD_FULLY_QUALIFIED_NAME.equals(sortFilter.getSortField())) {
       String field = sortFilter.getSortField();
       SortOrder order =
-          "desc".equalsIgnoreCase(sortFilter.getSortType()) ? SortOrder.Desc : SortOrder.Asc;
+          SORT_ORDER_DESC.equalsIgnoreCase(sortFilter.getSortType())
+              ? SortOrder.Desc
+              : SortOrder.Asc;
       sortOptions.add(SortOptions.of(so -> so.field(f -> f.field(field).order(order))));
     }
     // Always append a stable tiebreaker on fullyQualifiedName (keyword, unique per page) so
@@ -1207,7 +1210,8 @@ public class OpenSearchClient implements SearchClient {
     // _id cannot be used as a sort field on ES 9.x / OpenSearch 3.x without setting
     // indices.id_field_data.enabled=true at the cluster level.
     sortOptions.add(
-        SortOptions.of(so -> so.field(f -> f.field("fullyQualifiedName").order(SortOrder.Asc))));
+        SortOptions.of(
+            so -> so.field(f -> f.field(Entity.FIELD_FULLY_QUALIFIED_NAME).order(SortOrder.Asc))));
     return sortOptions;
   }
 


### PR DESCRIPTION
## What

Adds `sortBy` / `sortOrder` query params to `GET /v1/contextCenter/pages/search/hierarchy` so the Context Center left-tree can control ordering — e.g. a newly created article or quick link surfaces at the top instead of the bottom.

`Fixes open-metadata/openmetadata-collate#4781` (item 1 — article hierarchy sorting).

## How

Threads a `SearchSortFilter` from the resource through `KnowledgePageRepository` → the `SearchClient` interface → the ES/OS client implementations:

- **`KnowledgePageResource`** — `listHierarchyWithSearch` gains `sortBy` (`name` / `createdAt` / `updatedAt`) and `sortOrder` (`asc` / `desc`). Reuses the existing `resolveSortField` / `resolveSortOrder` validators, so invalid values return **400**. Default is **`updatedAt desc`** (newest first).
- **`ElasticSearchClient` / `OpenSearchClient`** — a shared `buildPageHierarchySortOptions` applies the requested primary sort, then **always appends `fullyQualifiedName` (keyword, unique per page) as a stable tiebreaker** so `from`/`size` pagination cannot miss or duplicate hits when the primary sort field (e.g. `updatedAt`) is non-unique.
- **`SearchClient` / `KnowledgePageRepository`** — signature threading only.

The Collate `ElasticSearchClientExt` / `OpenSearchClientExt` override these same methods; the matching Collate change is in openmetadata-collate (linked below) and depends on this PR + a submodule bump.

## Tests

`KnowledgePageHierarchyIT` gains three cases:
- `testSearchHierarchyRejectsInvalidSortBy` → 400
- `testSearchHierarchyRejectsInvalidSortOrder` → 400
- `testSearchHierarchySortsByName` → asc `aaa < mmm < zzz`, desc reversed (Awaitility-gated on the search index)

Verified locally: `mvn spotless:check`, `compile` (openmetadata-service), and `test-compile` (openmetadata-integration-tests) all pass.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds configurable, stable ordering to Context Center hierarchy search.
- Accepts and validates hierarchy sort field and direction parameters.
- Threads the sort filter through the resource, repository, and search-client layers.
- Applies deterministic Elasticsearch and OpenSearch ordering with an FQN tiebreaker.
- Adds integration coverage for validation and name ordering.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/resources/knowledge/KnowledgePageResource.java | Adds validated hierarchy sort parameters and forwards the resulting filter to both hierarchy query paths. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/KnowledgePageRepository.java | Threads the hierarchy sort filter from the resource into the configured search client. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/SearchClient.java | Extends the hierarchy-search interface methods with a sort-filter parameter. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java | Applies the requested primary hierarchy sort and a deterministic FQN tiebreaker to Elasticsearch requests. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java | Applies equivalent stable hierarchy ordering to OpenSearch requests. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/KnowledgePageHierarchyIT.java | Covers invalid sorting parameters and observable ascending and descending name ordering. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Context Center UI
  participant Resource as KnowledgePageResource
  participant Repo as KnowledgePageRepository
  participant Search as SearchClient
  participant Index as Elasticsearch/OpenSearch
  UI->>Resource: "GET /search/hierarchy?sortBy&sortOrder"
  Resource->>Resource: Validate and build SearchSortFilter
  Resource->>Repo: getHierarchyWithSearch(..., sortFilter)
  Repo->>Search: listPageHierarchy(..., sortFilter)
  Search->>Index: Search with primary sort + FQN tiebreaker
  Index-->>Search: Ordered hierarchy hits
  Search-->>UI: "ResultList<PageHierarchy>"
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(contextCenter): honest sort con..."](https://github.com/open-metadata/openmetadata/commit/8e740865f5af703929cba48bc0ecad72159a83dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53895344)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)

<!-- /greptile_comment -->