### PR TITLE
fix(trino): don't ingest an unset column comment as an empty description

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/trino/metadata.py
@@ -120,7 +120,10 @@ def _get_columns(self, connection: Connection, table_name: str, schema: str = No
             "name": record.Column,
             "type": col_type,
             "nullable": True,
-            "comment": record.Comment,
+            # SHOW COLUMNS reports an unset comment as '' rather than NULL, and it reports an
+            # explicit COMMENT '' the same way, so the two are indistinguishable here. Normalize
+            # to None so we don't ingest a blank description that then blocks later updates.
+            "comment": record.Comment or None,
             "system_data_type": record.Type,
         }
         type_str = record.Type.strip().lower()
@@ -168,7 +171,7 @@ def get_table_comment(  # pylint: disable=unused-argument
                 connection,
                 TRINO_TABLE_COMMENTS.format(catalog_name=catalog_name, schema_name=schema),
             )
-        return {"text": self.all_table_comments.get((table_name, schema))}
+        return {"text": self.all_table_comments.get((table_name, schema)) or None}
     except error.TrinoQueryError as exe:
         if exe.error_name in (error.PERMISSION_DENIED,):
             return {"text": None}

--- a/ingestion/tests/unit/topology/database/test_trino_metadata.py
+++ b/ingestion/tests/unit/topology/database/test_trino_metadata.py
@@ -18,6 +18,7 @@ from metadata.generated.schema.entity.data.table import TableType
 from metadata.ingestion.source.database.common_db_source import TableNameAndType
 from metadata.ingestion.source.database.trino.metadata import (
     TrinoSource,
+    _get_columns,
     get_view_definition,
 )
 
@@ -237,6 +238,42 @@ class TestTrinoIcebergDetection(unittest.TestCase):
         mock_self.inspector.get_table_names.return_value = ["orders"]
         result = TrinoSource.query_table_names_and_types(mock_self, "test_schema")
         assert result == [TableNameAndType(name="orders", type_=TableType.Regular)]
+
+
+class TestTrinoColumnComments:
+    """`SHOW COLUMNS` reports an unset column comment as '', which must not become a description"""
+
+    @staticmethod
+    def _mock_connection(records):
+        connection = Mock()
+        connection.dialect.identifier_preparer.quote.side_effect = lambda value: f'"{value}"'
+        connection.execute.return_value = records
+        return connection
+
+    @staticmethod
+    def _record(name, comment):
+        record = Mock()
+        record.Column = name
+        record.Type = "varchar"
+        record.Comment = comment
+        return record
+
+    def _columns_for(self, records):
+        mock_self = Mock()
+        mock_self._get_default_schema_name.return_value = "test_schema"
+        return _get_columns(mock_self, self._mock_connection(records), "test_table", "test_schema")
+
+    def test_unset_comment_is_none(self):
+        columns = self._columns_for([self._record("id", "")])
+        assert columns[0]["comment"] is None
+
+    def test_populated_comment_is_preserved(self):
+        columns = self._columns_for([self._record("name", "Name of the student")])
+        assert columns[0]["comment"] == "Name of the student"
+
+    def test_null_comment_is_none(self):
+        columns = self._columns_for([self._record("age", None)])
+        assert columns[0]["comment"] is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Describe your changes:

Fixes #31544

- I worked on the connector half of #31544: Trino columns with no comment were
ingested with an empty-string description.

- Trino's `SHOW COLUMNS` reports a column with no comment as the **empty string**,
never `NULL` — and it reports an explicit `COMMENT ''` identically, so the two
are indistinguishable at that layer. `_get_columns` passed `record.Comment`
straight through, and `sql_column_handler` maps it onto `description`, so every
uncommented column landed in OpenMetadata with `"description": ""` rather than no
description at all.

- Normalizing `''` to `None` is enough to fix it: the sink serializes with
`exclude_none=True`, so the field is now omitted from the payload entirely.

