### PR TITLE
fix(e2e): isolate delete tests to adminUser to prevent cross-worker toast pollution

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts
@@ -1329,9 +1329,11 @@ test.describe('Glossary tests', () => {
   test('Delete Glossary and Glossary Term using Delete Modal', async ({
     browser,
   }) => {
-    const { page, afterAction, apiContext } = await performAdminLogin(browser, {
-      navigate: true,
-    });
+    const { page, afterAction, apiContext } = await performUserLogin(
+      browser,
+      adminUser
+    );
+    await redirectToHomePage(page);
     const glossary1 = new Glossary();
     const glossaryTerm1 = new GlossaryTerm(glossary1);
     glossary1.data.terms = [glossaryTerm1];
@@ -1350,9 +1352,11 @@ test.describe('Glossary tests', () => {
   });
 
   test('Async Delete - single delete success', async ({ browser }) => {
-    const { page, afterAction, apiContext } = await performAdminLogin(browser, {
-      navigate: true,
-    });
+    const { page, afterAction, apiContext } = await performUserLogin(
+      browser,
+      adminUser
+    );
+    await redirectToHomePage(page);
     const glossary1 = new Glossary();
 
     try {
@@ -1416,9 +1420,11 @@ test.describe('Glossary tests', () => {
   });
 
   test('Async Delete - multiple deletes all succeed', async ({ browser }) => {
-    const { page, afterAction, apiContext } = await performAdminLogin(browser, {
-      navigate: true,
-    });
+    const { page, afterAction, apiContext } = await performUserLogin(
+      browser,
+      adminUser
+    );
+    await redirectToHomePage(page);
     const glossaryA = new Glossary();
     const glossaryB = new Glossary();
     const glossaryC = new Glossary();


### PR DESCRIPTION
Backport of #31602 to the 2.0 release branch.

## Root cause

All parallel Playwright workers log in as the same global `admin` user. OpenMetadata broadcasts entity change events via WebSocket to **all browser sessions of the same user**. So when any worker's delete test removes a glossary through an admin browser, the backend emits a `deleteEntityChannel` WebSocket event that appears as a `"… deleted successfully!"` toast in **every other worker's admin browser page** simultaneously.

The toast sits at `z-[1000]` and intercepts the pointer event on `save-glossary` in tests that are creating a glossary concurrently — causing an intermittent 180-second timeout in `Glossary.spec.ts › Approve and reject glossary term from Glossary Listing`.

## Fix

Switch the three UI-deletion tests (**Delete Modal**, **Async single**, **Async multi**) from `performAdminLogin` → `performUserLogin(browser, adminUser)`.

`adminUser` is a unique per-describe-block user (created in `beforeAll`, deleted in `afterAll`) with admin role. No other parallel worker is ever logged in as `adminUser`, so WebSocket events from its deletions are isolated to its own session and never reach other workers' admin browsers.

The two mocked-WebSocket tests are intentionally left on global admin because they deliberately intercept the global WebSocket channel.

## Test plan

- [ ] `Glossary.spec.ts › Approve and reject glossary term from Glossary Listing` passes without timeout across parallel workers
- [ ] `Delete Glossary and Glossary Term using Delete Modal` still verifies the delete UI flow correctly
- [ ] `Async Delete - single delete success` and `Async Delete - multiple deletes all succeed` pass as before

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR isolates three real glossary-deletion tests from the shared global administrator session by authenticating them as a per-suite admin user.
- Replaces global admin login in the delete-modal test.
- Applies the same isolated login to single- and multi-entity asynchronous deletion tests.
- Explicitly navigates each new user session to the ready home page before interacting with the glossary UI.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the changed test authentication flow.

The suite creates and promotes adminUser before these tests, runs tests in this spec serially, and the added home-page redirect preserves the navigation and loader guarantees of the replaced admin-login helper.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Glossary.spec.ts | The three deletion tests now use the suite-scoped adminUser session, with lifecycle, permissions, navigation readiness, and cleanup remaining consistent with their requirements. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(e2e): use adminUser for delete-moda..."](https://github.com/open-metadata/openmetadata/commit/471231289c3726ae3113688dc8b1327dc5668f65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53948795)</sub>

<!-- /greptile_comment -->