### PR TITLE
fix(cache): invalidate persona AI context caches across pods

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextCache.java
@@ -31,16 +31,24 @@ import org.openmetadata.schema.type.PersonaContext;
 import org.openmetadata.schema.type.PersonaContextDefinition;
 import org.openmetadata.schema.type.personaContext.PersonaContextCacheState;
 import org.openmetadata.schema.utils.JsonUtils;
+import org.openmetadata.service.Entity;
 import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.cache.CacheConfig;
+import org.openmetadata.service.cache.CacheInvalidationPubSub;
 import org.openmetadata.service.cache.CacheKeys;
 import org.openmetadata.service.cache.CacheProvider;
+import org.openmetadata.service.cache.Invalidatable;
 
 /** Two-level cache and distributed single-flight coordinator for persona context documents. */
 @Slf4j
-public class PersonaContextCache {
+public class PersonaContextCache implements Invalidatable {
   public static final String CACHE_HEADER = "X-Cache";
   private static final int MAX_CACHEABLE_CHARS = 8_000_000;
+  // The local Caffeine entry is a front for the shared Redis copy, so it must not outlive the
+  // cluster's view of the document by much. Nothing invalidates when a *referenced* asset changes
+  // (a retagged table, an edited KB article), and that drift has no entity to key an invalidation
+  // off — this cap is what bounds it, and it also bounds any pub/sub message that gets dropped.
+  private static final long LOCAL_TTL_CAP_SECONDS = 60;
   private static final Duration BUILD_LEASE = Duration.ofSeconds(120);
   private static final int POLL_ATTEMPTS = 30;
   private static final long POLL_MILLIS = 500;
@@ -62,6 +70,11 @@ public class PersonaContextCache {
           },
           new ThreadPoolExecutor.AbortPolicy());
   private static volatile PersonaContextCache instance;
+  // Registered with CacheBundle instead of the instance itself: getInstance() swaps the singleton
+  // whenever the cache provider changes, and a registration holding the old object would silently
+  // stop invalidating anything. This delegate resolves the current instance on every call.
+  private static final Invalidatable INVALIDATOR =
+      (type, id, fqn) -> getInstance().invalidate(type, id, fqn);
 
   private final CacheProvider provider;
   private final CacheKeys keys;
@@ -97,6 +110,11 @@ public class PersonaContextCache {
       }
     }
     return current;
