### PR TITLE
test(e2e): stop persona specs asserting the system default persona fallback

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts
@@ -48,7 +48,6 @@ const PERSONA_DETAILS = {
   description: `Persona description ${uuid()}.`,
 };
 
-const user = new UserClass();
 const persona1 = new PersonaClass();
 const persona2 = new PersonaClass();
 
@@ -303,16 +302,31 @@ test.describe.serial('Persona operations', () => {
 });
 
 test.describe.serial('Default persona setting and removal flow', () => {
+  const user1 = new UserClass();
+
   test.beforeAll('Setup user for default persona flow', async ({ browser }) => {
     const { apiContext, afterAction } = await createNewPage(browser);
-    await user.create(apiContext);
+    await user1.create(apiContext);
     const adminResponse = await apiContext.get('/api/v1/users/name/admin');
     const adminData = await adminResponse.json();
 
-    await persona1.create(apiContext, [user.responseData.id, adminData.id]);
-    await persona2.create(apiContext, [user.responseData.id]);
+    await persona1.create(apiContext, [user1.responseData.id, adminData.id]);
+    await persona2.create(apiContext, [user1.responseData.id]);
     await afterAction();
   });
+
+  test.afterAll(
+    'Teardown user for default persona flow',
+    async ({ browser }) => {
+      const { apiContext, afterAction } = await createNewPage(browser);
+      await Promise.all([
+        user1.delete(apiContext),
+        persona1.delete(apiContext),
+        persona2.delete(apiContext),
+      ]);
+      await afterAction();
+    }
+  );
 
   test('Set and remove default persona should work properly', async ({
     adminPage,
@@ -320,138 +334,149 @@ test.describe.serial('Default persona setting and removal flow', () => {
   }) => {
     const userContext = await browser.newContext({ storageState: undefined });
     const userPage = await userContext.newPage();
-    await user.login(userPage);
+    await user1.login(userPage);
 
     test.slow(true);
 
-    await test.step('Admin creates a persona and sets the default persona', async () => {
-      await navigateToPersonaSettings(adminPage);
-      await adminPage.getByTestId('add-persona-button').click();
+    try {
+      await test.step('Admin creates a persona and sets the default persona', async () => {
+        await navigateToPersonaSettings(adminPage);
+        await adminPage.getByTestId('add-persona-button').click();
 
-      await validateFormNameFieldInput({
-        page: adminPage,
-        value: PERSONA_DETAILS.name,
-        fieldName: 'Name',
-        fieldSelector: '[data-testid="name"]',
-        errorDivSelector: '#name_help',
-      });
+        await validateFormNameFieldInput({
+          page: adminPage,
+          value: PERSONA_DETAILS.name,
+          fieldName: 'Name',
+          fieldSelector: '[data-testid="name"]',
+          errorDivSelector: '#name_help',
+        });
 
-      await adminPage
-        .getByTestId('displayName')
-        .fill(PERSONA_DETAILS.displayName);
+        await adminPage
+          .getByTestId('displayName')
+          .fill(PERSONA_DETAILS.displayName);
 
-      await adminPage.locator(descriptionBox).fill(PERSONA_DETAILS.description);
+        await adminPage
+          .locator(descriptionBox)
+          .fill(PERSONA_DETAILS.description);
 
-      const userListResponse = adminPage.waitForResponse(
-        '/api/v1/users?limit=*&isBot=false*'
-      );
-      await adminPage.getByTestId('add-users').click();
-      await userListResponse;
+        const userListResponse = adminPage.waitForResponse(
+          '/api/v1/users?limit=*&isBot=false*'
+        );
+        await adminPage.getByTestId('add-users').click();
+        await userListResponse;
 
-      await waitForAllLoadersToDisappear(adminPage);
+        await waitForAllLoadersToDisappear(adminPage);
 
-      const searchUser = adminPage.waitForResponse(
-        `/api/v1/search/query?q=*${encodeURIComponent(
-          user.responseData.displayName
-        )}*`
-      );
-      await adminPage
-        .getByTestId('searchbar')
-        .fill(user.responseData.displayName);
-      await searchUser;
+        const searchUser = adminPage.waitForResponse(
+          `/api/v1/search/query?q=*${encodeURIComponent(
+            user1.responseData.displayName
+          )}*`
+        );
+        await adminPage
+          .getByTestId('searchbar')
+          .fill(user1.responseData.displayName);
+        await searchUser;
 
-      await adminPage
-        .getByRole('listitem', { name: user.responseData.displayName })
-        .click();
-      await adminPage.getByTestId('selectable-list-update-btn').click();
+        await adminPage
+          .getByRole('listitem', { name: user1.responseData.displayName })
+          .click();
+        await adminPage.getByTestId('selectable-list-update-btn').click();
 
-      await adminPage.getByRole('button', { name: 'Create' }).click();
+        await adminPage.getByRole('button', { name: 'Create' }).click();
 
-      await navigateToPersonaSettings(adminPage);
+        await navigateToPersonaSettings(adminPage);
 
-      await waitForAllLoadersToDisappear(adminPage, 'skeleton-card-loader');
+        await waitForAllLoadersToDisappear(adminPage, 'skeleton-card-loader');
 
-      const personaResponse = adminPage.waitForResponse(
-        `/api/v1/personas/name/${encodeURIComponent(
+        const personaResponse = adminPage.waitForResponse(
+          `/api/v1/personas/name/${encodeURIComponent(
+            PERSONA_DETAILS.name
+          )}?fields=users`
+        );
+
+        await navigateToPersonaWithPagination(
+          adminPage,
+          PERSONA_DETAILS.name,
+          true
+        );
+
+        await personaResponse;
+
+        await adminPage.getByRole('tab', { name: 'Users' }).click();
+
+        await adminPage.getByTestId('entity-header-name').waitFor({
+          state: 'visible',
+        });
+
+        await expect(adminPage.getByTestId('entity-header-name')).toContainText(
           PERSONA_DETAILS.name
-        )}?fields=users`
-      );
+        );
 
-      await navigateToPersonaWithPagination(
-        adminPage,
-        PERSONA_DETAILS.name,
-        true
-      );
+        await expect(
+          adminPage.getByTestId('entity-header-display-name')
+        ).toContainText(PERSONA_DETAILS.displayName);
 
-      await personaResponse;
+        await expect(
+          adminPage.locator(
+            '[data-testid="viewer-container"] [data-testid="markdown-parser"]'
+          )
+        ).toContainText(PERSONA_DETAILS.description);
 
-      await adminPage.getByRole('tab', { name: 'Users' }).click();
+        await expect(
+          adminPage.getByTestId(user1.responseData.name)
+        ).toContainText(user1.responseData.name);
 
-      await adminPage.getByTestId('entity-header-name').waitFor({
-        state: 'visible',
+        await setPersonaAsDefault(adminPage);
       });
 
-      await expect(adminPage.getByTestId('entity-header-name')).toContainText(
-        PERSONA_DETAILS.name
-      );
+      await test.step('User refreshes and checks the default persona is applied', async () => {
+        await userPage.reload();
+        await waitForAllLoadersToDisappear(userPage);
+        await checkPersonaInProfile(userPage, PERSONA_DETAILS.displayName);
+        await redirectToHomePage(userPage);
+      });
 
-      await expect(
-        adminPage.getByTestId('entity-header-display-name')
-      ).toContainText(PERSONA_DETAILS.displayName);
+      await test.step('Changing default persona', async () => {
+        const personaListResponse =
+          adminPage.waitForResponse(`/api/v1/personas?*`);
 
-      await expect(
-        adminPage.locator(
-          '[data-testid="viewer-container"] [data-testid="markdown-parser"]'
-        )
-      ).toContainText(PERSONA_DETAILS.description);
+        await settingClick(adminPage, GlobalSettingOptions.PERSONA);
+        await personaListResponse;
+        await navigateToPersonaWithPagination(
+          adminPage,
+          persona1.responseData.fullyQualifiedName ??
+            persona1.responseData.name,
+          true
+        );
 
-      await expect(adminPage.getByTestId(user.responseData.name)).toContainText(
-        user.responseData.name
-      );
+        await setPersonaAsDefault(adminPage);
+      });
 
-      await setPersonaAsDefault(adminPage);
-    });
+      await test.step('Verify changed default persona for new user', async () => {
+        await userPage.reload();
+        await waitForAllLoadersToDisappear(userPage);
+        await checkPersonaInProfile(
+          userPage,
+          persona1.responseData.displayName
+        );
+      });
 
-    await test.step('User refreshes and checks the default persona is applied', async () => {
-      await userPage.reload();
-      await waitForAllLoadersToDisappear(userPage);
-      await checkPersonaInProfile(userPage, PERSONA_DETAILS.displayName);
-    });
+      await test.step('Admin removes the default persona', async () => {
+        await navigateToPersonaSettings(adminPage);
+        await removePersonaDefault(
+          adminPage,
+          persona1.responseData?.fullyQualifiedName
+        );
+      });
 
-    await test.step('Changing default persona', async () => {
-      const personaListResponse =
-        adminPage.waitForResponse(`/api/v1/personas?*`);
-
-      await settingClick(adminPage, GlobalSettingOptions.PERSONA);
-      await personaListResponse;
-      await navigateToPersonaWithPagination(
-        adminPage,
-        persona1.responseData.fullyQualifiedName ?? persona1.responseData.name,
-        true
-      );
-
-      await setPersonaAsDefault(adminPage);
-    });
-
-    await test.step('Verify changed default persona for new user', async () => {
-      await userPage.reload();
-      await waitForAllLoadersToDisappear(userPage);
-      await checkPersonaInProfile(userPage, persona1.responseData.displayName);
-    });
-
-    await test.step('Admin removes the default persona', async () => {
-      await navigateToPersonaSettings(adminPage);
-      await removePersonaDefault(
-        adminPage,
-        persona1.responseData?.fullyQualifiedName
-      );
-    });
-
-    await test.step('User refreshes and sees no default persona', async () => {
-      await userPage.reload();
-      await waitForAllLoadersToDisappear(userPage);
-      await checkPersonaInProfile(userPage); // Expect no persona again
-    });
+      await test.step('User refreshes and sees no default persona', async () => {
+        await userPage.reload();
+        await waitForAllLoadersToDisappear(userPage);
+        await checkPersonaInProfile(userPage); // Expect no persona again
+      });
+    } finally {
+      await userContext.close();
+    }
   });
 });
 
@@ -622,10 +647,19 @@ test.describe.serial('Team persona setting flow', () => {
       await adminPage.getByTestId(teamUser.responseData.name).click();
       await userProfileResponse;
 
-      // The inherited team persona must NOT be shown as the user's default persona
       await adminPage.getByTestId('persona-details-card').waitFor();
-      await expect(adminPage.getByTestId('default-persona-chip')).toContainText(
-        'No default persona'
+
+      const defaultPersonaChip = adminPage.getByTestId('default-persona-chip');
+      // Asserted first so the negative check cannot pass on a chip that never
+      // rendered.
+      await expect(defaultPersonaChip).toBeVisible();
+
+      // The inherited team persona must NOT be shown as the user's default
+      // persona. Not asserting the "No default persona" placeholder: the
+      // backend resolves an unset user default to the system default persona,
+      // which is global state this test does not own.
+      await expect(defaultPersonaChip).not.toContainText(
+        teamPersona.responseData.displayName
       );
 
       // The misleading inherited icon must not be rendered on the default persona

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -982,19 +982,28 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
       await moreButton.click();
     }
 
-    // Verify no default persona tag exists
+    // Scope to the user's own personas: a system-wide default persona still
+    // renders here as a fallback.
     const finalPersonaLabels = adminPage.locator(
       '[data-testid="persona-label"]'
     );
 
-    await expect(
-      finalPersonaLabels.locator('[data-testid="default-persona-tag"]')
-    ).not.toBeVisible();
+    for (const personaName of [
+      persona1.responseData.displayName,
+      persona2.responseData.displayName,
+    ]) {
+      const userPersonaLabel = finalPersonaLabels.filter({
+        hasText: personaName,
+      });
 
-    // Verify there are no selected nor a default persona
-    const checkedRadios = adminPage.locator('input[type="radio"]:checked');
+      await expect(
+        userPersonaLabel.locator('[data-testid="default-persona-tag"]')
+      ).not.toBeVisible();
 
-    await expect(checkedRadios).toHaveCount(0);
+      await expect(
+        userPersonaLabel.locator('input[type="radio"]')
+      ).not.toBeChecked();
+    }
   });
 });
 

--- a/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts
@@ -996,6 +996,10 @@ test.describe('User Profile Dropdown Persona Interactions', () => {
         hasText: personaName,
       });
 
+      // Asserted first so the negative checks below cannot pass against a
+      // label that never rendered.
+      await expect(userPersonaLabel).toBeVisible();
+
       await expect(
         userPersonaLabel.locator('[data-testid="default-persona-tag"]')
       ).not.toBeVisible();

--- a/openmetadata-ui/src/main/resources/ui/playwright/utils/persona.ts
+++ b/openmetadata-ui/src/main/resources/ui/playwright/utils/persona.ts
@@ -80,14 +80,29 @@ export const checkPersonaInProfile = async (
  */
 export const setPersonaAsDefault = async (page: Page) => {
   await page.getByTestId('manage-button').click();
-  await page.getByTestId('set-as-default-button').click();
 
-  const setAsDefaultResponse = page.waitForResponse('/api/v1/personas/*');
+  const setAsDefaultButton = page.getByTestId('set-as-default-button');
+  await setAsDefaultButton.waitFor({ state: 'visible' });
+  await setAsDefaultButton.click();
+
+  // The modal testid sits on the 0x0 `.ant-modal-root` wrapper, so wait on the
+  // "Yes" button instead.
   const setAsDefaultConfirmationModal = page.getByTestId(
     'default-persona-confirmation-modal'
   );
+  const yesButton = setAsDefaultConfirmationModal.getByRole('button', {
+    name: 'Yes',
+  });
+  await expect(yesButton).toBeVisible();
 
-  await setAsDefaultConfirmationModal.getByText('Yes').click();
+  // Filter by PATCH so an in-flight GET on /api/v1/personas/* cannot satisfy it.
+  const setAsDefaultResponse = page.waitForResponse(
+    (response) =>
+      /\/api\/v1\/personas\/[^/]+$/.test(response.url()) &&
+      response.request().method() === 'PATCH'
+  );
+
+  await yesButton.click();
   await setAsDefaultResponse;
 };
 
@@ -144,13 +159,28 @@ export const removePersonaDefault = async (
   await navigateToPersonaWithPagination(page, personaName ?? '');
 
   await page.getByTestId('manage-button').click();
-  await page.getByTestId('remove-default-button').click();
 
-  const removeDefaultResponse = page.waitForResponse('/api/v1/personas/*');
+  const removeDefaultButton = page.getByTestId('remove-default-button');
+  await removeDefaultButton.waitFor({ state: 'visible' });
+  await removeDefaultButton.click();
+
+  // The modal testid sits on the 0x0 `.ant-modal-root` wrapper, so wait on the
+  // "Yes" button instead.
   const removeDefaultConfirmationModal = page.getByTestId(
     'default-persona-confirmation-modal'
   );
+  const yesButton = removeDefaultConfirmationModal.getByRole('button', {
+    name: 'Yes',
+  });
+  await expect(yesButton).toBeVisible();
 
-  await removeDefaultConfirmationModal.getByText('Yes').click();
+  // Filter by PATCH so an in-flight GET on /api/v1/personas/* cannot satisfy it.
+  const removeDefaultResponse = page.waitForResponse(
+    (response) =>
+      /\/api\/v1\/personas\/[^/]+$/.test(response.url()) &&
+      response.request().method() === 'PATCH'
+  );
+
+  await yesButton.click();
   await removeDefaultResponse;
 };


### PR DESCRIPTION
## What

Backports the persona-specific parts of #31063, #30699, #30203 and #30732 to **1.13**, where they were never cherry-picked. `main` and `2.0` already carry all four, which is why this failure is 1.13-only.

## RCA

`Team persona setting flow > Set default persona for team should work properly` fails at:

```
expect(locator).toContainText(expected) failed
Locator:  getByTestId('default-persona-chip')
Expected substring: "No default persona"
Received string:    "PW Persona ac9eb…"
```

Not a product bug — the assertion depends on global state the test does not own.

1. The chip renders `user.defaultPersona` (`UserProfilePersona.component.tsx`).
2. When a user has no default persona, the backend resolves the field to the **system** default persona (`UserRepository.getDefaultPersona`).
3. So `"No default persona"` only ever renders when *nothing else* has a system default set.
4. The sibling describe in this same file (`Default persona setting and removal flow`) sets and then clears a system default, and the AUT ships with a pre-seeded `Onboarding System Default Experience` persona. The received value in the trace — `PW Persona ac9eb…` — is that sibling's own fixture, **not** the team persona.

So the assertion was passing on another test's side effect. In 1.13 that leak is worse than upstream: the sibling describe shares a module-level `UserClass` with `Persona operations` and has **no teardown at all**, so its personas and the system default it set survive the run.

Two secondary defects in the shared helpers, same class of problem:

- `persona.ts` waited on `page.waitForResponse('/api/v1/personas/*')` — an unfiltered matcher that any in-flight **GET** can satisfy, so the helper could return before the PATCH landed.
- It also awaited `toBeVisible` on `default-persona-confirmation-modal`, a testid that sits on the antd `.ant-modal-root` wrapper (0x0) and therefore always reports hidden.

`Users.spec.ts` carried the same system-default-fallback bug in the persona-removal test: it asserted no `default-persona-tag` and zero checked radios across **every** `persona-label` in the dropdown, which the system default persona trips.

`#30278` (`fix(ui): stop showing inherited team persona as user default persona`) is **already in 1.13** as `bba09e4424e` — `UserProfilePersona.component.tsx` is byte-identical to `main`. Not the cause here.

## Changes

- **`PersonaFlow.spec.ts`** — team persona step now asserts the real invariant (the team's persona is **not** auto-applied as the user default) instead of the placeholder text, preceded by a visibility check so the negative assertion cannot pass against a chip that never rendered. *(#31063)*
- **`PersonaFlow.spec.ts`** — `Default persona setting and removal flow` gets a describe-local `UserClass`, an `afterAll` deleting the user and both personas, `userContext.close()` in a `finally`, and the `redirectToHomePage(userPage)` after the first verification step. Stops this describe leaking a system default persona into sibling specs. *(#30180, #30203; upstream shipped the teardown inside the #29964 HeaderShell refactor, so applied directly rather than cherry-picked)*
- **`Users.spec.ts`** — persona-removal assertions scoped to the user's own `persona1`/`persona2` labels. *(#30732)*
- **`utils/persona.ts`** — `setPersonaAsDefault` / `removePersonaDefault` wait on the modal's **Yes** button and scope the response wait to `PATCH /api/v1/personas/{id}`, registered immediately before the click. *(#30699)*

## Deliberately not backported

The `default-persona-select-list` server-side search step present in `main` — it requires `/api/v1/personas/search` from #30469, a feature PR absent from 1.13. Porting the test alone would 404.

## Verification

- Prettier: clean on all three files
- ESLint: clean on all three files
- `tsc --noEmit -p playwright/tsconfig.json`: error set for these three files unchanged against the pre-change baseline (one pre-existing unused `getApiContext` in `Users.spec.ts`)
- Specs not run locally — needs a live AUT; only a nightly can confirm the flake is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR makes persona E2E coverage independent of the system-default persona fallback and improves test isolation and response synchronization.
- Scopes persona-removal checks to the two user-owned fixture personas and now verifies each matching label exists.
- Gives the default-persona flow isolated fixtures and teardown.
- Waits specifically for persona PATCH responses and actionable confirmation buttons.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Flow/PersonaFlow.spec.ts | Isolates default-persona fixtures, adds cleanup, and replaces a global-state-dependent team-persona assertion with the intended invariant. |
| openmetadata-ui/src/main/resources/ui/playwright/e2e/Pages/Users.spec.ts | Completes the prior fix by requiring each fixture persona label to be visible before checking that it is neither selected nor marked as default. |
| openmetadata-ui/src/main/resources/ui/playwright/utils/persona.ts | Synchronizes default-persona actions with visible confirmation controls and method-specific PATCH responses. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(e2e): require the persona label to ..."](https://github.com/open-metadata/openmetadata/commit/8bc6fd3cd1877a1a5913ead3fa5e0c9623a2ef01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54324840)</sub>

<!-- /greptile_comment -->