### PR TITLE
test(ui): allow async import/export flow to finish (#31559) [2.0]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts
@@ -46,6 +46,11 @@ const testCaseEditPolicy = new PolicyClass();
 const testCaseEditRole = new RolesClass();
 const testCaseEditUser = new UserClass();
 
+// Successful runs already take over four minutes because this flow waits for
+// multiple bounded CSV jobs. Keep the enclosing budget large enough for one
+// slow job to report its own timeout before Playwright closes the page.
+const COMPLETE_IMPORT_EXPORT_FLOW_TIMEOUT = 10 * 60 * 1000;
+
 // Extend test with custom user page
 const test = base.extend<{
   testCaseEditPage: Page;
@@ -99,7 +104,7 @@ test.describe(
      * 5. Verify Bulk Edit capabilities (Display Name, Tags)
      */
     test('Admin: Complete export-import-validate flow', async ({ page }) => {
-      test.setTimeout(300_000);
+      test.setTimeout(COMPLETE_IMPORT_EXPORT_FLOW_TIMEOUT);
       await redirectToHomePage(page);
       await performE2EExportImportFlow(page, table, 'admin');
     });
@@ -175,7 +180,7 @@ test.describe(
     test('EditAll User: Complete export-import-validate flow', async ({
       testCaseEditPage,
     }) => {
-      test.setTimeout(300_000);
+      test.setTimeout(COMPLETE_IMPORT_EXPORT_FLOW_TIMEOUT);
       await redirectToHomePage(testCaseEditPage);
       await performE2EExportImportFlow(testCaseEditPage, table, 'edituser');
     });


### PR DESCRIPTION
### Describe your changes:

Backport of #31559 to the `2.0` branch.

Related issue: #31558

This PR cherry-picks the TestCase import/export timeout-budget correction from `main` without changing the patch. It gives the complete export/import/validate Playwright flows an enclosing timeout that matches their actual asynchronous workload. It does not change product behavior or relax the existing operation-level waits.

## Root cause analysis

### Failure signature

The Admin scenario intermittently exhausted its explicit 300-second test timeout during the chained export → import → validate → update → bulk-edit flow. Once the enclosing timeout fired, Playwright closed the page and browser context while the current operation-level assertion was still pending. The active wait then surfaced the secondary error:

```text
Target page, context or browser has been closed
```

The page/context closure is therefore where cancellation became visible, not the initiating defect. The initiating defect is that the five-minute enclosing budget is too close to the successful runtime of a flow containing several sequential bounded asynchronous jobs.

### Artifact-based reproduction and timing evidence

The timing baseline used by the original fix was generated from [workflow run 30865939611](https://github.com/open-metadata/OpenMetadata/actions/runs/30865939611). It records successful executions—not timeout cases—at:

| Scenario | Successful duration | Share of old 300s budget | Remaining headroom |
|---|---:|---:|---:|
| Admin | 249,466 ms (4m 9s) | 83.2% | 50.5s |
| EditAll User | 258,678 ms (4m 19s) | 86.2% | 41.3s |

A successful run thus enters its final phases with less remaining test budget than one operation's existing 90-second allowance. Under normal CI variance, a slower-but-valid final operation can be interrupted by the global timeout before its own local wait expires. With one retry, two attempts that each reach the 300-second cap account for the approximately ten-minute retry-inclusive failure duration.

### Why this flow legitimately consumes several bounded waits

The scenario explicitly covers export, import preparation, validation, update, verification, and bulk edit in one test: [TestCaseImportExportE2eFlow.spec.ts lines 98-109](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts#L98-L109).

The shared helper executes those phases sequentially: [testCases.ts lines 737-880](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts#L737-L880).

In particular:

1. Export starts an asynchronous CSV job, captures its `jobId`, and waits for its result: [testCases.ts lines 405-430](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts#L405-L430).
2. The CSV job poll is condition-based and independently bounded at 90 seconds: [common.ts lines 1292-1323](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts#L1292-L1323).
3. Import preview waits for the preview action and grid readiness with a 90-second default: [importUtils.ts lines 1028-1065](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts#L1028-L1065).
4. Import-result counters use the shared 90-second operation-level limit: [importUtils.ts lines 1008-1025](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/importUtils.ts#L1008-L1025).
5. The validated import and bulk-edit validation/update phases then run after those earlier jobs, rather than in parallel: [testCases.ts lines 787-880](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/utils/testCases.ts#L787-L880).

These waits already fail at useful, operation-specific boundaries. The defect is the relationship between their cumulative runtime and the old global five-minute limit: late operations were not guaranteed their own bounded allowance before the enclosing test timer closed the page.

### Fix

A documented ten-minute enclosing timeout constant is added at [TestCaseImportExportE2eFlow.spec.ts lines 49-52](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts#L49-L52). The comment explains why the larger outer budget is needed and why the operation-level timeouts should remain responsible for reporting a stalled job.

The same constant is applied to both callers of the shared flow:

- Admin scenario: [lines 106-109](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts#L106-L109).
- EditAll User scenario: [lines 180-185](https://github.com/open-metadata/OpenMetadata/blob/a3a566d6dd/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts#L180-L185).

Both scenarios invoke the same helper and have nearly identical measured runtimes, so changing only the reported Admin scenario would leave the EditAll variant with the same structural timeout risk.

The ten-minute value is a maximum budget, not a sleep. Successful runs still finish immediately when their assertions complete. The existing 90-second export/import limits remain unchanged, so a genuinely stalled operation still fails at the responsible local boundary instead of consuming the full ten minutes.

## Backport integrity

- Source PR: #31559
- Source commit: `5adfae2592369745dfc0938ca3214183c9683f03`
- 2.0 cherry-pick commit: `a3a566d6dd`
- The source and backport commits have the same stable patch ID: `9d5e03803b0751feb29a91cdf531b49090d93eab`.
- The cherry-pick applied without conflicts.
- One Playwright spec is changed; no production UI, API, database, or search code is touched.

## Alternatives considered

- **Blind sleep:** rejected because it would slow every execution and would not establish that an asynchronous job completed.
- **Increase every operation timeout:** rejected because the local limits already provide useful failure locality and the measured defect is exhaustion of the enclosing budget.
- **Only update the Admin scenario:** rejected because the EditAll scenario executes the same helper and has slightly higher measured runtime.
- **Remove or weaken assertions:** rejected because the flow's coverage is valid and the failure occurs before the assertions receive their intended local budget.
- **Split the flow into order-dependent tests:** rejected because that would introduce cross-test state dependencies or duplicate expensive setup without reducing the aggregate asynchronous work.

## Scope and risk

- One Playwright spec changed.
- No product behavior changed.
- No assertion or coverage removed.
- No per-operation timeout loosened.
- No dependency introduced.
- The change is an exact patch-equivalent cherry-pick from the queued `main` PR.

#
### Type of change:

- [x] Bug fix / 2.0 backport

#
### High-level design:

Not applicable—this is a one-file test-budget correction. Existing condition-based asynchronous waits remain unchanged.

#
### Tests and validation:

Playwright was not executed per request.

Local non-test validation:

- Prettier check passed for the changed spec.
- ESLint completed with zero errors; one existing expected multi-user fixture warning remains outside the changed lines.
- Playwright TypeScript analysis produced no diagnostic for the changed spec; unrelated project diagnostics remain outside this file.
- `git diff --check origin/2.0...HEAD` passed.
- Stable patch ID matches the source PR exactly.

#
### UI screen recording / screenshots:

Not applicable—no product UI behavior or visual output changed.

#
### Checklist:

- [x] Targets `2.0`.
- [x] Backports the single source commit from #31559.
- [x] Includes explanatory comments for the non-obvious timeout relationship.
- [x] Preserves the existing condition-based assertions and local timeouts.
- [x] Links the related issue and original PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This backport raises the enclosing timeout for two long-running Playwright import/export scenarios from five to ten minutes while preserving their operation-level waits.
- Adds a documented shared timeout constant.
- Applies the timeout consistently to the Admin and EditAll User flows.
- Does not change product behavior, assertions, or per-operation timeout limits.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only expands the enclosing test budget while preserving shorter failure boundaries for individual operations.

The two affected scenarios receive enough aggregate time to complete their sequential asynchronous jobs, while existing polling, assertion, locator, and navigation limits continue to detect stalled operations earlier.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/TestCaseImportExportE2eFlow.spec.ts | Safely increases the enclosing timeout for both callers of the sequential asynchronous import/export flow without weakening their independently bounded waits. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): allow async import export flow..."](https://github.com/open-metadata/openmetadata/commit/a3a566d6dd93d2c5a43616a5f35ba62168ee7a80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54262783)</sub>

<!-- /greptile_comment -->