### PR TITLE
test(e2e): stop TableClass losing entity identity on a failed PATCH

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts
@@ -395,9 +395,26 @@ export class TableClass extends EntityClass {
       return;
     }
 
+    // The global-search flow types `searchTerm` into the search box and waits
+    // for the resulting query response. An empty term types nothing, so no
+    // request is ever triggered and the wait burns its full 30s before the test
+    // times out — a hang whose error names the helper, not the cause. Every
+    // route to an FQN above has already been tried, so stop here and say so.
+    const effectiveSearchTerm = searchTerm ?? tableFqn;
+
+    if (!effectiveSearchTerm) {
+      throw new Error(
+        `TableClass.visitEntityPage: cannot resolve a fullyQualifiedName for table "${
+          this.entityResponseData?.name ?? this.entity.name
+        }" (id: ${
+          this.entityResponseData?.id ?? 'unknown'
+        }). Refusing to fall back to global search with an empty term.`
+      );
+    }
+
     await visitEntityPage({
       page,
-      searchTerm: searchTerm ?? tableFqn,
+      searchTerm: effectiveSearchTerm,
       dataTestId: `${
         this.entityResponseData.service?.name ?? this.service.name
       }-${this.entityResponseData.name ?? this.entity.name}`,
@@ -581,6 +598,19 @@ export class TableClass extends EntityClass {
         },
       }
     );
+
+    // Only adopt the response body when the PATCH succeeded. An error body
+    // ({code, message}) carries neither id nor fullyQualifiedName, so assigning
+    // it unconditionally erased the table's identity — and every later
+    // visitEntityPage then had nothing to navigate by, surfacing much further
+    // downstream as a 30s search hang rather than as the failed PATCH it was.
+    if (!response.ok()) {
+      throw new Error(
+        `TableClass.patch: PATCH failed with ${response.status()} for table "${
+          this.entityResponseData?.name ?? this.entity.name
+        }": ${await response.text()}`
+      );
+    }
 
     this.entityResponseData = await response.json();
 


### PR DESCRIPTION
## What

Three `PlatformLineage` tests are the largest remaining flaky cluster in the AUT nightly — **17 flake occurrences across 12 runs** (Aug 14–18, `1.11.13 → 2.0`, both MySQL and PostgreSQL lanes):

| Rate | Test |
|---|---|
| 9/12 (75%) | `Verify platform view switching` |
| 4/12 (33%) | `Verify service platform view` |
| 4/12 (33%) | `Verify domain platform view` |

All three die in the shared `beforeEach`, so one cause covers all of them.

## Root cause

The step timeline from run `31983245166` (Aug 17):

```
02:19:02.455     5000ms  Wait for selector getByTestId('searchBox').first()   <== ERR
02:19:07.456      224ms  Navigate to "/my-data"
02:19:08.727    30001ms  Wait for event "response"                            <== ERR
02:19:08.728      130ms  Fill "" getByTestId('searchBox')
```

The search box is filled with an **empty string**. No keystroke means no `/search/query` request, so the 30s wait can never resolve and the test times out.

That happens because `TableClass.visitEntityPage` ends with:

```ts
searchTerm: searchTerm ?? tableFqn,   // '' when the FQN is unavailable
```

and `patch()` ended with an unconditional:

```ts
this.entityResponseData = await response.json();
```

A failed PATCH therefore replaced the table's response data with an error body (`{code, message}`) carrying **neither `id` nor `fullyQualifiedName`** — so every later `visitEntityPage` had nothing to navigate by, and fell through to global search with an empty term.

Supporting observation from the same run: only the by-**name** recovery lookup fires in `beforeEach`, never the by-**id** one that `visitEntityPage` attempts first whenever `entityResponseData.id` is set. Both were absent, while `create()` sets both.

## The change

`patch()` now throws on a non-ok response instead of adopting its body — that is the identity loss at source.

`visitEntityPage` refuses to run global search on an empty term. If identity is ever lost by another route, the test now fails in seconds naming the table, instead of hanging 30s naming the helper.

**Deliberately not restored:** the constructed-FQN recovery removed in #31528. That was a fallback *for* the identity loss rather than a fix for it, and re-adding it would mask the cause this PR removes.

## Reviewer notes

- **Blast radius:** `TableClass` is shared across many suites. Making `patch()` throw is correct — silent identity corruption is never wanted — but any suite where that PATCH has been failing quietly will now fail loudly rather than flake later. That is the intent, though it may surface new red in the next nightly.
- **Verified against current `origin/main`**, not against a stale reading: both defects are still present and the files are identical on `main` and `2.0`.
- **Acceptance is the measured nightly rate, not local runs.** This class of failure does not reproduce at low worker counts — a previous attempt at a related ports flake (#31063) verified 43/43 locally at `workers=2` and still flaked in 18/18 nightlies.
- No open PR touches `PlatformLineage.spec.ts` or `TableClass.ts`, so this should not collide with in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves a table helper’s entity identity by rejecting failed PATCH requests before adopting their error bodies.
- Adds an immediate diagnostic when entity navigation cannot derive a non-empty search term.
- Throws at the failed PATCH operation while retaining the previous successful entity state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with failed PATCH requests now reported at their source and no supported caller-contract regression.

The changed helper preserves existing entity identity on PATCH failure, keeps successful response parsing unchanged, and prevents the known empty-search timeout; current callers do not depend on failed responses being returned.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/support/entity/TableClass.ts | Adds focused failure handling for unsuccessful PATCH requests and unresolved entity navigation without introducing an actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(e2e): stop TableClass losing entity..."](https://github.com/open-metadata/openmetadata/commit/c1ecea1f03e3f4c6c0a475c580f08bbd86efd08b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54270031)</sub>

<!-- /greptile_comment -->