### PR TITLE
Fixes 31688: show a skeleton in the Queries tab badge while the count loads

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/common/TabsLabel/TabsLabel.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/TabsLabel/TabsLabel.component.tsx
@@ -10,11 +10,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+import { Skeleton } from '@openmetadata/ui-core-components';
 import { Badge } from 'antd';
 import { isNil } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { getCountBadge } from '../../../utils/EntityDisplayPureUtils';
-import Loader from '../Loader/Loader';
 import './tabs-label.less';
 import { TabsLabelProps } from './TabsLabel.interface';
 
@@ -35,9 +35,9 @@ const TabsLabel = ({
         {name}
         {isLoading ? (
           <span
-            className="d-flex justify-center items-center"
+            className="tw:flex tw:items-center"
             data-testid="loading-skeleton">
-            <Loader size="small" />
+            <Skeleton height={16} variant="rounded" width={24} />
           </span>
         ) : (
           !isNil(count) && (

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
@@ -12,7 +12,7 @@
  */
 import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useParams } from 'react-router-dom';
 import TabsLabel from '../../components/common/TabsLabel/TabsLabel.component';
 import { GenericTab } from '../../components/Customization/GenericTab/GenericTab';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
@@ -764,6 +764,89 @@ describe('TestDetailsPageV1 component', () => {
       await waitFor(() =>
         expect(getLatestQueriesTabProps()).toEqual(
           expect.objectContaining({ count: 0, isLoading: false })
+        )
+      );
+    });
+
+    it('should ignore a late count response for a table the user already left', async () => {
+      const resolvers: Record<
+        string,
+        (value: { paging: { total: number } }) => void
+      > = {};
+      (getQueriesList as jest.Mock).mockImplementation(
+        ({ entityId }: { entityId: string }) =>
+          new Promise((resolve) => {
+            resolvers[entityId] = resolve;
+          })
+      );
+      const tableFor = (id: string) => ({
+        name: `test-${id}`,
+        id,
+        fullyQualifiedName: `fqn-${id}`,
+        columns: [],
+      });
+
+      (usePermissionProvider as jest.Mock).mockImplementation(() => ({
+        getEntityPermissionByFqn: jest.fn().mockImplementation(() => ({
+          ViewBasic: true,
+        })),
+      }));
+      (getTableDetailsByFQN as jest.Mock).mockImplementation((fqn: string) =>
+        Promise.resolve(tableFor(fqn === 'fqn-b' ? 'b' : 'a'))
+      );
+      (useParams as jest.Mock).mockReturnValue({ fqn: 'fqn-a', tab: 'schema' });
+
+      let rerender: (ui: React.ReactElement) => void = () => undefined;
+
+      await act(async () => {
+        ({ rerender } = render(
+          <MemoryRouter>
+            <TableDetailsPageV1 />
+          </MemoryRouter>
+        ));
+      });
+
+      await waitFor(() =>
+        expect(getQueriesList).toHaveBeenCalledWith({
+          limit: 0,
+          entityId: 'a',
+        })
+      );
+
+      (useParams as jest.Mock).mockReturnValue({ fqn: 'fqn-b', tab: 'schema' });
+
+      await act(async () => {
+        rerender(
+          <MemoryRouter>
+            <TableDetailsPageV1 />
+          </MemoryRouter>
+        );
+      });
+
+      await waitFor(() =>
+        expect(getQueriesList).toHaveBeenCalledWith({
+          limit: 0,
+          entityId: 'b',
+        })
+      );
+
+      // Table A's request resolves only now, after the user moved to table B.
+      await act(async () => {
+        resolvers.a({ paging: { total: 7 } });
+      });
+
+      expect(getLatestQueriesTabProps()).toEqual(
+        expect.objectContaining({ isLoading: true })
+      );
+      expect(getLatestQueriesTabProps()?.count).not.toBe(7);
+
+      await act(async () => {
+        resolvers.b({ paging: { total: 3 } });
+      });
+
+      await waitFor(() =>
+        expect(getLatestQueriesTabProps()).toEqual(
+          expect.objectContaining({ count: 3, isLoading: false })
         )
       );
     });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
@@ -10,13 +10,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
+import TabsLabel from '../../components/common/TabsLabel/TabsLabel.component';
 import { GenericTab } from '../../components/Customization/GenericTab/GenericTab';
 import PageLayoutV1 from '../../components/PageLayoutV1/PageLayoutV1';
 import { usePermissionProvider } from '../../context/PermissionProvider/PermissionProvider';
+import { EntityTabs } from '../../enums/entity.enum';
 import { TableType } from '../../generated/entity/data/table';
+import { getQueriesList } from '../../rest/queryAPI';
 import { getTableDetailsByFQN } from '../../rest/tableAPI';
 import { DEFAULT_ENTITY_PERMISSION } from '../../utils/PermissionsUtils';
 import TableDetailsPageV1 from './TableDetailsPageV1';
@@ -678,5 +681,91 @@ describe('TestDetailsPageV1 component', () => {
       }),
       expect.anything()
     );
+  });
+
+  describe('Queries tab count', () => {
+    const getQueriesTabProps = () =>
+      (TabsLabel as unknown as jest.Mock).mock.calls
+        .map(([props]) => props)
+        .filter((props) => props.id === EntityTabs.TABLE_QUERIES);
+
+    const getLatestQueriesTabProps = () => getQueriesTabProps().pop();
+
+    const renderPage = async () => {
+      (usePermissionProvider as jest.Mock).mockImplementationOnce(() => ({
+        getEntityPermissionByFqn: jest.fn().mockImplementationOnce(() => ({
+          ViewBasic: true,
+        })),
+      }));
+      // The count effect keys on fullyQualifiedName, which the shared mock omits —
+      // without it the effect never re-runs once tableDetails resolves.
+      (getTableDetailsByFQN as jest.Mock).mockImplementationOnce(() =>
+        Promise.resolve({
+          name: 'test',
+          id: '123',
+          fullyQualifiedName: 'fqn',
+          columns: [],
+        })
+      );
+
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <TableDetailsPageV1 />
+          </MemoryRouter>
+        );
+      });
+    };
+
+    beforeEach(() => {
+      (TabsLabel as unknown as jest.Mock).mockClear();
+      (getQueriesList as jest.Mock).mockClear();
+    });
+
+    it('should render the skeleton instead of a count while the request is in flight', async () => {
+      let resolveCount: (value: { paging: { total: number } }) => void = () =>
+        undefined;
+      (getQueriesList as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCount = resolve;
+          })
+      );
+
+      await renderPage();
+
+      await waitFor(() => expect(getQueriesList).toHaveBeenCalled());
+
+      // Every render so far, not just the latest — one frame with isLoading
+      // false is the placeholder 0 this guards against.
+      expect(getQueriesTabProps()).not.toHaveLength(0);
+      expect(
+        getQueriesTabProps().every((props) => props.isLoading)
+      ).toBeTruthy();
+
+      await act(async () => {
+        resolveCount({ paging: { total: 7 } });
+      });
+
+      await waitFor(() =>
+        expect(getLatestQueriesTabProps()).toEqual(
+          expect.objectContaining({ count: 7, isLoading: false })
+        )
+      );
+    });
+
+    it('should fall back to 0 when the count request fails', async () => {
+      (getQueriesList as jest.Mock).mockRejectedValue(new Error('failed'));
+
+      await renderPage();
+
+      await waitFor(() => expect(getQueriesList).toHaveBeenCalled());
+
+      await waitFor(() =>
+        expect(getLatestQueriesTabProps()).toEqual(
+          expect.objectContaining({ count: 0, isLoading: false })
+        )
+      );
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx
@@ -850,5 +850,89 @@ describe('TestDetailsPageV1 component', () => {
         )
       );
     });
