### PR TITLE
fix(ui): eliminate race condition in owner picker tab selection (DataContracts flakiness)

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/UserTeamSelectableList.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/UserTeamSelectableList.component.tsx
@@ -223,11 +223,11 @@ export const UserTeamSelectableList = ({
   const init = async () => {
     if (popupVisible || popoverProps?.open) {
       if (ownerType === EntityType.USER) {
-        await getTeamCount();
         setActiveTab('users');
+        await getTeamCount();
       } else {
-        await getUserCount();
         setActiveTab('teams');
+        await getUserCount();
       }
     }
   };


### PR DESCRIPTION
## Summary

- **Root cause**: `UserTeamSelectableList.init()` called `setActiveTab` *after* an async API call (`getUserCount` / `getTeamCount`). When the owner picker popover opened, the count fetch was in flight; if a user (or test) clicked the "Users" tab during that window, `init()` would reset the tab back to "teams" once the fetch completed.
- **Fix**: Move `setActiveTab` *before* the `await` so the correct tab is selected synchronously on popover open. The count badge still populates in the background — it's just no longer a gate on tab selection.

## Why this caused `DataContracts.spec.ts` to flake

`addOwnerWithoutValidation` in `playwright/utils/entity.ts` clicks the "Users" tab and then asserts `aria-selected="true"` within 15 s. The race meant the assertion retried 18–19 times and always saw `false` because `init()` kept resetting the tab. Both "Create Data Contract and validate for Table @ingestion" and "Create Data Contract and validate for Store Procedure" failed this way in run [32086175102](https://github.com/open-metadata/openmetadata-nightly/actions/runs/32086175102).

## Test plan

- [ ] Open any entity's owner picker — confirm the correct tab (Users vs Teams) is active immediately when the popover opens
- [ ] Switch between Teams and Users tabs — both still work
- [ ] Owner count badges still display correctly
- [ ] `DataContracts.spec.ts` — "Create Data Contract and validate for Table" and "Create Data Contract and validate for Store Procedure" no longer flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Moves owner-picker tab initialization before the asynchronous count request, preventing a completed request from reverting a tab selected while the request was pending.
- Selects the Users or Teams tab synchronously when the picker opens.
- Preserves asynchronous loading of the opposite owner-type count badge.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the reordered state update removes the described race without exposing another reachable tab-reset path.

The active tab is now selected synchronously when the picker opens, and the subsequent count request only updates badge state, so a manual tab selection cannot be reverted when that request completes.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/common/UserTeamSelectableList/UserTeamSelectableList.component.tsx | Reorders active-tab initialization ahead of count fetching without changing request selection or count state handling. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ui): eliminate race condition in own..."](https://github.com/open-metadata/openmetadata/commit/2a6ad5f19115aad9bec2280824b6da79cc4c86a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54251922)</sub>

<!-- /greptile_comment -->