### PR TITLE
ci(playwright): keep a main-scoped apt-deps cache warm for merge-queue runs

### DIFF
--- a/.github/workflows/populate-playwright-apt-cache.yml
+++ b/.github/workflows/populate-playwright-apt-cache.yml
@@ -1,0 +1,69 @@
+# Keep a MAIN-scoped copy of the Playwright chromium apt-deps cache alive.
+#
+# Why this workflow exists: GitHub Actions cache scoping means a workflow run
+# can only restore caches created on its own ref or on the default branch.
+# Merge-queue refs (gh-readonly-queue/main/pr-N-sha) are unique per queue
+# entry and deleted after the run — so an apt cache populated during a
+# merge_group run is unreachable by every other queue entry. Unless a run ON
+# MAIN has saved this cache, every merge-queue shard misses it, falls back to
+# `apt-get install` against the Azure Ubuntu mirror, and the whole matrix
+# goes red whenever that mirror has a bad day (runs 32157314266, 32166970973,
+# 32209207109 — zero tests executed, all shards dead in setup).
+#
+# This job saves the same cache key the Playwright reusable workflow restores
+# (`playwright-chromium-deps-v2` + identical package list), from main's
+# scope, so every merge_group / PR / nightly run downstream gets a hit and
+# never talks to the mirror on the hot path.
+#
+# Triggers:
+#   * schedule (6h)      — keeps the cache warm; GitHub evicts caches unused
+#                          for 7 days and LRU-evicts beyond the 10 GB repo
+#                          budget, so a periodic touch guarantees presence.
+#   * workflow_dispatch  — populate immediately (first run, or after an
+#                          eviction during an incident).
+#   * push to main touching the reusable workflow — the package list and the
+#                          `version:` key live there; any change repopulates
+#                          the new key right away instead of waiting ≤6 h,
+#                          during which every queue run would take the
+#                          mirror-dependent miss path.
+#
+# IMPORTANT: the package list and `version:` below MUST stay identical to the
+# two "Cache Playwright system deps" steps in playwright-e2e-reusable.yml —
+# a drifted list populates a key nobody restores. Update both files together.
+name: Populate Playwright apt cache
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/playwright-e2e-reusable.yml
+      - .github/workflows/populate-playwright-apt-cache.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: populate-playwright-apt-cache
+  cancel-in-progress: false
+
+jobs:
+  populate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Populate Playwright system deps cache
+        uses: awalsh128/cache-apt-pkgs-action@v1.5.1
+        with:
+          packages: >-
+            fonts-ipafont-gothic fonts-freefont-ttf fonts-tlwg-loma-otf
+            fonts-unifont fonts-wqy-zenhei xfonts-encodings xfonts-utils
+            xfonts-cyrillic xfonts-scalable
+            libasound2t64 libatk-bridge2.0-0t64 libatk1.0-0t64
+            libatspi2.0-0t64 libcairo2 libcups2t64 libgbm1 libglib2.0-0t64
+            libnspr4 libnss3 libpango-1.0-0 libx11-6 libxcb1 libxcomposite1
+            libxdamage1 libxext6 libxfixes3 libxkbcommon0 libxrandr2
+          version: playwright-chromium-deps-v2


### PR DESCRIPTION
## Summary

The cache-hit gate on `install-deps` (#31691) works — **but only when the cache hits, and in the merge queue it never does.**

## Root cause — GitHub Actions cache scoping

A workflow run can only restore caches created on **its own ref** or on **the default branch**. Merge-queue refs (`gh-readonly-queue/main/pr-N-sha`) are unique per queue entry and deleted after the run. Live evidence from the caches API:

```
cache-apt-pkgs_1a177b42…  ref=refs/heads/gh-readonly-queue/main/pr-31632-…
cache-apt-pkgs_1a177b42…  ref=refs/heads/gh-readonly-queue/main/pr-31700-…
cache-apt-pkgs_1a177b42…  ref=refs/heads/gh-readonly-queue/main/pr-31537-…
```

Every `playwright-chromium-deps-v2` cache is queue-ref-scoped; **no main-scoped copy exists**. So every merge-queue shard misses, attempts a mirror-dependent populate, and the whole matrix goes red whenever Azure's Ubuntu mirror has a bad day (runs [32157314266](https://github.com/open-metadata/OpenMetadata/actions/runs/32157314266), [32166970973](https://github.com/open-metadata/OpenMetadata/actions/runs/32166970973), [32209207109](https://github.com/open-metadata/OpenMetadata/actions/runs/32209207109) — all shards dead in setup, zero tests executed).

The old fonts-only v1 key worked in the queue precisely because **nightly scheduled runs execute on main** and had saved a main-scoped copy. v2 shipped yesterday and never got that chance.

## Change

One new 2-minute workflow that populates the same key from main's scope:

| Trigger | Purpose |
|---|---|
| `schedule` (every 6 h) | Keeps the cache warm across GitHub's 7-day-unused eviction / 10 GB LRU pressure; re-saves within 6 h when a runner-image roll shifts resolved package versions (which changes the action's computed key) |
| `workflow_dispatch` | Immediate first populate; recovery after mid-incident eviction |
| `push` to main touching `playwright-e2e-reusable.yml` or this file | A package-list / version-key change repopulates immediately instead of leaving a ≤6 h queue-wide miss window |

## Parity guarantee

Package list and `version:` are **byte-identical** to both `Cache Playwright system deps` steps in `playwright-e2e-reusable.yml` — verified programmatically (28 packages, `playwright-chromium-deps-v2`, both call sites match). The header comment pins the invariant: update both files together, since a drifted list populates a key nobody restores.

Follow-up (not blocking): extract the shared list into a composite action so it exists in exactly one place.

## Test plan

- [x] YAML validated locally.
- [x] Package/version parity with the reusable workflow verified programmatically.
- [ ] After merge: `workflow_dispatch` this workflow once → confirm a `cache-apt-pkgs_*` cache appears with `ref=refs/heads/main` in the caches API.
- [ ] Next merge_group run: every shard's `Cache Playwright system deps` step logs a cache hit, and `Install Playwright Browsers` completes in ~1-5 s (the #31691 gate skip path).

Related: #31691 (cache-hit gate), #30847 (original apt cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds a main-scoped scheduled workflow that populates the Playwright Chromium apt-dependency cache for merge-queue and PR jobs.
- Runs every six hours, on manual dispatch, and when either relevant workflow changes on `main`.
- Uses the same package list and explicit cache version as both Playwright restore sites.
- The cache key does not account for runner-image changes, and the recurring third-party action remains referenced through a mutable tag.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with non-blocking hardening needed around runner-image cache invalidation and immutable action pinning.

The workflow should populate the same key restored by the Playwright jobs, but image transitions can retain stale cache contents and the recurring job allows a third-party tag to change executable code without a repository update.

**Files Needing Attention:** .github/workflows/populate-playwright-apt-cache.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

The recurring trusted-branch workflow invokes a mutable third-party action tag. Pinning the action to a full commit SHA prevents publisher-side tag changes from altering code executed by scheduled runs. The scheduled, push, and manual triggers all reach the `@v1.5.1` reference at line 59.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/populate-playwright-apt-cache.yml | Adds the main-scoped apt-cache population workflow with matching restore inputs, but its static key does not isolate runner-image generations and its third-party action reference is mutable. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(playwright): keep a main-scoped apt-d..."](https://github.com/open-metadata/openmetadata/commit/74eb2ed54cdff519bb43c0cd0bedfbc84ce917c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54638671)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->