### PR TITLE
fix(search): pin httpclient5 to 5.5.2 and bound the connection-request timeout

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -104,6 +104,11 @@ public class ElasticSearchClient implements SearchClient {
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
 
+  // How long a caller waits for a connection from the pool. HC5 defaults this to 3 minutes,
+  // so a saturated pool blocks a Jetty thread that long before failing. Fail fast instead.
+  private static final org.apache.hc.core5.util.Timeout CONNECTION_REQUEST_TIMEOUT =
+      org.apache.hc.core5.util.Timeout.ofSeconds(10);
+
   private volatile boolean isNewClientAvailable;
 
   private final String clusterAlias;
@@ -872,8 +877,8 @@ public class ElasticSearchClient implements SearchClient {
                         org.apache.hc.core5.util.Timeout.ofSeconds(
                             esConfig.getConnectionTimeoutSecs()))
                     .setResponseTimeout(
-                        org.apache.hc.core5.util.Timeout.ofSeconds(
-                            esConfig.getSocketTimeoutSecs())));
+                        org.apache.hc.core5.util.Timeout.ofSeconds(esConfig.getSocketTimeoutSecs()))
+                    .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT));
 
         restClientBuilder.setCompressionEnabled(true);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -102,6 +102,10 @@ import software.amazon.awssdk.regions.Region;
 public class OpenSearchClient implements SearchClient {
   private static final int REQUEST_COMPRESSION_THRESHOLD_BYTES = 8 * 1024;
 
+  // How long a caller waits for a connection from the pool. HC5 defaults this to 3 minutes,
+  // so a saturated pool blocks a Jetty thread that long before failing. Fail fast instead.
+  private static final Timeout CONNECTION_REQUEST_TIMEOUT = Timeout.ofSeconds(10);
+
   private volatile boolean isClientAvailable;
   private static final long HEALTH_CHECK_CACHE_MS = 5000;
   private final AtomicLong lastHealthCheckAt = new AtomicLong();
@@ -920,7 +924,8 @@ public class OpenSearchClient implements SearchClient {
           requestConfigBuilder ->
               requestConfigBuilder
                   .setConnectTimeout(Timeout.ofSeconds(esConfig.getConnectionTimeoutSecs()))
-                  .setResponseTimeout(Timeout.ofSeconds(esConfig.getSocketTimeoutSecs())));
+                  .setResponseTimeout(Timeout.ofSeconds(esConfig.getSocketTimeoutSecs()))
+                  .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT));
 
       var defaultFactory =
           os.org.opensearch.client.transport.httpclient5.ApacheHttpClient5Options.DEFAULT

--- a/pom.xml
+++ b/pom.xml
@@ -800,6 +800,18 @@
         <artifactId>httpcore5-h2</artifactId>
         <version>5.4.3</version>
       </dependency>
+      <!--
+        Must stay >= 5.5.2 for as long as httpcore5 above is pinned to the 5.4 line.
+        httpclient5 5.5 is built against httpcore5 5.3.4; on 5.4.x its I/O reactor
+        dispatchers die silently, leaking search connection-pool leases until every
+        request fails with DeadlineTimeoutException. 5.5.2 is the release that
+        "Fixed incompatibility with HttpCore 5.4". Bump both artifacts together.
+      -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>5.5.2</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>


### PR DESCRIPTION
## Problem

Search dies completely and never recovers. Every OpenSearch-backed endpoint fails while everything else stays healthy.

Observed in production over a 20+ minute window:

| | |
|---|---|
| Endpoints not touching OpenSearch | p50 **3ms** (`loggedInUser` 38ms, `docStore` 5ms, `tasks/visible` 21ms) |
| Endpoints touching OpenSearch | **195,000–257,000ms**, 20 of 20 `search/query` → 500 |

`slowrequest` confirms where it goes: `search: 257467ms, searchOps: 1`. DB, Jetty and gRPC were all fine.

The only error in the logs, thousands of times, is:

```
org.apache.hc.core5.util.DeadlineTimeoutException: Deadline: ..., -29839 MILLISECONDS overdue
	at org.apache.hc.core5.pool.StrictConnPool.processPendingRequest(StrictConnPool.java:319)
	at org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager$1.closeExpired(...)
	at org.apache.hc.core5.reactor.IdleConnectionEvictor.lambda$new$0(...)
```

Zero successes. Zero response timeouts. Zero connect errors. Only the evictor sweeping rotted pool leases.

## Root cause

**Version skew introduced by #31442.** Pinning `httpcore5` to 5.4.3 for CVE-2026-54399 left `httpclient5` unmanaged, so it resolved to **5.5** — a release built against **httpcore5 5.3.4**:

| httpclient5 | built against httpcore5 |
|---|---|
| 5.5 (what resolves today) | 5.3.4 |
| **5.5.2** | 5.3.6 — changelog: *"Fixed incompatibility with HttpCore 5.4"* |
| 5.6 | 5.4 |

Verified in the current tree:

```
org.apache.httpcomponents.client5:httpclient5:jar:5.5:runtime
 \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime
    org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
```