+  }
+
+  /** The {@link Invalidatable} to register with {@code CacheBundle} for this cache. */
+  public static Invalidatable invalidator() {
+    return INVALIDATOR;
   }
 
   public CachedResult get(Persona persona, boolean refresh) {
@@ -197,10 +215,28 @@ public class PersonaContextCache {
     generationStates.remove(original.getId());
   }
 
+  /**
+   * Drop this pod's local copy of a persona's context. Called for a local entity write through
+   * {@code CacheBundle.invalidateEntity} and for a remote one through the pub/sub subscriber.
+   *
+   * <p>Local only, deliberately: the pod that published already wrote the authoritative Redis
+   * copy (or deleted it). A peer deleting those keys here would throw away a document that was
+   * just rebuilt and make every pod re-run the ES-heavy build.
+   */
+  @Override
+  public void invalidate(String type, UUID id, String fqn) {
+    boolean persona =
+        Entity.PERSONA.equals(type) || CacheInvalidationPubSub.TYPE_PERSONA_CONTEXT.equals(type);
+    if (persona && id != null) {
+      invalidateLocal(id);
+    }
+  }
+
   public CachedResult refresh(Persona persona) {
     try {
       CachedResult result = get(persona, true);
       markFresh(persona);
+      publishRefresh(persona);
       return result;
     } catch (RuntimeException exception) {
       markFailed(persona, exception);
@@ -267,6 +303,34 @@ public class PersonaContextCache {
         keys.personaContextMarkdown(personaId, definitionHash),
         keys.personaContextJson(personaId, definitionHash));
     local.invalidate(localKey(personaId, definitionHash));
+  }
+
+  /**
+   * Drop every local entry for a persona. Peers receiving an invalidation don't know the
+   * definition hash the entry is keyed by, so match on the {@code personaId:} prefix.
+   */
+  private void invalidateLocal(UUID personaId) {
+    String prefix = personaId + ":";
+    local.asMap().keySet().removeIf(key -> key.startsWith(prefix));
+    generationStates.remove(personaId);
+  }
+
+  /**
+   * A refresh rewrites Redis but mutates no entity, so nothing else broadcasts it — without this
+   * an admin regenerate is silently a no-op on every pod but the one that served the request.
+   */
+  private void publishRefresh(Persona persona) {
+    if (persona == null || persona.getId() == null) {
+      return;
+    }
+    CacheInvalidationPubSub pubsub = CacheBundle.getCacheInvalidationPubSub();
+    if (pubsub != null) {
+      pubsub.publish(
+          CacheInvalidationPubSub.TYPE_PERSONA_CONTEXT,
+          persona.getId(),
+          persona.getFullyQualifiedName(),
+          "refresh");
+    }
   }
 
   protected PersonaContextBuilder.MaterializedPersonaContext build(Persona persona) {
@@ -353,8 +417,18 @@ public class PersonaContextCache {
       String key, PersonaContextBuilder.MaterializedPersonaContext value, int ttlSeconds) {
     local.put(
         key,
-        new LocalEntry(
-            value, System.nanoTime() + TimeUnit.SECONDS.toNanos(Math.max(1, ttlSeconds))));
+        new LocalEntry(value, System.nanoTime() + TimeUnit.SECONDS.toNanos(localTtl(ttlSeconds))));
+  }
+
+  /**
+   * With Redis up, expiring the local entry costs one {@code mget} of the shared copy, so the cap
+   * is cheap insurance against drift the invalidation path cannot see. With Redis down the local
+   * entry <em>is</em> the cache — capping there would make every pod re-run the build every minute,
+   * so the definition's TTL stands.
+   */
+  private long localTtl(int ttlSeconds) {
+    long ttl = Math.max(1, ttlSeconds);
+    return provider.available() ? Math.min(ttl, LOCAL_TTL_CAP_SECONDS) : ttl;
   }
 
   private void markFresh(Persona persona) {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheBundle.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheBundle.java
@@ -89,6 +89,12 @@ public class CacheBundle implements ConfiguredBundle<OpenMetadataApplicationConf
       // the full audit and the planned migration of those layers to the registry.
       registerInvalidatable(cachedLineage);
       registerInvalidatable(notFoundCache);
+      // Per-JVM caches behind Ask Collate's persona context. Both are keyed by data a peer's write
+      // changes, so without this a persona edit, a context regenerate, or a persona assignment is
+      // visible on the writing pod only, for up to that cache's TTL.
+      registerInvalidatable(org.openmetadata.service.aicontext.PersonaContextCache.invalidator());
+      registerInvalidatable(
+          org.openmetadata.service.security.policyevaluator.SubjectCache.invalidator());
       cacheInvalidationPubSub = new CacheInvalidationPubSub(cacheConfig);
       cacheInvalidationPubSub.setHandler(
           msg -> {
@@ -108,10 +114,15 @@ public class CacheBundle implements ConfiguredBundle<OpenMetadataApplicationConf
                 }
                 return;
               }
-              org.openmetadata.service.jdbi3.EntityRepository.onRemoteCacheInvalidate(
-                  msg.type(), msg.id(), msg.fqn());
-              if (msg.id() != null && cachedReadBundle != null) {
-                cachedReadBundle.invalidate(msg.type(), msg.id());
+              // Non-entity signals ride this channel too (a persona context rebuild mutates no
+              // entity). Evicting entity caches for them would bump a write epoch and force a
+              // needless reload of an entity that did not change.
+              if (!CacheInvalidationPubSub.TYPE_PERSONA_CONTEXT.equals(msg.type())) {
+                org.openmetadata.service.jdbi3.EntityRepository.onRemoteCacheInvalidate(
+                    msg.type(), msg.id(), msg.fqn());
+                if (msg.id() != null && cachedReadBundle != null) {
+                  cachedReadBundle.invalidate(msg.type(), msg.id());
+                }
               }
               // Fan invalidation out to every Invalidatable registered with the bundle. This is
               // the path new cache layers should plug into — implement Invalidatable, call

--- a/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheInvalidationPubSub.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheInvalidationPubSub.java
@@ -41,6 +41,15 @@ import org.openmetadata.schema.utils.JsonUtils;
 public class CacheInvalidationPubSub {
   private static final String CHANNEL = "om:cache:invalidate";
 
+  /**
+   * Non-entity invalidation type. Published when a persona's materialized AI context is rebuilt
+   * ({@code ?refresh=true}), which mutates no entity — peers must drop their local copy of the
+   * document without the message being treated as an entity write (no L1 epoch bump, no entity
+   * cache eviction). Rides the same channel so no second subscriber is needed, exactly like the
+   * {@code session}/{@code revoke} signal handled in {@code CacheBundle}.
+   */
+  public static final String TYPE_PERSONA_CONTEXT = "personaContext";
+
   private final CacheConfig.Redis redisConfig;
   @Getter private final String instanceId;
   private final AtomicBoolean running = new AtomicBoolean(false);

--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java
@@ -39,6 +39,7 @@ import org.openmetadata.schema.utils.JsonUtils;
 import org.openmetadata.service.Entity;
 import org.openmetadata.service.aicontext.PersonaContextBuilder;
 import org.openmetadata.service.aicontext.PersonaContextCache;
+import org.openmetadata.service.cache.CacheBundle;
 import org.openmetadata.service.resources.teams.PersonaResource;
 import org.openmetadata.service.security.policyevaluator.SubjectCache;
 import org.openmetadata.service.util.EntityUtil.Fields;
@@ -295,6 +296,13 @@ public class PersonaRepository extends EntityRepository<Persona> {
       SubjectCache.invalidateAllUserContexts();
     } else {
       invalidateUserContexts(persona.getUsers(), List.of());
+    }
+    // Creates don't broadcast (only the update and delete paths publish), so peers would keep a
+    // user context without the persona this create just assigned for the full 15-minute TTL —
+    // long enough for the user's persona selection to be rejected as "not assigned".
+    var pubsub = CacheBundle.getCacheInvalidationPubSub();
+    if (pubsub != null) {
+      pubsub.publish(PERSONA, persona.getId(), persona.getFullyQualifiedName(), "create");
     }
   }
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
@@ -77,7 +77,7 @@ public class SubjectCache {
 
   private static final Invalidatable INVALIDATOR =
       (type, id, fqn) -> {
-        if (Entity.PERSONA.equals(type)) {
+        if (Entity.PERSONA.equals(type) || Entity.TEAM.equals(type)) {
           invalidateAllUserContexts();
         } else if (Entity.USER.equals(type) && fqn != null) {
           invalidateUserContextByFqn(fqn);
@@ -159,11 +159,15 @@ public class SubjectCache {
    * {@code SubjectContext.getActivePersona()} discards the requested persona as "not assigned" —
    * which reads to the user as a persona switch that intermittently doesn't take.
    *
-   * <p>A persona write drops every user context because the affected set isn't derivable from the
-   * message: assignments change through the persona, the user's {@code defaultPersona}, and a
-   * team's default alike. Persona writes are rare admin actions and the reload is a cached entity
-   * read, so the blunt drop is the cheaper trade. A context {@code refresh} is published under
-   * {@code TYPE_PERSONA_CONTEXT} and so does not land here.
+   * <p>A persona or team write drops every user context because the affected set isn't derivable
+   * from the message: assignments change through the persona, the user's {@code defaultPersona},
+   * and a team's default (which reaches users as {@code inheritedPersonas}, via membership or the
+   * parent hierarchy) alike. Both are rare admin actions, so the blunt drop is the cheaper trade.
+   * A context {@code refresh} is published under {@code TYPE_PERSONA_CONTEXT} and so does not land
+   * here.
+   *
+   * <p>Scoped to user contexts. {@code USER_POLICIES_CACHE} has its own 2-minute TTL and peers
+   * relying on it is pre-existing behaviour that this persona fix deliberately doesn't widen.
    */
   public static Invalidatable invalidator() {
     return INVALIDATOR;
@@ -173,6 +177,14 @@ public class SubjectCache {
    * A user's FQN is the lower-cased quoted name while the cache is keyed by the principal name as
    * the request presented it, so match case-insensitively rather than dropping a key that may not
    * exist in that exact form.
+   *
+   * <p>Not an exact-key {@code invalidate}: {@code SecurityUtil.getUserName} only splits the
+   * principal on {@code [/@]} and does not case-fold, so an IdP emitting {@code John.Doe@corp.com}
+   * keys this cache under {@code John.Doe} while the FQN is {@code john.doe}. Keys also arrive
+   * from {@code createdBy}/{@code updatedBy} strings. An O(1) lookup would silently miss those and
+   * leave exactly the stale persona this fix is about. The scan is bounded by the cache's maximum
+   * size and only runs on user writes, which are logins and profile edits — per-request activity
+   * tracking updates the row through a raw {@code JSON_SET} that publishes nothing.
    */
   private static void invalidateUserContextByFqn(String fqn) {
     try {

--- a/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java
@@ -36,7 +36,9 @@ import org.openmetadata.schema.entity.teams.Team;
 import org.openmetadata.schema.entity.teams.User;
 import org.openmetadata.schema.type.EntityReference;
 import org.openmetadata.service.Entity;
+import org.openmetadata.service.cache.Invalidatable;
 import org.openmetadata.service.security.policyevaluator.SubjectContext.PolicyContext;
+import org.openmetadata.service.util.FullyQualifiedName;
 
 /**
  * Cache for user policies to improve authorization performance. Caches the compiled policies for
@@ -72,6 +74,15 @@ public class SubjectCache {
           .expireAfterWrite(15, TimeUnit.MINUTES)
           .recordStats()
           .build(new UserContextLoader());
+
+  private static final Invalidatable INVALIDATOR =
+      (type, id, fqn) -> {
+        if (Entity.PERSONA.equals(type)) {
+          invalidateAllUserContexts();
+        } else if (Entity.USER.equals(type) && fqn != null) {
+          invalidateUserContextByFqn(fqn);
+        }
+      };
 
   private SubjectCache() {}
 
@@ -139,6 +150,37 @@ public class SubjectCache {
   public static void invalidateAllUserContexts() {
     LOG.info("Invalidating all user context caches");
     USER_CONTEXT_CACHE.invalidateAll();
+  }
+
+  /**
+   * The {@link Invalidatable} to register with {@code CacheBundle} so persona assignments converge
+   * across pods. The repositories invalidate only the JVM that served the write, so without this a
+   * peer keeps a {@code User} carrying the old persona list for up to the 15-minute TTL and
+   * {@code SubjectContext.getActivePersona()} discards the requested persona as "not assigned" —
+   * which reads to the user as a persona switch that intermittently doesn't take.
+   *
+   * <p>A persona write drops every user context because the affected set isn't derivable from the
+   * message: assignments change through the persona, the user's {@code defaultPersona}, and a
+   * team's default alike. Persona writes are rare admin actions and the reload is a cached entity
+   * read, so the blunt drop is the cheaper trade. A context {@code refresh} is published under
+   * {@code TYPE_PERSONA_CONTEXT} and so does not land here.
+   */
+  public static Invalidatable invalidator() {
+    return INVALIDATOR;
+  }
+
+  /**
+   * A user's FQN is the lower-cased quoted name while the cache is keyed by the principal name as
+   * the request presented it, so match case-insensitively rather than dropping a key that may not
+   * exist in that exact form.
+   */
+  private static void invalidateUserContextByFqn(String fqn) {
+    try {
+      String userName = FullyQualifiedName.unquoteName(fqn);
+      USER_CONTEXT_CACHE.asMap().keySet().removeIf(key -> key.equalsIgnoreCase(userName));
+    } catch (Exception e) {
+      LOG.debug("Could not invalidate user context for fqn {}", fqn, e);
+    }
   }
 
   public static void invalidateAll() {

--- a/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/PersonaContextCacheTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/aicontext/PersonaContextCacheTest.java
@@ -29,10 +29,13 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.openmetadata.schema.entity.teams.Persona;
 import org.openmetadata.schema.type.PersonaContext;
 import org.openmetadata.schema.type.PersonaContextDefinition;
+import org.openmetadata.service.Entity;
+import org.openmetadata.service.cache.CacheInvalidationPubSub;
 import org.openmetadata.service.cache.CacheKeys;
 import org.openmetadata.service.cache.CacheProvider;
 
@@ -104,5 +107,73 @@ class PersonaContextCacheTest {
         .setIfAbsent(eq(keys.personaContextLock(personaId)), any(), any(Duration.class));
     verify(provider, never()).set(anyString(), anyString(), any(Duration.class));
     verify(provider, never()).deleteIfValue(eq(keys.personaContextLock(personaId)), anyString());
+  }
+
+  @Test
+  void remoteInvalidationDropsTheLocalDocument() {
+    UUID personaId = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    AtomicInteger builds = new AtomicInteger();
+    PersonaContextCache cache = cacheThatCountsBuilds(personaId, builds);
+    Persona persona = personaFor(personaId);
+
+    assertEquals(PersonaContextCache.CacheStatus.MISS, cache.get(persona, false).status());
+    assertEquals(PersonaContextCache.CacheStatus.HIT, cache.get(persona, false).status());
+    assertEquals(1, builds.get());
+
+    // A peer edited the persona: the local entry is keyed by a definition hash this pod is the
+    // only one that can compute, so the drop has to match on the persona id alone.
+    cache.invalidate(Entity.PERSONA, personaId, "analyst");
+
+    assertEquals(PersonaContextCache.CacheStatus.MISS, cache.get(persona, false).status());
+    assertEquals(2, builds.get());
+  }
+
+  @Test
+  void remoteRefreshDropsTheLocalDocumentAndOtherEntitiesLeaveItAlone() {
+    UUID personaId = UUID.fromString("44444444-4444-4444-4444-444444444444");
+    AtomicInteger builds = new AtomicInteger();
+    PersonaContextCache cache = cacheThatCountsBuilds(personaId, builds);
+    Persona persona = personaFor(personaId);
+
+    assertEquals(PersonaContextCache.CacheStatus.MISS, cache.get(persona, false).status());
+
+    cache.invalidate(Entity.TABLE, personaId, "service.database.schema.table");
+    cache.invalidate(Entity.PERSONA, null, "analyst");
+    assertEquals(PersonaContextCache.CacheStatus.HIT, cache.get(persona, false).status());
+    assertEquals(1, builds.get());
+
+    cache.invalidate(CacheInvalidationPubSub.TYPE_PERSONA_CONTEXT, personaId, "analyst");
+
+    assertEquals(PersonaContextCache.CacheStatus.MISS, cache.get(persona, false).status());
+    assertEquals(2, builds.get());
+  }
+
+  private static Persona personaFor(UUID personaId) {
+    return new Persona()
+        .withId(personaId)
+        .withName("analyst")
+        .withContextDefinition(new PersonaContextDefinition());
+  }
+
+  /** A cache whose Redis is up but always empty, so every local miss falls through to a build. */
+  private static PersonaContextCache cacheThatCountsBuilds(UUID personaId, AtomicInteger builds) {
+    CacheProvider provider = mock(CacheProvider.class);
+    CacheKeys keys = new CacheKeys("om:test");
+    PersonaContextBuilder.MaterializedPersonaContext materialized =
+        new PersonaContextBuilder.MaterializedPersonaContext(
+            new PersonaContext().withGeneratedAt(1L), "compiled context");
+
+    when(provider.available()).thenReturn(true);
+    when(provider.mget(anyList())).thenReturn(List.of(Optional.empty(), Optional.empty()));
+    when(provider.setIfAbsent(eq(keys.personaContextLock(personaId)), any(), any(Duration.class)))
+        .thenReturn(true);
+
+    return new PersonaContextCache(provider, keys) {
+      @Override
+      protected PersonaContextBuilder.MaterializedPersonaContext build(Persona ignored) {
+        builds.incrementAndGet();
+        return materialized;
+      }
+    };
   }
 }

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
@@ -204,6 +204,20 @@ public class SubjectCacheTest {
   }
 
   @Test
+  void testRemoteTeamWriteDropsAllUserContexts() {
+    // A team's defaultPersona reaches users as inheritedPersonas, and membership/hierarchy edits
+    // change which teams contribute — all of which arrive as a TEAM message, not a PERSONA one.
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    SubjectCache.invalidator().invalidate(Entity.TEAM, UUID.randomUUID(), "team11");
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
   void testRemoteUnrelatedWriteLeavesUserContextWarm() {
     SubjectCache.getUserContext("testUser");
     clearInvocations(userRepository);

--- a/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
+++ b/openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -174,6 +175,45 @@ public class SubjectCacheTest {
 
     verify(userRepository, times(1))
         .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
+  void testRemoteUserWriteDropsThatUserContext() {
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    // A user's FQN is the lower-cased name while the cache is keyed by the principal name as the
+    // request presented it, so the match has to be case-insensitive to hit anything at all.
+    SubjectCache.invalidator().invalidate(Entity.USER, UUID.randomUUID(), "testuser");
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
+  void testRemotePersonaWriteDropsAllUserContexts() {
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    SubjectCache.invalidator().invalidate(Entity.PERSONA, UUID.randomUUID(), "analyst");
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, times(1))
+        .getByName(isNull(), eq("testUser"), isNull(), any(Include.class), anyBoolean());
+  }
+
+  @Test
+  void testRemoteUnrelatedWriteLeavesUserContextWarm() {
+    SubjectCache.getUserContext("testUser");
+    clearInvocations(userRepository);
+
+    SubjectCache.invalidator()
+        .invalidate(Entity.TABLE, UUID.randomUUID(), "service.database.schema.table");
+    SubjectCache.getUserContext("testUser");
+
+    verify(userRepository, never())
+        .getByName(isNull(), anyString(), isNull(), any(Include.class), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
## Problem

`PersonaContextCache.local` (Caffeine) and `SubjectCache.USER_CONTEXT_CACHE` (Guava) are per-JVM and were never reached by the `CacheInvalidationPubSub` subscriber — neither implements `Invalidatable` and neither is passed to `CacheBundle.registerInvalidatable`. On a multi-replica deployment a persona change is visible on one pod and stale on the others for up to that cache's TTL (30 min / 15 min), intermittently, depending on which pod the load balancer picks.

Symptoms, all reported against Ask Collate:

- **Admin "regenerate persona context" appears broken.** `refresh()` rewrites Redis and the calling pod's local entry only. The definition hash doesn't change, so peers keep serving the identically-keyed stale entry until their own TTL.
- **A persona switch intermittently doesn't take.** After assigning a persona, peers keep a `User` without it, so `SubjectContext.getActivePersona()` silently discards the `X-OpenMetadata-Persona` header and falls back to the default persona (`Requested persona '<id>' is not assigned to user '<user>'`).
- **Same user, same question, different answers depending on routing.**

Reported downstream as open-metadata/openmetadata-collate#5847, which has the full analysis.

## Changes

- **`PersonaContextCache implements Invalidatable`**, registered with `CacheBundle`. A peer can't know the definition hash the local entry is keyed by (`personaId:definitionHash`), so it drops by `personaId:` prefix and clears `generationStates`.

  The drop is **local only**, deliberately: the publishing pod already wrote (or deleted) the authoritative Redis copy, and a peer deleting those keys would throw away a document that was just rebuilt and make every pod re-run the ES-heavy build.

- **`refresh()` publishes explicitly.** It rewrites Redis but mutates no entity, so nothing broadcast it before. It goes out under a non-entity type (`CacheInvalidationPubSub.TYPE_PERSONA_CONTEXT`) so peers drop the document without bumping the persona write epoch or evicting entity caches for a change that touched no entity. The handler in `CacheBundle` gates the entity-cache work on that type; the `Invalidatable` fan-out still runs.

- **`SubjectCache` registers an `Invalidatable` too.** A `user` write drops that user's context; a `persona` or `team` write drops all of them (a team's `defaultPersona` reaches users as `inheritedPersonas`, via membership or the parent hierarchy).

  The all-drop is blunt on purpose — the affected user set isn't derivable from the message, since assignments change through the persona, the user's `defaultPersona`, and a team's default alike. Persona writes are rare admin actions and the reload is a cached entity read. A context `refresh` publishes under `TYPE_PERSONA_CONTEXT` and so does not land here.

  The user match is case-insensitive: a user's FQN is the lower-cased quoted name, while the cache is keyed by the principal name as the request presented it.

- **`PersonaRepository.postCreate` publishes.** `EntityRepository.postCreate` calls `CacheBundle.invalidateEntity` (local fan-out) but never publishes — only the update and delete paths do. So a persona created with users already assigned never reached peers at all.

- **Local context TTL capped at 60 s while Redis is up.** Nothing invalidates when a *referenced* asset changes (a retagged table, an edited KB article, a new asset matching a rule), and that drift has no single entity to key an invalidation off — the cap is what bounds it, and it also bounds any dropped pub/sub message. Expiry then costs one `mget` of the shared copy, not a rebuild.

  With Redis down the local entry *is* the cache, so the definition's `cacheTtlMinutes` still stands there — capping unconditionally would make every pod re-run the build every minute.

## Testing

`PersonaContextCacheTest` (2 new) and `SubjectCacheTest` (3 new) cover the remote-invalidate path: a message in, local entry gone, next read rebuilds; unrelated entity types leave the entry warm.

Both were confirmed non-vacuous by short-circuiting the two invalidators and watching all four positive tests fail (`expected: <MISS> but was: <HIT>`), then restoring.

- `mvn spotless:check` clean, `compile` clean.
- 315 tests green across `aicontext`, `cache`, `policyevaluator`, and `PersonaRepositoryTest`.

## Not covered

- No Redis-backed multi-pod integration test — the wiring is exercised at the `Invalidatable` boundary only.
- `generationStates` is still pod-local, so `GET /v1/personas/{id}/context/status` can still report `GENERATING` on one pod and `FRESH`/`STALE` on another. Invalidation now clears it, but making the status genuinely shared needs Redis-backed state.
- Invalidating on referenced-asset changes remains a design question rather than wiring; the TTL cap is the interim answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes open-metadata/openmetadata-collate#5847

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds distributed invalidation for persona AI context and user-context caches so persona changes converge across service pods.
- Registers persona and subject cache invalidators with the shared cache bundle.
- Publishes persona-context refresh and persona-create events to peer pods.
- Handles persona, team, and user invalidations with cache-specific eviction behavior.
- Caps local persona-context freshness while Redis is available.
- Adds focused tests for remote invalidation behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/aicontext/PersonaContextCache.java | Adds local-only distributed invalidation, explicit refresh publication, and a Redis-aware local TTL cap. |
| openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheBundle.java | Registers the new invalidators and separates non-entity persona-context signals from entity-cache eviction. |
| openmetadata-service/src/main/java/org/openmetadata/service/cache/CacheInvalidationPubSub.java | Defines the non-entity persona-context invalidation message type. |
| openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/PersonaRepository.java | Publishes persona creation so peer pods invalidate contexts for initially assigned users. |
| openmetadata-service/src/main/java/org/openmetadata/service/security/policyevaluator/SubjectCache.java | Clears peer user contexts for persona and team changes and selectively evicts users for USER messages. |
| openmetadata-service/src/test/java/org/openmetadata/service/aicontext/PersonaContextCacheTest.java | Exercises persona-context remote invalidation and unrelated-message behavior. |
| openmetadata-service/src/test/java/org/openmetadata/service/security/policyevaluator/SubjectCacheTest.java | Covers persona, team, user, and unrelated invalidation behavior for cached user contexts. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Admin
  participant Writer as Writing pod
  participant Redis
  participant Peer as Peer pod
  participant Subject as SubjectCache
  Admin->>Writer: Update team/persona or refresh context
  Writer->>Redis: Update or invalidate shared cache
  Writer->>Redis: Publish invalidation message
  Redis-->>Peer: TEAM / USER / PERSONA / personaContext
  Peer->>Subject: Fan out through registered Invalidatable
  Subject->>Subject: Evict affected local user contexts
  Note over Peer: Next request reloads current shared or persisted state
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cache): drop peer user contexts on t..."](https://github.com/open-metadata/openmetadata/commit/c059194c57ade45531098543b2b5651a9bed9548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54102105)</sub>

**Context used:**

- Knowledge Base — [OpenMetadata Service Core: Entities, Resources, Repositories](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-core.md)
- Knowledge Base — [Auth and Security: Authentication, Authorization, Secrets, and SCIM](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-auth-security.md)

<!-- /greptile_comment -->