### PR TITLE
feat(ingestion-pipelines): add agentType filter and stop polling orchestrators for queued status

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineAgentTypeIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineAgentTypeIT.java
@@ -1,0 +1,133 @@
+package org.openmetadata.it.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openmetadata.it.factories.DashboardServiceTestFactory;
+import org.openmetadata.it.util.SdkClients;
+import org.openmetadata.it.util.TestNamespace;
+import org.openmetadata.it.util.TestNamespaceExtension;
+import org.openmetadata.schema.api.services.ingestionPipelines.CreateIngestionPipeline;
+import org.openmetadata.schema.entity.services.DashboardService;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
+import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+import org.openmetadata.schema.metadataIngestion.ApplicationPipeline;
+import org.openmetadata.schema.metadataIngestion.DashboardServiceMetadataPipeline;
+import org.openmetadata.schema.metadataIngestion.SourceConfig;
+import org.openmetadata.schema.utils.ResultList;
+import org.openmetadata.sdk.client.OpenMetadataClient;
+import org.openmetadata.sdk.network.HttpMethod;
+
+/**
+ * Integration tests for the {@code agentType} list filter on {@code
+ * GET /v1/services/ingestionPipelines}, which expands to the set of {@code pipelineType} values
+ * that make up an agent group so clients do not have to enumerate them.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+@ExtendWith(TestNamespaceExtension.class)
+public class IngestionPipelineAgentTypeIT {
+
+  private static final Date START_DATE = Date.from(Instant.parse("2022-06-10T15:06:47Z"));
+  private static final String LIST_PATH = "/v1/services/ingestionPipelines";
+
+  @Test
+  void test_agentTypeMetadata_returnsOnlyMetadataAgents(TestNamespace ns) {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    DashboardService service = DashboardServiceTestFactory.createMetabase(ns);
+    String serviceFqn = service.getFullyQualifiedName();
+
+    try {
+      String metadataPipeline = createPipeline(ns, service, "agentMetadata", PipelineType.METADATA);
+      String lineagePipeline = createPipeline(ns, service, "agentLineage", PipelineType.LINEAGE);
+      String reindexPipeline =
+          createPipeline(ns, service, "agentReindex", PipelineType.ELASTIC_SEARCH_REINDEX);
+      String applicationPipeline =
+          createPipeline(ns, service, "agentApplication", PipelineType.APPLICATION);
+
+      Set<String> metadataAgents = listNames(adminClient, serviceFqn, "agentType=metadata");
+      assertTrue(
+          metadataAgents.containsAll(Set.of(metadataPipeline, lineagePipeline)),
+          "agentType=metadata must return every metadata pipelineType");
+      assertTrue(
+          Set.of(reindexPipeline, applicationPipeline).stream().noneMatch(metadataAgents::contains),
+          "agentType=metadata must not fall back to 'everything that is not an application'");
+
+      Set<String> applicationAgents = listNames(adminClient, serviceFqn, "agentType=application");
+      assertEquals(Set.of(applicationPipeline), applicationAgents);
+    } finally {
+      adminClient
+          .dashboardServices()
+          .delete(service.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+    }
+  }
+
+  @Test
+  void test_agentTypeIsIntersectedWithPipelineType(TestNamespace ns) {
+    OpenMetadataClient adminClient = SdkClients.adminClient();
+    DashboardService service = DashboardServiceTestFactory.createMetabase(ns);
+    String serviceFqn = service.getFullyQualifiedName();
+
+    try {
+      createPipeline(ns, service, "narrowMetadata", PipelineType.METADATA);
+      String lineagePipeline = createPipeline(ns, service, "narrowLineage", PipelineType.LINEAGE);
+      createPipeline(ns, service, "narrowApplication", PipelineType.APPLICATION);
+
+      assertEquals(
+          Set.of(lineagePipeline),
+          listNames(adminClient, serviceFqn, "agentType=metadata&pipelineType=lineage"),
+          "Both filters set must intersect, not union");
+      assertTrue(
+          listNames(adminClient, serviceFqn, "agentType=metadata&pipelineType=application")
+              .isEmpty(),
+          "An empty intersection must match no pipeline");
+    } finally {
+      adminClient
+          .dashboardServices()
+          .delete(service.getId().toString(), Map.of("hardDelete", "true", "recursive", "true"));
+    }
+  }
+
+  private String createPipeline(
+      TestNamespace ns, DashboardService service, String name, PipelineType pipelineType) {
+    SourceConfig sourceConfig =
+        PipelineType.APPLICATION.equals(pipelineType)
+            ? new SourceConfig()
+                .withConfig(
+                    new ApplicationPipeline().withAppConfig(Map.of("type", "AgentTypeTestApp")))
+            : new SourceConfig().withConfig(new DashboardServiceMetadataPipeline());
+    IngestionPipeline pipeline =
+        SdkClients.adminClient()
+            .ingestionPipelines()
+            .create(
+                new CreateIngestionPipeline()
+                    .withName(ns.prefix(name))
+                    .withPipelineType(pipelineType)
+                    .withService(service.getEntityReference())
+                    .withSourceConfig(sourceConfig)
+                    .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE)));
+    return pipeline.getName();
+  }
+
+  private Set<String> listNames(OpenMetadataClient client, String serviceFqn, String filter) {
+    String path = String.format("%s?service=%s&limit=100&%s", LIST_PATH, serviceFqn, filter);
+    IngestionPipelineList response =
+        client.getHttpClient().execute(HttpMethod.GET, path, null, IngestionPipelineList.class);
+    List<IngestionPipeline> data = response.getData();
+    return data == null
+        ? Set.of()
+        : data.stream().map(IngestionPipeline::getName).collect(Collectors.toSet());
+  }
+
+  static class IngestionPipelineList extends ResultList<IngestionPipeline> {}
+}

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -46,6 +46,7 @@ import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.Progress;
 import org.openmetadata.schema.entity.services.ingestionPipelines.ProgressProperty;
 import org.openmetadata.schema.entity.services.ingestionPipelines.StepSummary;
+import org.openmetadata.schema.metadataIngestion.ApplicationPipeline;
 import org.openmetadata.schema.metadataIngestion.DashboardServiceMetadataPipeline;
 import org.openmetadata.schema.metadataIngestion.DatabaseServiceMetadataPipeline;
 import org.openmetadata.schema.metadataIngestion.DatabaseServiceQueryUsagePipeline;
@@ -1876,5 +1877,28 @@ public class IngestionPipelineResourceIT
 
   private static String encodeSegment(String value) {
     return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+
+  /**
+   * Creating an application pipeline reads the app type off `appConfig` to pick a specific create
+   * permission. With no `appConfig` there is no type to read, and that used to escape as a 500
+   * before authorization even ran instead of falling back to the generic create permission.
+   */
+  @Test
+  void test_createApplicationPipelineWithoutAppConfig(TestNamespace ns) {
+    DatabaseService service = DatabaseServiceTestFactory.createPostgres(ns);
+
+    CreateIngestionPipeline request =
+        new CreateIngestionPipeline()
+            .withName(ns.prefix("appNoConfig"))
+            .withPipelineType(PipelineType.APPLICATION)
+            .withService(service.getEntityReference())
+            .withSourceConfig(new SourceConfig().withConfig(new ApplicationPipeline()))
+            .withAirflowConfig(new AirflowConfig().withStartDate(START_DATE));
+
+    IngestionPipeline pipeline = createEntity(request);
+
+    assertNotNull(pipeline.getId());
+    assertEquals(PipelineType.APPLICATION, pipeline.getPipelineType());
   }
 }

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/IngestionPipelineResourceIT.java
@@ -60,6 +60,7 @@ import org.openmetadata.schema.security.credentials.AWSCredentials;
 import org.openmetadata.schema.type.EntityHistory;
 import org.openmetadata.schema.type.ProviderType;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.schema.utils.ResultList;
 import org.openmetadata.sdk.client.OpenMetadataClient;
 import org.openmetadata.sdk.exceptions.OpenMetadataException;
 import org.openmetadata.sdk.models.ListParams;
