### PR TITLE
fix(search): move httpclient5 to 5.6.3 and disable transport-level content compression

### DIFF
--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java
@@ -1086,8 +1086,15 @@ public class TestSuiteBootstrap implements LauncherSessionListener {
     Rest5ClientBuilder builder =
         Rest5Client.builder(httpHost)
             .setHttpClientConfigCallback(
-                httpClientBuilder ->
-                    httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+                httpClientBuilder -> {
+                  httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+                  // httpclient5 5.6.0 enables automatic gzip decompression by default; the
+                  // elasticsearch-java client also decompresses the response body, so leaving
+                  // both on runs the second pass over already-inflated bytes and throws
+                  // "java.util.zip.ZipException: Not in GZIP format". Let the ES client own
+                  // decompression. Mirrors the production ElasticSearchClient fix.
+                  httpClientBuilder.disableContentCompression();
+                });
     return builder.build();
   }
 

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchConsumerFieldBehaviorIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchConsumerFieldBehaviorIT.java
@@ -128,6 +128,16 @@ class SearchConsumerFieldBehaviorIT {
     ApacheHttpClient5Transport transport =
         ApacheHttpClient5TransportBuilder.builder(httpHost)
             .setMapper(new JacksonJsonpMapper())
+            .setHttpClientConfigCallback(
+                httpClientBuilder -> {
+                  // httpclient5 5.6.0 enables automatic gzip decompression by default; the
+                  // opensearch-java transport also decompresses the response body, so leaving
+                  // both on runs the second pass over already-inflated bytes and throws
+                  // "java.util.zip.ZipException: Not in GZIP format". Let opensearch-java own
+                  // decompression. Mirrors the production OpenSearchClient fix.
+                  httpClientBuilder.disableContentCompression();
+                  return httpClientBuilder;
+                })
             .build();
     openSearchClient = new OpenSearchClient(transport);
     mapper = new ObjectMapper();

--- a/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
+++ b/openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java
@@ -69,6 +69,16 @@ class VectorEmbeddingIntegrationIT {
     ApacheHttpClient5Transport transport =
         ApacheHttpClient5TransportBuilder.builder(httpHost)
             .setMapper(new JacksonJsonpMapper())
+            .setHttpClientConfigCallback(
+                httpClientBuilder -> {
+                  // httpclient5 5.6.0 enables automatic gzip decompression by default; the
+                  // opensearch-java transport also decompresses the response body, so leaving
+                  // both on runs the second pass over already-inflated bytes and throws
+                  // "java.util.zip.ZipException: Not in GZIP format". Let opensearch-java own
+                  // decompression. Mirrors the production OpenSearchClient fix.
+                  httpClientBuilder.disableContentCompression();
+                  return httpClientBuilder;
+                })
             .build();
     openSearchClient = new OpenSearchClient(transport);
 

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java
@@ -868,6 +868,14 @@ public class ElasticSearchClient implements SearchClient {
                   org.apache.hc.core5.util.TimeValue.ofSeconds(30));
 
               httpAsyncClientBuilder.useSystemProperties();
+
+              // httpclient5 5.6.0 turned on automatic gzip decompression in the async client
+              // pipeline by default. Rest5Client / elasticsearch-java's transport also
+              // decompresses the response body itself (see setCompressionEnabled(true) below),
+              // so leaving both enabled makes the second pass run on already-inflated bytes
+              // and throws "java.util.zip.ZipException: Not in GZIP format". Disable at the
+              // transport layer and let the ES client own decompression.
+              httpAsyncClientBuilder.disableContentCompression();
             });
 
         restClientBuilder.setRequestConfigCallback(

--- a/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java
@@ -917,6 +917,14 @@ public class OpenSearchClient implements SearchClient {
 
             httpClientBuilder.useSystemProperties();
 
+            // httpclient5 5.6.0 turned on automatic gzip decompression in the async client
+            // pipeline by default. opensearch-java's ApacheHttpClient5Transport also
+            // decompresses the response body itself, so leaving both enabled makes the second
+            // pass run on already-inflated bytes and throws
+            // "java.util.zip.ZipException: Not in GZIP format" out of LazyDecompressingInputStream.
+            // Disable at the transport layer and let opensearch-java own decompression.
+            httpClientBuilder.disableContentCompression();
+
             return httpClientBuilder;
           });
 

--- a/pom.xml
+++ b/pom.xml
@@ -801,16 +801,24 @@
         <version>5.4.3</version>
       </dependency>
       <!--
-        Must stay >= 5.5.2 for as long as httpcore5 above is pinned to the 5.4 line.
-        httpclient5 5.5 is built against httpcore5 5.3.4; on 5.4.x its I/O reactor
-        dispatchers die silently, leaking search connection-pool leases until every
-        request fails with DeadlineTimeoutException. 5.5.2 is the release that
-        "Fixed incompatibility with HttpCore 5.4". Bump both artifacts together.
+        Keep this in step with the httpcore5 pin above - Apache releases the two together
+        and mixing lines breaks search. httpclient5 5.5/5.5.2 are built against httpcore5
+        5.3.x; on 5.4.x their I/O reactor dispatchers die silently, leaking connection-pool
+        leases until every request fails with DeadlineTimeoutException. 5.6.3 declares
+        httpcore5 5.4.3, so client and core match.
+
+        5.6.3 is also the first release outside the CVE-2026-64607 range (affects
+        5.0-alpha1 through 5.6.2: the classic i/o client leaks a connection when a response
+        carries an invalid Content-Encoding).
+
+        The 5.6 line enables automatic content decompression in the async client, which the
+        search transports also do - see disableContentCompression() in OpenSearchClient and
+        ElasticSearchClient. Do not drop those when touching this pin.
       -->
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.5.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Follow-up to #31657. Self-contained, branched off current `main`, no conflicts.