`SingleCoreIOReactor` was substantially rewritten between 5.3.4 and 5.4.3 (406 added / 291 removed / 72 modified lines), while `MultiCoreIOReactor`, `IOWorkers` and `IOReactorWorker` are byte-identical — the client's assumptions about reactor lifecycle did not move with the reactor underneath.

Why that produces exactly the symptoms above, all verified in HC5 source:

1. A `Throwable` on an I/O dispatcher kills its `SingleCoreIOReactor`. `IOReactorWorker.run()` stores it in a package-private field nothing reads and the thread exits — **silently**, no log, no callback.
2. `MultiCoreIOReactor.status` is only ever written by `start()` / `initiateShutdown()` / `close()`. A dead dispatcher never flips it, so the client stays `ACTIVE` and keeps accepting requests. **A status check cannot detect this.**
3. Timeout enforcement lives *inside* `SingleCoreIOReactor.execute()`'s select loop (`checkTimeout`). A dead loop enforces nothing — hence 20+ minutes with no response timeout despite `socketTimeoutSecs: 120`.
4. Connections bound to a dead dispatcher are leased forever. `IOWorkers` selection is blind round-robin with no health awareness, so pool slots keep migrating onto dead dispatchers.
5. Once the pool is at `maxConnPerRoute`, no new connect is attempted, so `IOReactorShutdownException` never surfaces. Leases just queue.
6. Queued leases rot until the connection-request deadline → `DeadlineTimeoutException`. Permanent; no recovery path exists short of a restart.

`SafeResponseConsumer` (#27698) guards only the response-consumer path, so it does not cover this.

## Changes

**1. Pin `httpclient5` to 5.5.2** so it moves together with the `httpcore5` pin.

5.5.2 over 5.6 deliberately: 5.6 is the release paired with the 5.4 core line, but it changes default hostname verification to `BUILTIN` and enables 5s TCP keep-alive by default. Both need TLS validation against `createElasticSearchSSLContext` / `truststorePath` setups. 5.5.2 is a patch on the 5.5 line that carries exactly the compatibility fix, with no breaking changes. 5.6 is worth doing separately.

**2. Bound `connectionRequestTimeout` to 10s** in both `OpenSearchClient` and `ElasticSearchClient`.

Both set connect and response timeouts but never set the connection-request (pool lease) timeout, leaving HC5's **3-minute** default. A saturated pool therefore blocks a Jetty thread for three minutes per request before failing. This is independent of the version bug and worth having regardless — it turns a multi-minute hang into a fast error.

## Verification

Resolution after the pin, including the shaded uber-jar (which bundles `org.apache.hc.*` unrelocated, so it needed checking):

```
# openmetadata-service
\- org.apache.httpcomponents.client5:httpclient5:jar:5.5.2
   +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3
   \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3

# openmetadata-shaded-deps/opensearch-dep
+- org.apache.httpcomponents.client5:httpclient5:jar:5.5.2:compile
+- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:compile
\- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
```

`mvn -pl openmetadata-service compile` → BUILD SUCCESS. `mvn spotless:apply` clean.

CVE-2026-54399 stays closed — `httpcore5` remains at 5.4.3.

## Follow-ups (not in this PR)

- `SearchIndexMetrics.countMissingIndices` probes every index individually — 71 mappings × 2 calls. `refreshStats()` already fetches `listIndicesByPrefix("")`; diffing that against `getEntityIndexMap()` keys would make it 1 call.
- `DatabseAndSearchServiceStatusJob` has no `@DisallowConcurrentExecution`. During this outage 9 concurrent instances were observed across Quartz workers 1-5 and 7-10, consuming the entire 10-thread `DefaultQuartzScheduler` pool, so no scheduled job could run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR pins Apache HttpClient 5.5.2 to remain compatible with the existing HttpCore 5.4.3 pin and adds a 10-second connection-pool lease timeout to both search clients.
- Adds consistent connection-request timeout handling for Elasticsearch and OpenSearch.
- Prevents pool saturation from blocking service threads for the previous three-minute default.
- Aligns the managed HttpClient dependency used by the service and shaded search transports.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The dependency pin consistently applies the intended HC5 compatibility pairing, and both search-client builders now bound connection-pool acquisition without evidence of a broken build, ineffective configuration, or reachable regression.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java | Adds a bounded connection-request timeout to the Elasticsearch HC5 request configuration; no actionable defect identified. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java | Adds the same bounded pool-lease timeout to the OpenSearch transport configuration; no actionable defect identified. |
| pom.xml | Manages httpclient5 at 5.5.2 alongside the existing httpcore5 5.4.3 pins to avoid the documented compatibility failure. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(search): pin httpclient5 to 5.5.2 an..."](https://github.com/open-metadata/openmetadata/commit/9fedf5c6b1a1b2e9b15c2ec17a047d5bb784646b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54118152)</sub>

**Context used:**

- Knowledge Base — [Search Indexing and Event/Notification Sync](https://app.greptile.com/getcollate/-/custom-context/knowledge-base/open-metadata/openmetadata/-/docs/openmetadata-service-search-events.md)

<!-- /greptile_comment -->