### PR TITLE
fix(security): name the token's own claims when principal resolution finds none

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -246,8 +247,11 @@ public final class SecurityUtil {
         .orElseThrow(
             () ->
                 new AuthenticationException(
-                    "Invalid JWT token, none of the following claims are present "
-                        + jwtPrincipalClaimsOrder));
+                    String.format(
+                        "Invalid JWT token, none of the configured principal claims %s are present"
+                            + " -- the token carries %s. Set jwtPrincipalClaims to a claim this"
+                            + " identity provider issues.",
+                        jwtPrincipalClaimsOrder, new TreeSet<>(claims.keySet()))));
   }
 
   /**

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java
@@ -381,7 +381,30 @@ class SecurityUtilTest {
             AuthenticationException.class,
             () -> SecurityUtil.getFirstMatchJwtClaim(List.of("email"), Map.of("sub", "1234")));
 
-    assertTrue(exception.getMessage().contains("none of the following claims are present"));
+    assertTrue(exception.getMessage().contains("none of the configured principal claims"));
+  }
+
+  @Test
+  void testGetFirstMatchJwtClaimNamesTheClaimsTheTokenActuallyCarries() {
+    // Naming only what was expected leaves an admin guessing what to configure instead: the token's
+    // own claim names are what turn this into a one-line jwtPrincipalClaims change. Names only --
+    // claim values identify people and must not reach a log.
+    AuthenticationException exception =
+        assertThrows(
+            AuthenticationException.class,
+            () ->
+                SecurityUtil.getFirstMatchJwtClaim(
+                    List.of("email"),
+                    Map.of(
+                        "preferred_username", stringClaim("alice@example.com"),
+                        "oid", stringClaim("6bf1d0f6-opaque"))));
+
+    String message = exception.getMessage();
+    assertTrue(message.contains("[email]"), "the configured claims must be named");
+    assertTrue(message.contains("preferred_username"), "the token's own claims must be named");
+    assertTrue(message.contains("oid"), "the token's own claims must be named");
+    assertFalse(message.contains("alice@example.com"), "claim values must never be disclosed");
+    assertFalse(message.contains("6bf1d0f6-opaque"), "claim values must never be disclosed");
   }
 
   @Test


### PR DESCRIPTION
Fixes #31615 

When a token carries none of the claims a deployment resolves principals from, `SecurityUtil.getFirstMatchJwtClaim` reported only what was expected:

```
Invalid JWT token, none of the following claims are present [email]
```

That names the configuration but not the token, so an administrator cannot tell what to set `jwtPrincipalClaims` *to* — only that the current value is wrong.

It matters because of where this fails. `JwtFilter` runs this on every request, so the symptom is a total lockout: every API call 401s and the UI logs the user out with no explanation. The server log is the only diagnostic available, and it withheld the one fact that resolves the incident.

Now both sides are named:

```
Invalid JWT token, none of the configured principal claims [email] are present
-- the token carries [aud, exp, iat, iss, oid, preferred_username, sub, tid].
Set jwtPrincipalClaims to a claim this identity provider issues.
```

**Claim names only** — values identify people and must not reach a log; a test pins that.

This is a common shape rather than an edge case. Azure AD / Entra emits `email` only for accounts with a populated `mail` attribute, so a deployment configured for `email` locks out exactly those users who lack one while working for everyone else. One line from the message above identifies it; without it the investigation is largely guesswork.

Tests: the existing assertion is updated to the new wording, plus one new test covering that the token's own claim names appear and its claim *values* do not. Verified to fail without the change. No other test or source in the repo asserts the old string.
<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR improves JWT principal-resolution diagnostics by naming both the configured principal claims and the claim names carried by the token, while deliberately excluding claim values.
- Sorts token claim names for deterministic exception output.
- Updates the existing assertion and adds coverage ensuring claim names appear without exposing claim values.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no blocking or independently actionable issues identified.

The changed failure path preserves authentication behavior, emits only claim names from a signature-verified token, and has focused tests preventing claim-value disclosure.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/security/SecurityUtil.java | Enhances the missing-principal-claim AuthenticationException with a deterministic list of token claim names and configuration guidance; no actionable defect found. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/SecurityUtilTest.java | Updates the expected diagnostic and verifies that claim names, but not identifying claim values, are included. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): name the token&#39;s own clai..."](https://github.com/open-metadata/openmetadata/commit/6ffa4e9f9ba95f33f32769f4cf7198177eb9224d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53918454)</sub>

**Context used:**

- Knowledge Base — [Auth and Security: Authentication, Authorization, Secrets, and SCIM](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-auth-security.md)

<!-- /greptile_comment -->
