### PR TITLE
fix(ci): scope SSO Login Nightly concurrency group by ref

### DIFF
--- a/.github/workflows/playwright-sso-login-nightly.yml
+++ b/.github/workflows/playwright-sso-login-nightly.yml
@@ -36,7 +36,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: sso-login-nightly-${{ github.event.inputs.sso_provider || 'scheduled' }}
+  group: sso-login-nightly-${{ github.ref }}-${{ github.event.inputs.sso_provider || 'scheduled' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

The `SSO Login Nightly` workflow's concurrency group is keyed only on the `sso_provider` input:

```yaml
concurrency:
  group: sso-login-nightly-${{ github.event.inputs.sso_provider || 'scheduled' }}
  cancel-in-progress: true
```

Because the branch/ref is not part of the key, back-to-back `workflow_dispatch` runs fired by `collate-release-automations[bot]` on different release branches (`1.13`, `2.0`, and `main`) all land in the same group (e.g. `sso-login-nightly-okta`), and `cancel-in-progress: true` makes the newer one kill the older mid-setup. Example: [run 32202346681](https://github.com/open-metadata/OpenMetadata/actions/runs/32202346681) on `1.13` was cancelled ~23s after a sibling dispatch on `2.0` entered the same group.

The pattern is visible across recent history (498/499, 501/502, 505/506/507, …): whenever two branches dispatch close together, one gets cancelled.

Include `github.ref` in the concurrency group so each branch (and the schedule on `main`) gets its own lane, while re-dispatching the same branch still supersedes an older run as intended.

## Test plan

- [ ] Merge, then trigger `workflow_dispatch` on `main` and, within a few minutes, on `1.13` (or wait for the release automation's next post-merge pair) — both runs should proceed to completion instead of one cancelling the other.
- [ ] Re-dispatching the same branch with the same input should still cancel the older in-progress run (unchanged behavior).
- [ ] The nightly cron on `main` continues to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR scopes the SSO Login Nightly concurrency group by Git ref, preventing runs for different release branches from cancelling one another while preserving cancellation for repeated runs of the same ref and provider.
- Adds `github.ref` to the workflow concurrency key.
- Retains provider-level isolation and `cancel-in-progress: true`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the new concurrency key matches the intended per-ref cancellation behavior.

The workflow now gives each ref and provider a distinct concurrency lane, while repeated dispatches for the same ref and provider retain identical keys and continue to supersede older runs.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/playwright-sso-login-nightly.yml | The concurrency key now correctly separates workflow runs by ref and SSO provider without changing job behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): scope SSO Login Nightly concurr..."](https://github.com/open-metadata/openmetadata/commit/9c72f55bc56e176134711220db12056034827fe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54645231)</sub>

<!-- /greptile_comment -->