### PR TITLE
fix(data-quality): don't fail logical-suite adds when revisions don't read back

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java
@@ -1111,9 +1111,14 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
             List.of(testSuite),
             null,
             null,
-            new EntityUpdateContext(
-                Map.of(testSuite.getId(), relationshipChange.relationshipRevision())));
+            revisionContext(testSuite.getId(), relationshipChange.relationshipRevision()));
     RdfUpdater.updateEntity(testSuite);
+  }
+
+  private static EntityUpdateContext revisionContext(UUID entityId, Long revision) {
+    return revision == null
+        ? EntityUpdateContext.empty()
+        : new EntityUpdateContext(Map.of(entityId, revision));
   }
 
   @Override
@@ -1264,8 +1269,10 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
         Lists.partition(relationshipChange.get().testCaseReferences(), 100)) {
       Map<UUID, Long> batchRevisions = new HashMap<>();
       for (EntityReference testCase : batch) {
-        batchRevisions.put(
-            testCase.getId(), relationshipChange.get().testCaseRevisions().get(testCase.getId()));
+        Long revision = relationshipChange.get().testCaseRevisions().get(testCase.getId());
+        if (revision != null) {
+          batchRevisions.put(testCase.getId(), revision);
+        }
       }
       postLogicalSuiteRelationshipUpdate(List.copyOf(batch), batchRevisions);
     }
@@ -1347,7 +1354,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     return testCases;
   }
 