+
+    it('should ignore a stale response for a table the user returned to', async () => {
+      // Same entityId for both A requests, so they can only be told apart by
+      // request order — keyed by call index, not by id.
+      const resolvers: Array<(value: { paging: { total: number } }) => void> =
+        [];
+      (getQueriesList as jest.Mock).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(resolve);
+          })
+      );
+      const tableFor = (id: string) => ({
+        name: `test-${id}`,
+        id,
+        fullyQualifiedName: `fqn-${id}`,
+        columns: [],
+      });
+
+      (usePermissionProvider as jest.Mock).mockImplementation(() => ({
+        getEntityPermissionByFqn: jest.fn().mockImplementation(() => ({
+          ViewBasic: true,
+        })),
+      }));
+      (getTableDetailsByFQN as jest.Mock).mockImplementation((fqn: string) =>
+        Promise.resolve(tableFor(fqn === 'fqn-b' ? 'b' : 'a'))
+      );
+
+      const goTo = async (
+        fqn: string,
+        rerender?: (ui: React.ReactElement) => void
+      ) => {
+        (useParams as jest.Mock).mockReturnValue({ fqn, tab: 'schema' });
+        const ui = (
+          <MemoryRouter>
+            <TableDetailsPageV1 />
+          </MemoryRouter>
+        );
+        let result: ReturnType<typeof render> | undefined;
+
+        await act(async () => {
+          if (rerender) {
+            rerender(ui);
+          } else {
+            result = render(ui);
+          }
+        });
+
+        return result;
+      };
+
+      const { rerender } = (await goTo('fqn-a'))!;
+
+      await waitFor(() => expect(resolvers).toHaveLength(1));
+
+      await goTo('fqn-b', rerender);
+
+      await waitFor(() => expect(resolvers).toHaveLength(2));
+
+      await goTo('fqn-a', rerender);
+
+      await waitFor(() => expect(resolvers).toHaveLength(3));
+
+      // The first request for table A resolves only now — after the user left A and
+      // came back, so a newer request for the same id is already in flight.
+      await act(async () => {
+        resolvers[0]({ paging: { total: 7 } });
+      });
+
+      expect(getLatestQueriesTabProps()).toEqual(
+        expect.objectContaining({ isLoading: true })
+      );
+      expect(getLatestQueriesTabProps()?.count).not.toBe(7);
+
+      await act(async () => {
+        resolvers[2]({ paging: { total: 3 } });
+      });
+
+      await waitFor(() =>
+        expect(getLatestQueriesTabProps()).toEqual(
+          expect.objectContaining({ count: 3, isLoading: false })
+        )
+      );
+    });
   });
 });

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -125,10 +125,11 @@ const TableDetailsPageV1: React.FC = () => {
 
   const [queryCount, setQueryCount] = useState(0);
   const [isQueryCountLoading, setIsQueryCountLoading] = useState(true);
-  // Table whose query count is currently in flight. Navigating between tables leaves the
-  // previous request running, and its late response would otherwise clear this table's
-  // skeleton and paint the previous table's count.
-  const queryCountRequestIdRef = useRef<string>();
+  // Sequence number of the newest query-count request. Navigating away leaves the previous
+  // request running, and its late response would otherwise clear this table's skeleton and
+  // paint a stale count. A counter rather than the table id, because A -> B -> A gives two
+  // concurrent requests for the same id and only the newest may settle the badge.
+  const queryCountRequestSeqRef = useRef(0);
 
   const [loading, setLoading] = useState(!isTourOpen);
   const [tablePermissions, setTablePermissions] = useState<OperationPermission>(
@@ -302,27 +303,27 @@ const TableDetailsPageV1: React.FC = () => {
     // Tour mode renders a mock without an id — settle the skeleton rather than
     // leaving it spinning against a count that will never arrive.
     if (!tableDetails?.id) {
-      queryCountRequestIdRef.current = undefined;
+      queryCountRequestSeqRef.current += 1;
       setIsQueryCountLoading(false);
 
       return;
     }
 
-    const requestedId = tableDetails.id;
-    queryCountRequestIdRef.current = requestedId;
+    queryCountRequestSeqRef.current += 1;
+    const requestSeq = queryCountRequestSeqRef.current;
     setIsQueryCountLoading(true);
 
     try {
       const response = await getQueriesList({
         limit: 0,
-        entityId: requestedId,
+        entityId: tableDetails.id,
       });
-      if (queryCountRequestIdRef.current === requestedId) {
+      if (queryCountRequestSeqRef.current === requestSeq) {
         setQueryCount(response.paging.total);
         setIsQueryCountLoading(false);
       }
     } catch {
-      if (queryCountRequestIdRef.current === requestedId) {
+      if (queryCountRequestSeqRef.current === requestSeq) {
         setQueryCount(0);
         setIsQueryCountLoading(false);
       }
@@ -810,7 +811,7 @@ const TableDetailsPageV1: React.FC = () => {
       setTableDetails(undefined);
       // Invalidate any in-flight count before the new table's request starts, so a
       // response for the table we just left cannot settle this table's badge.
-      queryCountRequestIdRef.current = undefined;
+      queryCountRequestSeqRef.current += 1;
       setIsQueryCountLoading(true);
       fetchTableDetails();
       getEntityFeedCount();

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -124,6 +124,7 @@ const TableDetailsPageV1: React.FC = () => {
   );
 
   const [queryCount, setQueryCount] = useState(0);
+  const [isQueryCountLoading, setIsQueryCountLoading] = useState(true);
 
   const [loading, setLoading] = useState(!isTourOpen);
   const [tablePermissions, setTablePermissions] = useState<OperationPermission>(
@@ -294,7 +295,11 @@ const TableDetailsPageV1: React.FC = () => {
   };
 
   const fetchQueryCount = async () => {
+    // Tour mode renders a mock without an id — settle the skeleton rather than
+    // leaving it spinning against a count that will never arrive.
     if (!tableDetails?.id) {
+      setIsQueryCountLoading(false);
+
       return;
     }
     try {
@@ -305,6 +310,8 @@ const TableDetailsPageV1: React.FC = () => {
       setQueryCount(response.paging.total);
     } catch {
       setQueryCount(0);
+    } finally {
+      setIsQueryCountLoading(false);
     }
   };
 
@@ -533,6 +540,7 @@ const TableDetailsPageV1: React.FC = () => {
 
     const tabs = tableClassBase.getTableDetailPageTabs({
       queryCount,
+      isQueryCountLoading,
       isTourOpen,
       tablePermissions,
       activeTab,
@@ -564,6 +572,7 @@ const TableDetailsPageV1: React.FC = () => {
     return updatedTabs;
   }, [
     queryCount,
+    isQueryCountLoading,
     isTourOpen,
     tablePermissions,
     activeTab,
@@ -785,6 +794,7 @@ const TableDetailsPageV1: React.FC = () => {
       setTableDetails(mockDatasetData.tableDetails as unknown as Table);
     } else if (viewBasicPermission) {
       setTableDetails(undefined);
+      setIsQueryCountLoading(true);
       fetchTableDetails();
       getEntityFeedCount();
     }

--- a/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx
@@ -16,7 +16,7 @@ import { AxiosError } from 'axios';
 import { compare } from 'fast-json-patch';
 import { isEmpty } from 'lodash';
 import { EntityTags } from 'Models';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
 import { ReactComponent as RedAlertIcon } from '../../assets/svg/ic-alert-red.svg';
@@ -125,6 +125,10 @@ const TableDetailsPageV1: React.FC = () => {
 
   const [queryCount, setQueryCount] = useState(0);
   const [isQueryCountLoading, setIsQueryCountLoading] = useState(true);
+  // Table whose query count is currently in flight. Navigating between tables leaves the
+  // previous request running, and its late response would otherwise clear this table's
+  // skeleton and paint the previous table's count.
+  const queryCountRequestIdRef = useRef<string>();
 
   const [loading, setLoading] = useState(!isTourOpen);
   const [tablePermissions, setTablePermissions] = useState<OperationPermission>(
@@ -298,20 +302,30 @@ const TableDetailsPageV1: React.FC = () => {
     // Tour mode renders a mock without an id — settle the skeleton rather than
     // leaving it spinning against a count that will never arrive.
     if (!tableDetails?.id) {
+      queryCountRequestIdRef.current = undefined;
       setIsQueryCountLoading(false);
 
       return;
     }
+
+    const requestedId = tableDetails.id;
+    queryCountRequestIdRef.current = requestedId;
+    setIsQueryCountLoading(true);
+
     try {
       const response = await getQueriesList({
         limit: 0,
-        entityId: tableDetails.id,
+        entityId: requestedId,
       });
-      setQueryCount(response.paging.total);
+      if (queryCountRequestIdRef.current === requestedId) {
+        setQueryCount(response.paging.total);
+        setIsQueryCountLoading(false);
+      }
     } catch {
-      setQueryCount(0);
-    } finally {
-      setIsQueryCountLoading(false);
+      if (queryCountRequestIdRef.current === requestedId) {
+        setQueryCount(0);
+        setIsQueryCountLoading(false);
+      }
     }
   };
 
@@ -794,6 +808,9 @@ const TableDetailsPageV1: React.FC = () => {
       setTableDetails(mockDatasetData.tableDetails as unknown as Table);
     } else if (viewBasicPermission) {
       setTableDetails(undefined);
+      // Invalidate any in-flight count before the new table's request starts, so a
+      // response for the table we just left cannot settle this table's badge.
+      queryCountRequestIdRef.current = undefined;
       setIsQueryCountLoading(true);
       fetchTableDetails();
       getEntityFeedCount();

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts
@@ -36,6 +36,7 @@ import {
 
 export interface TableDetailPageTabProps {
   queryCount: number;
+  isQueryCountLoading: boolean;
   isTourOpen: boolean;
   activeTab: EntityTabs;
   feedCount: FeedCounts;

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx
@@ -150,6 +150,7 @@ const PartitionedKeys = withSuspenseFallback(
 
 export const getTableDetailPageBaseTabs = ({
   queryCount,
+  isQueryCountLoading,
   isTourOpen,
   tablePermissions,
   activeTab,
@@ -242,6 +243,7 @@ export const getTableDetailPageBaseTabs = ({
           count={queryCount}
           id={EntityTabs.TABLE_QUERIES}
           isActive={activeTab === EntityTabs.TABLE_QUERIES}
+          isLoading={isQueryCountLoading}
           name={get(
             labelMap,
             EntityTabs.TABLE_QUERIES,

--- a/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.test.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.test.tsx
@@ -1168,6 +1168,7 @@ describe('TableUtils', () => {
     fetchTableDetails: jest.fn(),
     getEntityFeedCount: jest.fn(),
     handleFeedCount: jest.fn(),
+    isQueryCountLoading: false,
     isTourOpen: false,
     isViewTableType: true,
     queryCount: 0,


### PR DESCRIPTION
### Describe your changes:

Fixes #31688

The **Queries** tab badge on the Table details page rendered a real-looking `0` for the first frames of every table page load, then switched to the true count. `queryCount` starts at `0`, the count request only fires once the entity resolves, and `TabsLabel` renders the badge whenever `!isNil(count)` — so the placeholder was displayed as if it were the count.

**This is the 1.13-only remainder of #31571, not a backport of #31572.** On `main`/`2.0` the count fetch was *also* deferred until the Queries tab was activated (`useDeferredTabData`), so there the badge stayed at `0` until the tab was clicked. That deferral was never on 1.13 — this branch already fetches eagerly when the entity resolves — so only the loading-state half applies here. The `main` fix could not be cherry-picked regardless: `TableDetailsPageV1.tsx` differs by ~330 lines between the branches and 1.13 has no React Query on that page, so the loading state is a `useState` flag here rather than `useQuery`'s `isFetching`.

Changes:
- `TableDetailsPageV1.tsx` — added `isQueryCountLoading`, set around `fetchQueryCount` (including the no-id early return, so tour mode doesn't leave the skeleton spinning). The flag is re-armed in the same effect that clears `tableDetails`, so the new table's first render cannot briefly show the previous table's count.
- `TableClassBase.ts` / `TableTabsUtils.tsx` — new `isQueryCountLoading` prop, forwarded to the Queries `TabsLabel` as `isLoading`.
- `TabsLabel.component.tsx` — that `isLoading` branch rendered `<Loader size="small" />`; a spinner in place of a small static pill draws more attention than the number it stands in for, so it now renders the core-components `Skeleton`. The resulting file is byte-identical to the same file on `main` after #31572, so the branches stay in sync.

Note the `isLoading` branch had no production consumer on this branch before now — only its own unit test — so no other tab's appearance changes.


https://github.com/user-attachments/assets/7a2b846b-ee2f-48f9-b28b-17644b24a578



#
### Type of change:
- [x] Bug fix

#
### High-level design:

N/A — small change.

#
### Tests:

#### Use cases covered
- While the count request is in flight the Queries badge shows a skeleton, never a placeholder `0`.
- Once it resolves the badge shows the true count.
- Navigating to another table shows the skeleton again rather than the previous table's count.
- A failing count request settles the badge at `0` instead of leaving it loading forever.

#### Unit tests
- [x] I added unit tests for the changed logic.
- `openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx` — new `Queries tab count` block. The in-flight test asserts that **every** render before the request resolves kept the badge in its loading state, which is what actually rules out the `0` flash; asserting only the end state would pass even with a flash. Plus the `0` fallback on rejection.
- `openmetadata-ui/src/main/resources/ui/src/utils/TableUtils.test.tsx` — fixture updated for the new required prop.
- `yarn test src/pages/TableDetailsPageV1 src/components/common/TabsLabel src/utils/TableUtils.test.tsx` → **165 passed, 6 suites**.
- `yarn eslint` on all six touched files → clean, zero problems. `npx tsc --noEmit` → 427 errors both before and after the change, identical per-file and per-error-code distribution, none in the touched files.

#### Backend integration tests
- [x] Not applicable (no backend API changes).

#### Ingestion integration tests
- [x] Not applicable (no ingestion changes).

#### Playwright (UI) tests
- [x] Not applicable — covered by the unit tests above; no new UI surface was added.

#### Manual testing performed
Behaviour verified through the unit tests above, which assert the badge's loading state across every render rather than only its settled value.

#
### UI screen recording / screenshots:

Before: the Queries badge reads `Queries 0` on first paint, then flips to the real count. After: a skeleton pill in the badge, then the correct count.

#
### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [x] My PR title is `Fixes <issue-number>: <short explanation>`
- [x] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] For UI changes: described above.
- [x] I have added tests and listed them above.

- [x] I have added a test that covers the exact scenario we are fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces the Queries badge’s placeholder count with a skeleton while loading and prevents obsolete requests from settling the badge.
- Adds and propagates query-count loading state through the table tab configuration.
- Uses a monotonically increasing request sequence to reject stale responses, including A → B → A navigation.
- Adds tests for loading, failure, cross-table navigation, and revisiting a table.
- Replaces the badge spinner with a compact skeleton.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.tsx | Adds query-count loading state and sequence-based stale-response rejection; the previously reported overlapping-request races are addressed. |
| openmetadata-ui/src/main/resources/ui/src/pages/TableDetailsPageV1/TableDetailsPageV1.test.tsx | Covers in-flight loading, request failure, navigation between tables, and overlapping requests when revisiting a table. |
| openmetadata-ui/src/main/resources/ui/src/components/common/TabsLabel/TabsLabel.component.tsx | Replaces the loading spinner with a compact rounded skeleton. |
| openmetadata-ui/src/main/resources/ui/src/utils/TableTabsUtils.tsx | Forwards the query-count loading state to the Queries tab label. |
| openmetadata-ui/src/main/resources/ui/src/utils/TableClassBase.ts | Extends the table tab configuration contract with the required loading-state property. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant P as TableDetailsPageV1
  participant API as Queries API
  U->>P: Navigate to table
  P->>P: Increment request sequence
  P->>P: Show badge skeleton
  P->>API: Fetch query count with captured sequence
  alt Response belongs to latest sequence
    API-->>P: Query count
    P->>P: Display count and clear loading
  else Response is obsolete
    API-->>P: Stale response
    P->>P: Ignore response
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Identify query-count requests by sequenc..."](https://github.com/open-metadata/openmetadata/commit/0bc41ba60472f67e3d4367b60b15900d8aa5206c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54311043)</sub>

<!-- /greptile_comment -->