### PR TITLE
fix(oracle): use configured catalog for constraint reflection

### DIFF
--- a/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/metadata.py
@@ -58,17 +58,19 @@ from metadata.ingestion.source.database.oracle.queries import (
 )
 from metadata.ingestion.source.database.oracle.utils import (
     _get_col_type,
-    _get_constraint_data,
     denormalize_name,
     get_all_view_definitions,
     get_columns,
+    get_foreign_keys,
     get_indexes_preserve_case,
     get_mview_names,
     get_mview_names_dialect,
+    get_pk_constraint,
     get_table_comment,
     get_table_comment_preserve_case,
     get_table_names,
     get_table_prefix_from_connection,
+    get_unique_constraints,
     get_view_definition,
     get_view_definition_preserve_case,
     get_view_names,
@@ -109,7 +111,9 @@ OracleDialect.get_view_names = get_view_names_dialect
 Inspector.get_all_table_ddls = get_all_table_ddls
 Inspector.get_table_ddl = get_table_ddl
 
-OracleDialect._get_constraint_data = _get_constraint_data
+OracleDialect.get_pk_constraint = get_pk_constraint
+OracleDialect.get_unique_constraints = get_unique_constraints
+OracleDialect.get_foreign_keys = get_foreign_keys
 
 
 class OracleSource(CommonDbSourceService):

--- a/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/queries.py
@@ -354,7 +354,8 @@ ORACLE_CONSTRAINTS = textwrap.dedent(
             loc.position as loc_pos,
             rem.position as rem_pos,
             ac.search_condition,
-            ac.delete_rule
+            ac.delete_rule,
+            ac.index_name
         FROM {prefix}_CONSTRAINTS{dblink} ac,
             {prefix}_CONS_COLUMNS{dblink} loc,
             {prefix}_CONS_COLUMNS{dblink} rem

--- a/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
+++ b/ingestion/src/metadata/ingestion/source/database/oracle/utils.py
@@ -414,6 +414,142 @@ def _get_constraint_data(self, connection, table_name, schema=None, dblink="", *
     return constraint_data  # noqa: RET504
 
 
+def _prepare_constraint_args(self, connection, table_name, schema, **kw):
+    dblink = kw.get("dblink", "")
+    if dblink and not dblink.startswith("@"):
+        dblink = f"@{dblink}"
+
+    if kw.get("oracle_resolve_synonyms", False):
+        rows = list(
+            self._get_synonyms(
+                connection,
+                schema,
+                [table_name],
+                dblink,
+                info_cache=kw.get("info_cache"),
+            )
+        )
+        if rows:
+            row = rows[0]
+            table_name = self.denormalize_name(row.table_name)
+            schema = self.denormalize_name(row.table_owner)
+            if row.db_link:
+                dblink = row.db_link if row.db_link.startswith("@") else f"@{row.db_link}"
+    else:
+        table_name = self.denormalize_name(table_name)
+        schema = self.denormalize_name(schema or self.default_schema_name)
+
+    return table_name, schema, dblink
+
+
+@reflection.cache
+def get_pk_constraint(self, connection, table_name, schema=None, **kw):
+    """Reflect a primary key from the selected Oracle catalog."""
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    constrained_columns = []
+    constraint_name = None
+    for row in constraint_data:
+        if row[1] == "P":
+            constraint_name = constraint_name or self.normalize_name(row[0])
+            constrained_columns.append(self.normalize_name(row[2]))
+
+    return {"constrained_columns": constrained_columns, "name": constraint_name}
+
+
+@reflection.cache
+def get_unique_constraints(self, connection, table_name, schema=None, **kw):
+    """Reflect unique constraints from the selected Oracle catalog."""
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    unique_constraints = {}
+    for row in constraint_data:
+        if row[1] != "U":
+            continue
+        constraint_name = self.normalize_name(row[0])
+        index_name = self.normalize_name(row[10])
+        constraint = unique_constraints.setdefault(
+            constraint_name,
+            {
+                "name": constraint_name,
+                "column_names": [],
+                "duplicates_index": constraint_name if index_name == constraint_name else None,
+            },
+        )
+        constraint["column_names"].append(self.normalize_name(row[2]))
+
+    return list(unique_constraints.values())
+
+
+@reflection.cache
+def get_foreign_keys(self, connection, table_name, schema=None, **kw):
+    """Reflect foreign keys from the selected Oracle catalog."""
+    requested_schema = schema
+    table_name, schema, dblink = _prepare_constraint_args(self, connection, table_name, schema, **kw)
+    constraint_data = _get_constraint_data(
+        self,
+        connection,
+        table_name,
+        schema,
+        dblink,
+        info_cache=kw.get("info_cache"),
+    )
+
+    foreign_keys = {}
+    for row in constraint_data:
+        if row[1] != "R":
+            continue
+
+        constraint_name = self.normalize_name(row[0])
+        local_column = self.normalize_name(row[2])
+        remote_table = self.normalize_name(row[3])
+        remote_column = self.normalize_name(row[4])
+        remote_owner = self.normalize_name(row[5])
+
+        if remote_table is None:
+            util.warn(
+                f"Got 'None' querying 'table_name' from {_get_table_prefix(self)}_CONS_COLUMNS{dblink}; "
+                "does the user have proper rights to the table?"
+            )
+            continue
+
+        foreign_key = foreign_keys.setdefault(
+            constraint_name,
+            {
+                "name": constraint_name,
+                "constrained_columns": [],
+                "referred_schema": None,
+                "referred_table": remote_table,
+                "referred_columns": [],
+                "options": {},
+            },
+        )
+        if requested_schema is not None or self.denormalize_name(remote_owner) != schema:
+            foreign_key["referred_schema"] = remote_owner
+        if row[9] != "NO ACTION":
+            foreign_key["options"]["ondelete"] = row[9]
+        foreign_key["constrained_columns"].append(local_column)
+        foreign_key["referred_columns"].append(remote_column)
+
+    return list(foreign_keys.values())
+
+
 # ---------------------------------------------------------------------------
 # Preserve-case variants — bound at instance level only when
 # preserveIdentifierCase=True.  The original functions above are unchanged.

--- a/ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py
+++ b/ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py
@@ -1,0 +1,131 @@
+#  Copyright 2025 Collate
+#  Licensed under the Collate Community License, Version 1.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  https://github.com/open-metadata/OpenMetadata/blob/main/ingestion/LICENSE
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.dialects.oracle.base import OracleDialect
+
+CONSTRAINT_ROWS = [
+    (
+        "FK_MY_TABLE_PARENT",
+        "R",
+        "PARENT_ID",
+        "PARENT_TABLE",
+        "ID",
+        "PARENT_SCHEMA",
+        1,
+        1,
+        None,
+        "CASCADE",
+        None,
+    ),
+    ("PK_MY_TABLE", "P", "ID", None, None, None, 1, None, None, None, "PK_MY_TABLE"),
+    ("UQ_MY_TABLE_CODE", "U", "CODE", None, None, None, 1, None, None, None, "UQ_MY_TABLE_CODE"),
+    ("UQ_MY_TABLE_CODE", "U", "REGION", None, None, None, 2, None, None, None, "UQ_MY_TABLE_CODE"),
+]
+
+
+def _dialect(prefix: str) -> OracleDialect:
+    import_module("metadata.ingestion.source.database.oracle.metadata")
+    dialect = OracleDialect()
+    dialect.table_prefix = prefix  # type: ignore[attr-defined]
+    return dialect
+
+
+def _connection(rows):
+    connection = MagicMock()
+    connection.execute.return_value.fetchall.return_value = rows
+    return connection
+
+
+@pytest.mark.parametrize("prefix", ["DBA", "ALL"])
+def test_constraint_reflection_uses_configured_catalog(prefix):
+    dialect = _dialect(prefix)
+    connection = _connection(CONSTRAINT_ROWS)
+
+    assert dialect.get_pk_constraint(connection, "my_table", schema="my_schema") == {
+        "constrained_columns": ["id"],
+        "name": "pk_my_table",
+    }
+    assert dialect.get_unique_constraints(connection, "my_table", schema="my_schema") == [
+        {
+            "name": "uq_my_table_code",
+            "column_names": ["code", "region"],
+            "duplicates_index": "uq_my_table_code",
+        }
+    ]
+    assert dialect.get_foreign_keys(connection, "my_table", schema="my_schema") == [
+        {
+            "name": "fk_my_table_parent",
+            "constrained_columns": ["parent_id"],
+            "referred_schema": "parent_schema",
+            "referred_table": "parent_table",
+            "referred_columns": ["id"],
+            "options": {"ondelete": "CASCADE"},
+        }
+    ]
+
+    assert len(connection.execute.call_args_list) == 3
+    for call in connection.execute.call_args_list:
+        query = str(call.args[0])
+        assert f"FROM {prefix}_CONSTRAINTS" in query
+        assert query.count(f"{prefix}_CONS_COLUMNS") == 2
+        assert call.args[1] == {"table_name": "MY_TABLE", "owner": "MY_SCHEMA"}
+
+
+def test_constraint_reflection_returns_empty_defaults():
+    dialect = _dialect("DBA")
+    connection = _connection([])
+
+    assert dialect.get_pk_constraint(connection, "my_table", schema="my_schema") == {
+        "constrained_columns": [],
+        "name": None,
+    }
+    assert dialect.get_unique_constraints(connection, "my_table", schema="my_schema") == []
+    assert dialect.get_foreign_keys(connection, "my_table", schema="my_schema") == []
+
+
+def test_constraint_reflection_resolves_synonym_before_denormalizing():
+    dialect = _dialect("DBA")
+    dialect._get_synonyms = MagicMock(
+        return_value=[
+            SimpleNamespace(
+                table_name="ACTUAL_TABLE",
+                table_owner="ACTUAL_SCHEMA",
+                db_link=None,
+            )
+        ]
+    )
+    connection = _connection(CONSTRAINT_ROWS)
+
+    assert dialect.get_pk_constraint(
+        connection,
+        "alias_table",
+        schema="alias_schema",
+        oracle_resolve_synonyms=True,
+    ) == {
+        "constrained_columns": ["id"],
+        "name": "pk_my_table",
+    }
+    dialect._get_synonyms.assert_called_once_with(
+        connection,
+        "alias_schema",
+        ["alias_table"],
+        "",
+        info_cache=None,
+    )
+    assert connection.execute.call_args.args[1] == {
+        "table_name": "ACTUAL_TABLE",
+        "owner": "ACTUAL_SCHEMA",
+    }


### PR DESCRIPTION
### Describe your changes:

Related to #29997

Oracle ingestion can enumerate a table through `DBA_TABLES` while SQLAlchemy 2 reflects its constraints through `ALL_CONSTRAINTS`. For an ingestion account with catalog visibility but no direct table grants, that produces this per-table trace:

`DBA_TABLES: 1 table → ALL_CONSTRAINTS: no table → NoSuchTableError → table omitted from the run`

This change binds the connector catalog-aware query to the active SQLAlchemy 2 public reflection methods: `get_pk_constraint`, `get_unique_constraints`, and `get_foreign_keys`. The selected `DBA` or `ALL` prefix is therefore used consistently for table, column, and constraint discovery.

The constraint query now returns `index_name` so unique constraints retain SQLAlchemy compatible `duplicates_index` metadata.

#
### Type of change:

- [x] Bug fix

#
### High-level design:

N/A — small connector bug fix.

#
### Tests:

#### Use cases covered

- `DBA_*` table discovery and constraint reflection use the same catalog.
- `ALL_*` table discovery and constraint reflection use the same catalog.
- Primary keys, composite unique constraints, foreign keys, delete rules, and empty defaults are preserved.
- Synonym resolution completes before identifier denormalization.

#### Unit tests

- [x] I added unit tests for the changed logic.
- File added: `ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py`
- `22 passed` across the Oracle connector tests and the new regression tests.

#### Backend integration tests

- [x] Not applicable (no backend API changes).

#### Ingestion integration tests

- [ ] No automated integration test was added.
- The exact ingestion reflection boundary was validated against Oracle Free with `DBA_TABLES=2` and `ALL_TABLES=0`; five columns, the primary key, a composite unique constraint, and a foreign key were returned.

#### Playwright (UI) tests

- [x] Not applicable (no UI changes).

#### Manual testing performed

1. Ran the Oracle unit and regression tests: `22 passed`.
2. Ran the complete ingestion Ruff and formatting checks: `2661 files already formatted`.
3. Ran Basedpyright on the changed files: `0 errors`.
4. Ran `SqlColumnHandlerMixin._get_columns_with_constraints` against Oracle Free using catalog-only visibility and verified PK, unique, and FK metadata.

#
### UI screen recording / screenshots:

Not applicable.

#
### Checklist:

- [x] I have read the CONTRIBUTING document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`.
- [ ] My PR is linked to an open GitHub issue via `Fixes #<issue-number>`.
- [x] For JSON Schema changes: not applicable.
- [x] For UI changes: not applicable.
- [x] I have added tests and listed them above.
- [x] I have added a test that covers the exact scenario being fixed.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR redirects Oracle primary-key, unique-constraint, and foreign-key reflection through the connector’s configured DBA or ALL catalog and preserves backing-index metadata.
- Adds catalog-aware implementations for SQLAlchemy’s public constraint reflection methods.
- Extends the Oracle constraint query with index names.
- Adds regression coverage for DBA/ALL catalogs, composite constraints, foreign keys, empty results, and direct synonym resolution.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until synonym resolution remains enabled when preserve-case index reflection delegates to the new primary-key reflector.

The new primary-key implementation ignores the resolve_synonyms keyword used by the existing preserve-case index path, causing synonym-backed primary-key indexes to be emitted as ordinary indexes.

**Files Needing Attention:** ingestion/src/metadata/ingestion/source/database/oracle/utils.py
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ingestion/src/metadata/ingestion/source/database/oracle/metadata.py | Rebinds SQLAlchemy’s public Oracle constraint reflection methods to catalog-aware connector implementations. |
| ingestion/src/metadata/ingestion/source/database/oracle/queries.py | Adds the backing index name to each reflected constraint row. |
| ingestion/src/metadata/ingestion/source/database/oracle/utils.py | Implements catalog-aware constraint reflection, but drops synonym resolution when the preserve-case index path forwards resolve_synonyms. |
| ingestion/tests/unit/topology/database/test_oracle_constraint_reflection.py | Covers direct catalog and synonym reflection but omits the preserve-case index-to-PK synonym path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-metadata/openmetadata/commit/b54f18bff93ad3b6bb092783a16437e5aa6a3073) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54265366)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->