### PR TITLE
ci: build the Collate branch matching the PR base, not always main

### DIFF
--- a/.github/workflows/maven-build-collate.yml
+++ b/.github/workflows/maven-build-collate.yml
@@ -87,7 +87,12 @@ jobs:
           SHA: ${{ github.event_name == 'push' && github.event.after || github.event.pull_request.head.sha || github.sha }}
         with:
           workflow: OpenMetadata Collate Test
-          ref: main
+          # Collate mirrors each OpenMetadata release line on an identically
+          # named branch, so build the Collate branch matching the PR base.
+          # Dispatching main for a 1.13 PR builds main-only Collate code
+          # against a 1.13 checkout. Falls through to the pushed/dispatched ref
+          # when there is no pull request in the payload.
+          ref: ${{ github.event.pull_request.base.ref || github.ref_name || 'main' }}
           repo: open-metadata/openmetadata-collate
           token: ${{ secrets.COLLATE_PAT }}
           wait-for-completion: true


### PR DESCRIPTION
## What

Collate CI validated **every** OpenMetadata PR against Collate `main`, whatever branch the PR was actually for. Build the Collate branch matching the PR's base branch instead.

## The bug, plainly

Collate keeps one branch per OpenMetadata release line, with the same name on both sides — `main`, `1.13`, `2.0` — and each Collate branch pins the matching OpenMetadata branch in `.gitmodules`. The two halves are a matched pair: Collate `1.13` is meant to be built against OpenMetadata `1.13`.

The dispatch step ignored that and always asked for `main`:

```yaml
        with:
          workflow: OpenMetadata Collate Test
          ref: main          # <- always main, whatever the PR base is
```

So a PR against `1.13` built **Collate's newest code against a 1.13 OpenMetadata checkout** — a mismatched pair. It passes only for as long as the two lines happen not to have diverged, and breaks the moment they have, on whatever happens to have diverged that day.

#31689 (base `1.13`) is that failure. Its Collate run reports `headBranch: main`, and the build died in `collate-ui`:

```
[vite]: Rollup failed to resolve import "openmetadata-ui/src/constants/appMode.constants"
        from ".../collate-ui/src/main/resources/ui/src/App.tsx"
```

- Collate `main` → `App.tsx:20` imports `AI_APP_MODE` from `openmetadata-ui/src/constants/appMode.constants`
- Collate `1.13` → no `appMode` reference at all
- OpenMetadata `1.13` → that constants file does not exist

`collate-spec`, `collate-service`, `collate-mcp` and the integration-test module all compiled; only `collate-ui` failed, exactly where the lines diverge. The reactor header also read `2.0.0-SNAPSHOT` — the main line — while validating a 1.13 PR.

Nothing about this is specific to that import. `2.0` PRs are mis-routed identically today; they simply have not tripped over a divergence yet.

Runs:
- PR: https://github.com/open-metadata/OpenMetadata/pull/31689
- OpenMetadata job: https://github.com/open-metadata/OpenMetadata/actions/runs/32128130179/job/95683140608
- Collate build: https://github.com/open-metadata/openmetadata-collate/actions/runs/32128198485

## Change

One line — the dispatch target is read from the event payload:

```yaml
ref: ${{ github.event.pull_request.base.ref || github.ref_name || 'main' }}
```

- a pull request in the payload → its base branch
- otherwise (`push`, `workflow_dispatch`) → the current ref
- neither set → `main`

Branch names already match across the two repos, so this is an identity mapping — no lookup table, no API call. Reading the payload directly rather than testing `github.event_name` keeps it correct whichever pull-request trigger fires the workflow.

If Collate has no branch of the resolved name — a PR stacked on a feature branch, or the window right after a release branch is cut — the dispatch fails with `workflow not found on ref`. That is deliberate: a loud failure rather than the silent fallback to `main` this PR exists to remove. An earlier revision probed the Collate branches API to fall back in that case; dropped per review.

The trigger stays on `pull_request_target`. An earlier revision moved it to `pull_request`; reverted per review, since that would also make the workflow file per-branch and require cherry-picking it to every release line.

## Why this lands on `main`

`pull_request_target` takes the workflow file from the **default branch**, not from the PR's base branch. One commit on `main` therefore fixes `main`, `1.13` and `2.0` at once, and a commit on `1.13` would have no effect at all.

That is measured, not assumed. A probe PR based on this branch still dispatched Collate `main` (`head_branch=main`) — main's hardcoded `ref` ran, not the base branch's fixed one. Independently, #31792 (`base=1.13`) runs the step `Restore openmetadata-ui dist cache`, which exists only in main's `maven-sonar-build.yml`; 1.13's copy has no such step.

An earlier revision of this PR targeted `1.13` on that wrong assumption and has been retargeted.

## Verification

- `yaml.safe_load` parses the workflow; triggers read back unchanged (`workflow_dispatch`, `push`, `pull_request_target`), the step list is unchanged (`Wait for the labeler → Verify PR labels → Checkout → Trigger Collate build & wait`), and the dispatch `ref:` reads back as the expression above
- Collate carries `main`, `1.13` and `2.0`, and each has `openmetadata-dispatch.yml` named `OpenMetadata Collate Test` with the same two inputs (`sha`, `event`) — so every release line resolves to a real branch with a matching dispatch signature
- the resolution logic was exercised against the live Collate API for each release line and for absent branches while an API-probing revision was on this branch: `main` → `main`, `1.13` → `1.13`, `2.0` → `2.0`, `antd-migration/wave-1` → absent, `does-not-exist-xyz` → absent
- end-to-end dispatch behaviour can only be observed once this is merged and a PR runs it

## Not included

`on.push.branches` is still `main` only, so merges to `1.13` / `2.0` never trigger a Collate build and regressions on those lines land silently. Adding them is a one-line change but switches on Slack alerting for those branches, so it is left as a separate decision.

## Found while testing, not fixed here

1. Every PR based on a non-`main` release line fails `Maven SonarCloud CI` at `Restore openmetadata-ui dist cache` — main's `maven-sonar-build.yml` uses `./.github/actions/cache-ui-dist`, which exists only on `main` (absent on `2.0`, `1.13`, `1.12.11`). Same shape as this bug, different workflow. Pre-existing: see #31792.
2. In this same file, `timeout-minutes: 60` on the dispatch step is below its own `wait-timeout-seconds: 3660`, so the step is cancelled a minute before the wait can time out. Pre-existing on `main` and untouched here.

Both belong to CI/infra and are worth their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates Collate workflow dispatches to select the branch matching a pull request’s base ref, while retaining the existing `pull_request_target` trigger.
- Replaces the hard-coded Collate `main` ref with the PR base branch.
- Uses the current ref for push and manual-dispatch events.
- Preserves a final `main` fallback when neither event value is available.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/maven-build-collate.yml | The dispatch now targets the matching Collate branch; the two previously reported failure modes are no longer present at current HEAD. |

</details>

<sub>Reviews (7): Last reviewed commit: ["ci: build the Collate branch matching th..."](https://github.com/open-metadata/openmetadata/commit/ce4049ff5a617425e49d93d71851a7f47c2e8f05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54328251)</sub>

<!-- /greptile_comment -->