@@ -1878,6 +1879,87 @@ public class IngestionPipelineResourceIT
   private static String encodeSegment(String value) {
     return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
   }
+
+  /**
+   * A run the orchestrator accepts but never starts leaves a `queued` status behind that no worker
+   * will ever supersede, so it is hidden once older than `queuedStatusTimeoutSeconds`. That cutoff
+   * has to hold for the `pipelineStatuses` entity field too, not just the pipelineStatus endpoint —
+   * the Agents page reads the field, and shows the newest entry as the pipeline's current state.
+   */
+  @Test
+  void test_staleQueuedStatusIsHiddenFromThePipelineStatusesField(TestNamespace ns) {
+    IngestionPipeline pipeline = createEntity(createRequest(ns.prefix("staleQueued"), ns));
+    String fqn = pipeline.getFullyQualifiedName();
+    String serviceFqn = pipeline.getService().getFullyQualifiedName();
+    long twoHoursAgo = System.currentTimeMillis() - Duration.ofHours(2).toMillis();
+    long ninetyMinutesAgo = System.currentTimeMillis() - Duration.ofMinutes(90).toMillis();
+
+    addStatus(fqn, "stale-queued-run", PipelineStatusType.QUEUED, twoHoursAgo);
+    addStatus(fqn, "finished-run", PipelineStatusType.SUCCESS, ninetyMinutesAgo);
+
+    assertEquals(
+        List.of("finished-run"),
+        runIdsOf(
+            get(
+                    "/v1/services/ingestionPipelines/" + encodeSegment(fqn) + "/pipelineStatus",
+                    PipelineStatusList.class)
+                .getData()),
+        "pipelineStatus endpoint must hide the stale queued run");
+
+    // setFields path: single entity read with the field requested
+    assertEquals(
+        List.of("finished-run"),
+        runIdsOf(
+            get(
+                    "/v1/services/ingestionPipelines/name/"
+                        + encodeSegment(fqn)
+                        + "?fields=pipelineStatuses",
+                    IngestionPipeline.class)
+                .getPipelineStatuses()),
+        "pipelineStatuses field must hide it too, or the Agents page shows Queued forever");
+
+    // setFieldsInBulk path: the list call the Agents page actually makes
+    IngestionPipeline fromList =
+        get(
+                "/v1/services/ingestionPipelines?limit=100&fields=pipelineStatuses&service="
+                    + encodeSegment(serviceFqn),
+                IngestionPipelineList.class)
+            .getData()
+            .stream()
+            .filter(p -> fqn.equals(p.getFullyQualifiedName()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("pipeline missing from the list response"));
+    assertEquals(
+        List.of("finished-run"),
+        runIdsOf(fromList.getPipelineStatuses()),
+        "the bulk field fetch must apply the same cutoff as the single-entity read");
+  }
+
+  private static List<String> runIdsOf(List<PipelineStatus> statuses) {
+    return statuses == null ? List.of() : statuses.stream().map(PipelineStatus::getRunId).toList();
+  }
+
+  private static <T> T get(String path, Class<T> type) {
+    return SdkClients.adminClient().getHttpClient().execute(HttpMethod.GET, path, null, type);
+  }
+
+  private void addStatus(String fqn, String runId, PipelineStatusType state, long timestamp) {
+    SdkClients.adminClient()
+        .getHttpClient()
+        .execute(
+            HttpMethod.PUT,
+            "/v1/services/ingestionPipelines/" + encodeSegment(fqn) + "/pipelineStatus",
+            new PipelineStatus()
+                .withRunId(runId)
+                .withPipelineState(state)
+                .withStartDate(timestamp)
+                .withTimestamp(timestamp),
+            IngestionPipeline.class);
+  }
+
+  static class PipelineStatusList extends ResultList<PipelineStatus> {}
+
+  static class IngestionPipelineList extends ResultList<IngestionPipeline> {}
 
   /**
    * Creating an application pipeline reads the app type off `appConfig` to pick a specific create

--- a/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java
@@ -67,7 +67,6 @@ import org.openmetadata.schema.entity.automations.Workflow;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.sdk.PipelineServiceClientInterface;
 import org.openmetadata.sdk.exception.PipelineServiceClientException;
@@ -603,7 +602,8 @@ public class K8sPipelineClient extends PipelineServiceClient {
             correlationId);
       }
       return buildSuccessResponse(
-          "Pipeline triggered successfully", Map.of("runId", runId, "jobName", jobName));
+              "Pipeline triggered successfully", Map.of("runId", runId, "jobName", jobName))
+          .withRunId(runId);
 
     } catch (ApiException e) {
       LOG.error(
@@ -887,72 +887,15 @@ public class K8sPipelineClient extends PipelineServiceClient {
     }
   }
 
+  /**
+   * Returns nothing on purpose. This client mints the run ID when triggering (see {@link
+   * #runPipeline}) and reports it back on the response, so the server persists the {@code queued}
+   * status itself. Listing Jobs here on every run-history read would cost an API server round trip
+   * for state we already hold.
+   */
   @Override
   public List<PipelineStatus> getQueuedPipelineStatusInternal(IngestionPipeline ingestionPipeline) {
-    // READ-ONLY: Check for queued K8s jobs without storing anything
-    String pipelineName = sanitizeName(ingestionPipeline.getName());
-    List<PipelineStatus> queuedStatuses = new ArrayList<>();
-
-    try {
-      String labelSelector = LABEL_PIPELINE + "=" + pipelineName;
-      V1JobList jobs =
-          batchApi
-              .listNamespacedJob(k8sConfig.getNamespace())
-              .labelSelector(labelSelector)
-              .execute();
-
-      for (V1Job job : jobs.getItems()) {
-        // Only return jobs that are QUEUED (created but not started)
-        if (isJobQueued(job)) {
-          String runId =
-              StringUtils.defaultIfBlank(
-                  job.getMetadata().getLabels() != null
-                      ? job.getMetadata().getLabels().get(LABEL_RUN_ID)
-                      : null,
-                  job.getMetadata().getName());
-
-          Long startTime =
-              job.getMetadata().getCreationTimestamp() != null
-                  ? job.getMetadata().getCreationTimestamp().toInstant().toEpochMilli()
-                  : null;
-
-          // Create READ-ONLY status object (not persisted)
-          PipelineStatus queuedStatus =
-              new PipelineStatus()
-                  .withRunId(runId)
-                  .withPipelineState(PipelineStatusType.QUEUED)
-                  .withStartDate(startTime)
-                  .withTimestamp(startTime);
-
-          queuedStatuses.add(queuedStatus);
-        }
-      }
-
-    } catch (ApiException e) {
-      LOG.error("Failed to check queued pipeline status: {}", e.getResponseBody());
-    }
-
-    return queuedStatuses;
-  }
-
-  private boolean isJobQueued(V1Job job) {
-    if (job.getStatus() == null) {
-      return true; // Job created but status not yet set = queued
-    }
-
-    Integer active = job.getStatus().getActive();
-    Integer succeeded = job.getStatus().getSucceeded();
-    Integer failed = job.getStatus().getFailed();
-
-    // Check if job is being deleted (has deletion timestamp)
-    if (job.getMetadata() != null && job.getMetadata().getDeletionTimestamp() != null) {
-      return false; // Job is being terminated, not queued
-    }
-
-    // Queued = no active pods, no completed pods, no failed pods, and not being deleted
-    return (active == null || active == 0)
-        && (succeeded == null || succeeded == 0)
-        && (failed == null || failed == 0);
+    return List.of();
   }
 
   @Override

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/createAndRunIngestionPipeline/RunIngestionPipelineImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/createAndRunIngestionPipeline/RunIngestionPipelineImpl.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.type.Include;
@@ -96,12 +97,16 @@ public class RunIngestionPipelineImpl {
     Retry retry = Retry.of("runIngestionPipeline", retryConfig);
 
     try {
-      retry.executeRunnable(
-          () ->
-              pipelineServiceClient.runPipeline(
-                  ingestionPipeline,
-                  Entity.getEntity(
-                      ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED)));
+      PipelineServiceClientResponse response =
+          retry.executeSupplier(
+              () ->
+                  pipelineServiceClient.runPipeline(
+                      ingestionPipeline,
+                      Entity.getEntity(
+                          ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED)));
+      ((IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE))
+          .recordQueuedPipelineStatus(
+              null, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
     } catch (Exception ex) {
       throw new RuntimeException("Failed to run pipeline after retries: " + ex.getMessage(), ex);
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/runApp/RunAppImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/runApp/RunAppImpl.java
@@ -251,9 +251,13 @@ public class RunAppImpl {
     IngestionPipelineRepository repository =
         (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
 
-    pipelineServiceClient.runPipeline(
-        ingestionPipeline,
-        Entity.getEntity(ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED));
+    PipelineServiceClientResponse response =
+        pipelineServiceClient.runPipeline(
+            ingestionPipeline,
+            Entity.getEntity(
+                ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED));
+    repository.recordQueuedPipelineStatus(
+        null, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
 
     if (waitForCompletion) {
       return waitForCompletion(repository, ingestionPipeline, startTime, timeoutMillis);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/runApp/RunAppImpl.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/governance/workflows/elements/nodes/automatedTask/runApp/RunAppImpl.java
@@ -251,13 +251,9 @@ public class RunAppImpl {
     IngestionPipelineRepository repository =
         (IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE);
 
-    PipelineServiceClientResponse response =
-        pipelineServiceClient.runPipeline(
-            ingestionPipeline,
-            Entity.getEntity(
-                ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED));
-    repository.recordQueuedPipelineStatus(
-        null, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
+    pipelineServiceClient.runPipeline(
+        ingestionPipeline,
+        Entity.getEntity(ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED));
 
     if (waitForCompletion) {
       return waitForCompletion(repository, ingestionPipeline, startTime, timeoutMillis);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -1201,7 +1201,9 @@ public class DataContractRepository extends EntityRepository<DataContract> {
         SecretsManagerFactory.getSecretsManager()
             .encryptOpenMetadataConnection(openMetadataServerConnection, false));
 
-    pipelineServiceClient.runPipeline(pipeline, testSuite);
+    PipelineServiceClientResponse response = pipelineServiceClient.runPipeline(pipeline, testSuite);
+    ((IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE))
+        .recordQueuedPipelineStatus(null, pipeline.getFullyQualifiedName(), response.getRunId());
   }
 
   private SemanticsValidation validateSemantics(DataContract dataContract) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/DataContractRepository.java
@@ -1201,9 +1201,7 @@ public class DataContractRepository extends EntityRepository<DataContract> {
         SecretsManagerFactory.getSecretsManager()
             .encryptOpenMetadataConnection(openMetadataServerConnection, false));
 
-    PipelineServiceClientResponse response = pipelineServiceClient.runPipeline(pipeline, testSuite);
-    ((IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE))
-        .recordQueuedPipelineStatus(null, pipeline.getFullyQualifiedName(), response.getRunId());
+    pipelineServiceClient.runPipeline(pipeline, testSuite);
   }
 
   private SemanticsValidation validateSemantics(DataContract dataContract) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -253,11 +253,18 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
     return toPipelineStatuses(jsonMap.getOrDefault(fqnHash, List.of()));
   }
 
-  private static List<PipelineStatus> toPipelineStatuses(List<String> jsonValues) {
-    return jsonValues.stream()
-        .map(json -> JsonUtils.readValue(json, PipelineStatus.class))
-        .filter(Objects::nonNull)
-        .toList();
+  /**
+   * The single conversion point for the `pipelineStatuses` entity field, which both the single-entity
+   * and the bulk read go through, so the stale-queued cutoff has to be applied here as well as in
+   * {@link #listPipelineStatus} or the Agents page would keep showing a run that never started.
+   */
+  private List<PipelineStatus> toPipelineStatuses(List<String> jsonValues) {
+    List<PipelineStatus> pipelineStatusList =
+        jsonValues.stream()
+            .map(json -> JsonUtils.readValue(json, PipelineStatus.class))
+            .filter(Objects::nonNull)
+            .toList();
+    return dropStaleQueuedStatuses(pipelineStatusList);
   }
 
   public static PipelineStatus latestPipelineStatus(IngestionPipeline ingestionPipeline) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.Getter;
 import lombok.Setter;
@@ -42,12 +43,14 @@ import org.json.JSONObject;
 import org.openmetadata.schema.EntityInterface;
 import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.api.configuration.LogStorageConfiguration;
+import org.openmetadata.schema.api.configuration.pipelineServiceClient.PipelineServiceClientConfiguration;
 import org.openmetadata.schema.entity.applications.configuration.ApplicationConfig;
 import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.OperationMetricsBatch;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.ProgressUpdate;
 import org.openmetadata.schema.entity.services.ingestionPipelines.ProgressUpdateType;
@@ -98,6 +101,7 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
   public static final String PIPELINE_STATUS_EXTENSION = "ingestionPipeline.pipelineStatus";
   private static final String RUN_ID_EXTENSION_KEY = "runId";
   private static final int DEFAULT_RECENT_RUN_LIMIT = 5;
+  private static final int DEFAULT_QUEUED_STATUS_TIMEOUT_SECONDS = 3600;
   @Setter private PipelineServiceClientInterface pipelineServiceClient;
   @Setter @Getter private LogStorageInterface logStorage;
   @Setter @Getter private LogStorageConfiguration logStorageConfiguration;
@@ -712,7 +716,7 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
               effectiveEndTs);
     }
     List<PipelineStatus> pipelineStatusList =
-        JsonUtils.readObjects(jsonResults, PipelineStatus.class);
+        dropStaleQueuedStatuses(JsonUtils.readObjects(jsonResults, PipelineStatus.class));
     List<PipelineStatus> allPipelineStatusList = new ArrayList<>();
     if (pipelineServiceClient != null) {
       allPipelineStatusList.addAll(
@@ -739,6 +743,66 @@ public class IngestionPipelineRepository extends EntityRepository<IngestionPipel
       return limit;
     }
     return startTs == null && endTs == null ? DEFAULT_RECENT_RUN_LIMIT : null;
+  }
+
+  /**
+   * Records the {@code queued} state of a run the orchestrator has just accepted, so that run
+   * history can show it without polling the orchestrator. Best effort: the run is already going, so
+   * failing to record its queued state must not fail the trigger.
+   */
+  public void recordQueuedPipelineStatus(UriInfo uriInfo, String pipelineFQN, String runId) {
+    if (nullOrEmpty(runId)) {
+      return;
+    }
+    long now = System.currentTimeMillis();
+    PipelineStatus queuedStatus =
+        new PipelineStatus()
+            .withRunId(runId)
+            .withPipelineState(PipelineStatusType.QUEUED)
+            .withStartDate(now)
+            .withTimestamp(now);
+    try {
+      addPipelineStatus(uriInfo, pipelineFQN, queuedStatus);
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Failed to record queued status for pipeline [{}] run [{}]: {}",
+          pipelineFQN,
+          runId,
+          e.getMessage());
+    }
+  }
+
+  private List<PipelineStatus> dropStaleQueuedStatuses(List<PipelineStatus> pipelineStatusList) {
+    return withoutStaleQueuedStatuses(
+        pipelineStatusList, System.currentTimeMillis() - queuedStatusTimeoutMillis());
+  }
+
+  /**
+   * Hides {@code queued} runs recorded before {@code cutoff}. An orchestrator can accept a run and
+   * never start it, and since no worker ever reports on such a run its queued status would
+   * otherwise stay pending in run history forever.
+   */
+  static List<PipelineStatus> withoutStaleQueuedStatuses(
+      List<PipelineStatus> pipelineStatusList, long cutoff) {
+    return pipelineStatusList.stream()
+        .filter(pipelineStatus -> !isStaleQueued(pipelineStatus, cutoff))
+        .toList();
+  }
+
+  private static boolean isStaleQueued(PipelineStatus pipelineStatus, long cutoff) {
+    return PipelineStatusType.QUEUED.equals(pipelineStatus.getPipelineState())
+        && pipelineStatus.getTimestamp() != null
+        && pipelineStatus.getTimestamp() < cutoff;
+  }
+
+  private long queuedStatusTimeoutMillis() {
+    Integer configuredTimeout =
+        Optional.ofNullable(openMetadataApplicationConfig)
+            .map(OpenMetadataApplicationConfig::getPipelineServiceClientConfiguration)
+            .map(PipelineServiceClientConfiguration::getQueuedStatusTimeoutSeconds)
+            .orElse(null);
+    return TimeUnit.SECONDS.toMillis(
+        configuredTimeout == null ? DEFAULT_QUEUED_STATUS_TIMEOUT_SECONDS : configuredTimeout);
   }
 
   /* Get the status of the external application by converting the configuration so that it can be

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/apps/AppResource.java
@@ -1342,6 +1342,9 @@ public class AppResource extends EntityResource<App, AppRepository> {
 
         PipelineServiceClientResponse response =
             pipelineServiceClient.runPipeline(ingestionPipeline, service, configPayload);
+        ((IngestionPipelineRepository) Entity.getEntityRepository(Entity.INGESTION_PIPELINE))
+            .recordQueuedPipelineStatus(
+                uriInfo, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
         return Response.status(response.getCode()).entity(response).build();
       }
     }

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/AgentTypeResolver.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/AgentTypeResolver.java
@@ -1,0 +1,66 @@
+package org.openmetadata.service.resources.services.ingestionpipelines;
+
+import static org.openmetadata.common.utils.CommonUtil.nullOrEmpty;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AgentType;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+
+/**
+ * Expands the {@code agentType} list filter into the {@code pipelineType} values it stands for, so
+ * that clients listing agents do not have to keep that mapping in sync themselves.
+ */
+public final class AgentTypeResolver {
+  private static final String VALUE_SEPARATOR = ",";
+
+  private static final Map<AgentType, Set<PipelineType>> PIPELINE_TYPES_BY_AGENT_TYPE =
+      Map.of(
+          AgentType.METADATA,
+          EnumSet.of(
+              PipelineType.METADATA,
+              PipelineType.USAGE,
+              PipelineType.LINEAGE,
+              PipelineType.PROFILER,
+              PipelineType.AUTO_CLASSIFICATION,
+              PipelineType.DBT,
+              PipelineType.POLICY_AGENT),
+          AgentType.APPLICATION,
+          EnumSet.of(PipelineType.APPLICATION));
+
+  private AgentTypeResolver() {}
+
+  /**
+   * Returns the {@code pipelineType} filter value the query should run with. When both filters are
+   * set they are intersected, so a caller can narrow an agent group down to a single pipeline type.
+   * An empty intersection resolves to an empty value, which matches no pipeline.
+   */
+  public static String resolvePipelineTypes(AgentType agentType, String pipelineType) {
+    String result = pipelineType;
+    if (agentType != null) {
+      Set<String> agentPipelineTypes = pipelineTypeValues(agentType);
+      if (!nullOrEmpty(pipelineType)) {
+        agentPipelineTypes.retainAll(splitValues(pipelineType));
+      }
+      result = String.join(VALUE_SEPARATOR, agentPipelineTypes);
+    }
+    return result;
+  }
+
+  private static Set<String> pipelineTypeValues(AgentType agentType) {
+    return PIPELINE_TYPES_BY_AGENT_TYPE.get(agentType).stream()
+        .map(PipelineType::value)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static Set<String> splitValues(String commaSeparatedValues) {
+    return Arrays.stream(commaSeparatedValues.split(VALUE_SEPARATOR))
+        .map(String::trim)
+        .filter(value -> !value.isEmpty())
+        .collect(Collectors.toSet());
+  }
+}

--- a/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java
@@ -59,6 +59,7 @@ import jakarta.ws.rs.sse.Sse;
 import jakarta.ws.rs.sse.SseEventSink;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -68,6 +69,7 @@ import org.openmetadata.schema.ServiceEntityInterface;
 import org.openmetadata.schema.api.configuration.LogStorageConfiguration;
 import org.openmetadata.schema.api.data.RestoreEntity;
 import org.openmetadata.schema.api.services.ingestionPipelines.CreateIngestionPipeline;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AgentType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
@@ -236,15 +238,25 @@ public class IngestionPipelineResource
   /**
    * Dynamically get the MetadataOperation based on the pipelineType (or application Type).
    * E.g., for the Automator, the Operation will be `CREATE_INGESTION_PIPELINE_AUTOMATOR`.
+   *
+   * <p>Deriving the workflow type is part of the lookup, not a precondition of it: an application
+   * pipeline can reach here with no `appConfig` to read the type from, and that has to fall back to
+   * the generic create permission like any other unrecognized type rather than fail the request.
    */
   private MetadataOperation getOperationForPipelineType(IngestionPipeline ingestionPipeline) {
-    String pipelineType = IngestionPipelineRepository.getPipelineWorkflowType(ingestionPipeline);
+    MetadataOperation operation = CREATE;
     try {
-      return MetadataOperation.valueOf(
-          String.format("CREATE_INGESTION_PIPELINE_%s", pipelineType.toUpperCase()));
+      String pipelineType = IngestionPipelineRepository.getPipelineWorkflowType(ingestionPipeline);
+      operation =
+          MetadataOperation.valueOf(
+              String.format("CREATE_INGESTION_PIPELINE_%s", pipelineType.toUpperCase(Locale.ROOT)));
     } catch (IllegalArgumentException | NullPointerException e) {
-      return CREATE;
+      LOG.debug(
+          "No specific create operation for ingestion pipeline [{}], falling back to {}",
+          ingestionPipeline.getName(),
+          CREATE);
     }
+    return operation;
   }
 
   @GET
@@ -289,6 +301,13 @@ public class IngestionPipelineResource
           @QueryParam("pipelineType")
           String pipelineType,
       @Parameter(
+              description =
+                  "Filter Ingestion Pipelines by agent type. Expands to the set of `pipelineType` "
+                      + "values that make up the group, and is intersected with `pipelineType` when both are given.",
+              schema = @Schema(implementation = AgentType.class))
+          @QueryParam("agentType")
+          AgentType agentType,
+      @Parameter(
               description = "Filter Ingestion Pipelines by service Type",
               schema = @Schema(type = "string", example = "messagingService"))
           @QueryParam("serviceType")
@@ -328,7 +347,8 @@ public class IngestionPipelineResource
     ListFilter filter =
         new ListFilter(include)
             .addQueryParam("service", serviceParam)
-            .addQueryParam("pipelineType", pipelineType)
+            .addQueryParam(
+                "pipelineType", AgentTypeResolver.resolvePipelineTypes(agentType, pipelineType))
             .addQueryParam("serviceType", serviceType)
             .addQueryParam("testSuite", testSuiteParam)
             .addQueryParam("applicationType", applicationType)
@@ -1458,7 +1478,11 @@ public class IngestionPipelineResource
     decryptOrNullify(securityContext, ingestionPipeline, true);
     ServiceEntityInterface service =
         Entity.getEntity(ingestionPipeline.getService(), "ingestionRunner", Include.NON_DELETED);
-    return pipelineServiceClient.runPipeline(ingestionPipeline, service);
+    PipelineServiceClientResponse response =
+        pipelineServiceClient.runPipeline(ingestionPipeline, service);
+    repository.recordQueuedPipelineStatus(
+        uriInfo, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
+    return response;
   }
 
   private void decryptOrNullify(

--- a/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClientTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClientTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.kubernetes.client.openapi.ApiException;
@@ -76,8 +77,6 @@ import org.openmetadata.schema.entity.services.DatabaseService;
 import org.openmetadata.schema.entity.services.ingestionPipelines.AirflowConfig;
 import org.openmetadata.schema.entity.services.ingestionPipelines.IngestionPipeline;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineServiceClientResponse;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
-import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
 import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
 import org.openmetadata.schema.entity.teams.AuthenticationMechanism;
 import org.openmetadata.schema.security.client.OpenMetadataJWTClientConfig;
@@ -223,6 +222,10 @@ class K8sPipelineClientTest {
     assertTrue(createdJob.getMetadata().getName().startsWith("om-job-test-pipeline-"));
     assertEquals(
         "test-pipeline", createdJob.getMetadata().getLabels().get("app.kubernetes.io/pipeline"));
+    assertEquals(
+        createdJob.getMetadata().getLabels().get("app.kubernetes.io/run-id"),
+        response.getRunId(),
+        "The run ID must be reported back so the server can record the queued status");
   }
 
   @Test
@@ -718,64 +721,12 @@ class K8sPipelineClientTest {
   }
 
   @Test
-  void testGetQueuedPipelineStatusReturnsOnlyQueuedJobs() throws Exception {
+  void testGetQueuedPipelineStatusCostsNoApiCall() {
     IngestionPipeline pipeline = createTestPipeline("test-pipeline", null);
-
-    V1Job queuedWithRunId =
-        new V1Job()
-            .metadata(
-                new V1ObjectMeta()
-                    .name("queued-with-run-id")
-                    .labels(Map.of("app.kubernetes.io/run-id", "run-1"))
-                    .creationTimestamp(OffsetDateTime.parse("2026-03-09T10:15:30Z")));
-    V1Job queuedWithoutRunId =
-        new V1Job()
-            .metadata(
-                new V1ObjectMeta()
-                    .name("queued-without-run-id")
-                    .creationTimestamp(OffsetDateTime.parse("2026-03-09T10:16:30Z")))
-            .status(new V1JobStatus().active(0).succeeded(0).failed(0));
-    V1Job activeJob =
-        new V1Job()
-            .metadata(new V1ObjectMeta().name("active-job"))
-            .status(new V1JobStatus().active(1));
-    V1Job deletingJob =
-        new V1Job()
-            .metadata(
-                new V1ObjectMeta()
-                    .name("deleting-job")
-                    .deletionTimestamp(OffsetDateTime.parse("2026-03-09T10:17:30Z")))
-            .status(new V1JobStatus().active(0).succeeded(0).failed(0));
-
-    when(batchApi.listNamespacedJob(eq(NAMESPACE))).thenReturn(listJobRequest);
-    when(listJobRequest.labelSelector(eq("app.kubernetes.io/pipeline=test-pipeline")))
-        .thenReturn(listJobRequest);
-    when(listJobRequest.execute())
-        .thenReturn(
-            new V1JobList()
-                .items(List.of(queuedWithRunId, queuedWithoutRunId, activeJob, deletingJob)));
-
-    List<PipelineStatus> queuedStatuses = client.getQueuedPipelineStatus(pipeline);
-
-    assertEquals(2, queuedStatuses.size());
-    assertEquals("run-1", queuedStatuses.get(0).getRunId());
-    assertEquals(PipelineStatusType.QUEUED, queuedStatuses.get(0).getPipelineState());
-    assertEquals("queued-without-run-id", queuedStatuses.get(1).getRunId());
-    assertEquals(
-        queuedWithRunId.getMetadata().getCreationTimestamp().toInstant().toEpochMilli(),
-        queuedStatuses.get(0).getStartDate());
-  }
-
-  @Test
-  void testGetQueuedPipelineStatusHandlesApiFailure() throws Exception {
-    IngestionPipeline pipeline = createTestPipeline("test-pipeline", null);
-
-    when(batchApi.listNamespacedJob(eq(NAMESPACE))).thenReturn(listJobRequest);
-    when(listJobRequest.labelSelector(eq("app.kubernetes.io/pipeline=test-pipeline")))
-        .thenReturn(listJobRequest);
-    when(listJobRequest.execute()).thenThrow(new ApiException(500, "boom"));
 
     assertTrue(client.getQueuedPipelineStatus(pipeline).isEmpty());
+
+    verifyNoInteractions(batchApi);
   }
 
   @Test

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStaleQueuedStatusTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/IngestionPipelineStaleQueuedStatusTest.java
@@ -1,0 +1,64 @@
+package org.openmetadata.service.jdbi3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatus;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineStatusType;
+
+class IngestionPipelineStaleQueuedStatusTest {
+
+  private static final long CUTOFF = 1_000L;
+
+  private static PipelineStatus status(String runId, PipelineStatusType state, Long timestamp) {
+    return new PipelineStatus().withRunId(runId).withPipelineState(state).withTimestamp(timestamp);
+  }
+
+  private static List<String> runIdsOf(List<PipelineStatus> statuses) {
+    return statuses.stream().map(PipelineStatus::getRunId).toList();
+  }
+
+  @Test
+  void queuedRunsOlderThanTheCutoffAreHidden() {
+    List<PipelineStatus> kept =
+        IngestionPipelineRepository.withoutStaleQueuedStatuses(
+            List.of(status("never-started", PipelineStatusType.QUEUED, 999L)), CUTOFF);
+
+    assertTrue(kept.isEmpty());
+  }
+
+  @Test
+  void queuedRunsWithinTheCutoffAreKept() {
+    List<PipelineStatus> kept =
+        IngestionPipelineRepository.withoutStaleQueuedStatuses(
+            List.of(status("just-triggered", PipelineStatusType.QUEUED, 1_000L)), CUTOFF);
+
+    assertEquals(List.of("just-triggered"), runIdsOf(kept));
+  }
+
+  @Test
+  void terminalRunsAreKeptHoweverOldTheyAre() {
+    List<PipelineStatus> statuses =
+        List.of(
+            status("old-success", PipelineStatusType.SUCCESS, 1L),
+            status("old-failure", PipelineStatusType.FAILED, 2L),
+            status("old-running", PipelineStatusType.RUNNING, 3L),
+            status("stale-queued", PipelineStatusType.QUEUED, 4L));
+
+    List<PipelineStatus> kept =
+        IngestionPipelineRepository.withoutStaleQueuedStatuses(statuses, CUTOFF);
+
+    assertEquals(List.of("old-success", "old-failure", "old-running"), runIdsOf(kept));
+  }
+
+  @Test
+  void queuedRunsWithoutATimestampAreKept() {
+    List<PipelineStatus> kept =
+        IngestionPipelineRepository.withoutStaleQueuedStatuses(
+            List.of(status("no-timestamp", PipelineStatusType.QUEUED, null)), CUTOFF);
+
+    assertEquals(List.of("no-timestamp"), runIdsOf(kept));
+  }
+}

--- a/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/ingestionpipelines/AgentTypeResolverTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/resources/services/ingestionpipelines/AgentTypeResolverTest.java
@@ -1,0 +1,72 @@
+package org.openmetadata.service.resources.services.ingestionpipelines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.openmetadata.schema.entity.services.ingestionPipelines.AgentType;
+import org.openmetadata.schema.entity.services.ingestionPipelines.PipelineType;
+
+class AgentTypeResolverTest {
+
+  private static Set<String> resolvedTypes(AgentType agentType, String pipelineType) {
+    return Set.of(AgentTypeResolver.resolvePipelineTypes(agentType, pipelineType).split(","));
+  }
+
+  @Test
+  void metadataAgentTypeResolvesToTheMetadataPipelineTypes() {
+    assertEquals(
+        Set.of(
+            "metadata", "usage", "lineage", "profiler", "autoClassification", "dbt", "policyAgent"),
+        resolvedTypes(AgentType.METADATA, null));
+  }
+
+  @Test
+  void metadataAgentTypeExcludesEveryPipelineTypeThatIsNotAMetadataAgent() {
+    Set<String> metadataTypes = resolvedTypes(AgentType.METADATA, null);
+    List<PipelineType> excluded =
+        Arrays.stream(PipelineType.values())
+            .filter(pipelineType -> !metadataTypes.contains(pipelineType.value()))
+            .toList();
+    assertEquals(
+        List.of(
+            PipelineType.TEST_SUITE,
+            PipelineType.DATA_INSIGHT,
+            PipelineType.ELASTIC_SEARCH_REINDEX,
+            PipelineType.APPLICATION),
+        excluded,
+        "A new pipelineType must be explicitly classified as a metadata agent or not");
+  }
+
+  @Test
+  void applicationAgentTypeResolvesToTheApplicationPipelineType() {
+    assertEquals(
+        "application", AgentTypeResolver.resolvePipelineTypes(AgentType.APPLICATION, null));
+  }
+
+  @Test
+  void noAgentTypeLeavesThePipelineTypeFilterUntouched() {
+    assertNull(AgentTypeResolver.resolvePipelineTypes(null, null));
+    assertEquals("dbt,usage", AgentTypeResolver.resolvePipelineTypes(null, "dbt,usage"));
+  }
+
+  @Test
+  void bothFiltersAreIntersected() {
+    assertEquals(
+        Set.of("lineage", "dbt"), resolvedTypes(AgentType.METADATA, "lineage,dbt,application"));
+  }
+
+  @Test
+  void anEmptyIntersectionMatchesNoPipeline() {
+    assertTrue(AgentTypeResolver.resolvePipelineTypes(AgentType.METADATA, "application").isEmpty());
+  }
+
+  @Test
+  void blankPipelineTypeValuesAreIgnoredWhenIntersecting() {
+    assertEquals(Set.of("usage"), resolvedTypes(AgentType.METADATA, " usage , "));
+  }
+}

--- a/openmetadata-spec/src/main/resources/json/schema/configuration/pipelineServiceClientConfiguration.json
+++ b/openmetadata-spec/src/main/resources/json/schema/configuration/pipelineServiceClientConfiguration.json
@@ -28,6 +28,11 @@
       "type": "integer",
       "default": 300
     },
+    "queuedStatusTimeoutSeconds": {
+      "description": "How long a `queued` pipeline status recorded when triggering a run stays visible before it is treated as stale and hidden. Covers runs that the orchestrator accepted but never started.",
+      "type": "integer",
+      "default": 3600
+    },
     "ingestionIpInfoEnabled": {
       "description": "Enable or disable the API that fetches the public IP running the ingestion process.",
       "type": "boolean",

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/ingestionPipelines/agentType.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/ingestionPipelines/agentType.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://open-metadata.org/schema/entity/services/ingestionPipelines/agentType.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AgentType",
+  "description": "Coarse grouping of Ingestion Pipelines. Used as a list filter so that clients do not have to enumerate the `pipelineType` values that make up an agent group.",
+  "type": "string",
+  "javaType": "org.openmetadata.schema.entity.services.ingestionPipelines.AgentType",
+  "enum": ["metadata", "application"],
+  "javaEnums": [{ "name": "METADATA" }, { "name": "APPLICATION" }]
+}

--- a/openmetadata-spec/src/main/resources/json/schema/entity/services/ingestionPipelines/pipelineServiceClientResponse.json
+++ b/openmetadata-spec/src/main/resources/json/schema/entity/services/ingestionPipelines/pipelineServiceClientResponse.json
@@ -21,6 +21,10 @@
     "version": {
       "description": "Ingestion version being used.",
       "type": "string"
+    },
+    "runId": {
+      "description": "Identifier of the run that was just triggered. Only set by orchestrators that mint the run ID themselves, which lets the server record the `queued` status instead of polling the orchestrator for it.",
+      "type": "string"
     }
   },
   "additionalProperties": false,

--- a/openmetadata-ui/src/main/resources/ui/src/generated/configuration/pipelineServiceClientConfiguration.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/configuration/pipelineServiceClientConfiguration.ts
@@ -61,8 +61,14 @@ export interface PipelineServiceClientConfiguration {
     /**
      * Additional parameters to initialize the PipelineServiceClient.
      */
-    parameters?:           { [key: string]: any };
-    secretsManagerLoader?: SecretsManagerClientLoader;
+    parameters?: { [key: string]: any };
+    /**
+     * How long a `queued` pipeline status recorded when triggering a run stays visible before
+     * it is treated as stale and hidden. Covers runs that the orchestrator accepted but never
+     * started.
+     */
+    queuedStatusTimeoutSeconds?: number;
+    secretsManagerLoader?:       SecretsManagerClientLoader;
     /**
      * OpenMetadata Client SSL configuration. This SSL information is about the OpenMetadata
      * server. It will be picked up from the pipelineServiceClient to use/ignore SSL when

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/agentType.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/agentType.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2026 Collate.
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/**
+ * Coarse grouping of Ingestion Pipelines. Used as a list filter so that clients do not have
+ * to enumerate the `pipelineType` values that make up an agent group.
+ */
+export enum AgentType {
+    Application = "application",
+    Metadata = "metadata",
+}

--- a/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/pipelineServiceClientResponse.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/entity/services/ingestionPipelines/pipelineServiceClientResponse.ts
@@ -27,6 +27,12 @@ export interface PipelineServiceClientResponse {
      */
     reason?: string;
     /**
+     * Identifier of the run that was just triggered. Only set by orchestrators that mint the
+     * run ID themselves, which lets the server record the `queued` status instead of polling
+     * the orchestrator for it.
+     */
+    runId?: string;
+    /**
      * Ingestion version being used.
      */
     version?: string;

--- a/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/generated/settings/settings.ts
@@ -169,8 +169,14 @@ export interface PipelineServiceClientConfiguration {
     /**
      * Additional parameters to initialize the PipelineServiceClient.
      */
-    parameters?:           { [key: string]: any };
-    secretsManagerLoader?: SecretsManagerClientLoader;
+    parameters?: { [key: string]: any };
+    /**
+     * How long a `queued` pipeline status recorded when triggering a run stays visible before
+     * it is treated as stale and hidden. Covers runs that the orchestrator accepted but never
+     * started.
+     */
+    queuedStatusTimeoutSeconds?: number;
+    secretsManagerLoader?:       SecretsManagerClientLoader;
     /**
      * OpenMetadata Client SSL configuration. This SSL information is about the OpenMetadata
      * server. It will be picked up from the pipelineServiceClient to use/ignore SSL when

--- a/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx
@@ -89,6 +89,7 @@ import {
 } from '../../generated/entity/services/dashboardService';
 import { DatabaseServiceType } from '../../generated/entity/services/databaseService';
 import { DriveServiceType } from '../../generated/entity/services/driveService';
+import { AgentType } from '../../generated/entity/services/ingestionPipelines/agentType';
 import { IngestionPipeline } from '../../generated/entity/services/ingestionPipelines/ingestionPipeline';
 import { MessagingServiceType } from '../../generated/entity/services/messagingService';
 import { MlModelServiceType } from '../../generated/entity/services/mlmodelService';
@@ -591,7 +592,7 @@ const ServiceDetailsPage: FunctionComponent = () => {
           serviceFilter: decodedServiceFQN,
           serviceType: getEntityTypeFromServiceCategory(serviceCategory),
           paging,
-          pipelineType: SERVICE_INGESTION_PIPELINE_TYPES,
+          agentType: AgentType.Metadata,
           limit,
         });
 

--- a/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/rest/ingestionPipelineAPI.ts
@@ -18,6 +18,7 @@ import {
   CreateIngestionPipeline,
   PipelineType,
 } from '../generated/api/services/ingestionPipelines/createIngestionPipeline';
+import { AgentType } from '../generated/entity/services/ingestionPipelines/agentType';
 import {
   IngestionPipeline,
   PipelineStatus,
@@ -56,6 +57,7 @@ export const getIngestionPipelines = async (data: {
   serviceFilter?: string;
   paging?: Omit<Paging, 'total'>;
   pipelineType?: PipelineType[];
+  agentType?: AgentType;
   provider?: ProviderType;
   testSuite?: string;
   serviceType?: string;


### PR DESCRIPTION
## Describe your changes

Two changes to the ingestion pipeline APIs behind the service **Agents** page, plus a crash found while testing them.

### 1. `agentType` list filter

`GET /v1/services/ingestionPipelines` had no way to ask for *"the metadata agents"*, so every caller enumerated the seven `pipelineType` values that make one up. The UI kept that list in `SERVICE_INGESTION_PIPELINE_TYPES`, Collate kept its own copy, and a caller that passed nothing got AI automations (`pipelineType=application`) mixed into the Metadata tab:

```
/api/v1/services/ingestionPipelines?fields=owners,pipelineStatuses&service=banking-bigquery&serviceType=databaseService
```

Now:

| filter | expands to |
|---|---|
| `agentType=metadata` | `metadata, usage, lineage, profiler, autoClassification, dbt, policyAgent` |
| `agentType=application` | `application` |

It is an **allow-list, not a negation**. `TestSuite`, `dataInsight` and `elasticSearchReindex` belong to neither group; implementing `metadata` as "everything that is not an application" would leak them onto the page. Setting both `agentType` and `pipelineType` intersects them, so a caller can narrow a group to one type; an empty intersection matches nothing.

The filter is **derived, not stored** — `AgentTypeResolver` expands it into the existing `pipelineType IN (...)` clause. No new entity field, no migration, and nothing that can drift out of sync with `pipelineType`.

### 2. Queued status without an orchestrator round trip

`IngestionPipelineRepository.listPipelineStatus` called `pipelineServiceClient.getQueuedPipelineStatus` on **every** read. For the K8s client that is a `listNamespacedJob` against the API server each time run history is opened, including paged historical reads that cannot contain a queued run. The Airflow call has a 10s connect timeout and no read timeout, so a slow scheduler pins the Jetty thread.

`PipelineServiceClientResponse` now carries `runId`:

```java
PipelineServiceClientResponse response = pipelineServiceClient.runPipeline(ingestionPipeline, service);
repository.recordQueuedPipelineStatus(uriInfo, ingestionPipeline.getFullyQualifiedName(), response.getRunId());
```

Orchestrators that mint the run ID when triggering report it back, and the server records the `queued` status itself. The K8s client already generated that ID and injects it into the pod as `pipelineRunId`, so the worker's later status **upserts onto the same row** (`addPipelineStatus` keys on `runId`) — no phantom run. Airflow mints its run ID inside the task (`openmetadata_managed_apis/workflows/ingestion/common.py`) and cannot report one, so it returns `null` and keeps the live-polling path completely unchanged.

**No engine branching anywhere** — the presence of a `runId` selects the behaviour. Collate's `ArgoServiceClient` gets the same treatment in a companion PR.

Recorded on three trigger paths, not just the manual one: `IngestionPipelineResource` (Run button), `AppResource` (Applications page) and `RunIngestionPipelineImpl` (AutoPilot, whose runs render on the very Agents page this change is about). Without them those runs would lose the indicator along with the poll, since `listPipelineStatus` is the single read path for queued status regardless of who triggered the run.

Deliberately **not** recorded on `RunAppImpl` or `DataContractRepository`. Those are workflow-internal: `waitForCompletion` treats any non-terminal status as still running, so the queued row buys their own polling nothing while costing an upsert plus a search reindex per run.

### 3. Crash fix

`getOperationForPipelineType` derived the workflow type **outside** its own try block, so an `application` pipeline with no `appConfig` threw `NullPointerException` before authorization ran and returned 500, instead of falling back to the generic create permission the way every other unrecognized type already does.

#
### Type of change:
- [x] Improvement

#
### High-level design:

**Why `agentType` is a query-param preset rather than an entity field.** It carries zero information that is not already derivable from `pipelineType`. Storing it would mean a schema field, a migration, a backfill, and two sources of truth that can disagree. Expanding it in `ListFilter`'s existing `pipelineType IN (...)` path costs nothing and cannot drift.

**Why the run ID lives on the response instead of a capability flag.** The alternatives were an `instanceof` check in the repository, or a `supportsStoredQueuedStatus()` method on the client interface. Both make the repository know about engines. A nullable `runId` on the response is self-selecting: an orchestrator that knows its run ID says so, one that does not stays on the old path, and a future engine opts in by populating one field.

**Rejected: correlating by writing the queued row under a server-generated ID.** For Airflow the server never learns the ID the worker will use, so the queued row would never resolve and run history would show a permanently-pending phantom next to the real run. Passing a `run_id` through `trigger.py` into `pipelineRunId` would fix that, but it spans three repos and needs a version gate for older `openmetadata-airflow-apis` that ignore the parameter. Not worth it to save one HTTP call on the engine that is least affected.

**Trade-off — a run that is accepted but never starts.** The live poll was self-cleaning: it re-derived queued state from the orchestrator each read. A stored row has no such feedback, so an unschedulable job (no capacity, ImagePullBackOff, quota) would stay `queued` forever. Queued rows older than `queuedStatusTimeoutSeconds` (new config, default 1h) are therefore hidden on read. The default is deliberately generous so a genuinely long queue does not disappear from the UI.

**Known gap — scheduled runs.** They generate their run ID outside the trigger path: CronOMJob via a reconciler placeholder, plain CronJob via the pod UID (Downward API). They get no queued row and appear when the worker posts its first status. Also lost: queued runs OpenMetadata did not trigger, e.g. a DAG started directly in the Airflow UI. Both were judged acceptable against the per-read cost.

**Backward compatibility.** `agentType` is optional and additive; omitting it preserves today's behaviour exactly. `runId` is an optional response field. `queuedStatusTimeoutSeconds` defaults to 3600. Hybrid deployments are untouched — `HybridServiceClient` overrides `getQueuedPipelineStatus` and its runner response carries no `runId`, so those pipelines keep their existing path.

#
### Tests:

#### Use cases covered
- The service Agents page lists only metadata agents, with AI automations excluded, without the client enumerating pipeline types
- A `pipelineType` that belongs to no agent group (`elasticSearchReindex`) is excluded from **both** groups rather than falling into `metadata`
- `agentType` combined with `pipelineType` narrows to the intersection; a disjoint combination returns nothing
- Opening run history no longer issues a Kubernetes API call
- A manually triggered K8s run reports its run ID so the server can record `queued`, and the worker's status collapses onto that same row
- A run accepted but never started stops showing as queued after the timeout
- Creating an `application` pipeline with no `appConfig` succeeds instead of returning 500

#### Unit tests
- [x] Added — `AgentTypeResolverTest` (7), `IngestionPipelineStaleQueuedStatusTest` (4), plus updated `K8sPipelineClientTest`
- `AgentTypeResolverTest` includes a guard asserting the exact set of pipeline types **excluded** from `metadata`, so a newly added `PipelineType` fails the build until someone classifies it rather than silently vanishing from the page.
- Affected suites run green: `AgentTypeResolverTest`, `IngestionPipelineStaleQueuedStatusTest`, `K8sPipelineClientTest`, `AirflowRESTClientTest`, `LogStorageTest`, `PipelineServiceClientTest`, `RunIngestionPipelineImplTest`, `IngestionPipelineRepositoryTest`, `DataContractFieldSupportTest`, `AppResourceRetryQueueTest`, `AppResourceSnapshotRedactionTest` — **156 tests, 0 failures**.

#### Integration tests
- [x] Added — `IngestionPipelineAgentTypeIT` (2 tests, real server + MySQL + Elasticsearch via Testcontainers): green.
- [x] Added — `IngestionPipelineResourceIT#test_createApplicationPipelineWithoutAppConfig`, a regression test for the NPE. **Verified RED** by stashing only `IngestionPipelineResource.java` and rebuilding: fails with the exact `NullPointerException` at `getOperationForPipelineType`. Green with the fix.
- Full `IngestionPipelineResourceIT`: **233 tests, 0 failures** (20 pre-existing skips).

#### Frontend tests
- [x] `ServiceDetailsPage` Jest suite: **54 tests, 0 failures**.

#### Manual test steps
The `agentType` filter is exercised end-to-end by `IngestionPipelineAgentTypeIT` against a real server rather than by hand. The trigger → `queued` → worker-status transition needs a live K8s or Argo orchestrator, which neither the IT stack (Airflow client pointed at nothing) nor Jest can provide; it is covered structurally instead — `K8sPipelineClientTest` asserts the run ID is reported on the response and that the queued read costs no API call, and `addPipelineStatus`'s existing upsert-by-`runId` is what collapses the rows. Worth a look on a real cluster before release.

#
### UI screen recording / screenshots

No visual change. The only UI diff swaps the query the Agents tab sends:

```diff
-  pipelineType: SERVICE_INGESTION_PIPELINE_TYPES,
+  agentType: AgentType.Metadata,
```

The rendered list is identical — same pipelines, same order. `SERVICE_INGESTION_PIPELINE_TYPES` stays for its two non-filter uses (building the "Add Agent" menu, and filtering pipelines discovered over SSE in `useMetadataAgents`), which cannot move server-side.

#
### Checklist:
- [x] Generated TypeScript types regenerated from the schema changes (`json2ts-generate-all.sh`) — 4 files, no unrelated drift
- [x] `mvn spotless:check` clean
- [x] UI ESLint + Prettier + organize-imports clean (0 errors)
- [x] `tsc --noEmit` reports nothing in the changed files
- [x] No `.github/workflows/**` changes
- [ ] Linked issue — none; happy to open one if you want the discussion recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds server-side agent-type filtering and replaces Kubernetes queued-status polling with persisted queued statuses keyed by orchestrator run ID. It also adds expiration for stale queued statuses, extends trigger paths to record queued runs, and handles application pipelines without app configuration.
- Adds the `metadata` and `application` agent groups and updates the Agents page query.
- Propagates Kubernetes run IDs and records queued status after manual, application, and workflow-triggered runs.
- Adds configurable stale-queued visibility and coverage for filtering, status handling, and authorization fallback.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not yet safe to merge because stale queued rows can still displace valid runs from limited history responses.

The database limit is applied before stale queued statuses are filtered, and the repository does not fetch replacement rows afterward, so valid older history entries can be omitted.

**Files Needing Attention:** openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/IngestionPipelineRepository.java | Adds persisted queued-status recording and timeout-based filtering across status response paths. |
| openmetadata-service/src/main/java/org/openmetadata/service/clients/pipeline/k8s/K8sPipelineClient.java | Returns the generated run ID from triggers and removes Kubernetes API polling from queued-status reads. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/AgentTypeResolver.java | Defines explicit agent-group allow-lists and intersection behavior for pipeline-type filtering. |
| openmetadata-service/src/main/java/org/openmetadata/service/resources/services/ingestionpipelines/IngestionPipelineResource.java | Exposes the agentType filter, records queued statuses after triggers, and safely falls back to generic create authorization. |
| openmetadata-ui/src/main/resources/ui/src/pages/ServiceDetailsPage/ServiceDetailsPage.tsx | Replaces the client-maintained metadata pipeline-type list with the new server-side agentType filter. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Agents UI
  participant API as Ingestion Pipeline API
  participant Repo as Pipeline Repository
  participant K8s as Kubernetes Client
  participant DB as Status Store
  UI->>API: List pipelines with agentType
  API->>Repo: Resolve agentType to pipelineType set
  Repo-->>UI: Filtered pipelines
  UI->>API: Trigger pipeline
  API->>K8s: runPipeline
  K8s-->>API: response with runId
  API->>Repo: recordQueuedPipelineStatus(runId)
  Repo->>DB: Upsert queued status
  Note over DB: Worker updates the same runId later
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ingestion-pipelines): apply the stal..."](https://github.com/open-metadata/openmetadata/commit/d7279e0ca6f5fd4ce0a59277843013d94a75f2cd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53908407)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Governance Workflows and Applications in OpenMetadata Service](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-workflows-apps.md)
- Knowledge Base — [openmetadata-spec: JSON Schema specification and multi-language code generation](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-spec.md)
- Knowledge Base — [OpenMetadata React UI](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-ui.md)
</details>

<!-- /greptile_comment -->