-  private LogicalSuiteRelationshipChange prepareLogicalSuiteRelationshipChange(
+  LogicalSuiteRelationshipChange prepareLogicalSuiteRelationshipChange(
       UUID testSuiteId, List<EntityReference> testCaseReferences) {
     if (nullOrEmpty(testCaseReferences)) {
       return LogicalSuiteRelationshipChange.empty();
@@ -1366,17 +1373,37 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
             TestSuiteRepository.TESTS_REVISION_EXTENSION,
             TestSuiteRepository.getTestsRevisionSchema());
     Map<UUID, Long> testCaseRevisions = getTestSuiteRelationshipRevisions(testCaseIds);
-    if (testCaseRevisions.size() != testCaseIds.size()) {
-      throw new IllegalStateException("Failed to persist every test suite relationship revision");
-    }
     Long relationshipRevision =
         TestSuiteRepository.getTestsRelationshipRevisions(List.of(testSuiteId)).get(testSuiteId);
-    if (relationshipRevision == null) {
-      throw new IllegalStateException("Failed to persist the test suite tests revision");
-    }
-
+    logUnresolvedRevisions(testSuiteId, testCaseIds, testCaseRevisions, relationshipRevision);
     return new LogicalSuiteRelationshipChange(
         testSuiteId, testCaseReferences, testCaseRevisions, relationshipRevision);
+  }
+
+  /**
+   * The read-back above is a snapshot read issued inside the flush transaction, so under concurrent
+   * writers on the same revision rows it can return fewer rows than were just advanced — MySQL's
+   * default REPEATABLE READ makes that far likelier than Postgres' READ COMMITTED. Revisions only
+   * order concurrent search writes, and both index builders already re-read a revision they were not
+   * handed ({@link org.openmetadata.service.search.indexes.TestCaseIndex}, {@link
+   * org.openmetadata.service.search.indexes.TestSuiteIndex}), so an unresolved revision costs one
+   * extra read at index time. Failing the request instead would roll back membership rows that
+   * persisted correctly, which is how contention here used to surface as a 500.
+   */
+  private void logUnresolvedRevisions(
+      UUID testSuiteId,
+      List<UUID> testCaseIds,
+      Map<UUID, Long> testCaseRevisions,
+      Long relationshipRevision) {
+    if (testCaseRevisions.size() != testCaseIds.size()) {
+      LOG.warn(
+          "Logical test suite {} advanced test case revisions that did not read back: {}",
+          testSuiteId,
+          testCaseIds.stream().filter(id -> !testCaseRevisions.containsKey(id)).toList());
+    }
+    if (relationshipRevision == null) {
+      LOG.warn("Logical test suite {} tests revision did not read back", testSuiteId);
+    }
   }
 
   public static Map<UUID, Long> getTestSuiteRelationshipRevisions(List<UUID> testCaseIds) {
@@ -1438,12 +1465,12 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
 
   private record TestSuiteRelationshipRevision(long revision) {}
 
-  private record LogicalSuiteRelationshipChange(
+  record LogicalSuiteRelationshipChange(
       UUID testSuiteId,
       List<EntityReference> testCaseReferences,
       Map<UUID, Long> testCaseRevisions,
-      long relationshipRevision) {
-    private LogicalSuiteRelationshipChange {
+      Long relationshipRevision) {
+    LogicalSuiteRelationshipChange {
       testCaseReferences = List.copyOf(testCaseReferences);
       testCaseRevisions = Map.copyOf(testCaseRevisions);
     }
@@ -1453,7 +1480,7 @@ public class TestCaseRepository extends EntityRepository<TestCase> {
     }
 
     private static LogicalSuiteRelationshipChange empty() {
-      return new LogicalSuiteRelationshipChange(null, List.of(), Map.of(), 0L);
+      return new LogicalSuiteRelationshipChange(null, List.of(), Map.of(), null);
     }
   }
 

--- a/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java
@@ -3,6 +3,7 @@ package org.openmetadata.service.jdbi3;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -63,6 +64,51 @@ class TestCaseRepositoryTest {
       assertEquals(
           Map.of(firstId, 7L, secondId, 11L),
           TestCaseRepository.getTestSuiteRelationshipRevisions(List.of(firstId, secondId)));
+    }
+  }
+
+  /**
+   * The revision read-back runs inside the flush transaction and can return fewer rows than were
+   * just advanced when other writers touch the same rows. Treating that as a persistence failure
+   * rolled back membership rows that had persisted correctly and answered the caller with a 500.
+   */
+  @Test
+  void unresolvedRevisionsKeepTheMembershipChange() {
+    UUID testSuiteId = UUID.randomUUID();
+    List<EntityReference> testCases =
+        List.of(
+            entityReference(Entity.TEST_CASE, "readsBack"),
+            entityReference(Entity.TEST_CASE, "doesNotReadBack"));
+    UUID resolvedId = testCases.getFirst().getId();
+    List<String> requestedIds =
+        testCases.stream().map(EntityReference::getId).sorted().map(UUID::toString).toList();
+
+    CollectionDAO collectionDAO = mock(CollectionDAO.class);
+    CollectionDAO.EntityExtensionDAO extensionDAO = mock(CollectionDAO.EntityExtensionDAO.class);
+    when(collectionDAO.testCaseDAO()).thenReturn(mock(CollectionDAO.TestCaseDAO.class));
+    when(collectionDAO.entityExtensionDAO()).thenReturn(extensionDAO);
+    when(extensionDAO.getExtensionBatch(
+            requestedIds, TestCaseRepository.TEST_SUITES_REVISION_EXTENSION))
+        .thenReturn(
+            List.of(
+                new CollectionDAO.ExtensionRecordWithId(
+                    resolvedId,
+                    TestCaseRepository.TEST_SUITES_REVISION_EXTENSION,
+                    "{\"revision\":4}")));
+    when(extensionDAO.getExtensionBatch(
+            List.of(testSuiteId.toString()), TestSuiteRepository.TESTS_REVISION_EXTENSION))
+        .thenReturn(List.of());
+
+    try (MockedStatic<Entity> entity = Mockito.mockStatic(Entity.class)) {
+      entity.when(Entity::getCollectionDAO).thenReturn(collectionDAO);
+      entity.when(() -> Entity.getEntityFields(TestCase.class)).thenCallRealMethod();
+
+      TestCaseRepository.LogicalSuiteRelationshipChange change =
+          new TestCaseRepository().prepareLogicalSuiteRelationshipChange(testSuiteId, testCases);
+
+      assertEquals(Map.of(resolvedId, 4L), change.testCaseRevisions());
+      assertNull(change.relationshipRevision(), "an unread suite revision must not gate indexing");
+      assertEquals(testCases, change.testCaseReferences());
     }
   }
 


### PR DESCRIPTION
## Describe your changes

`TestCaseRepository.prepareLogicalSuiteRelationshipChange` advanced the `testSuitesRevision` `entity_extension` rows for the added test cases and the suite, immediately re-read them, and threw `IllegalStateException("Failed to persist every test suite relationship revision")` if the read-back returned fewer rows than were advanced.

That read-back is a snapshot read issued inside the `flushInOneTransaction` transaction. Under concurrent writers on the same revision rows it can come up short — MySQL's default REPEATABLE READ far more readily than Postgres' READ COMMITTED (nothing in `conf/` or the Jdbi setup overrides either default). The throw then rolled back the `entity_relationship` rows that had persisted correctly and answered the caller with a **500**.

The guard was never load-bearing. Revisions only order concurrent search writes, and every consumer already tolerates one it wasn't handed:

- `EntityUpdateContext.forEntity` returns `EMPTY` for an absent id
- `SearchIndexHandler` falls back to the ungated `onEntityUpdated` path
- `TestCaseIndex` / `TestSuiteIndex` re-read the revision themselves, defaulting to `0L`

So this logs the unresolved ids at WARN and carries on. An unresolved revision now costs one extra read at index time instead of losing the user's write.

Also:
- `LogicalSuiteRelationshipChange.relationshipRevision` becomes nullable, and `updateLogicalTestSuite` passes `EntityUpdateContext.empty()` rather than a bogus `0L` that would gate the suite's own index update.
- `addAllTestCasesToLogicalTestSuite` skips null revisions when building its per-batch map — `EntityUpdateContext`'s `Map.copyOf` rejects null values.

### Why this matters

This has been turning `integration-tests-mysql-elasticsearch` red intermittently on unrelated PRs (#31526, #31527, #31540 all hit it; #31538 and #31543 didn't). `integration-tests-postgres-opensearch` stays green throughout. In the #31526 run all six concurrent `PUT /api/v1/dataQuality/testCases/logicalTestCases` calls from `test_concurrentLogicalSuiteTestAddsPreserveEverySearchTest` returned 500 inside the same 30 ms window, with no deadlock, lock-wait timeout, or pool error in the log.

Affected tests:
- `TestSuiteResourceIT.test_createLogicalTestSuiteAndAddTestCases`
- `TestSuiteResourceIT.test_deleteLogicalTestSuiteKeepsTestCases`
- `TestSuiteResourceIT.test_summaryTotalIncludesUnexecutedAndExcludesDeletedTests`
- `TestCaseResourceIT.test_concurrentLogicalSuiteTestAddsPreserveEverySearchTest`
- `TestCaseResourceIT.test_bulkAddTestCasesToLogicalTestSuiteByIds`
- `TestCaseResourceIT.test_bulkAddAllTestCasesWithExcludeIds`

Introduced by #30120.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

`TestCaseRepositoryTest.unresolvedRevisionsKeepTheMembershipChange` drives `prepareLogicalSuiteRelationshipChange` with a deliberately short test-case read-back and a missing suite revision, and asserts the change still carries the membership references plus the revisions that did resolve.

Verified RED → GREEN — with the two throws restored the new test reproduces the exact CI error:

```
[ERROR] TestCaseRepositoryTest.unresolvedRevisionsKeepTheMembershipChange
        » IllegalState Failed to persist every test suite relationship revision
```

and with the fix:

```
Tests run: 66, Failures: 0, Errors: 0, Skipped: 0
  TestCaseRepositoryTest, TestSuiteRepositoryTest, TestCaseResolutionStatusRepositoryTest,
  EntityLifecycleEventDispatcherTest, SearchIndexHandlerTest
```

`mvn -pl openmetadata-service spotless:check` clean.

The existing ITs above are the end-to-end check — they should stop flaking on the MySQL lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR prevents logical-suite membership writes from rolling back when transactional revision read-backs are incomplete.
- Logs unresolved test-case and suite revision IDs instead of throwing.
- Omits unresolved test-case revisions from update contexts and uses an empty context for a missing suite revision.
- Adds a regression test covering partial and absent revision read-backs.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable correctness or security failures identified.

Missing revisions flow through existing index-time re-reads and relationship-preserving or revision-gated search updates, while transactional revision upserts continue to surface genuine persistence failures.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/TestCaseRepository.java | Converts incomplete revision read-backs from request-failing exceptions into logged fallback behavior while retaining search relationship ordering safeguards. |
| openmetadata-service/src/test/java/org/openmetadata/service/jdbi3/TestCaseRepositoryTest.java | Adds regression coverage confirming partial test-case revisions and an absent suite revision no longer discard the membership change. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as Logical-suite API
  participant DB as Relational DB
  participant Repo as TestCaseRepository
  participant Events as Lifecycle Dispatcher
  participant Search as Search Index
  API->>DB: Commit membership and increment revisions
  DB-->>Repo: Partial revision read-back
  Repo->>Repo: Warn and retain resolved revisions
  Repo->>Events: Publish committed membership snapshot
  Events->>DB: Re-read omitted revisions as needed
  Events->>Search: Preserve or revision-gate relationship fields
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(data-quality): don&#39;t fail logical-su..."](https://github.com/open-metadata/openmetadata/commit/6c170ad4dc3864c4984e4081698e308d280a49f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53983386)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)

<!-- /greptile_comment -->