### PR TITLE
test(ui): stabilize Data Quality and Incident Manager tests (#31519) [2.0]

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1458,20 +1458,17 @@ test.describe(
         });
 
         await test.step('Test page size dropdown', async () => {
-          await expect(
-            page.locator('[data-testid="page-size-selection-dropdown"]')
-          ).toBeVisible();
+          const pageSizeDropdown = page.getByTestId(
+            'page-size-selection-dropdown'
+          );
+          const pageSizeMenu = page.locator(
+            '.ant-dropdown:not(.ant-dropdown-hidden) .ant-dropdown-menu'
+          );
 
-          await page.click('[data-testid="page-size-selection-dropdown"]');
-
-          // Wait for dropdown menu to be visible
-          await page.locator('.ant-dropdown-menu').waitFor({
-            state: 'visible',
-            timeout: 5000,
-          });
-
-          // Verify dropdown options are visible
-          await expect(page.locator('.ant-dropdown-menu-item')).toHaveCount(3);
+          await expect(pageSizeDropdown).toBeVisible();
+          await pageSizeDropdown.hover();
+          await expect(pageSizeMenu).toBeVisible();
+          await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);
         });
       } finally {
         await paginationTable.delete(apiContext);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts
@@ -1466,6 +1466,8 @@ test.describe(
           );
 
           await expect(pageSizeDropdown).toBeVisible();
+          // NextPrevious inherits Ant Dropdown's hover trigger; clicking this
+          // button only runs its preventDefault handler and may not open the menu.
           await pageSizeDropdown.hover();
           await expect(pageSizeMenu).toBeVisible();
           await expect(pageSizeMenu.getByRole('menuitem')).toHaveCount(3);

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1082,7 +1082,56 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
     );
     await assigneeOption.click();
