### PR TITLE
fix(data-products): remove Lifecycle Stage from Data Products filters

### DIFF
--- a/openmetadata-ui/src/main/resources/ui/src/constants/DataProduct.constants.ts
+++ b/openmetadata-ui/src/main/resources/ui/src/constants/DataProduct.constants.ts
@@ -22,7 +22,6 @@ export const DATAPRODUCT_DEFAULT_QUICK_FILTERS = [
   EntityFields.OWNERS,
   EntityFields.DOMAINS,
   EntityFields.DATA_PRODUCT_TYPE,
-  EntityFields.LIFECYCLE_STAGE,
   EntityFields.CLASSIFICATION_TAGS,
   EntityFields.GLOSSARY_TERMS,
 ];
@@ -39,10 +38,6 @@ export const DATAPRODUCT_FILTERS = [
   {
     label: 'label.type',
     key: EntityFields.DATA_PRODUCT_TYPE,
-  },
-  {
-    label: 'label.lifecycle-stage',
-    key: EntityFields.LIFECYCLE_STAGE,
   },
   {
     label: 'label.visibility',


### PR DESCRIPTION
## Summary
- Removes `EntityFields.LIFECYCLE_STAGE` from `DATAPRODUCT_DEFAULT_QUICK_FILTERS`
- Removes the Lifecycle Stage entry from `DATAPRODUCT_FILTERS`

The Lifecycle Stage filter was removed from general entity filter lists in 1.13.2 but was accidentally left in the Data Products-specific filter configuration in `DataProduct.constants.ts`, causing it to still appear in the Data Products filter panel.

## Test plan
- [ ] Navigate to Data Products explore/listing page
- [ ] Open the Filters panel — confirm "Lifecycle Stage" is no longer listed
- [ ] Confirm other filters (Owner, Domain, Type, Visibility, Portfolio Priority, Tags, Glossary Terms) still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Removes the accidentally retained Lifecycle Stage filter from the Data Products listing configuration.
- Removes Lifecycle Stage from the default Data Product quick filters.
- Removes Lifecycle Stage from the Data Product filter-panel options.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the targeted filter removed consistently from both Data Product filter lists.

The changed constants feed the Data Product listing and quick-filter UI, and removing Lifecycle Stage from both prevents it from being displayed while stale URL values are ignored rather than sent as malformed search filters.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| openmetadata-ui/src/main/resources/ui/src/constants/DataProduct.constants.ts | Consistently removes Lifecycle Stage from both Data Product filter registries without affecting the remaining filter configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(data-products): remove Lifecycle Sta..."](https://github.com/open-metadata/openmetadata/commit/237a186bd179a71ad80760d5c6273ed7476e2564) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54340282)</sub>

<!-- /greptile_comment -->