### PR TITLE
fix(ui): suppress string lint warnings in test TypeScript files

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs
@@ -29,6 +29,13 @@ const duplicateLiteralJsx = `
     </>
   );
 `;
+const duplicateLiteralTypescript = `
+  const iconNames = [
+    'database-icon',
+    'database-icon',
+    'database-icon',
+  ];
+`;
 
 test('suppresses string warnings in test TSX files', async () => {
   const [result] = await eslint.lintText(duplicateLiteralJsx, {
@@ -40,6 +47,23 @@ test('suppresses string warnings in test TSX files', async () => {
     )
   );
 
+  assert.deepEqual(stringRuleMessages, []);
+});
+
+test('suppresses string warnings in test TS files', async () => {
+  const filePath = 'src/Component.test.ts';
+  const config = await eslint.calculateConfigForFile(filePath);
+  const [result] = await eslint.lintText(duplicateLiteralTypescript, {
+    filePath,
+  });
+  const stringRuleMessages = result.messages.filter(({ ruleId }) =>
+    ['i18next/no-literal-string', 'sonarjs/no-duplicate-string'].includes(
+      ruleId
+    )
+  );
+
+  assert.equal(config.rules['i18next/no-literal-string']?.[0], 0);
+  assert.equal(config.rules['sonarjs/no-duplicate-string']?.[0], 0);
   assert.deepEqual(stringRuleMessages, []);
 });
 

--- a/openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { ESLint } from 'eslint';
+
+const eslint = new ESLint();
+const duplicateLiteralJsx = `
+  const iconNames = [
+    'database-icon',
+    'database-icon',
+    'database-icon',
+  ];
+  const Component = () => (
+    <>
+      <span>database-icon</span>
+      <span>database-icon</span>
+      <span>database-icon</span>
+    </>
+  );
+`;
+
+test('suppresses string warnings in test TSX files', async () => {
+  const [result] = await eslint.lintText(duplicateLiteralJsx, {
+    filePath: 'src/Component.test.tsx',
+  });
+  const stringRuleMessages = result.messages.filter(({ ruleId }) =>
+    ['i18next/no-literal-string', 'sonarjs/no-duplicate-string'].includes(
+      ruleId
+    )
+  );
+
+  assert.deepEqual(stringRuleMessages, []);
+});
+
+test('keeps string warnings enabled in production TSX files', async () => {
+  const [result] = await eslint.lintText(duplicateLiteralJsx, {
+    filePath: 'src/Component.tsx',
+  });
+  const reportedRuleIds = new Set(result.messages.map(({ ruleId }) => ruleId));
+
+  assert.equal(reportedRuleIds.has('i18next/no-literal-string'), true);
+  assert.equal(reportedRuleIds.has('sonarjs/no-duplicate-string'), true);
+});

--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -538,7 +538,7 @@ export default [
   // Test fixtures use literal and repeated strings as selectors and controlled inputs,
   // so production-facing string rules create noise without protecting user-visible copy.
   {
-    files: ['src/**/*.test.tsx'],
+    files: ['src/**/*.test.{ts,tsx}'],
     rules: {
       'i18next/no-literal-string': 'off',
       'sonarjs/no-duplicate-string': 'off',

--- a/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
+++ b/openmetadata-ui/src/main/resources/ui/eslint.config.mjs
@@ -535,6 +535,16 @@ export default [
     },
   },
 
+  // Test fixtures use literal and repeated strings as selectors and controlled inputs,
+  // so production-facing string rules create noise without protecting user-visible copy.
+  {
+    files: ['src/**/*.test.tsx'],
+    rules: {
+      'i18next/no-literal-string': 'off',
+      'sonarjs/no-duplicate-string': 'off',
+    },
+  },
+
   // Test setup files
   {
     files: [


### PR DESCRIPTION
### Describe your changes:

Disable i18next/no-literal-string and sonarjs/no-duplicate-string only for src/**/*.test.ts and src/**/*.test.tsx files. Test fixtures commonly use literal labels, selectors, and repeated controlled inputs that are not user-visible copy. Production TypeScript files keep both warnings enabled.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small ESLint flat-config override.

#
### Tests:

#### Use cases covered
- Test TS and TSX fixtures can use literal and repeated strings without these two warnings.
- Production TS and TSX files continue to retain both configured warnings.

#### Unit tests
- [x] Added behavior-based ESLint configuration regression tests.
- File added: openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs
- Full ESLint-rule suite: 85 tests passed.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable (no runtime UI changes).

#### Manual testing performed
1. Resolved the updated flat config for controlled .test.ts and .test.tsx paths.
2. Confirmed both rules use severity 0 for test files.
3. Confirmed production TypeScript paths retain severity 1.

#
### UI screen recording / screenshots:

Not applicable — lint configuration only.

#
### Checklist:
- [x] I have read the CONTRIBUTING document.
- [x] I have commented on the non-obvious test-fixture exception.
- [x] I have added tests for the exact behavior change.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows two string-oriented lint rules away from TypeScript test fixtures while retaining them for production TSX files.
- Disables `i18next/no-literal-string` and `sonarjs/no-duplicate-string` for `src/**/*.test.{ts,tsx}`.
- Adds behavior-based tests covering TSX and TS test files and confirming production TSX remains checked.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/eslint.config.mjs | Adds a focused flat-config override for TypeScript test fixtures without changing production-file lint behavior. |
| openmetadata-ui/src/main/resources/ui/eslint-rules/eslint-config.test.mjs | Adds regression coverage for effective string-rule behavior in test TSX, test TS, and production TSX files. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): suppress string warnings in tes..."](https://github.com/open-metadata/openmetadata/commit/1ce163c3e7bc3dbcf527f0fd80ab987b8b548166) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53902130)</sub>

<!-- /greptile_comment -->