## What this does

**1. `httpclient5` 5.5.2 → 5.6.3** (edits the existing pin, does not add a second block)

#31657 pinned 5.5.2 to stop httpclient5 being mismatched against the `httpcore5` 5.4 line. That was the minimal fix, but 5.5.2 is still inside the **CVE-2026-64607** range — affects 5.0-alpha1 through 5.6.2, where the classic i/o client leaks a connection on an invalid `Content-Encoding` and eventually exhausts the pool.

5.6.3 clears the CVE and is the better pairing anyway:

| httpclient5 | declares httpcore5 |
|---|---|
| 5.5 (the original bug) | 5.3.4 |
| 5.5.2 (currently on main) | 5.3.6 |
| **5.6.3** | **5.4.3** ← exactly what's pinned here |

**2. `disableContentCompression()` in `OpenSearchClient` and `ElasticSearchClient`**

Required by the move, not optional. httpclient5 5.6.0 turned on automatic content decompression in the async client pipeline by default. Both search transports already decompress the response body themselves, so leaving both enabled runs the second pass over already-inflated bytes:

```
java.util.zip.ZipException: Not in GZIP format
  at ... LazyDecompressingInputStream
```

Disabled at the transport layer; the search clients keep ownership of decompression.

The `connectionRequestTimeout` bound from #31657 is untouched.

## Verification

```
# openmetadata-service
+- org.apache.httpcomponents.client5:httpclient5:jar:5.6.3:runtime
   +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
   \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime

# openmetadata-shaded-deps/{opensearch,elasticsearch}-dep — rebuilt, embedded copies:
elasticsearch-deps   httpclient5=5.6.3  httpcore5=5.4.3
opensearch-deps      httpclient5=5.6.3  httpcore5=5.4.3
```

`mvn -pl openmetadata-service compile` → BUILD SUCCESS. `spotless:apply` clean.

## Worth knowing for the next bump

The shaded uber-jars in `openmetadata-shaded-deps` bundle `org.apache.hc.*` **unrelocated**, so each carries its own copy of httpclient5/httpcore5 and they precede the standalone jars on the classpath. Before this change they held httpclient5 5.4.4 (elasticsearch-deps) and 5.5 (opensearch-deps).

They inherit this `dependencyManagement` block, so a clean build keeps every copy aligned — but the pin only takes effect once those modules are rebuilt, and a stale local uber-jar will shadow the pinned version. Relocating `org.apache.hc.*` in the shade config would remove the ambiguity; left out of scope here.

## Relationship to #31525

#31525 covers the same pin + gzip fix but branched before #31657 merged, so it adds a duplicate `httpclient5` block and its copies of the two client files predate `CONNECTION_REQUEST_TIMEOUT` — resolving those conflicts risks reverting it. This PR is the rebased equivalent; #31525 can be closed in favour of it (its integration-test changes are worth keeping separately if still needed).

## Follow-up, not included

`2.0` and `1.13` carry `httpcore5` 5.4.3 with no `httpclient5` pin, so they have the original mismatch and need this backported. `1.13.3` has no core pin and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns Apache HttpClient 5 with the pinned HttpCore version and prevents duplicate response decompression in the Elasticsearch and OpenSearch transports.

- Updates `httpclient5` from 5.5.2 to 5.6.3.
- Disables transport-level content compression in production search clients.
- Mirrors the compression configuration in integration-test clients.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pom.xml | Updates the managed HttpClient 5 dependency to 5.6.3 while retaining the aligned HttpCore 5.4.3 pin. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/elasticsearch/ElasticSearchClient.java | Disables Apache transport decompression so the configured Elasticsearch client transport remains responsible for response compression handling. |
| openmetadata-service/src/main/java/org/openmetadata/service/search/opensearch/OpenSearchClient.java | Disables Apache transport decompression on the non-IAM OpenSearch transport path to avoid a second decompression pass. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/bootstrap/TestSuiteBootstrap.java | Mirrors the Elasticsearch production compression configuration while preserving credentials setup. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/SearchConsumerFieldBehaviorIT.java | Configures the integration-test OpenSearch transport with transport-level decompression disabled. |
| openmetadata-integration-tests/src/test/java/org/openmetadata/it/tests/VectorEmbeddingIntegrationIT.java | Configures the vector integration-test OpenSearch transport consistently with production. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Search request] --> B[Apache HttpClient 5 transport]
  B -->|Compressed response retained| C[Elasticsearch or OpenSearch transport]
  C -->|Single decompression pass| D[JSON response handling]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(search): disable transport-level co..."](https://github.com/open-metadata/openmetadata/commit/f303b4b0c78777e060fcf9c2d15bf69a79233f59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54251370)</sub>

<!-- /greptile_comment -->