### PR TITLE
fix rules builder conjuction overllaping issue

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx
+++ b/openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx
@@ -55,17 +55,19 @@ export const RuleQueryBuilderField = ({
 
   return (
     <DrawerPopupContainerProvider>
-      <QueryBuilderWidgetV1
-        entityType={entityType as EntityType}
-        getQueryActions={setQueryActions}
-        outputType={SearchOutputType.ElasticSearch}
-        readonly={readonly}
-        showCountPreview={false}
-        tree={tree}
-        value={queryFilter ?? ''}
-        onChange={handleChange}
-        onValidityChange={onValidityChange}
-      />
+      <div className="persona-context-rule-builder">
+        <QueryBuilderWidgetV1
+          entityType={entityType as EntityType}
+          getQueryActions={setQueryActions}
+          outputType={SearchOutputType.ElasticSearch}
+          readonly={readonly}
+          showCountPreview={false}
+          tree={tree}
+          value={queryFilter ?? ''}
+          onChange={handleChange}
+          onValidityChange={onValidityChange}
+        />
+      </div>
       {!readonly && (
         <Button
           className="m-t-sm tw:self-start"

--- a/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/query-builder-widget-v1.less
+++ b/openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/query-builder-widget-v1.less
@@ -275,3 +275,27 @@
     display: none;
   }
 }
+
+// Persona rule editor (io.collate PersonaAIContext): push the AND/OR conjunction
+// toggle up to the group header (as the workflow / JSONLogic builder does)
+// instead of the centered default that overlaps the condition rows. Scoped to
+// the `.persona-context-rule-builder` wrapper so other elasticsearch query
+// builders (ScopeFilter, DataContract) are unaffected.
+.persona-context-rule-builder {
+  .query-builder-card.elasticsearch .query-builder-container {
+    .group-or-rule-container.group-container
+      > .group.group-or-rule
+      > .group--header {
+      order: 0;
+
+      .group--conjunctions {
+        top: -75px;
+      }
+
+      // The persona editor renders its own "Add condition" button below.
+      .action.action--ADD-RULE {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Unless your change is trivial, please create an issue to discuss the change before creating a PR.
-->

### Describe your changes:

Before - 
<img width="748" height="808" alt="Screenshot 2026-08-18 at 5 05 03 PM" src="https://github.com/user-attachments/assets/d636f17c-9d4c-4caa-ab12-e63fee4d8438" />

After - 

<img width="703" height="812" alt="Screenshot 2026-08-18 at 5 03 55 PM" src="https://github.com/user-attachments/assets/a9d027ad-5851-4006-ab3c-5918912f4e40" />


#
### Type of change:
<!-- You should choose 1 option and delete options that aren't relevant -->
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

#
### High-level design:
<!--
REQUIRED for large PRs (new features, refactors, breaking changes, or anything touching >5 files).
Skip for small bug fixes and trivial changes.

Cover:
- Architecture / approach you took and why
- Key components or files added/changed and how they interact
- Alternatives considered and why you rejected them
- Any migration, backward-compatibility, or rollout concerns
- Diagrams or links to design docs / RFCs if available
-->

N/A — small change. <!-- Or fill in the design above -->

#
### Tests:

#### Use cases covered
<!--
List the user-visible scenarios this PR exercises. Example:
- User with Admin role can create a Glossary Term with a parent term
- Ingestion run for Snowflake correctly extracts row counts for partitioned tables
-->

#### Unit tests
<!--
- [ ] I added unit tests for the new/changed logic.
- Files added/updated:
- Coverage on changed classes (run `mvn jacoco:report` for backend, `yarn test:coverage` for UI,
  `make unit_ingestion` for ingestion). Target is 90% line coverage on changed classes.
- Coverage %: <e.g., 92% on EntityRepository.java>
-->

#### Backend integration tests
<!--
- [ ] I added integration tests in `openmetadata-integration-tests/` for new/changed API endpoints.
- [ ] Not applicable (no backend API changes).
- Files added/updated:
-->

#### Ingestion integration tests
<!--
- [ ] I added/updated ingestion integration tests for connector changes.
- [ ] Not applicable (no ingestion changes).
- Files added/updated:
-->

#### Playwright (UI) tests
<!--
- [ ] I added Playwright E2E tests under `openmetadata-ui/.../ui/playwright/` for UI changes.
- [ ] Not applicable (no UI changes).
- Files added/updated:
-->

#### Manual testing performed
<!--
List the manual test steps you performed before requesting review. Example:
1. Started local stack via `./docker/run_local_docker.sh -m ui -d mysql`
2. Logged in as admin, created entity X, verified Y appears in the UI
3. Triggered ingestion for Snowflake source, confirmed lineage edges in the explore page
-->

#
### UI screen recording / screenshots:
<!--
REQUIRED for any PR that changes the UI. Drag-and-drop a short screen recording (.mov / .mp4 / .gif)
demonstrating the change end-to-end, plus before/after screenshots where relevant.
Mark "Not applicable" if there are no UI changes.
-->

Not applicable. <!-- Or attach recording/screenshots above -->

#
### Checklist:
<!-- add an x in [] if done, don't mark items that you didn't do !-->
- [x] I have read the [**CONTRIBUTING**](https://docs.open-metadata.org/developers/contribute) document.
- [ ] My PR title is `Fixes <issue-number>: <short explanation>`
- [ ] My PR is linked to a GitHub issue via `Fixes #<issue-number>` above.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] For JSON Schema changes: I updated the migration scripts or explained why it is not needed.
- [ ] For UI changes: I attached a screen recording and/or screenshots above.
- [ ] I have added tests (unit / integration / Playwright as applicable) and listed them above.

<!-- Based on the type(s) of your change, uncomment the required checklist 👇 -->

<!-- Bug fix
- [ ] I have added a test that covers the exact scenario we are fixing. For complex issues, comment the issue number in the test for future reference.
-->

<!-- Improvement
- [ ] I have added tests around the new logic.
- [ ] For connector/ingestion changes: I updated the documentation.
-->

<!-- New feature
- [ ] The issue properly describes why the new feature is needed, what's the goal, and how we are building it. Any discussion
    or decision-making process is reflected in the issue.
- [ ] I have updated the documentation.
- [ ] I have added tests around the new logic.
-->

<!-- Breaking change
- [ ] I have added the tag `Backward-Incompatible-Change`.
-->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adjusts the Persona AI context rule builder layout to prevent its conjunction control from overlapping condition rows.
- Adds a Persona-specific wrapper around the shared query builder.
- Repositions conjunction controls and hides the builder’s internal add-rule action within that wrapper.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up review scope.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/components/Settings/Persona/PersonaAIContext/ContextRuleEditor/RuleQueryBuilderField.component.tsx | Adds a scoped wrapper around the Persona query builder so its layout overrides do not affect other consumers. |
| openmetadata-ui/src/main/resources/ui/src/components/common/QueryBuilderWidgetV1/query-builder-widget-v1.less | Adds Persona-specific styles that move the conjunction control and hide the redundant internal add-condition action. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into rules-builder"](https://github.com/open-metadata/openmetadata/commit/81713f5b75a43e31c754c0a613714e47897f2a3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54333675)</sub>

<!-- /greptile_comment -->