### PR TITLE
fix: add missing DatasourceConfig import in CollectionDAO (2.0 build break)

### DIFF
--- a/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
+++ b/openmetadata-service/src/main/java/org/openmetadata/service/jdbi3/CollectionDAO.java
@@ -188,6 +188,7 @@ import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlBatch;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlQuery;
 import org.openmetadata.service.jdbi3.locator.ConnectionAwareSqlUpdate;
 import org.openmetadata.service.jdbi3.oauth.OAuthRecords;
+import org.openmetadata.service.resources.databases.DatasourceConfig;
 import org.openmetadata.service.resources.events.subscription.TypedEvent;
 import org.openmetadata.service.resources.feeds.MessageParser.EntityLink;
 import org.openmetadata.service.resources.tags.TagLabelUtil;


### PR DESCRIPTION
## Problem

`openmetadata-service` fails to compile on the `2.0` branch:

```
CollectionDAO.java:[6225,34] cannot find symbol
  symbol:   variable DatasourceConfig
  location: interface CollectionDAO.IngestionPipelineDAO
```

`IngestionPipelineDAO.displayNameSortExpression()` references `DatasourceConfig.getInstance()` with a **bare** class name, but `CollectionDAO.java` on `2.0` has no import for it.

## Cause

#31072 added `displayNameSortExpression()` **and** the `DatasourceConfig` import on `main`, so `main` compiles. The Release Bot then auto-cherry-picked #31072 to `2.0` (commit 6dd48cfc2f85, `cherry picked from 3a989ceb`). The method-body hunk applied cleanly, but the **import-block hunk did not apply** — that region of the import list differs between `main` and `2.0` — and the partial result was committed anyway. So `2.0` got the bare reference without its import.

## Fix

Re-add `import org.openmetadata.service.resources.databases.DatasourceConfig;` on `2.0`.

## Impact

**2.0-only.** `main` already has the import; `1.13` has not received this feature yet. The break surfaces in any build that compiles `openmetadata-service` from the `2.0` tip (e.g. the nightly Java IT jobs, which recompile via a `--remote` submodule bump).

> Note for whoever backports #31072 to the 1.13 patch line: verify the `DatasourceConfig` import survives the cherry-pick there too — it dropped on `2.0`.