### PR TITLE
fix(search-export): await count API before export click in browse mode

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts
@@ -346,7 +346,16 @@ test.describe('Search Export', { tag: ['@Features', '@Discovery'] }, () => {
       page.locator('[data-testid^="table-data-card_"]').first()
     ).toBeVisible();
 
+    const modalCountApiPromise = page.waitForResponse(
+      (response) =>
+        response.url().includes('/api/v1/search/query') &&
+        response.url().includes('index=dataAsset')
+    );
+
     await openExportScopeModal(page);
+    const modalCountResponse = await modalCountApiPromise;
+
+    expect(modalCountResponse.status()).toBe(200);
 
     const modalContent = getExportModalContent(page);
 


### PR DESCRIPTION
Backport of #31623 to the 2.0 release branch.

## Why

The **Browse mode visible export** Playwright test was flaking with a timeout on `waitForResponse` for `/api/v1/search/export/async`.

Root cause: when `openExportScopeModal` is called, `handleOpenExportScopeModal` fires a background `searchQuery` (to get the total asset count) and sets `isCountLoading = true`. The Export button's `okButtonProps.disabled` includes `isCountLoading`, so the button stays disabled until that API call resolves.

In browse mode, `getExportCountFromModal` resolves **immediately** (no skeleton), so `startAsyncExport` tried to click the Export button while it was still disabled. The click was a no-op and the async-export `waitForResponse` timed out.

## What changed

Added a `waitForResponse` for the count query (`/api/v1/search/query?…index=dataAsset…`) set up **before** `openExportScopeModal`, then awaited **after** — exactly the pattern the search-mode tests already use. This guarantees `isCountLoading` has been reset to `false` before `startAsyncExport` tries to click.

## Test plan

- [ ] The "Browse mode visible export downloads CSV with current page row count" test passes reliably
- [ ] No other SearchExport tests regressed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport stabilizes the browse-mode visible-export Playwright test by waiting for the modal’s asset-count request before clicking Export.
- Registers the response listener before opening the export-scope modal.
- Waits for the matching `dataAsset` search response and verifies that it succeeded.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The new listener is registered before the modal action, the preceding browse request is already awaited, and the matched modal response resolves before the export click proceeds.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/SearchExport.spec.ts | Adds correctly ordered synchronization for the export modal count request, preventing the test from clicking Export while count loading still disables the button. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search-export): await count API befo..."](https://github.com/open-metadata/openmetadata/commit/9e1737cff908d8ce1929e4313ca4b980c6df3f85) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53952514)</sub>

<!-- /greptile_comment -->