-    await assigneeFilterRes;
+    const assigneeFilterResponse = await assigneeFilterRes;
+    const assignedIncident = page.getByTestId(
+      `test-case-${assigneeTestCase.testCaseName}`
+    );
+
+    if (!(await assignedIncident.isVisible().catch(() => false))) {
+      await expect
+        .poll(
+          async () => {
+            const retryResponse = await page.request.get(
+              assigneeFilterResponse.url()
+            );
+
+            if (!retryResponse.ok()) {
+              return false;
+            }
+
+            const searchData = (await retryResponse.json()) as {
+              data?: Array<{
+                testCaseReference?: { name?: string };
+                testCaseResolutionStatusDetails?: {
+                  assignee?: { name?: string };
+                };
+              }>;
+            };
+
+            return Boolean(
+              searchData.data?.some(
+                (incident) =>
+                  incident.testCaseReference?.name ===
+                    assigneeTestCase.testCaseName &&
+                  incident.testCaseResolutionStatusDetails?.assignee?.name ===
+                    assigneeTestCase.username
+              )
+            );
+          },
+          {
+            message: `Wait for ${assigneeTestCase.testCaseName} assignee to be indexed`,
+            timeout: 60_000,
+            intervals: [1_000, 2_000, 5_000],
+          }
+        )
+        .toBe(true);
+
+      const indexedAssigneeFilterRes = page.waitForResponse(
+        `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
+      );
+      await page.reload();
+      await indexedAssigneeFilterRes;
+    }
 
     await expectIncidentTableRowsToContain(
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -24,6 +24,7 @@ import { UserClass } from '../../support/user/UserClass';
 import { performAdminLogin } from '../../utils/admin';
 import { resetTokenFromBotPage } from '../../utils/bot';
 import { getApiContext, redirectToHomePage } from '../../utils/common';
+import { waitForIncidentToBeIndexed } from '../../utils/dataQuality';
 import { waitForAllLoadersToDisappear } from '../../utils/entity';
 import {
   acknowledgeTask,
@@ -1050,6 +1051,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       username: user1.data.email.split('@')[0].toLocaleLowerCase(),
       userDisplayName: user1.getUserDisplayName(),
       testCaseName: table1.testCasesResponseData[2]?.['name'],
+      testCaseFqn: table1.testCasesResponseData[2]?.['fullyQualifiedName'],
     };
     const testCase1 = table1.testCasesResponseData[0]?.['name'];
     const incidentDetailsRes = page.waitForResponse(
@@ -1058,6 +1060,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
     await sidebarClick(page, SidebarItem.INCIDENT_MANAGER);
     await incidentDetailsRes;
 
+    const assignmentStartedAt = Date.now();
     await assignIncident({
       page,
       testCaseName: assigneeTestCase.testCaseName,
@@ -1067,6 +1070,13 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       },
       direct: true,
     });
+    await waitForIncidentToBeIndexed(
+      page.request,
+      assigneeTestCase.testCaseFqn,
+      assignmentStartedAt,
+      'Assigned',
+      assigneeTestCase.username
+    );
 
     await page.click('[data-testid="select-assignee"]');
     const assigneeOption = page.locator(
@@ -1082,60 +1092,7 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
     );
     await assigneeOption.click();
-    const assigneeFilterResponse = await assigneeFilterRes;
-    const assignedIncident = page.getByTestId(
-      `test-case-${assigneeTestCase.testCaseName}`
-    );
-
-    // The resolve API confirms the write before the search index necessarily
-    // exposes it, so wait on the exact filtered request the UI already issued.
-    if (!(await assignedIncident.isVisible().catch(() => false))) {
-      await expect
-        .poll(
-          async () => {
-            const retryResponse = await page.request.get(
-              assigneeFilterResponse.url()
-            );
-
-            if (!retryResponse.ok()) {
-              return false;
-            }
-
-            const searchData = (await retryResponse.json()) as {
-              data?: Array<{
-                testCaseReference?: { name?: string };
-                testCaseResolutionStatusDetails?: {
-                  assignee?: { name?: string };
-                };
-              }>;
-            };
-
-            return Boolean(
-              searchData.data?.some(
-                (incident) =>
-                  incident.testCaseReference?.name ===
-                    assigneeTestCase.testCaseName &&
-                  incident.testCaseResolutionStatusDetails?.assignee?.name ===
-                    assigneeTestCase.username
-              )
-            );
-          },
-          {
-            message: `Wait for ${assigneeTestCase.testCaseName} assignee to be indexed`,
-            timeout: 60_000,
-            intervals: [1_000, 2_000, 5_000],
-          }
-        )
-        .toBe(true);
-
-      const indexedAssigneeFilterRes = page.waitForResponse(
-        `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
-      );
-      // The assignee lives in the URL query, so reload preserves the filter and
-      // renders the indexed response without rebuilding UI state in the test.
-      await page.reload();
-      await indexedAssigneeFilterRes;
-    }
+    await assigneeFilterRes;
 
     await expectIncidentTableRowsToContain(
       page,

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1087,6 +1087,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       `test-case-${assigneeTestCase.testCaseName}`
     );
 
+    // The resolve API confirms the write before the search index necessarily
+    // exposes it, so wait on the exact filtered request the UI already issued.
     if (!(await assignedIncident.isVisible().catch(() => false))) {
       await expect
         .poll(
@@ -1129,6 +1131,8 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       const indexedAssigneeFilterRes = page.waitForResponse(
         `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?*assignee=${assigneeTestCase.username}*`
       );
+      // The assignee lives in the URL query, so reload preserves the filter and
+      // renders the indexed response without rebuilding UI state in the test.
       await page.reload();
       await indexedAssigneeFilterRes;
     }

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts
@@ -1070,13 +1070,22 @@ test.describe('Incident Manager', PLAYWRIGHT_INGESTION_TAG_OBJ, () => {
       },
       direct: true,
     });
