### PR TITLE
fix(security): backport transitive CVE dependency bumps to 1.13

### DIFF
--- a/openmetadata-service/pom.xml
+++ b/openmetadata-service/pom.xml
@@ -29,7 +29,7 @@
     <logback-core.version>1.5.36</logback-core.version>
     <logback-classic.version>1.5.36</logback-classic.version>
     <resilience4j-ratelimiter.version>2.3.0</resilience4j-ratelimiter.version>
-    <kubernetes-client.version>24.0.0</kubernetes-client.version>
+    <kubernetes-client.version>25.0.1</kubernetes-client.version>
   </properties>
 
   <dependencyManagement>
@@ -974,7 +974,7 @@
     <dependency>
       <groupId>org.eclipse.parsson</groupId>
       <artifactId>parsson</artifactId>
-      <version>1.1.5</version>
+      <version>1.1.8</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
     <postgres.connector.version>42.7.12</postgres.connector.version>
     <jsonschema2pojo.version>1.3.1</jsonschema2pojo.version>
     <lombok.version>1.18.36</lombok.version>
-    <tomcat-jdbc.version>11.0.5</tomcat-jdbc.version>
+    <tomcat-jdbc.version>11.0.11</tomcat-jdbc.version>
     <hikaricp.version>7.0.2</hikaricp.version>
     <elasticsearch.version>7.17.25</elasticsearch.version>
     <opensearch.version>2.6.0</opensearch.version>
@@ -196,7 +196,7 @@
       <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
-        <version>1.2.16</version>
+        <version>1.2.18</version>
       </dependency>
       <!-- CVE-2026-45292: opentelemetry-api 1.37.0 (transitive of
            co.elastic.clients:elasticsearch-java, shaded into elasticsearch-deps)
@@ -799,7 +799,7 @@
       <dependency>
         <groupId>tools.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>3.1.3</version>
+        <version>3.1.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## What

Backport of 5 transitive-dependency CVE version bumps that are already on `main` but were never carried into `1.13`. These artifacts are declared in OpenMetadata's own poms (root `pom.xml` + `openmetadata-service/pom.xml`), so `1.13` ships them at the vulnerable versions.

## CVEs

| CVE | Severity | Artifact | 1.13 (before) | Fixed | Source PR on `main` |
|---|---|---|---|---|---|
| CVE-2026-9563 | HIGH | `org.eclipse.parsson:parsson` | 1.1.5 | **1.1.8** | #30051 |
| CVE-2026-59889 | HIGH | `tools.jackson:jackson-bom` (Jackson 3.x) | 3.1.3 | **3.1.5** | #30498 |
| CVE-2026-41715 | MEDIUM | `io.projectreactor.netty:reactor-netty-http` | 1.2.16 | **1.2.18** | #31257 |
| CVE-2026-15687 | MEDIUM | `io.kubernetes:client-java` | 24.0.0 | **25.0.1** | #31342 |
| CVE-2025-55754 | MEDIUM | `org.apache.tomcat:tomcat-jdbc` / `tomcat-juli` | 11.0.5 | **11.0.11** | #31258 |

## Changes

Version-only, no source changes:
- root `pom.xml`: `tomcat-jdbc.version` 11.0.5→11.0.11, `reactor-netty-http` 1.2.16→1.2.18, `tools.jackson:jackson-bom` 3.1.3→3.1.5
- `openmetadata-service/pom.xml`: `kubernetes-client.version` 24.0.0→25.0.1, `parsson` 1.1.5→1.1.8

All five target versions are identical to what `main` already builds against.

## Verification

`mvn validate` passes across all 16 reactor modules (poms well-formed, enforcer Java/Maven rules pass). All five versions are byte-identical to what `main` already ships and builds against, so the full `dependencyConvergence` enforcer + build is left to CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports five security-related dependency version updates from the main branch to 1.13.
- Updates Kubernetes Java Client and Parsson in `openmetadata-service`.
- Updates Tomcat JDBC, Reactor Netty HTTP, and the Jackson 3 BOM in root dependency management.
- Makes no source-code or application-configuration changes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the dependency-only backports introduce no concrete build, runtime, or security regression.

The updated artifacts retain coherent dependency relationships, and investigation of their consumers and managed dependency graph found no actionable incompatibility or broken contract.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/pom.xml | Updates the Kubernetes Java Client and Parsson versions; no concrete compatibility failure was identified in their existing service consumers. |
| pom.xml | Updates three centrally managed dependency versions without introducing a demonstrated resolution, convergence, build, or runtime defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): backport transitive CVE d..."](https://github.com/open-metadata/openmetadata/commit/751163eb42cdd55507ae13443e6d5c6c9be8f73f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53907873)</sub>

<!-- /greptile_comment -->