- Applied the same normalization to the table comment in `get_table_comment`.
`TRINO_TABLE_COMMENTS` filters `"comment" is not null` but not `COMMENT ''`, so a
table commented with an empty string had the same problem.

- **Why this matters beyond cosmetics:** a blank description counts as empty on the
server side, so it is the one state a bot PUT is allowed to overwrite. That made
the sync look functional — an uncommented column would accept its *first* comment
— while a column with any real description silently stopped updating. The
server-side half of that behaviour is fixed separately on branch
`trino_column_description_update_issue`; both are needed to close #31544.

#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- A Trino column created without a comment is ingested with no description,
  rather than an empty-string description
- A Trino column created with `COMMENT ''` is likewise ingested with no
  description
- A Trino column with a real comment still carries it through unchanged

#### Unit tests
- [x] I added unit tests for the new/changed logic.
- File updated: `ingestion/tests/unit/topology/database/test_trino_metadata.py` —
  new `TestTrinoColumnComments` class covering `_get_columns`:
  - `test_unset_comment_is_none` — `''` → `None`
  - `test_populated_comment_is_preserved` — real comment unchanged
  - `test_null_comment_is_none` — `None` → `None`
- `pytest ingestion/tests/unit/topology/database/test_trino_metadata.py` →
  **16 passed**.
- `ruff check` and `ruff format --check` clean on both changed files.

#### Backend integration tests
- [x] Not applicable (no backend changes on this branch).

#### Ingestion integration tests
- [x] Not applicable — covered by the unit tests above plus the manual
  end-to-end run below. Trino integration tests require a live Trino instance.

#### Playwright (UI) tests
- [x] Not applicable (no UI changes).

#### Manual testing performed

Local Trino (`memory` catalog) against a local OpenMetadata stack.

1. Created tables covering all three comment states:
   ```sql
   CREATE TABLE memory.testdb.sample_table (
       id BIGINT COMMENT 'Unique identifier for the record',
       age INTEGER COMMENT '',
       created_at TIMESTAMP COMMENT 'Timestamp when the record was created'
   );
   CREATE TABLE memory.testdb.student_data (
       id BIGINT,
       name VARCHAR COMMENT 'Name of the student'
   );
   ```
2. Ran `metadata ingest -c trino.yaml` and fetched the columns from the API.
3. **Before:** `age` and `student_data.id` came back as `"description": ""`.
4. **After:** neither column has a `description` field, while `id`, `created_at`
   and `name` keep their comment text unchanged.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #31544` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For JSON Schema changes: not applicable, no schema changes.
- [x] For UI changes: not applicable.
- [x] I have added tests (unit) and listed them above.

<!-- Bug fix -->
- [x] I have added a test that covers the exact scenario we are fixing.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR normalizes empty Trino column and table comments to `None`, preventing blank descriptions from being emitted during ingestion.

- Converts empty `SHOW COLUMNS` comments to absent column descriptions while preserving populated comments.
- Applies equivalent normalization to cached table comments.
- Adds focused unit coverage for empty, populated, and null column comments.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking test-coverage gap for the new table-comment normalization.

The normalization matches Trino’s string-or-null comment contract and existing connector conventions; the only accepted concern is that the parallel table-comment behavior is not directly tested.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/trino/metadata.py, ingestion/tests/unit/topology/database/test_trino_metadata.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/trino/metadata.py | Correctly normalizes empty Trino comments, but the new table-comment branch lacks direct regression coverage. |
| ingestion/tests/unit/topology/database/test_trino_metadata.py | Adds focused coverage for all relevant column-comment states without testing the parallel table-comment change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(trino): don&#39;t ingest an unset column..."](https://github.com/open-metadata/openmetadata/commit/cff55556effcc11e3a439daf1da9934b38d18c1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53947589)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Ingestion Framework](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/ingestion-framework.md)

<!-- /greptile_comment -->