-    await waitForIncidentToBeIndexed(
-      page.request,
-      assigneeTestCase.testCaseFqn,
-      assignmentStartedAt,
-      'Assigned',
-      assigneeTestCase.username
-    );
+    // Browser API calls read the JWT from local storage, which page.request
+    // does not inherit. Poll with an authenticated context so a 401 cannot be
+    // mistaken for search-index lag.
+    const { apiContext, afterAction } = await getApiContext(page);
+
+    try {
+      await waitForIncidentToBeIndexed(
+        apiContext,
+        assigneeTestCase.testCaseFqn,
+        assignmentStartedAt,
+        'Assigned',
+        assigneeTestCase.username
+      );
+    } finally {
+      await afterAction();
+    }
 
     await page.click('[data-testid="select-assignee"]');
     const assigneeOption = page.locator(

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts
@@ -567,40 +567,68 @@ export async function applyDashboardCertificationFilter(
 }
 
 /**
- * Polls the incident status API until an incident for `testCaseFqn` appears
- * within the [failTs-60s, failTs+120s] window.
- * Call this immediately after `addTestCaseResult` to guarantee the incident
- * document is indexed before any UI assertions.
- * Pass `expectedStatus` to also wait until the incident reaches that resolution
- * status (e.g. "Resolved") — useful after posting a status transition.
+ * Polls the incident search API until an incident for `testCaseFqn` appears
+ * within the [eventTs-60s, eventTs+120s] window.
+ * Call this after creating or updating an incident to guarantee the search
+ * document contains the state required by subsequent UI assertions.
+ * Assignee transitions filter on `updatedAt` because they update an existing
+ * incident whose original `timestamp` remains unchanged.
  */
 export async function waitForIncidentToBeIndexed(
   apiContext: APIRequestContext,
   testCaseFqn: string,
-  failTs: number,
-  expectedStatus?: string
+  eventTs: number,
+  expectedStatus?: string,
+  expectedAssignee?: string
 ): Promise<void> {
   await expect
     .poll(
       async () => {
         const res = await apiContext.get(
-          `/api/v1/dataQuality/testCases/testCaseIncidentStatus?latest=true` +
-            `&startTs=${failTs - 60_000}` +
-            `&endTs=${failTs + 120_000}`
+          '/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list',
+          {
+            params: {
+              latest: true,
+              startTs: eventTs - 60_000,
+              endTs: eventTs + 120_000,
+              dateField: expectedAssignee ? 'updatedAt' : 'timestamp',
+              testCaseFQN: testCaseFqn,
+              ...(expectedStatus && {
+                testCaseResolutionStatusType: expectedStatus,
+              }),
+              ...(expectedAssignee && { assignee: expectedAssignee }),
+            },
+          }
         );
+
+        if (!res.ok()) {
+          return false;
+        }
+
         const body = await res.json();
 
         return (body.data ?? []).some(
           (i: {
             testCaseReference?: { fullyQualifiedName?: string };
             testCaseResolutionStatusType?: string;
+            testCaseResolutionStatusDetails?: {
+              assignee?: { name?: string };
+            };
           }) => {
             if (i.testCaseReference?.fullyQualifiedName !== testCaseFqn) {
               return false;
             }
 
-            return expectedStatus
-              ? i.testCaseResolutionStatusType === expectedStatus
+            if (
+              expectedStatus &&
+              i.testCaseResolutionStatusType !== expectedStatus
+            ) {
+              return false;
+            }
+
+            return expectedAssignee
+              ? i.testCaseResolutionStatusDetails?.assignee?.name ===
+                  expectedAssignee
               : true;
           }
         );

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -259,6 +259,8 @@ export const addAssigneeFromPopoverWidget = async (data: {
   const taskHeaderAssignee = page.getByTestId(
     'incident-manager-task-header-container'
   );
+  // List pages can contain several incidents, so a generic first() may assert
+  // against an unrelated unassigned row instead of the incident just updated.
   const incidentAssignee = testCaseName
     ? page
         .locator('tr')

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts
@@ -256,21 +256,22 @@ export const addAssigneeFromPopoverWidget = async (data: {
   await page.click(`.ant-popover [title="${user.displayName}"]`);
   await updateIncident;
 
-  await page
-    .getByTestId('assignee')
-    .getByTestId('owner-link')
-    .first()
-    .waitFor();
-
   const taskHeaderAssignee = page.getByTestId(
     'incident-manager-task-header-container'
   );
+  const incidentAssignee = testCaseName
+    ? page
+        .locator('tr')
+        .filter({ has: page.getByTestId(`test-case-${testCaseName}`) })
+        .first()
+        .getByTestId('assignee')
+    : page.getByTestId('assignee').first();
 
   await expect(
     (await taskHeaderAssignee.isVisible().catch(() => false))
       ? taskHeaderAssignee
-      : page.getByTestId('assignee').first()
-  ).toContainText(user.displayName);
+      : incidentAssignee
+  ).toContainText(user.displayName, { timeout: 30_000 });
 };
 
 export const assignIncident = async (data: {


### PR DESCRIPTION
### Describe your changes:

Backport of #31519 to the `2.0` branch.

Related issue: #31518

This PR cherry-picks the complete four-commit Data Quality and Incident Manager stabilization series from `main`. It addresses two independent Playwright flakes where the test synchronized on an event weaker than the product state it intended to verify:

1. The Data Quality pagination test clicked a hover-triggered page-size control and waited for a broad menu selector.
2. The Incident Manager test treated completion of the assignment write as proof that the target row and search-backed filtered listing had both converged.

No product behavior or API contract changes. The patch only makes the tests interact with the actual UI contract and wait for the exact observable state.

## Root cause analysis

### 1. Data Quality pagination page-size dropdown

#### Failure signature

```text
locator.waitFor: Timeout 5000ms exceeded
waiting for locator('.ant-dropdown-menu') to be visible
```

The failure occurred after clicking the page-size trigger. The captured DOM showed the page-size button as active, but no visible dropdown menu was mounted during the fixed five-second window.

#### Product interaction contract

The pagination component wraps the page-size button in Ant Design `Dropdown` without an explicit `trigger`: [NextPrevious.tsx lines 125-144](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/src/components/common/NextPrevious/NextPrevious.tsx#L125-L144).

- Without an explicit trigger, Ant Dropdown uses hover interaction.
- The nested button's click handler only calls `preventDefault()`.
- A click does not itself satisfy the component contract; it opens the menu only when pointer movement around the click happens to produce the required hover state.

The original test clicked the trigger and then waited on the broad `.ant-dropdown-menu` selector with a hard five-second timeout: [original DataQuality.spec.ts lines 1460-1474](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1460-L1474).

That was flaky for two independent reasons:

- It relied on incidental pointer hover generated around a click instead of deliberately performing the configured interaction.
- `.ant-dropdown-menu` can match Ant menus that remain mounted but hidden, so it did not uniquely identify the popup associated with this trigger.

The original investigation reproduced the failure after four successful iterations. That pass/pass/pass/pass/fail pattern is consistent with an input-event race rather than a consistently slow render.

#### Fix

The corrected flow is at [DataQuality.spec.ts lines 1460-1474](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1460-L1474):

1. Assert that the page-size trigger is visible.
2. Use `hover()`, matching the component contract.
3. Scope the menu to `.ant-dropdown:not(.ant-dropdown-hidden)` so only the visible popup is considered.
4. Use Playwright's web-first visibility assertion instead of a manually constrained five-second `waitFor`.
5. Count semantic `menuitem` roles within that visible popup.

The explanatory comment at [lines 1468-1471](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts#L1468-L1471) records why a hover is required. Increasing the original timeout would only give an incorrect click interaction more time; it would not guarantee the hover-triggered menu opens.

### 2. Incident Manager assignee filter

This failure had two synchronization defects, followed by one authentication defect exposed by the first index-polling implementation.

#### 2a. The post-assignment assertion targeted the wrong incident row

The assignment helper identifies the target row by test-case identifier before opening its editor: [incidentManager.ts lines 177-185](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L177-L185).

The original post-write assertion discarded that identity and read `page.getByTestId('assignee').first()`: [original incidentManager.ts lines 254-272](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L254-L272).

On a multi-row Incident Manager listing, the first assignee is not necessarily the incident just updated. If the first unrelated row is unassigned, the assertion receives `No Assignee` even when the target assignment succeeded. The previous global `owner-link.first()` wait had the same weakness: it proved only that some owner link existed somewhere on the page.

The helper now retains the target identity and reads the assignee within the exact incident row: [incidentManager.ts lines 258-275](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L258-L275). The 30-second web-first assertion permits that row to rerender after the acknowledged update without a blind sleep. The inline comment explains why a generic `first()` is unsafe on this listing.

#### 2b. The assignment write completed before the search listing converged

Assignment waits for the task-resolution POST response: [task.ts lines 60-65](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/task.ts#L60-L65), consumed by the assignment helper at [incidentManager.ts lines 254-256](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts#L254-L256).

That response acknowledges the write side. The assignee filter reads `/api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?assignee=...`, so it observes an asynchronously updated search document. A successful task transition does not guarantee that the new assignee is already searchable.

The original filter flow waited for one search response and immediately asserted its rows: [original IncidentManager.spec.ts lines 1081-1090](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1081-L1090). If that request reached search before indexing completed, it returned a valid but stale result. Waiting longer on an already completed response cannot make that payload current.

#### Why the existing index helper had to be extended

`waitForIncidentToBeIndexed` already existed, but it previously called the database-backed incident endpoint: [original dataQuality.ts lines 577-611](https://github.com/open-metadata/OpenMetadata/blob/13e0ba24d567d3b3ad4d5e9719d58e1425b06044/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts#L577-L611).

The two server routes have different consistency boundaries:

- The non-search `GET /testCaseIncidentStatus` route ends in `repository.list(...)`: [TestCaseResolutionStatusResource.java lines 108-219](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java#L108-L219).
- Incident Manager uses `GET /testCaseIncidentStatus/search/list`, which calls `repository.listLatestFromSearch(...)` or `repository.listFromSearchWithOffset(...)`: [TestCaseResolutionStatusResource.java lines 639-791](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-service/src/main/java/org/openmetadata/service/resources/dqtests/TestCaseResolutionStatusResource.java#L639-L791).

The unchanged helper could therefore return as soon as the database row existed while Incident Manager's search document still contained the prior assignee. A generic document-presence check would also be insufficient: existence does not prove that the assignee transition was indexed.

The extended helper polls the same search-backed route and verifies the exact FQN, resolution status, and nested assignee: [dataQuality.ts lines 569-638](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts#L569-L638).

It now:

1. Calls `/testCaseIncidentStatus/search/list`.
2. Filters by the exact test-case FQN.
3. Retains the bounded event window and 60-second polling budget.
4. Optionally filters and verifies resolution status.
5. Optionally filters and verifies assignee.
6. Uses `updatedAt` for assignee transitions because they update an existing incident whose original `timestamp` is unchanged.
7. Rejects non-success responses instead of parsing them as incident data.
8. Verifies the returned source rather than trusting query parameters alone.

#### 2c. The first index poll was unauthenticated

The initial helper integration passed `page.request`. The resulting CI failure timed out in `waitForIncidentToBeIndexed` with `Expected: true / Received: false`.

The failed job's server diagnostics reproduced the actual request behavior without rerunning the test: [failed ingestion job](https://github.com/open-metadata/OpenMetadata/actions/runs/31805883036/job/94792616971).

The sequence was:

```text
POST /api/v1/tasks/<task-id>/resolve                                      200
GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/stateId/<id>   200
GET  /api/v1/dataQuality/testCases/testCaseIncidentStatus/search/list?... 401
...every subsequent poll returned 401 until timeout...
```

The retry repeated the same pattern. This ruled out an index query mismatch for that follow-up failure: the helper never reached an authenticated search read.

The application stores its JWT in browser local storage. Browser-originated API calls inject that token, but `page.request` did not inherit it. The established authenticated context reads the page token and adds `Authorization: Bearer <token>`: [common.ts lines 58-76](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts#L58-L76), wrapped by `getApiContext(page)` at [common.ts lines 294-305](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/utils/common.ts#L294-L305).

The corrected sequence is at [IncidentManager.spec.ts lines 1063-1104](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1063-L1104):

1. Complete the UI assignment.
2. Create an authenticated API context from the current page token.
3. Reuse `waitForIncidentToBeIndexed` with `Assigned + <username>`.
4. Dispose the temporary context in `finally`.
5. Apply the UI assignee filter only after the exact indexed state is observable.

The authentication rationale is documented inline at [lines 1073-1076](https://github.com/open-metadata/OpenMetadata/blob/78384ead45/openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts#L1073-L1076).

The original race remains a search-index propagation issue, so the existing helper is the correct synchronization primitive after extending it to verify the indexed assignee. The follow-up CI failure was caused by how the helper was called, not evidence against the indexing diagnosis.

## Why the failures were flaky

| Failure | State that varied | Incorrect synchronization |
|---|---|---|
| Data Quality page-size menu | Whether click/pointer processing incidentally produced Ant Dropdown's hover state | Click followed by a fixed five-second wait |
| Incident row assignee | Which incident appeared first and whether the target row rerendered | Global `assignee.first()` assertion |
| Incident assignee filter | Whether search consumed the assignment before the first filtered GET | Waiting for one response regardless of its data |
| Follow-up index poll | Not an index race: helper requests lacked authorization | Retrying HTTP 401 as if it meant “not indexed yet” |

## Backport integrity

The complete source series was cherry-picked in order and applied without conflicts:

| Source commit | 2.0 commit | Purpose |
|---|---|---|
| `fdac498e54` | `bad42284fc` | Stabilize pagination interaction and incident-row targeting |
| `d03fe29ac8` | `dc435dc494` | Add explanatory synchronization comments |
| `0888e9549f` | `16c07894cd` | Extend and reuse incident search-index polling |
| `e3e0516832` | `78384ead45` | Authenticate incident index polling |

`git range-diff` reports all four source/backport pairs as equal (`=`). No conflict-resolution edits or 2.0-only modifications were introduced.

## Scope and risk

- Test-only changes; no production UI, API, database, or search behavior is modified.
- Existing expectations remain: three page-size options and the selected assignee must be visible.
- Index polling is bounded and scoped to the exact test case, status, and assignee.
- Polling uses the authenticated API-context pattern already established in the spec.
- The temporary context is always disposed.
- Locators identify the visible menu or exact incident row.
- No new dependency is introduced.

#
### Type of change:

- [x] Bug fix / 2.0 backport

#
### High-level design:

The tests synchronize on observable business state:

- UI interaction uses the component's configured trigger and visible popup.
- List assertions retain the target incident identity.
- Search-backed assertions wait through an authenticated request for the exact target-assignee association, then refetch the filtered UI.

#
### Tests and validation:

Playwright was not executed per request.

Local non-test validation:

- Prettier check passed for all four changed files.
- ESLint completed with zero errors; two existing expected multi-user-login warnings remain outside the changed lines.
- Playwright TypeScript analysis produced no diagnostic for any changed file; unrelated baseline diagnostics remain elsewhere.
- `git diff --check origin/2.0...HEAD` passed.
- `git range-diff` verified exact equality for all four source/backport commits.

#
### UI screen recording / screenshots:

Not applicable—no product UI behavior or visual output changed.

#
### Checklist:

- [x] Targets `2.0`.
- [x] Backports all four commits from #31519 in order.
- [x] Includes explanatory comments for non-obvious synchronization behavior.
- [x] Preserves bounded polling and existing assertions.
- [x] Links the related issue and original PR.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backports test-only synchronization improvements for Data Quality pagination and Incident Manager assignment flows.

- Uses the pagination component's hover interaction and scopes assertions to the visible dropdown.
- Retains incident identity when checking the updated assignee row.
- Polls the authenticated search-backed incident endpoint for the exact indexed status and assignee before filtering the UI.
- Extends the shared incident-index helper while preserving bounded polling and cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed test synchronization.

The changed locators match the rendered UI structure, and the authenticated search polling aligns with the endpoint parameters, timestamp mapping, and incident response shape used by all current callers.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/DataQuality/DataQuality.spec.ts | Replaces a click-based broad dropdown wait with the configured hover interaction and a visible-popup-scoped assertion. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Features/IncidentManager.spec.ts | Waits for the exact assigned incident to appear in search through an authenticated, safely disposed API context. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/dataQuality.ts | Extends bounded incident polling to query and verify search-backed FQN, status, and assignee state. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/incidentManager.ts | Scopes post-assignment verification to the incident row identified by the target test case. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Test as Playwright Test
  participant UI as Incident Manager UI
  participant API as OpenMetadata API
  participant Search as Search Index
  Test->>UI: Assign incident
  UI->>API: Resolve assignment task
  API-->>UI: Assignment acknowledged
  Test->>API: Create authenticated API context
  loop Bounded polling
    Test->>API: Search exact FQN, status, and assignee
    API->>Search: Query indexed incident state
    Search-->>API: Current indexed document
    API-->>Test: Search response
  end
  Test->>UI: Apply assignee filter
  Test->>UI: Assert expected incident rows
```
</details>

<sub>Reviews (1): Last reviewed commit: ["test(ui): authenticate incident index po..."](https://github.com/open-metadata/openmetadata/commit/78384ead454d6a6182d13186355e5ba98f59bc16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54265772)</sub>

<!-- /greptile_comment -->